### PR TITLE
api: fix swagger drive definition

### DIFF
--- a/api/swagger/all.yaml
+++ b/api/swagger/all.yaml
@@ -913,7 +913,7 @@ definitions:
         type: string
         description: "host level path for the guest drive"
       is_root_device:
-        type: bool
+        type: boolean
       state:
         $ref: '#/definitions/DeviceState'
   NetworkInterface:

--- a/api/swagger/devices.yaml
+++ b/api/swagger/devices.yaml
@@ -453,7 +453,7 @@ definitions:
         type: string
         description: "host level path for the guest drive"
       is_root_device:
-        type: bool
+        type: boolean
       state:
         $ref: '#/definitions/DeviceState'
   NetworkInterface:


### PR DESCRIPTION
OpenApi spec does not recognize keyword 'bool', use 'boolean'

Signed-off-by: Adrian Catangiu <acatan@amazon.com>