### PR TITLE
Unit test catch-up: virtio/net.rs

### DIFF
--- a/devices/src/virtio/queue.rs
+++ b/devices/src/virtio/queue.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{fence, Ordering};
 
 use sys_util::{GuestAddress, GuestMemory};
 
-const VIRTQ_DESC_F_NEXT: u16 = 0x1;
-const VIRTQ_DESC_F_WRITE: u16 = 0x2;
+pub(super) const VIRTQ_DESC_F_NEXT: u16 = 0x1;
+pub(super) const VIRTQ_DESC_F_WRITE: u16 = 0x2;
 
 /// A virtio descriptor chain.
 pub struct DescriptorChain<'a> {


### PR DESCRIPTION
Added unit tests to the virtio/net.rs. Some test logic requires root privileges, or otherwise special capabilities to run. The most convenient way is to simply run all tests as root.