### PR TITLE
virtio devices: remove magic numbers

### DIFF
--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -22,6 +22,7 @@ use virtio_sys::virtio_blk::*;
 const SECTOR_SHIFT: u8 = 9;
 const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
 const QUEUE_SIZE: u16 = 256;
+const NUM_QUEUES: usize = 1;
 const QUEUE_SIZES: &'static [u16] = &[QUEUE_SIZE];
 
 pub const QUEUE_AVAIL_EVENT: DeviceEventT = 0;
@@ -361,8 +362,12 @@ impl VirtioDevice for Block {
         queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
-        if queues.len() != 1 || queue_evts.len() != 1 {
-            error!("virtio-block: expected 1 queue, got {}", queues.len());
+        if queues.len() != NUM_QUEUES || queue_evts.len() != NUM_QUEUES {
+            error!(
+                "virtio-block expected {} queue, got {}",
+                NUM_QUEUES,
+                queues.len()
+            );
             return Err(ActivateError::BadActivate);
         }
 

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -30,7 +30,8 @@ use virtio_sys::virtio_config::*;
 /// http://docs.oasis-open.org/virtio/virtio/v1.0/virtio-v1.0.html#x1-1740003
 const MAX_BUFFER_SIZE: usize = 65562;
 const QUEUE_SIZE: u16 = 256;
-const QUEUE_SIZES: &'static [u16] = &[QUEUE_SIZE, QUEUE_SIZE];
+const NUM_QUEUES: usize = 2;
+const QUEUE_SIZES: &'static [u16] = &[QUEUE_SIZE; NUM_QUEUES];
 
 // A frame is available for reading from the tap device to receive in the guest.
 pub const RX_TAP_EVENT: DeviceEventT = 0;
@@ -465,8 +466,12 @@ impl VirtioDevice for Net {
         mut queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
-        if queues.len() != 2 || queue_evts.len() != 2 {
-            error!("virtio-net: expected 2 queues, got {}", queues.len());
+        if queues.len() != NUM_QUEUES || queue_evts.len() != NUM_QUEUES {
+            error!(
+                "virtio-net expected {} queues, got {}",
+                NUM_QUEUES,
+                queues.len()
+            );
             return Err(ActivateError::BadActivate);
         }
 

--- a/devices/src/virtio/vhost/vsock.rs
+++ b/devices/src/virtio/vhost/vsock.rs
@@ -162,7 +162,7 @@ impl VirtioDevice for Vsock {
     ) -> ActivateResult {
         if queues.len() != NUM_QUEUES || queue_evts.len() != NUM_QUEUES {
             error!(
-                "vsock: virtio-vsock expected {} queues, got {}",
+                "virtio-vsock expected {} queues, got {}",
                 NUM_QUEUES,
                 queues.len()
             );


### PR DESCRIPTION
These magic numbers represented the number of queues for the virtio block and net device. Additionally, synchronized "BadActivate" error message format across net, block and vsock devices.