### PR TITLE
api: Added GET method for machine-config

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -198,17 +198,22 @@ fn parse_request<'a>(
                 .map_err(|s| Error::Generic(StatusCode::BadRequest, s))?),
             _ => Err(Error::InvalidPathMethod(path, method)),
         },
-        "machine-config" => match v[1..].len() {
-            0 if is_get => Ok(ParsedRequest::Dummy),
+        "machine-config" => {
+            match v[1..].len() {
+                0 if is_get => Ok(serde_json::from_slice::<request::MachineConfigurationBody>(
+                    body,
+                ).map_err(Error::SerdeJson)?
+                    .into_parsed_request(Method::Get)
+                    .map_err(|s| Error::Generic(StatusCode::BadRequest, s))?),
 
-            0 if is_put => Ok(
-                serde_json::from_slice::<request::MachineConfigurationBody>(body)
-                    .map_err(Error::SerdeJson)?
-                    .into_parsed_request()
-                    .map_err(|s| Error::Generic(StatusCode::BadRequest, s))?,
-            ),
-            _ => Err(Error::InvalidPathMethod(path, method)),
-        },
+                0 if is_put => Ok(serde_json::from_slice::<request::MachineConfigurationBody>(
+                    body,
+                ).map_err(Error::SerdeJson)?
+                    .into_parsed_request(Method::Put)
+                    .map_err(|s| Error::Generic(StatusCode::BadRequest, s))?),
+                _ => Err(Error::InvalidPathMethod(path, method)),
+            }
+        }
         "network-interfaces" => match v[1..].len() {
             0 if is_get => Ok(ParsedRequest::Dummy),
 

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -11,7 +11,7 @@ extern crate fc_util;
 extern crate net_util;
 extern crate sys_util;
 
-mod http_service;
+pub mod http_service;
 pub mod request;
 
 use std::cell::RefCell;

--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -1,7 +1,7 @@
 use std::result;
 
 use futures::sync::oneshot;
-use hyper::{Response, StatusCode};
+use hyper::{Method, Response, StatusCode};
 
 use http_service::{empty_response, json_fault_message, json_response};
 use request::{ParsedRequest, SyncRequest};
@@ -56,11 +56,18 @@ impl GenerateResponse for PutMachineConfigurationOutcome {
 }
 
 impl MachineConfigurationBody {
-    pub fn into_parsed_request(self) -> result::Result<ParsedRequest, String> {
+    pub fn into_parsed_request(self, method: Method) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
-        Ok(ParsedRequest::Sync(
-            SyncRequest::PutMachineConfiguration(self, sender),
-            receiver,
-        ))
+        match method {
+            Method::Get => Ok(ParsedRequest::Sync(
+                SyncRequest::GetMachineConfiguration(sender),
+                receiver,
+            )),
+            Method::Put => Ok(ParsedRequest::Sync(
+                SyncRequest::PutMachineConfiguration(self, sender),
+                receiver,
+            )),
+            _ => Ok(ParsedRequest::Dummy),
+        }
     }
 }

--- a/api_server/src/request/sync/mod.rs
+++ b/api_server/src/request/sync/mod.rs
@@ -53,6 +53,7 @@ pub enum DeviceState {
 // This enum contains messages for the VMM which represent sync requests. They each contain various
 // bits of information (ids, paths, etc.), together with an OutcomeSender, which is always present.
 pub enum SyncRequest {
+    GetMachineConfiguration(SyncOutcomeSender),
     PutBootSource(BootSourceBody, SyncOutcomeSender),
     PutDrive(DriveDescription, SyncOutcomeSender),
     PutMachineConfiguration(MachineConfigurationBody, SyncOutcomeSender),

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
+hyper = "=0.11.16"
 libc = ">=0.2.39"
 epoll = "=2.1.0"
 scopeguard = "=0.3.3"


### PR DESCRIPTION
## Testing Done
### Build
cargo build
cargo build --release
cargo fmt --all
sudo env "PATH=$PATH" cargo test --all

### Integration Tests
Test1a get machine-config; Should output vcpu_count: 1, mem_size: 128
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{ "vcpu_count": 1, "mem_size_mib": 128 }

=======================================================
Test1 setting the vCPU to 2; Should output Updated
HTTP/1.1 204 No Content
Date: Fri, 27 Apr 2018 08:33:51 GMT



=======================================================
Test1a get machine-config; Should output vcpu_count: 2, mem_size: 128
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{ "vcpu_count": 2, "mem_size_mib": 128 }

=======================================================
Test1 setting the vCPU to 3; Should output Error (The cpuid is not an even number) - EXPECTED TO FAIL NOW
HTTP/1.1 204 No Content
Date: Fri, 27 Apr 2018 08:33:51 GMT



=======================================================
Test2 setting the vCPU to -1; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "invalid value: integer `-1`, expected u8 at line 1 column 18"
}

=======================================================
Test3 setting the vCPU to string; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "invalid type: string "str", expected u8 at line 1 column 21"
}

=======================================================
Test3a get machine-config; Should output vcpu_count: 2 (this should be 2 in the future), mem_size: 128
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{ "vcpu_count": 3, "mem_size_mib": 128 }

=======================================================
Test4 setting the memory size to 256; Should output Updated
HTTP/1.1 204 No Content
Date: Fri, 27 Apr 2018 08:33:51 GMT



=======================================================
Test5 setting the memory size to -1; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "invalid value: integer `-1`, expected usize at line 1 column 20"
}

=======================================================
Test6 setting the memory size to string; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "invalid type: string "str", expected usize at line 1 column 23"
}

=======================================================
Test7 send request with empty body; Should output Bad Request
HTTP/1.1 204 No Content
Date: Fri, 27 Apr 2018 08:33:51 GMT



=======================================================
Test8 send request with both memory and vcpu configuration; Should output Updated
HTTP/1.1 204 No Content
Date: Fri, 27 Apr 2018 08:33:51 GMT



=======================================================
Test9 send request with vCPU set to 0; Should output BadRequest
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "The vCPU number is invalid!"
}

=======================================================
Test9 send request with memory set to 0; Should output BadRequest
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Fri, 27 Apr 2018 08:33:51 GMT

{
  "fault_message": "The memory size (MiB) is invalid!"
}

