### PR TITLE
Advance version number to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [0.1.1]
+
+### Changed
+
+- Users can now specify the MAC address of a guest network interface via the PUT network interface API request. Previously, the guest MAC address parameter was ignored.
+
+### Fixed
+
+- Fixed a guest memory allocation issue, which previously led to a potentially significant memory chunk being wasted.
+- Fixed an issue which caused compilation problems, due to a compatibility breaking transitive dependency in the tokio suite of crates.
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]


### PR DESCRIPTION
Changed the Firecracker version number to 0.2.0, and also added the
CHANGELOG.md file.
