### PR TITLE
unit tests: fixed dependency issue with pnet

### DIFF
--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The Chromium OS Authors"]
 [dependencies]
 byteorder = "=1.2.1"
 epoll = "=2.1.0"
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 net_util = { path = "../net_util" }
 net_sys = { path = "../net_sys" }

--- a/kernel_loader/Cargo.toml
+++ b/kernel_loader/Cargo.toml
@@ -3,6 +3,6 @@ name = "kernel_loader"
 version = "0.1.0"
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 sys_util = { path = "../sys_util" }

--- a/kvm/Cargo.toml
+++ b/kvm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 byteorder = "=1.2.1"
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 kvm_sys = { path = "../kvm_sys" }
 sys_util = { path = "../sys_util" }

--- a/kvm_sys/Cargo.toml
+++ b/kvm_sys/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 sys_util = { path = "../sys_util" }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 net_sys = { path = "../net_sys" }
 sys_util = { path = "../sys_util" }
 
 [dev-dependencies]
 lazy_static = "=1.0.0"
-pnet = "=0.20.0"
+pnet = "=0.21.0"

--- a/sys_util/Cargo.toml
+++ b/sys_util/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 syscall_defines = { path = "../syscall_defines" }
 data_model = { path = "../data_model" }

--- a/vhost_backend/Cargo.toml
+++ b/vhost_backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 vhost_sys = { path = "../vhost_sys" }
 sys_util = { path = "../sys_util" }

--- a/vhost_sys/Cargo.toml
+++ b/vhost_sys/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 sys_util = { path = "../sys_util" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-libc = "=0.2.32"
+libc = ">=0.2.39"
 epoll = "=2.1.0"
 scopeguard = "=0.3.3"
 

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 byteorder = "=1.2.1"
-libc = "=0.2.32"
+libc = ">=0.2.39"
 
 data_model = { path = "../data_model" }
 kvm_sys = { path = "../kvm_sys" }


### PR DESCRIPTION
### Changes
The pnet package broke its own compatibility with older versions.
Updated pnet from version 0.20.0 to 0.21.0. This version requires
a libc version >= 0.2.39.

### Testing Done
cargo test --all # ALL PASSED
sudo env "PATH=$PATH" scripts/unit_test_coverage/gen-code-coverage ~/sources/work/firecracker/stash/PRIVATE-firecracker/ kcov # Code Coverage reported correctly (41.3%)
