### PR TITLE
vmm: Set CPUID.1.ECX.TSC-Deadline[bit 24] to 1

### DIFF
--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -204,6 +204,7 @@ const EBX_CLFLUSH_SIZE_SHIFT: u32 = 8; // Bytes flushed when executing CLFLUSH.
 const EBX_CPU_COUNT_SHIFT: u32 = 16; // Index of this CPU.
 const EBX_CPUID_SHIFT: u32 = 24; // Index of this CPU.
 const ECX_EPB_SHIFT: u32 = 3; // "Energy Performance Bias" bit.
+const ECX_TSC_DEADLINE_TIMER_SHIFT: u32 = 24;
 const ECX_HYPERVISOR_SHIFT: u32 = 31; // Flag to be set when the cpu is running on a hypervisor.
 const EDX_HTT_SHIFT: u32 = 28; // Hyper Threading Enabled.
 
@@ -231,6 +232,7 @@ impl Vcpu {
                 1 => {
                     // X86 hypervisor feature
                     if entry.index == 0 {
+                        entry.ecx |= 1 << ECX_TSC_DEADLINE_TIMER_SHIFT;
                         entry.ecx |= 1 << ECX_HYPERVISOR_SHIFT;
                     }
                     entry.ebx = ((self.id as u32) << EBX_CPUID_SHIFT) as u32


### PR DESCRIPTION
... to advertize the availability of the TSC deadline timer, which is availble
since SNB (see the Intel 64 and IA-32 Architectures Software Developer's
Manual, Volume 2: Instruction Set Reference, A-Z for additional details).

This allows Linux (i.e., the guest kernel) to skip the local APIC timer
calibration, thus speeding up the boot process.

Signed-off-by: Filippo Sironi <sironi@amazon.de>