### PR TITLE
cargo: explicitly specify version for all external crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-clap = "2.27.1"
+clap = "=2.27.1"
 
 devices = { path = "devices" }
 sys_util = { path = "sys_util" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-
-byteorder = "1.2.1"
-libc = "0.2.32"
+byteorder = "=1.2.1"
+libc = "=0.2.32"
 
 net_util = { path = "../net_util" }
 net_sys = { path = "../net_sys" }

--- a/kernel_loader/Cargo.toml
+++ b/kernel_loader/Cargo.toml
@@ -3,5 +3,6 @@ name = "kernel_loader"
 version = "0.1.0"
 
 [dependencies]
-libc = "*"
+libc = "=0.2.32"
+
 sys_util = { path = "../sys_util" }

--- a/kvm/Cargo.toml
+++ b/kvm/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "*"
+byteorder = "=1.2.1"
+libc = "=0.2.32"
+
 kvm_sys = { path = "../kvm_sys" }
 sys_util = { path = "../sys_util" }
-byteorder = "*"

--- a/kvm_sys/Cargo.toml
+++ b/kvm_sys/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "*"
+libc = "=0.2.32"
+
 sys_util = { path = "../sys_util" }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "0.2.32"
+libc = "=0.2.32"
+
 net_sys = { path = "../net_sys" }
 sys_util = { path = "../sys_util" }

--- a/sys_util/Cargo.toml
+++ b/sys_util/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["The Chromium OS Authors"]
 build = "build.rs"
 
 [dependencies]
-data_model = { path = "../data_model" }
-libc = "*"
+libc = "=0.2.32"
+
 syscall_defines = { path = "../syscall_defines" }
+data_model = { path = "../data_model" }
 
 [build-dependencies]
 gcc = "=0.3.54"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-clap = "2.27.1"
 libc = "=0.2.32"
-epoll = "2.1.0"
-scopeguard = "0.3.3"
+epoll = "=2.1.0"
+scopeguard = "=0.3.3"
 
 kvm = { path = "../kvm" }
 kvm_sys = { path = "../kvm_sys" }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate clap;
 extern crate epoll;
 extern crate libc;
 #[macro_use(defer)]

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
+byteorder = "=1.2.1"
+libc = "=0.2.32"
+
 data_model = { path = "../data_model" }
 kvm_sys = { path = "../kvm_sys" }
 kvm = { path = "../kvm" }
 sys_util = { path = "../sys_util" }
-libc = "*"
-byteorder = "*"


### PR DESCRIPTION
* external crates should be added before internal crates
* one line break between external and internal crates
* a specific version is enforced with the "=" operator
* same version should be used across all crates

Testing done:
cargo update
cargo build
cargo test

Signed-off-by: Diana Popa <dpopa@amazon.com>