### PR TITLE
Fix cargo fmt issues

### DIFF
--- a/api_server/src/request/async/mod.rs
+++ b/api_server/src/request/async/mod.rs
@@ -97,7 +97,7 @@ mod tests {
             match (self, other) {
                 (&AsyncRequest::StartInstance(_), &AsyncRequest::StartInstance(_)) => true,
                 (&AsyncRequest::StopInstance(_), &AsyncRequest::StopInstance(_)) => true,
-                _ => false
+                _ => false,
             }
         }
     }
@@ -105,25 +105,28 @@ mod tests {
     impl PartialEq for ParsedRequest {
         fn eq(&self, other: &ParsedRequest) -> bool {
             match (self, other) {
-                (&ParsedRequest::Async(ref id, ref request, _),
-                    &ParsedRequest::Async(ref other_id, ref other_request, _)) =>
-                        id == other_id && request == other_request,
-                (&ParsedRequest::Sync(ref sync_req, _),
-                    &ParsedRequest::Sync(ref other_sync_req, _)) =>
-                        sync_req == other_sync_req,
+                (
+                    &ParsedRequest::Async(ref id, ref request, _),
+                    &ParsedRequest::Async(ref other_id, ref other_request, _),
+                ) => id == other_id && request == other_request,
+                (
+                    &ParsedRequest::Sync(ref sync_req, _),
+                    &ParsedRequest::Sync(ref other_sync_req, _),
+                ) => sync_req == other_sync_req,
                 (&ParsedRequest::Dummy, &ParsedRequest::Dummy) => true,
                 (&ParsedRequest::GetInstanceInfo, &ParsedRequest::GetInstanceInfo) => true,
                 (&ParsedRequest::GetActions, &ParsedRequest::GetActions) => true,
-                (&ParsedRequest::GetAction(ref id), &ParsedRequest::GetAction(ref other_id)) =>
-                    id == other_id,
-                _ => false
+                (&ParsedRequest::GetAction(ref id), &ParsedRequest::GetAction(ref other_id)) => {
+                    id == other_id
+                }
+                _ => false,
             }
         }
     }
 
     #[test]
     fn test_to_parsed_request() {
-        let jsons = vec!(
+        let jsons = vec![
             "{
                 \"action_id\": \"dummy\",
                 \"action_type\": \"InstanceStart\",
@@ -154,14 +157,14 @@ mod tests {
             "{
                 \"action_id\": \"dummy\",
                 \"action_type\": \"IAmNotAnActionType\"\
-              }"
-        );
+              }",
+        ];
         let (sender, receiver) = oneshot::channel();
         let req: ParsedRequest = ParsedRequest::Async(
-                String::from("dummy"),
-                AsyncRequest::StartInstance(sender),
-                receiver
-            );
+            String::from("dummy"),
+            AsyncRequest::StartInstance(sender),
+            receiver,
+        );
 
         let mut result: Result<AsyncRequestBody, serde_json::Error> =
             serde_json::from_str(jsons[0]);
@@ -189,8 +192,7 @@ mod tests {
                         \"force\": true},
                     \"timestamp\": 1522850095
                   }";
-        let mut async_body: AsyncRequestBody =
-            serde_json::from_slice(j).unwrap();
+        let mut async_body: AsyncRequestBody = serde_json::from_slice(j).unwrap();
         async_body.set_timestamp(1522850096);
 
         assert_eq!(async_body.timestamp, Some(1522850096));

--- a/api_server/src/request/sync/boot_source.rs
+++ b/api_server/src/request/sync/boot_source.rs
@@ -84,38 +84,60 @@ mod tests {
 
     #[test]
     fn test_generate_response_put_boot_source_config_error() {
-        assert_eq!(PutBootSourceConfigError::InvalidKernelPath.generate_response().status(),
-                   StatusCode::BadRequest);
-        assert_eq!(PutBootSourceConfigError::InvalidKernelCommandLine.generate_response().status(),
-                   StatusCode::BadRequest);
+        assert_eq!(
+            PutBootSourceConfigError::InvalidKernelPath
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            PutBootSourceConfigError::InvalidKernelCommandLine
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
     }
 
     #[test]
     fn test_generate_response_put_boot_source_outcome() {
-        assert_eq!(PutBootSourceOutcome::Created.generate_response().status(),
-                   StatusCode::Created);
-        assert_eq!(PutBootSourceOutcome::Updated.generate_response().status(),
-                   StatusCode::NoContent);
-        assert_eq!(PutBootSourceOutcome::Error(PutBootSourceConfigError::InvalidKernelPath)
-                       .generate_response().status(), StatusCode::BadRequest);
+        assert_eq!(
+            PutBootSourceOutcome::Created.generate_response().status(),
+            StatusCode::Created
+        );
+        assert_eq!(
+            PutBootSourceOutcome::Updated.generate_response().status(),
+            StatusCode::NoContent
+        );
+        assert_eq!(
+            PutBootSourceOutcome::Error(PutBootSourceConfigError::InvalidKernelPath)
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
     }
 
     #[test]
     fn test_into_parsed_request() {
-        let body  = BootSourceBody {
+        let body = BootSourceBody {
             boot_source_id: String::from("/foo/bar"),
             source_type: BootSourceType::LocalImage,
-            local_image: Some(LocalImage { kernel_image_path: String::from("/foo/bar") }),
-            boot_args: Some(String::from("foobar"))
+            local_image: Some(LocalImage {
+                kernel_image_path: String::from("/foo/bar"),
+            }),
+            boot_args: Some(String::from("foobar")),
         };
-        let same_body  = BootSourceBody {
+        let same_body = BootSourceBody {
             boot_source_id: String::from("/foo/bar"),
             source_type: BootSourceType::LocalImage,
-            local_image: Some(LocalImage { kernel_image_path: String::from("/foo/bar") }),
-            boot_args: Some(String::from("foobar"))
+            local_image: Some(LocalImage {
+                kernel_image_path: String::from("/foo/bar"),
+            }),
+            boot_args: Some(String::from("foobar")),
         };
         let (sender, receiver) = oneshot::channel();
         assert!(body.into_parsed_request().eq(&Ok(ParsedRequest::Sync(
-            SyncRequest::PutBootSource(same_body, sender), receiver))))
+            SyncRequest::PutBootSource(same_body, sender),
+            receiver
+        ))))
     }
 }

--- a/api_server/src/request/sync/drive.rs
+++ b/api_server/src/request/sync/drive.rs
@@ -102,33 +102,59 @@ mod tests {
 
     #[test]
     fn test_is_read_only() {
-        assert!(DriveDescription {
-            drive_id: String::from("foo"),
-            path_on_host: String::from("/foo/bar"),
-            state: DeviceState::Attached,
-            is_root_device: true,
-            permissions: DrivePermissions::ro
-        }.is_read_only());
+        assert!(
+            DriveDescription {
+                drive_id: String::from("foo"),
+                path_on_host: String::from("/foo/bar"),
+                state: DeviceState::Attached,
+                is_root_device: true,
+                permissions: DrivePermissions::ro,
+            }.is_read_only()
+        );
     }
 
     #[test]
     fn test_generate_response_drive_error() {
-        assert_eq!(DriveError::RootBlockDeviceAlreadyAdded.generate_response().status(),
-                   StatusCode::BadRequest);
-        assert_eq!(DriveError::InvalidBlockDevicePath.generate_response().status(),
-                   StatusCode::BadRequest);
-        assert_eq!(DriveError::BlockDevicePathAlreadyExists.generate_response().status(),
-                   StatusCode::BadRequest);
-        assert_eq!(DriveError::NotImplemented.generate_response().status(),
-                   StatusCode::InternalServerError);
+        assert_eq!(
+            DriveError::RootBlockDeviceAlreadyAdded
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            DriveError::InvalidBlockDevicePath
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            DriveError::BlockDevicePathAlreadyExists
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            DriveError::NotImplemented.generate_response().status(),
+            StatusCode::InternalServerError
+        );
     }
 
     #[test]
     fn test_generate_response_put_drive_outcome() {
-        assert_eq!(PutDriveOutcome::Created.generate_response().status(), StatusCode::Created);
-        assert_eq!(PutDriveOutcome::Updated.generate_response().status(), StatusCode::NoContent);
-        assert_eq!(PutDriveOutcome::Error(DriveError::NotImplemented).generate_response().status(),
-                   StatusCode::InternalServerError);
+        assert_eq!(
+            PutDriveOutcome::Created.generate_response().status(),
+            StatusCode::Created
+        );
+        assert_eq!(
+            PutDriveOutcome::Updated.generate_response().status(),
+            StatusCode::NoContent
+        );
+        assert_eq!(
+            PutDriveOutcome::Error(DriveError::NotImplemented)
+                .generate_response()
+                .status(),
+            StatusCode::InternalServerError
+        );
     }
 
     #[test]
@@ -138,12 +164,16 @@ mod tests {
             path_on_host: String::from("/foo/bar"),
             state: DeviceState::Attached,
             is_root_device: true,
-            permissions: DrivePermissions::ro
+            permissions: DrivePermissions::ro,
         };
 
         assert!(&desc.clone().into_parsed_request("bar").is_err());
         let (sender, receiver) = oneshot::channel();
-        assert!(&desc.clone().into_parsed_request("foo").eq(
-                   &Ok(ParsedRequest::Sync(SyncRequest::PutDrive(desc, sender), receiver))));
+        assert!(&desc.clone()
+            .into_parsed_request("foo")
+            .eq(&Ok(ParsedRequest::Sync(
+                SyncRequest::PutDrive(desc, sender),
+                receiver
+            ))));
     }
 }

--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -71,31 +71,56 @@ mod tests {
 
     #[test]
     fn test_generate_response_put_machine_configuration_error() {
-        assert_eq!(PutMachineConfigurationError::InvalidVcpuCount.generate_response().status(),
-                   StatusCode::BadRequest);
-        assert_eq!(PutMachineConfigurationError::InvalidMemorySize.generate_response().status(),
-                   StatusCode::BadRequest);
+        assert_eq!(
+            PutMachineConfigurationError::InvalidVcpuCount
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            PutMachineConfigurationError::InvalidMemorySize
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
     }
 
     #[test]
     fn test_generate_response_put_machine_configuration_outcome() {
-        assert_eq!(PutMachineConfigurationOutcome::Created.generate_response().status(),
-                   StatusCode::Created);
-        assert_eq!(PutMachineConfigurationOutcome::Updated.generate_response().status(),
-                   StatusCode::NoContent);
-        assert_eq!(PutMachineConfigurationOutcome::Error(
-            PutMachineConfigurationError::InvalidVcpuCount).generate_response().status(),
-                   StatusCode::BadRequest);
+        assert_eq!(
+            PutMachineConfigurationOutcome::Created
+                .generate_response()
+                .status(),
+            StatusCode::Created
+        );
+        assert_eq!(
+            PutMachineConfigurationOutcome::Updated
+                .generate_response()
+                .status(),
+            StatusCode::NoContent
+        );
+        assert_eq!(
+            PutMachineConfigurationOutcome::Error(PutMachineConfigurationError::InvalidVcpuCount)
+                .generate_response()
+                .status(),
+            StatusCode::BadRequest
+        );
     }
 
     #[test]
     fn test_into_parsed_request() {
         let body = MachineConfigurationBody {
             vcpu_count: Some(8),
-            mem_size_mib: Some(1024)
+            mem_size_mib: Some(1024),
         };
         let (sender, receiver) = oneshot::channel();
-        assert!(body.clone().into_parsed_request().eq(&Ok(ParsedRequest::Sync(
-            SyncRequest::PutMachineConfiguration(body, sender), receiver))));
+        assert!(
+            body.clone()
+                .into_parsed_request()
+                .eq(&Ok(ParsedRequest::Sync(
+                    SyncRequest::PutMachineConfiguration(body, sender),
+                    receiver
+                )))
+        );
     }
 }

--- a/api_server/src/request/sync/mod.rs
+++ b/api_server/src/request/sync/mod.rs
@@ -128,20 +128,26 @@ mod tests {
     impl PartialEq for SyncRequest {
         fn eq(&self, other: &SyncRequest) -> bool {
             match (self, other) {
-                (&SyncRequest::PutBootSource(ref bsb, _),
-                    &SyncRequest::PutBootSource(ref other_bsb, _))
-                => bsb == other_bsb,
-                (&SyncRequest::PutDrive(ref ddesc, _), &SyncRequest::PutDrive(ref other_ddesc, _))
-                => ddesc == other_ddesc,
-                (&SyncRequest::PutMachineConfiguration(ref mcb, _),
-                    &SyncRequest::PutMachineConfiguration(ref other_mcb, _))
-                => mcb == other_mcb,
-                (&SyncRequest::PutNetworkInterface(ref netif, _),
-                    &SyncRequest::PutNetworkInterface(ref other_netif, _))
-                => netif == other_netif,
-                (&SyncRequest::PutVsock(ref vjb, _), &SyncRequest::PutVsock(ref other_vjb, _))
-                => vjb == other_vjb,
-                _ => false
+                (
+                    &SyncRequest::PutBootSource(ref bsb, _),
+                    &SyncRequest::PutBootSource(ref other_bsb, _),
+                ) => bsb == other_bsb,
+                (
+                    &SyncRequest::PutDrive(ref ddesc, _),
+                    &SyncRequest::PutDrive(ref other_ddesc, _),
+                ) => ddesc == other_ddesc,
+                (
+                    &SyncRequest::PutMachineConfiguration(ref mcb, _),
+                    &SyncRequest::PutMachineConfiguration(ref other_mcb, _),
+                ) => mcb == other_mcb,
+                (
+                    &SyncRequest::PutNetworkInterface(ref netif, _),
+                    &SyncRequest::PutNetworkInterface(ref other_netif, _),
+                ) => netif == other_netif,
+                (&SyncRequest::PutVsock(ref vjb, _), &SyncRequest::PutVsock(ref other_vjb, _)) => {
+                    vjb == other_vjb
+                }
+                _ => false,
             }
         }
     }

--- a/api_server/src/request/sync/net.rs
+++ b/api_server/src/request/sync/net.rs
@@ -75,12 +75,19 @@ mod tests {
             iface_id: String::from("foo"),
             state: DeviceState::Attached,
             host_dev_name: String::from("bar"),
-            guest_mac: Some(MacAddr::parse_str("12:34:56:78:9A:BC").unwrap())
+            guest_mac: Some(MacAddr::parse_str("12:34:56:78:9A:BC").unwrap()),
         };
 
         assert!(netif.clone().into_parsed_request("bar").is_err());
         let (sender, receiver) = oneshot::channel();
-        assert!(netif.clone().into_parsed_request("foo").eq(&Ok(ParsedRequest::Sync(
-            SyncRequest::PutNetworkInterface(netif, sender), receiver))));
+        assert!(
+            netif
+                .clone()
+                .into_parsed_request("foo")
+                .eq(&Ok(ParsedRequest::Sync(
+                    SyncRequest::PutNetworkInterface(netif, sender),
+                    receiver
+                )))
+        );
     }
 }

--- a/api_server/src/request/sync/vsock.rs
+++ b/api_server/src/request/sync/vsock.rs
@@ -39,12 +39,19 @@ mod tests {
         let vsock = VsockJsonBody {
             vsock_id: String::from("foo"),
             guest_cid: 42,
-            state: DeviceState::Attached
+            state: DeviceState::Attached,
         };
 
         assert!(vsock.clone().into_parsed_request("bar").is_err());
         let (sender, receiver) = oneshot::channel();
-        assert!(vsock.clone().into_parsed_request("foo").eq(&Ok(ParsedRequest::Sync(
-            SyncRequest::PutVsock(vsock, sender), receiver))));
+        assert!(
+            vsock
+                .clone()
+                .into_parsed_request("foo")
+                .eq(&Ok(ParsedRequest::Sync(
+                    SyncRequest::PutVsock(vsock, sender),
+                    receiver
+                )))
+        );
     }
 }

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -140,7 +140,7 @@ mod tests {
 
         // We're waiting to detect that the signal handler has been called.
         const MAX_WAIT_ITERS: u32 = 20;
-        let mut iter_count =  0;
+        let mut iter_count = 0;
         loop {
             thread::sleep(Duration::from_millis(100));
 


### PR DESCRIPTION
My last PR went in without having passed through cargo fmt. This commit
fixes all the format errors introduced by the latest changes.

Signed-off-by: Alexandra Ghecenco <aghecen@amazon.com>

# Testing done

This PR introduces no functional changes. It only addresses format errors caused by previous PRs.

```bash
cargo build
cargo build --release
cargo fmt --all
```