### PR TITLE
mptable.rs: pull changes from crosvm/seabios

### DIFF
--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -129,10 +129,8 @@ pub fn configure_system(
     let first_addr_past_32bits = GuestAddress(FIRST_ADDR_PAST_32BITS);
     let end_32bit_gap_start = GuestAddress(FIRST_ADDR_PAST_32BITS - MEM_32BIT_GAP_SIZE);
 
-    // Note that this puts the mptable at 0x0 in guest physical memory.
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(
-        Error::MpTableSetup,
-    )?;
+    // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
+    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
 
     let mut params: boot_params = Default::default();
 


### PR DESCRIPTION
Changes:
* Move mptable definition from the guest physical address 0x0
to the last 1k of Linux's 640l base RAM.
* Fix bug in compute_mp_size (multiply the size of mpc_intsrc by
the number of interrupt sources - 16)
* Set the I/O APIC ID
* Modify the tests to match the changes

Testing Done:
cargo run --  --kernel-path $VMLINUX_PATH
cd x86_64 && cargo test

Signed-off-by: Andreea Florescu <fandree@amazon.com>