### PR TITLE
Read-only block devices are not reported by Linux as read-only

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -417,7 +417,7 @@ impl Vmm {
 
             let epoll_context = &mut self.epoll_context;
             for drive_config in self.block_device_configs.config_list.iter() {
-                // adding root blk device from file (currently always opened as read + write)
+                // adding root blk device from file
                 let root_image = OpenOptions::new()
                     .read(true)
                     .write(!drive_config.is_read_only)
@@ -425,8 +425,11 @@ impl Vmm {
                     .map_err(Error::RootDiskImage)?;
                 let epoll_config = epoll_context.allocate_virtio_block_tokens();
 
-                let block_box = Box::new(devices::virtio::Block::new(root_image, epoll_config)
-                    .map_err(Error::RootBlockDeviceNew)?);
+                let block_box = Box::new(devices::virtio::Block::new(
+                    root_image,
+                    drive_config.is_read_only,
+                    epoll_config,
+                ).map_err(Error::RootBlockDeviceNew)?);
                 device_manager
                     .register_mmio(block_box, &mut kernel_config.cmdline)
                     .map_err(Error::RegisterBlock)?;


### PR DESCRIPTION
## Changes
In order to mark a virtio block device as read only, we need to negotiate the VIRTIO_BLK_F_RO feature as per virtio 1.0 spec. 
A parameter was added to the initialization of the VirtioBlock device to tell whether or not the device should be read only. 

## Testing
* Create a read only device
```bash
dd if=/dev/zero of=rootfs.ext4 bs=1K count=100M
mkfs.ext4 rootfs.ext4
```
* Start firecracker's API server
```bash
rm -f /tmp/firecracker.socket.dpopa && target/debug/firecracker  --api-sock /tmp/firecracker.socket.dpopa
```
* Start sending curl requests for setting up the microVM:
    * Attach boot source through curl requests
     ```bash
    curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/boot-source" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"boot_source_id\": \"string\", \"source_type\": \"LocalImage\", \"local_image\": { \"kernel_image_path\": \"vmlinux.bin\", \"initrd_path\": \"string\" }}"

    ```

    * Add the root boot device as RW:
    ```bash
    curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/drives/1" -H "accept: application/jon" -H "Content-Type: application/json" -d "{ \"drive_id\": \"1\", \"path_on_host\": \"ubuntu.ext4\", \"state\": \"Attached\", \"permissions\": \"rw\", \"is_root_device\": true}"
    ```
    * Add the newly created block device as RO:
    ```bash
    curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/drives/3" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"drive_id\": \"3\", \"path_on_host\": \"rootfs.ext4\", \"state\": \"Attached\", \"permissions\": \"ro\", \"is_root_device\": false}"
    ```
    * Start the microVM:
    ```bash
    id=start1 ; curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT http://a/actions/$id -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"action_id\": \"$id\",  \"action_type\": \"InstanceStart\"}" -v
    ```
* While in the guest you should receive the output:
```bash
[root@localhost ~]# blockdev --report
RO    RA   SSZ   BSZ   StartSec            Size   Device
rw   256   512  4096          0      2147483648   /dev/vda
ro   256   512  4096          0         9314304   /dev/vdb
```
* Also for:
```bash
cat /sys/block/vdb/ro
1
```