### PR TITLE
add kill-api cmdline option

### DIFF
--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 clap = "=2.27.1"
 futures = "=0.1"
 iron = "=0.5"
+libc = "=0.2.32"
 
 api = { path = "../api" }
 vmm = { path = "../vmm" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,12 @@ fn main() {
         .author(crate_authors!())
         .about("Launch a microvm.")
         .arg(
+            Arg::with_name("kill_api")
+                .long("kill-api")
+                .help("Kill the REST API server on vmm exit")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("api_port")
                 .short("p")
                 .long("api-port")


### PR DESCRIPTION
When the kill-api option is present the vmm thread will send a SIGTERM signal to the API server thread after the vm exited.
 
Tested by:
cargo run -- --api-port 33333 -k ../linux-4.9/arch/x86/boot/compressed/vmlinux.bin --kill-api