### PR TITLE
kvm: set vCPU signal mask to allow SIGUSR1

### DIFF
--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -248,6 +248,7 @@ impl Vcpu {
     /// The `id` argument is the CPU number between [0, max vcpus).
     pub fn new(id: u8, vm: &Vm) -> Result<Self> {
         let kvm_vcpu = VcpuFd::new(id, &vm.fd).map_err(Error::VcpuFd)?;
+        kvm_vcpu.set_signal_mask()?;
 
         Ok(Vcpu { fd: kvm_vcpu, id })
     }


### PR DESCRIPTION
Set the signal mask using the vCPU ioctl SET_SIGNAL_MASK.
This is needed for sending an exit signal to the vCPUs for live
update.

Signed-off-by: Andreea Florescu <fandree@amazon.com>

Related to:  #109 