### PR TITLE
api_server: set number of Iron threads to 1

### DIFF
--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -554,8 +554,10 @@ pub fn start_api_server(cmd_arguments: &clap::ArgMatches) -> Result<()> {
         let chain = Chain::new(router);
         let sock_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), api_port);
 
-        Iron::new(chain)
-            .http(sock_addr)
+        let mut iron = Iron::new(chain);
+        // By default Iron uses 8 * num_cpus threads.
+        iron.threads = 1;
+        iron.http(sock_addr)
             .expect("Failed to start HTTP server");
     });
 


### PR DESCRIPTION
By default, Iron creates 8 * cpu_nums threads. We expect low
traffic on the API threads, so the number of threads should be 1.
With this change, the total number of firecracker threads is:
1 (VMM thread) + 1 devices thread + 1 * nr_vcpu + 3 Iron threads.

Signed-off-by: Andreea Florescu <fandree@amazon.com>

Tests:
1. Test with dummy vmlinux:
cargo run --  --kernel-path vmlinux_hello.bin --api-port 2020 --kill-api
2. Test with Amazon Linux Kernel:
cargo run --  --kernel-path vmlinux_alinux.bin -r rootfs.ext4 --api-port 2020 --vcpu-count 1;
ps -o nlwp $PID -> 5 threads