### PR TITLE
Logging updates prior to supporting configuration through the API

### DIFF
--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -8,6 +8,8 @@ use std::fmt;
 pub enum LoggerError {
     /// First attempt at initialization failed.
     NeverInitialized(String),
+    /// The logger does not allow reinitialization.
+    AlreadyInitialized,
     /// Initialization has previously failed and can not be retried.
     Poisoned(String),
     /// Creating log file fails.
@@ -24,6 +26,7 @@ impl fmt::Display for LoggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
             LoggerError::NeverInitialized(ref e) => e,
+            LoggerError::AlreadyInitialized => "Reinitialization of logger not allowed",
             LoggerError::Poisoned(ref e) => e,
             LoggerError::CreateLogFile(ref e) => e.description(),
             LoggerError::FileLogWrite(ref e) => e.description(),
@@ -47,6 +50,7 @@ mod tests {
                 LoggerError::NeverInitialized(String::from("Bad Log Path Provided"))
             ).contains("NeverInitialized")
         );
+        assert!(format!("{:?}", LoggerError::AlreadyInitialized).contains("AlreadyInitialized"));
         assert!(
             format!(
                 "{:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,22 +163,24 @@ fn vmm_no_api_handler(
     ).expect("cannot create VMM");
 
     // this is temporary; user will be able to customize logging subsystem through API
+    let mut l = Logger::new();
+    l.set_level(logger::Level::Info);
     if cmd_arguments.is_present("log_file") {
-        if let Err(e) = Logger::new()
-            .set_level(logger::Level::Info)
-            .init(Some(String::from(
-                cmd_arguments.value_of("log_file").unwrap(),
-            ))) {
+        if let Err(e) = l.init(Some(String::from(
+            cmd_arguments.value_of("log_file").unwrap(),
+        ))) {
             eprintln!(
                 "main: Failed to initialize logging subsystem: {:?}. Trying without a file",
                 e
             );
-            if let Err(e) = Logger::new().set_level(logger::Level::Info).init(None) {
+            l = Logger::new();
+            l.set_level(logger::Level::Info);
+            if let Err(e) = l.init(None) {
                 panic!("main: Failed to initialize logging subsystem: {:?}", e);
             }
         }
     } else {
-        if let Err(e) = Logger::new().set_level(logger::Level::Info).init(None) {
+        if let Err(e) = l.init(None) {
             panic!("main: Failed to initialize logging subsystem: {:?}", e);
         }
     }


### PR DESCRIPTION
## Changes
* changed signature of the set functions inside the logger to receive reference to self (when configuring the logger from an external struct we need to be able to call the set functions separately).
* added a constant to tell us when user attempts initialization of the logging system
* updated unit tests to match changes

## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Build tests
```bash
cargo fmt —all
cargo build # no warning
cargo build —release # no warning
sudo env "PATH=$PATH" cargo test --all #no warin
sudo env "PATH=$PATH" cargo kcov —all # overall 44.3%
```
### Integration Testing
```bash
rm -f /tmp/firecracker.socket && \
target/debug/firecracker --api-sock=/tmp/firecracker.socket
```
* in another console start sending curl requests for starting basic firecracker guest
```bash
curl --unix-socket /tmp/firecracker.socket -i  \
     -X PUT "http://localhost/boot-source" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
           \"boot_source_id\": \"alinux_kernel\",
           \"source_type\": \"LocalImage\", 
           \"local_image\": 
                { 
                    \"kernel_image_path\": \"${kernel_path}\" 
                }
        }"

echo 2
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/machine-config" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ \"vcpu_count\": 4, \"mem_size_mib\": 256}"

# Add root block device
echo 3
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/drives/root" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"drive_id\": \"root\",
            \"path_on_host\": \"${rootfs_path}\", 
            \"is_root_device\": true, 
            \"permissions\": \"rw\", 
            \"state\": \"Attached\"
         }"


# Add readonly device
echo 4
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/drives/read_only_drive" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"drive_id\": \"read_only_drive\",
            \"path_on_host\": \"${ro_drive_path}\", 
            \"is_root_device\": false, 
            \"permissions\": \"ro\", 
            \"state\": \"Attached\"
         }"

# Create a tap interface
ip tuntap add name vmtap33 mode tap
ifconfig vmtap33 192.168.241.1/24 up
echo 5
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/network-interfaces/1" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"iface_id\": \"1\", 
            \"host_dev_name\": \"vmtap33\", 
            \"guest_mac\": \"06:00:00:00:00:01\", 
            \"state\": \"Attached\" 
        }"

echo 6
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/actions/start" \
     -H  "accept: application/json" \
     -H  "Content-Type: application/json" \
     -d "{  
            \"action_id\": \"start\",  
            \"action_type\": \"InstanceStart\"
         }"

# Get the response of starting the instance
echo 7
curl --unix-socket /tmp/firecracker.socket -i \
     -X GET "http://localhost/actions/start" \
     -H "accept: application/json"

sudo ip link delete vmtap33
```
* in the initial console the guest should start up
```bash
# login: ...
# reboot
```