### PR TITLE
Update rate limiters swagger definition

### DIFF
--- a/api/swagger/firecracker-v1.0.yaml
+++ b/api/swagger/firecracker-v1.0.yaml
@@ -186,8 +186,9 @@ paths:
           schema:
             $ref: "#/definitions/Error"
     put:
-      summary: Creates new drive with ID specified by drive_id path parameter. If a drive with the specified ID
-               already exists, updates its state based on new input. May fail if update is not possible.
+      summary: Creates new drive with ID specified by drive_id path parameter.
+               If a drive with the specified ID already exists, updates its state based on new input.
+               May fail if update is not possible.
       operationId: putGuestDriveByID
       parameters:
       - name: drive_id
@@ -227,148 +228,6 @@ paths:
       responses:
         202:
           description: Drive deleted
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /drives/{drive_id}/limiters:
-    get:
-      summary: Retrieves list of limiters IDs currently applied to the drive with drive_id.
-      operationId: getLimitersForGuestDrive
-      parameters:
-      - name: drive_id
-        in: path
-        description: The id of the guest drive to get limiters for
-        required: true
-        type: string
-      responses:
-        200:
-          description: List of limiters IDs currently applied to this drive
-          schema:
-            type: array
-            items:
-              type: integer
-              format: int32
-        404:
-          description: Drive does not exist
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /drives/{drive_id}/limiters/{limiter_id}:
-    put:
-      summary: Applies limiter limiter_id to drive drive_id.
-      operationId: applyLimiterToDrive
-      parameters:
-      - name: drive_id
-        in: path
-        description: The id of the guest drive to apply limiter limiter_id to
-        required: true
-        type: string
-      - name: limiter_id
-        in: path
-        description: The id of the limiter to be applied to drive drive_id.
-        required: true
-        type: string
-      responses:
-        200:
-          description: Limiter applied
-        400:
-          description: Limiter cannot be applied due to bad input
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-
-  /limiters:
-    get:
-      summary: Retrieves list of currently created limiters.
-      operationId: listLimiters
-      parameters:
-        - name: next_token
-          in: query
-          type: string
-          description: |
-            Opaque token that specifies where to start the next list of limiters. If not provided or
-            NULL, start from the beginning.
-      responses:
-        200:
-          description: List of limiters
-          schema:
-            $ref: "#/definitions/LimiterList"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /limiters/{limiter_id}:
-    get:
-      summary: Retrieves limiter specified by limiter_id path parameter.
-      operationId: describeLimiter
-      parameters:
-        - name: limiter_id
-          in: path
-          description: Id of the limiter to retrieve
-          required: true
-          type: string
-      responses:
-        200:
-          description: Specified limiter
-          schema:
-            $ref: "#/definitions/Limiter"
-        404:
-          description: Limiter does not exist
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-    put:
-      summary: Creates new limiter with ID specified by limiter_id path parameter. If limiter with specified ID
-                already exists, updates its state based on new input. May fail if update is not possible.
-      operationId: updateLimiter
-      parameters:
-        - name: limiter_id
-          in: path
-          description: Id of the limiter to retrieve
-          required: true
-          type: string
-        - name: limiter
-          in: body
-          description: Limiter to create or update
-          required: true
-          schema:
-            $ref: "#/definitions/Limiter"
-      responses:
-        201:
-          description: Limiter created
-        204:
-          description: Limiter updated
-        400:
-          description: Limiter cannot be created due to bad input
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-    delete:
-      summary: Deletes limiter with ID specified by limiter_id path parameter.
-               Will clean up any resources associated with this limiter.
-      operationId: deleteLimiter
-      parameters:
-        - name: limiter_id
-          in: path
-          description: Id of the limiter to retrieve
-          required: true
-          type: string
-      responses:
-        202:
-          description: Limiter deleted
         default:
           description: Internal server error
           schema:
@@ -460,58 +319,6 @@ paths:
           description: Internal server error
           schema:
             $ref: "#/definitions/Error"
-  /network-interfaces/{iface_id}/limiters:
-    get:
-      summary: Retrieves list of limiters IDs currently applied to the network interface with iface_id.
-      operationId: getLimitersForGuestNetworkInterface
-      parameters:
-      - name: iface_id
-        in: path
-        description: The id of the guest network interface to get limiters for
-        required: true
-        type: string
-      responses:
-        200:
-          description: List of limiters IDs currently applied to this network interface
-          schema:
-            type: array
-            items:
-              type: integer
-              format: int32
-        404:
-          description: Network interface does not exist
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /network-interfaces/{iface_id}/limiters/{limiter_id}:
-    put:
-      summary: Applies limiter limiter_id to network interface iface_id.
-      operationId: applyLimiterToNetworkInterface
-      parameters:
-      - name: iface_id
-        in: path
-        description: The id of the guest network interface to apply limiter limiter_id to
-        required: true
-        type: string
-      - name: limiter_id
-        in: path
-        description: The id of the limiter to be applied to network interface iface_id
-        required: true
-        type: string
-      responses:
-        200:
-          description: Limiter applied.
-        400:
-          description: Limiter cannot be applied due to bad input.
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
 
   /vsocks:
     get:
@@ -553,8 +360,9 @@ paths:
           schema:
             $ref: "#/definitions/Error"
     put:
-      summary: Creates new vsock with ID specified by vsock_id path parameter. If vsock with specified ID
-               already exists, updates its state based on new input. May fail if update is not possible.
+      summary: Creates new vsock with ID specified by vsock_id path parameter.
+               If vsock with specified ID already exists, updates its state based on new input.
+               May fail if update is not possible.
       operationId: putGuestVsockByID
       parameters:
       - name: vsock_id
@@ -594,58 +402,6 @@ paths:
       responses:
         202:
           description: Vsock deleted
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /vsocks/{vsock_id}/limiters:
-    get:
-      summary: Retrieves list of limiters IDs currently applied to the vsock with vsock_id.
-      operationId: getLimitersForGuestVsock
-      parameters:
-      - name: vsock_id
-        in: path
-        description: The id of the guest vsock to get limiters for
-        required: true
-        type: string
-      responses:
-        200:
-          description: List of limiters IDs currently applied to this vsock
-          schema:
-            type: array
-            items:
-              type: integer
-              format: int32
-        404:
-          description: Vsock does not exist
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-  /vsocks/{vsock_id}/limiters/{limiter_id}:
-    put:
-      summary: Applies limiter limiter_id to vsock vsock_id
-      operationId: applyLimiterToVsock
-      parameters:
-      - name: vsock_id
-        in: path
-        description: The id of the guest vsock to apply limiter limiter_id to
-        required: true
-        type: string
-      - name: limiter_id
-        in: path
-        description: The id of the limiter to be applied to vsock vsock_id
-        required: true
-        type: string
-      responses:
-        200:
-          description: Limiter applied
-        400:
-          description: Limiter cannot be applied due to bad input
-          schema:
-            $ref: "#/definitions/Error"
         default:
           description: Internal server error
           schema:
@@ -700,6 +456,8 @@ definitions:
         type: boolean
       permissions:
         $ref: "#/definitions/DrivePermissions"
+      rate_limiter:
+        $ref: "#/definitions/RateLimiter"
       state:
         $ref: "#/definitions/DeviceState"
 
@@ -776,9 +534,8 @@ definitions:
       instance_id:
         type: string
       state:
-        description: |
-          The current detailed state of the Firecracker instance. This value is
-          read-only by the control-plane.
+        description: The current detailed state of the Firecracker instance.
+                     This value is read-only by the control-plane.
         type: string
         enum:
           - Initializing
@@ -828,63 +585,6 @@ definitions:
       timestamp:
         type: string
 
-  Limiter:
-    type: object
-    properties:
-      limiter_id:
-        description: Id of this limiter
-        type: string
-      egress:
-        $ref: "#/definitions/LimiterConfig"
-      ingress:
-        $ref: "#/definitions/LimiterConfig"
-      egress_counters:
-        $ref: "#/definitions/LimiterCounters"
-      ingress_counters:
-        $ref: "#/definitions/LimiterCounters"
-
-  LimiterConfig:
-    type: object
-    properties:
-      bandwidth:
-        $ref: "#/definitions/TokenBucket"
-        description: In bits
-      pps:
-        $ref: "#/definitions/TokenBucket"
-        description: In packets or ops
-      max_queue_len:
-        type: integer
-        format: int64
-
-  LimiterCounters:
-    type: object
-    properties:
-      packets:
-        type: integer
-        format: int64
-      bytes:
-        type: integer
-        format: int64
-      dropped_packets:
-        type: integer
-        format: int64
-      dropped_bytes:
-        type: integer
-        format: int64
-
-  LimiterList:
-    type: object
-    properties:
-      next_token:
-        type: string
-        description: |
-          Opaque token that specifies where to start the next list of limiters. If not present or
-          NULL, there are no more limiters to list.
-      limiters:
-        type: array
-        items:
-          $ref: "#/definitions/Limiter"
-
   LocalImage:
     type: object
     description: |
@@ -899,9 +599,8 @@ definitions:
 
   MachineConfiguration:
     type: object
-    description: |
-      Machine Configuration descriptor by which you can specify the number of vCPU of one machine with vcpu_count
-      and the memory size in MiB with mem_size_mib.
+    description: Machine Configuration descriptor by which you can specify the number of vCPU
+                 of one machine with vcpu_count and the memory size in MiB with mem_size_mib.
     properties:
       vcpu_count:
         type: integer
@@ -918,6 +617,22 @@ definitions:
         type: string
         description: unique identifier specifying which network interface to boot from
 
+  NetworkCounters:
+    type: object
+    properties:
+      packets:
+        type: integer
+        format: int64
+      bytes:
+        type: integer
+        format: int64
+      dropped_packets:
+        type: integer
+        format: int64
+      dropped_bytes:
+        type: integer
+        format: int64
+
   NetworkInterface:
     type: object
     required:
@@ -930,6 +645,10 @@ definitions:
       path_on_host:
         type: string
         description: host level path for the guest network interface
+      ingress_rate_limiter:
+        $ref: "#/definitions/RateLimiter"
+      egress_rate_limiter:
+        $ref: "#/definitions/RateLimiter"
       state:
         $ref: "#/definitions/DeviceState"
 
@@ -949,21 +668,27 @@ definitions:
         format: int64
         description: Bitmask for the active CPU features in this instance
 
+  RateLimiter:
+    type: object
+    properties:
+      bandwidth:
+        $ref: "#/definitions/TokenBucket"
+        description: Token bucket with bytes as tokens
+      ops:
+        $ref: "#/definitions/TokenBucket"
+        description: Token bucket with operations as tokens
+
   TokenBucket:
     type: object
     properties:
       size:
         type: integer
         format: int64
-      cost:
+        description: The total number of tokens this bucket can hold
+      refill_time:
         type: integer
         format: int64
-      initial_value:
-        type: integer
-        format: int64
-      refill_rate:
-        type: integer
-        format: int64
+        description: The amount of milliseconds it takes for the bucket to refill
 
   Vsock:
     type: object
@@ -975,5 +700,9 @@ definitions:
       path_on_host:
         type: string
         description: host level path for the guest vsock
+      ingress_rate_limiter:
+        $ref: "#/definitions/RateLimiter"
+      egress_rate_limiter:
+        $ref: "#/definitions/RateLimiter"
       state:
         $ref: "#/definitions/DeviceState"


### PR DESCRIPTION
Update rate limiters swagger definition

Block IO operations should not be reordered, making it impossible
to have independent read/write rate-limiting. In the case of block IO,
the rate limit will apply on the total ops or bandwidth regardless of
the request type (read/write).
Network rate limiting will support independent limiters for ingress and
egress operations.

Changes:
 - Changed 'generic' rate limiter definition
 - Added rate limiter as drive property
 - Added ingress and egress rate limiters as network and vsock properties
 - Removed counters from limiters definitions (should be part of metering)
 - Removed HTTP methods and URLs for handling limiters as stand-alone resources
 - Simplified token bucket API definition
 - Made a couple of formatting changes for consistency

These changes will be incrementally added to firecracker-beta.yaml alongside
their actual implementation.