### PR TITLE
Necessary changes for musl-enabled build

### DIFF
--- a/kvm_sys/tests/sanity.rs
+++ b/kvm_sys/tests/sanity.rs
@@ -4,10 +4,13 @@
 
 extern crate kvm_sys;
 extern crate libc;
-
-use libc::{c_char, ioctl, open, O_RDWR};
+extern crate sys_util;
 
 use kvm_sys::*;
+use libc::{c_char, open, O_RDWR};
+use std::fs::File;
+use std::os::unix::io::FromRawFd;
+use sys_util::{ioctl, ioctl_with_val};
 
 const KVM_PATH: &'static str = "/dev/kvm\0";
 
@@ -16,7 +19,7 @@ fn get_version() {
     let sys_fd = unsafe { open(KVM_PATH.as_ptr() as *const c_char, O_RDWR) };
     assert!(sys_fd >= 0);
 
-    let ret = unsafe { ioctl(sys_fd, KVM_GET_API_VERSION(), 0) };
+    let ret = unsafe { ioctl(&File::from_raw_fd(sys_fd), KVM_GET_API_VERSION()) };
     assert_eq!(ret as u32, KVM_API_VERSION);
 }
 
@@ -25,7 +28,7 @@ fn create_vm_fd() {
     let sys_fd = unsafe { open(KVM_PATH.as_ptr() as *const c_char, O_RDWR) };
     assert!(sys_fd >= 0);
 
-    let vm_fd = unsafe { ioctl(sys_fd, KVM_CREATE_VM(), 0) };
+    let vm_fd = unsafe { ioctl(&File::from_raw_fd(sys_fd), KVM_CREATE_VM()) };
     assert!(vm_fd >= 0);
 }
 
@@ -34,6 +37,12 @@ fn check_vm_extension() {
     let sys_fd = unsafe { open(KVM_PATH.as_ptr() as *const c_char, O_RDWR) };
     assert!(sys_fd >= 0);
 
-    let has_user_memory = unsafe { ioctl(sys_fd, KVM_CHECK_EXTENSION(), KVM_CAP_USER_MEMORY) };
+    let has_user_memory = unsafe {
+        ioctl_with_val(
+            &File::from_raw_fd(sys_fd),
+            KVM_CHECK_EXTENSION(),
+            KVM_CAP_USER_MEMORY.into(),
+        )
+    };
     assert_eq!(has_user_memory, 1);
 }

--- a/sys_util/src/lib.rs
+++ b/sys_util/src/lib.rs
@@ -33,6 +33,7 @@ pub use tempdir::*;
 pub use terminal::*;
 pub use signal::*;
 pub use ioctl::*;
+pub use libc_ioctl::*;
 
 pub use mmap::Error as MmapError;
 pub use guest_memory::Error as GuestMemoryError;

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -3,13 +3,10 @@
 // found in the LICENSE file.
 
 use libc::{c_int, pthread_kill, pthread_t, signal, EINVAL, SIG_ERR};
-
-use std::thread::JoinHandle;
 use std::os::unix::thread::JoinHandleExt;
+use std::thread::JoinHandle;
+use super::{errno_result, Error, Result};
 
-use {errno_result, Error, Result};
-
-#[link(name = "c")]
 extern "C" {
     fn __libc_current_sigrtmin() -> c_int;
     fn __libc_current_sigrtmax() -> c_int;


### PR DESCRIPTION
## Changes
* the ioctl signature function inside the musl libc source code has an i32 as second param (see [musl libc source)](https://git.musl-libc.org/cgit/musl/tree/src/misc/ioctl.c) while glibc declares an u64 as second parameter for the same function. See below:
```c
// glibc
int __ioctl (fd, request)
     int fd;
     unsigned long int request;
{
... 
 return -1;
}
```
```c
// musl libc
int ioctl(int fd, int req, ...)                                                 
 {                                                                               
              ...
          return syscall(SYS_ioctl, fd, req, arg);                                
  }   
```   
    * added a conditionally compiled module for musl and non-musl build to solve the above issue
* kvm_sys sanity tests would use libc::ioctl instead of the sys_util wrapper over the libc::ioctl call (the one that was previously changed to be conditonally compiled)
* signal.rs would declare an unnecessary ```#[link(name = "c")] ``` which would trigger musl build failure

## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Non-musl tests
```bash
cargo fmt —all
cargo build
cargo build —release
sudo su
cargo test --all
cargo kcov —all # overall 44.1%
```
#### Musl tests
```bash
cargo build --target=x86_64-unknown-linux-musl --release
cargo build --target=x86_64-unknown-linux-musl
sudo su
cargo kcov --all --target=x86_64-unknown-linux-musl #overall 42.6%, because the test_register_signal_handler fails and no coverage added
```
### Integration Testing
#### Non-musl tests
```bash
sudo mount ami-fea26484.ext4 mnt/ #some block device with AL1
sudo cp target/release/firecracker mnt/usr/bin/firecracker-release
rm -f /tmp/firecracker.socket.dpopa  && target/release/firecracker --api-sock /tmp/firecracker.socket.dpopa
```
* in another console start sending curl requests for starting basic firecracker guest

```bash
curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/boot-source" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"boot_source_id\": \"string\", \"source_type\": \"LocalImage\", \"local_image\": { \"kernel_image_path\": \"vmlinux.bin\", \"initrd_path\": \"string\" }}"
curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/drives/1" -H "accept: application/jon" -H "Content-Type: application/json" -d "{ \"drive_id\": \"1\", \"path_on_host\": \"ubuntu.ext4\", \"state\": \"Attached\", \"permissions\": \"rw\", \"is_root_device\": true}"
id=start1 ; curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT http://a/actions/$id -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"action_id\": \"$id\",  \"action_type\": \"InstanceStart\"}" -v
```
* try to start firecracker inside this AL1 
```bash
[root@localhost ~]# firecracker-release 
firecracker-release: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by firecracker-release)
```
* error received for not being able to load necessary runtime dependencies
#### Musl tests
```bash
cargo build --target=x86_64-unknown-linux-musl --release
sudo su
mount ami-fea26484.ext4 mnt/ # some block device with AL1
cp target/x86_64-unknown-linux-musl/release/firecracker mnt/usr/bin/firecracker
rm -f /tmp/firecracker.socket.dpopa  && target/x86_64-unknown-linux-musl/release/firecracker --api-sock /tmp/firecracker.socket.dpopa
```
* in another console start sending curl requests for starting basic firecracker guest

```bash
curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/boot-source" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"boot_source_id\": \"string\", \"source_type\": \"LocalImage\", \"local_image\": { \"kernel_image_path\": \"vmlinux.bin\", \"initrd_path\": \"string\" }}"
curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT "http://localhost/drives/1" -H "accept: application/jon" -H "Content-Type: application/json" -d "{ \"drive_id\": \"1\", \"path_on_host\": \"ubuntu.ext4\", \"state\": \"Attached\", \"permissions\": \"rw\", \"is_root_device\": true}"
id=start1 ; curl --unix-socket /tmp/firecracker.socket.dpopa -i -X PUT http://a/actions/$id -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"action_id\": \"$id\",  \"action_type\": \"InstanceStart\"}" -v
```
* try to start firecracker inside this AL1 
```bash
firecracker # no error is received, no dynamic dependencies
```