### PR TITLE
Fix build failure due to tokio-io

### DIFF
--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -11,6 +11,7 @@ serde_derive = "=1.0.27"
 serde_json = "=1.0.9"
 tokio-core = "=0.1.12"
 tokio-uds = "=0.1.7"
+tokio-io = "=0.1.5"
 
 fc_util = { path = "../fc_util" }
 net_util = { path = "../net_util" }


### PR DESCRIPTION
Hardcoding tokio-io version inside api_server as newly downloaded 0.1.6 version triggers build failure.

