### PR TITLE
Block device live resize

### DIFF
--- a/api_server/src/request/sync/drive.rs
+++ b/api_server/src/request/sync/drive.rs
@@ -36,6 +36,8 @@ pub enum DriveError {
     RootBlockDeviceAlreadyAdded,
     InvalidBlockDevicePath,
     BlockDevicePathAlreadyExists,
+    BlockDeviceUpdateFailed,
+    BlockDeviceUpdateNotAllowed,
     NotImplemented,
 }
 
@@ -55,9 +57,17 @@ impl GenerateResponse for DriveError {
                 StatusCode::BadRequest,
                 json_fault_message("The block device path was already added to a different drive!"),
             ),
+            BlockDeviceUpdateFailed => json_response(
+                StatusCode::InternalServerError,
+                json_fault_message("The update operation failed!"),
+            ),
+            BlockDeviceUpdateNotAllowed => json_response(
+                StatusCode::Forbidden,
+                json_fault_message("The update operation is not allowed!"),
+            ),
             NotImplemented => json_response(
                 StatusCode::InternalServerError,
-                json_fault_message("The update operation is not implemented!"),
+                json_fault_message("The operation is not implemented!"),
             ),
         }
     }
@@ -132,6 +142,18 @@ mod tests {
                 .generate_response()
                 .status(),
             StatusCode::BadRequest
+        );
+        assert_eq!(
+            DriveError::BlockDeviceUpdateFailed
+                .generate_response()
+                .status(),
+            StatusCode::InternalServerError
+        );
+        assert_eq!(
+            DriveError::BlockDeviceUpdateNotAllowed
+                .generate_response()
+                .status(),
+            StatusCode::Forbidden
         );
         assert_eq!(
             DriveError::NotImplemented.generate_response().status(),

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -19,6 +19,8 @@ pub trait BusDevice: Send {
     fn read(&mut self, offset: u64, data: &mut [u8]) {}
     /// Writes at `offset` into this device
     fn write(&mut self, offset: u64, data: &[u8]) {}
+    /// Triggers the `irq_mask` interrupt on this device
+    fn interrupt(&self, irq_mask: u32) {}
 }
 
 #[derive(Debug)]
@@ -79,7 +81,7 @@ impl Bus {
         None
     }
 
-    fn get_device(&self, addr: u64) -> Option<(u64, &Mutex<BusDevice>)> {
+    pub fn get_device(&self, addr: u64) -> Option<(u64, &Mutex<BusDevice>)> {
         if let Some((BusRange(start, len), dev)) = self.first_before(addr) {
             let offset = addr - start;
             if offset < len {

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -23,11 +23,14 @@ const DEVICE_DRIVER_OK: u32 = 0x04;
 const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_FAILED: u32 = 0x80;
 
-// Types taken from linux/virtio_ids.h
+/// Types taken from linux/virtio_ids.h.
 const TYPE_NET: u32 = 1;
 const TYPE_BLOCK: u32 = 2;
 
-const INTERRUPT_STATUS_USED_RING: u32 = 0x1;
+/// Interrupt flags (re: interrupt status & acknowledge registers).
+/// See linux/virtio_mmio.h.
+pub const VIRTIO_MMIO_INT_VRING: u32 = 0x01;
+pub const VIRTIO_MMIO_INT_CONFIG: u32 = 0x02;
 
 /// Offset from the base MMIO address of a virtio device used by the guest to notify the device of
 /// queue events.

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -20,7 +20,7 @@ use super::{ActivateError, ActivateResult};
 use epoll;
 use net_util::{MacAddr, Tap, TapError, MAC_ADDR_LEN};
 use net_sys;
-use super::{Queue, VirtioDevice, INTERRUPT_STATUS_USED_RING, TYPE_NET};
+use super::{Queue, VirtioDevice, TYPE_NET, VIRTIO_MMIO_INT_VRING};
 use sys_util::{Error as SysError, EventFd, GuestMemory};
 use virtio_sys::virtio_net::*;
 use virtio_sys::virtio_config::*;
@@ -85,7 +85,7 @@ struct NetEpollHandler {
 impl NetEpollHandler {
     fn signal_used_queue(&self) {
         self.interrupt_status
-            .fetch_or(INTERRUPT_STATUS_USED_RING as usize, Ordering::SeqCst);
+            .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
         self.interrupt_evt.write(1).unwrap();
     }
 

--- a/sys_util/src/tempdir.rs
+++ b/sys_util/src/tempdir.rs
@@ -21,7 +21,7 @@ pub struct TempDir {
 }
 
 impl TempDir {
-    /// Creates a new tempory directory.
+    /// Creates a new temporary directory.
     /// The directory will be removed when the object goes out of scope.
     ///
     /// # Examples

--- a/vmm/src/device_config/drive.rs
+++ b/vmm/src/device_config/drive.rs
@@ -83,7 +83,7 @@ impl BlockDeviceConfigs {
         }
 
         // check whether the Device Config belongs to a root device
-        // we need to satify the condition by which a VMM can only have on root device
+        // we need to satisfy the condition by which a VMM can only have on root device
         if block_device_config.is_root_device {
             if self.has_root_block {
                 return Err(DriveError::RootBlockDeviceAlreadyAdded);


### PR DESCRIPTION
Added support for resizing of block devices (as in: detecting the new
size and updating the block device) after the VM has booted.

See also: https://sim.amazon.com/issues/P12874968

Fixes #211

# Testing done

## Build

```bash
cargo build
cargo build --release
cargo fmt --all
sudo env "PATH=$PATH" cargo kcov --all --target=x86_64-unknown-linux-musl 
```

## Integration Tests

### Manual test - just block device resize

*Host*

```bash
$ kernel_path=$PWD/resources/kernels/vmlinux_login_network.bin 
$ rootfs_path=$PWD/resources/amis/ami-fea26484.ext4 
$ ro_drive_path=$PWD/rootfs.ext4 
$ truncate --size 0 rootfs.ext4 
$ ls -l rootfs.ext4 
-rw-r--r-- 1 aghecen domain^users 0 May  3 15:13 rootfs.ext4

$ curl --unix-socket /tmp/firecracker.socket -i  \
>      -X PUT "http://localhost/boot-source" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ 
>            \"boot_source_id\": \"alinux_kernel\",
>            \"source_type\": \"LocalImage\", 
>            \"local_image\": 
>                 { 
>                     \"kernel_image_path\": \"${kernel_path}\" 
>                 }
>         }"
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:15:29 GMT

$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/machine-config" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ \"vcpu_count\": 4, \"mem_size_mib\": 256}"
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 12:15:31 GMT

$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/drives/root" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ 
>             \"drive_id\": \"root\",
>             \"path_on_host\": \"${rootfs_path}\", 
>             \"is_root_device\": true, 
>             \"permissions\": \"rw\", 
>             \"state\": \"Attached\"
>          }"
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:15:38 GMT

$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/drives/read_only_drive" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ 
>             \"drive_id\": \"read_only_drive\",
>             \"path_on_host\": \"${ro_drive_path}\", 
>             \"is_root_device\": false, 
>             \"permissions\": \"ro\", 
>             \"state\": \"Attached\"
> }"
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:16:01 GMT

$ # Try to update before the guest boots: error
$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/drives/read_only_drive" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ 
>             \"drive_id\": \"read_only_drive\",
>             \"path_on_host\": \"${ro_drive_path}\", 
>             \"is_root_device\": false, 
>             \"permissions\": \"ro\", 
>             \"state\": \"Attached\"
>          }"
HTTP/1.1 403 Forbidden
Content-Type: application/json
Transfer-Encoding: chunked
Date: Mon, 07 May 2018 14:25:44 GMT

{
  "fault_message": "The update operation is not allowed!"
}

$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/actions/start" \
>      -H  "accept: application/json" \
>      -H  "Content-Type: application/json" \
>      -d "{  
>             \"action_id\": \"start\",  
>             \"action_type\": \"InstanceStart\"
>          }"
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:16:13 GMT
```

*Guest*

```bash
[root@localhost ~]# blockdev --report
RO    RA   SSZ   BSZ   StartSec            Size   Device
rw   256   512  4096          0      2147483648   /dev/vda
[root@localhost ~]# blockdev --getsz /dev/vdb
0
```

*Host*
```bash
$ truncate --size 100M rootfs.ext4 
$ mkfs.ext4 rootfs.ext4 
mke2fs 1.42.13 (17-May-2015)
Discarding device blocks: done                            
Creating filesystem with 102400 1k blocks and 25688 inodes
Filesystem UUID: b48937b4-b16c-43e0-ab73-64751ae89ccb
Superblock backups stored on blocks: 
	8193, 24577, 40961, 57345, 73729

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (4096 blocks): done
Writing superblocks and filesystem accounting information: done 

$ curl --unix-socket /tmp/firecracker.socket -i \
>      -X PUT "http://localhost/drives/read_only_drive" \
>      -H "accept: application/json" \
>      -H "Content-Type: application/json" \
>      -d "{ 
>             \"drive_id\": \"read_only_drive\",
>             \"path_on_host\": \"${ro_drive_path}\", 
>             \"is_root_device\": false, 
>             \"permissions\": \"ro\", 
>             \"state\": \"Attached\"
> }"
HTTP/1.1 204 No Content
Date: Mon, 07 May 2018 14:25:57 GMT

```

*Guest*
```bash
[root@localhost ~]# dmesg | tail -2
[  154.399370] virtio_blk virtio1: new size: 204800 512-byte logical blocks (105 MB/100 MiB)
[  154.407087] vdb: detected capacity change from 0 to 104857600
[root@localhost ~]# blockdev --report
RO    RA   SSZ   BSZ   StartSec            Size   Device
rw   256   512  4096          0      2147483648   /dev/vda
ro   256   512  4096          0       104857600   /dev/vdb
```

### Integration test scripts

```bash
$ ./test_put_boot_params.sh resources/kernels/vmlinux_login_network.bin 
Send request with invalid kernel path; should output Invalid Kernel Path; 400
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:33:52 GMT

{
  "fault_message": "The kernel path is invalid!"
}

=======================================================


Send request with no kernel path; should output Invalid Kernel Path; 400
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:33:52 GMT

{
  "fault_message": "The kernel path is invalid!"
}

=======================================================


Send request with correct parameters; Should output Created
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:33:52 GMT



=======================================================

$ ./test_put_drive.sh resources/amis/ami-fea26484.ext4 
Send req with different id in path/body
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:35:25 GMT

{
  "fault_message": "The id from the path does not match the id from the body!"
}

=======================================================


Send req with invalid path; should return Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:35:25 GMT

{
  "fault_message": "Invalid block device path!"
}

=======================================================


Send req all good; return Created
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 12:35:25 GMT



=======================================================


Send req update operation is not yet implemented
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:35:25 GMT

{
  "fault_message": "The update operation is not allowed!"
}

=======================================================
```
**Note** Expected to fail until the necessary changes to the integration tests are pushed. The updated test expects the update to report *not allowed* and the live update to work.

```bash
two drives with the same path, Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 12:35:25 GMT

{
  "fault_message": "The block device path was already added to a different drive!"
}

=======================================================

$ ./test_machine_configure.sh 
Test1 setting the vCPU to 2; Should output Updated
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:06:52 GMT



=======================================================
Test1 setting the vCPU to 3; Should output Error (The cpuid is not an even number)
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:06:53 GMT



=======================================================
```
**Note** This is expected to fail until Andreea's CPU topology changes are upstreamed.

```bash
Test2 setting the vCPU to -1; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "invalid value: integer `-1`, expected u8 at line 1 column 18"
}

=======================================================
Test3 setting the vCPU to string; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "invalid type: string "str", expected u8 at line 1 column 21"
}

=======================================================
Test4 setting the memory size to 256; Should output Updated
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:06:53 GMT



=======================================================
Test5 setting the memory size to -1; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "invalid value: integer `-1`, expected usize at line 1 column 20"
}

=======================================================
Test6 setting the memory size to string; Should output Bad Request
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "invalid type: string "str", expected usize at line 1 column 23"
}

=======================================================
Test7 send request with empty body; Should output Bad Request
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:06:53 GMT



=======================================================
```

**Note** Known issue, see #236

```bash
Test8 send request with both memory and vcpu configuration; Should output Updated
HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:06:53 GMT



=======================================================
Test9 send request with vCPU set to 0; Should output BadRequest
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "The vCPU number is invalid!"
}

=======================================================
Test9 send request with memory set to 0; Should output BadRequest
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:06:53 GMT

{
  "fault_message": "The memory size (MiB) is invalid!"
}

=======================================================

$ sudo ./test_all.sh resources/kernels/vmlinux_login_network.bin resources/amis/ami-fea26484.ext4 rootfs.ext4 
HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 204 No Content
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 201 Created
Content-Length: 0
Date: Thu, 03 May 2018 13:09:32 GMT

HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 May 2018 13:09:37 GMT

{"action_id":"start","action_type":"InstanceStart","timestamp":0}
```