### PR TITLE
Remove gnu leftover code

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ So far, no stress testing & benchmarking has been done. This is scheduled for a 
 
 # Getting Started
 
+## Add musl target to the active toolchain
+Firecracker supports musl-only build, so before building the project add the musl target to rust's active toolchain:
+```bash
+rustup target add x86_64-unknown-linux-musl
+```
+
 ## Build the Firecracker Binary
 Clone this repo and build it with Rust's: `cargo build --release`.
 

--- a/kvm/src/lib.rs
+++ b/kvm/src/lib.rs
@@ -67,7 +67,7 @@ impl Kvm {
     /// Gets the size of the mmap required to use vcpu's `kvm_run` structure.
     pub fn get_vcpu_mmap_size(&self) -> Result<usize> {
         // Safe because we know that our file is a KVM fd and we verify the return result.
-        let res = unsafe { ioctl(self, KVM_GET_VCPU_MMAP_SIZE() as c_ulong) };
+        let res = unsafe { ioctl(self, KVM_GET_VCPU_MMAP_SIZE()) };
         if res > 0 {
             Ok(res as usize)
         } else {

--- a/sys_util/src/ioctl.rs
+++ b/sys_util/src/ioctl.rs
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 //! Macros and wrapper functions for dealing with ioctls.
-
-use std::os::raw::c_uint;
+use libc;
+use std::os::raw::{c_int, c_uint, c_ulong, c_void};
+use std::os::unix::io::AsRawFd;
 
 /// Raw macro to declare a function that returns an ioctl number.
 #[macro_export]
@@ -77,88 +78,38 @@ pub const IOC_INOUT: c_uint = 3221225472;
 pub const IOCSIZE_MASK: c_uint = 1073676288;
 pub const IOCSIZE_SHIFT: c_uint = 16;
 
-/// separate module to deal with calling ioctl's inside libc
-/// libc musl has as second parameter an i32 so separate code goes for that
-#[cfg(not(target_env = "musl"))]
-pub mod libc_ioctl {
-    use libc;
-    use std::os::raw::{c_int, c_ulong, c_void};
-    use std::os::unix::io::AsRawFd;
-
-    /// Run an ioctl with no arguments.
-    pub unsafe fn ioctl<F: AsRawFd>(fd: &F, request: c_ulong) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, 0)
-    }
-
-    /// Run an ioctl with a single value argument.
-    pub unsafe fn ioctl_with_val<F: AsRawFd>(fd: &F, request: c_ulong, arg: c_ulong) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, arg)
-    }
-
-    /// Run an ioctl with an immutable reference.
-    pub unsafe fn ioctl_with_ref<F: AsRawFd, T>(fd: &F, request: c_ulong, arg: &T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, arg as *const T as *const c_void)
-    }
-
-    /// Run an ioctl with a mutable reference.
-    pub unsafe fn ioctl_with_mut_ref<F: AsRawFd, T>(
-        fd: &F,
-        request: c_ulong,
-        arg: &mut T,
-    ) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, arg as *mut T as *mut c_void)
-    }
-
-    /// Run an ioctl with a raw pointer.
-    pub unsafe fn ioctl_with_ptr<F: AsRawFd, T>(fd: &F, request: c_ulong, arg: *const T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, arg as *const c_void)
-    }
-
-    /// Run an ioctl with a mutable raw pointer.
-    pub unsafe fn ioctl_with_mut_ptr<F: AsRawFd, T>(
-        fd: &F,
-        request: c_ulong,
-        arg: *mut T,
-    ) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), request, arg as *mut c_void)
-    }
+/// Run an ioctl with no arguments.
+pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
+    libc::ioctl(fd.as_raw_fd(), req as c_int, 0)
 }
 
-#[cfg(target_env = "musl")]
-pub mod libc_ioctl {
-    use libc;
-    use std::os::raw::{c_int, c_ulong, c_void};
-    use std::os::unix::io::AsRawFd;
+/// Run an ioctl with a single value argument.
+pub unsafe fn ioctl_with_val<F: AsRawFd>(fd: &F, req: c_ulong, arg: c_ulong) -> c_int {
+    libc::ioctl(fd.as_raw_fd(), req as c_int, arg)
+}
 
-    /// Run an ioctl with no arguments.
-    pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, 0)
-    }
+/// Run an ioctl with an immutable reference.
+pub unsafe fn ioctl_with_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &T) -> c_int {
+    libc::ioctl(
+        fd.as_raw_fd(),
+        req as c_int,
+        arg as *const T as *const c_void,
+    )
+}
 
-    /// Run an ioctl with a single value argument.
-    pub unsafe fn ioctl_with_val<F: AsRawFd>(fd: &F, req: c_ulong, arg: c_ulong) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, arg)
-    }
+/// Run an ioctl with a mutable reference.
+pub unsafe fn ioctl_with_mut_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &mut T) -> c_int {
+    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *mut T as *mut c_void)
+}
 
-    /// Run an ioctl with an immutable reference.
-    pub unsafe fn ioctl_with_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, arg as *const T as *const c_void)
-    }
+/// Run an ioctl with a raw pointer.
+pub unsafe fn ioctl_with_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *const T) -> c_int {
+    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *const c_void)
+}
 
-    /// Run an ioctl with a mutable reference.
-    pub unsafe fn ioctl_with_mut_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &mut T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, arg as *mut T as *mut c_void)
-    }
-
-    /// Run an ioctl with a raw pointer.
-    pub unsafe fn ioctl_with_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *const T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, arg as *const c_void)
-    }
-
-    /// Run an ioctl with a mutable raw pointer.
-    pub unsafe fn ioctl_with_mut_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *mut T) -> c_int {
-        libc::ioctl(fd.as_raw_fd(), req as i32, arg as *mut c_void)
-    }
+/// Run an ioctl with a mutable raw pointer.
+pub unsafe fn ioctl_with_mut_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *mut T) -> c_int {
+    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *mut c_void)
 }
 
 #[cfg(test)]

--- a/sys_util/src/lib.rs
+++ b/sys_util/src/lib.rs
@@ -11,28 +11,26 @@ extern crate syscall_defines;
 #[macro_use]
 pub mod ioctl;
 
-mod mmap;
-mod eventfd;
 mod errno;
+mod eventfd;
 mod guest_address;
 mod guest_memory;
+mod mmap;
+mod signal;
 mod struct_util;
 mod tempdir;
 mod terminal;
-mod signal;
 
-pub use mmap::*;
+pub use errno::{errno_result, Error, Result};
 pub use eventfd::*;
-pub use errno::{Error, Result};
-pub use errno::errno_result;
 pub use guest_address::*;
 pub use guest_memory::*;
+pub use ioctl::*;
+pub use mmap::*;
+pub use signal::*;
 pub use struct_util::*;
 pub use tempdir::*;
 pub use terminal::*;
-pub use signal::*;
-pub use ioctl::*;
-pub use libc_ioctl::*;
 
-pub use mmap::Error as MmapError;
 pub use guest_memory::Error as GuestMemoryError;
+pub use mmap::Error as MmapError;


### PR DESCRIPTION
## Changes
* as part of the decision to only support musl-only-build, the cfg parts of the code were removed. 
* as per [rust documentation](https://github.com/rust-lang/cargo/issues/2332), I created ```.cargo/config``` to specify musl as the default cargo target build
* updated README to let users know that they need to add the musl target to the toolchain before doing ```cargo build```.
## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Build tests
```bash
cargo fmt —all
cargo build
cargo build —release
sudo env "PATH=$PATH" cargo test --all
sudo env "PATH=$PATH" cargo kcov —all # overall 44.0%
```
### Integration Testing
```bash
rm -f /tmp/firecracker.socket && target/debug/firecracker --api-sock=/tmp/firecracker.socket
```
* in another console start sending curl requests for starting basic firecracker guest
```bash
curl --unix-socket /tmp/firecracker.socket -i  \
     -X PUT "http://localhost/boot-source" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
           \"boot_source_id\": \"alinux_kernel\",
           \"source_type\": \"LocalImage\", 
           \"local_image\": 
                { 
                    \"kernel_image_path\": \"${kernel_path}\" 
                }
        }"

echo 2
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/machine-config" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ \"vcpu_count\": 4, \"mem_size_mib\": 256}"

# Add root block device
echo 3
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/drives/root" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"drive_id\": \"root\",
            \"path_on_host\": \"${rootfs_path}\", 
            \"is_root_device\": true, 
            \"permissions\": \"rw\", 
            \"state\": \"Attached\"
         }"


# Add readonly device
echo 4
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/drives/read_only_drive" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"drive_id\": \"read_only_drive\",
            \"path_on_host\": \"${ro_drive_path}\", 
            \"is_root_device\": false, 
            \"permissions\": \"ro\", 
            \"state\": \"Attached\"
         }"

# Create a tap interface
ip tuntap add name vmtap33 mode tap
ifconfig vmtap33 192.168.241.1/24 up
echo 5
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/network-interfaces/1" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"iface_id\": \"1\", 
            \"host_dev_name\": \"vmtap33\", 
            \"guest_mac\": \"06:00:00:00:00:01\", 
            \"state\": \"Attached\" 
        }"

echo 6
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/actions/start" \
     -H  "accept: application/json" \
     -H  "Content-Type: application/json" \
     -d "{  
            \"action_id\": \"start\",  
            \"action_type\": \"InstanceStart\"
         }"

# Get the response of starting the instance
echo 7
curl --unix-socket /tmp/firecracker.socket -i \
     -X GET "http://localhost/actions/start" \
     -H "accept: application/json"

sudo ip link delete vmtap33
```
* in the initial console the guest should start up
```bash
# login: ...
# reboot
```