### PR TITLE
sys_util: ignore test_killing_thread

### DIFF
--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -106,6 +106,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_killing_thread() {
         let killable = thread::spawn(|| thread::current().id());
         let killable_id = killable.join().unwrap();


### PR DESCRIPTION
## Changes
Add ignore to test_killing_thread. This test causes sporading fails when running all the tests because instead of killing the created thread, it kills all running threads.
## Testing Done
sudo env "PATH=$PATH" cargo test --all => works
sudo env "PATH=$PATH" cargo kcov --all => works