### PR TITLE
Return STDIN control to Firecracker when Guest VM inactive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,5 +251,11 @@ fn vmm_no_api_handler(
     };
     vmm.configure_kernel(kernel_config);
     vmm.boot_kernel().expect("cannot boot kernel");
-    vmm.run_control(false).expect("VMM loop error!");
+    let r = vmm.run_control(false);
+    // make sure we clean up when this loop breaks on error
+    if r.is_err() {
+        // stop() is safe to call at any moment; ignore the result
+        let _ = vmm.stop();
+    }
+    r.expect("VMM loop error!");
 }


### PR DESCRIPTION
STDIN is now taken over by the Guest VM serial when it boots, and
released back to Firecracker when the Guest VM is stopped.

As a nice side-effect we can now SIGINT/ctrl+c Firecracker when
the Guest VM is not running.

Testing done:
- Manually start/stop a Guest VM inside Firecracker multiple times using the API as well as shutting down the guest from within (reboot cmd).
- Ran all unit-tests.
- Ran integration tests.
