### PR TITLE
Enable link time optimization for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,7 @@ sys_util = { path = "sys_util" }
 vmm = { path = "vmm" }
 logger = { path = "logger" }
 
+[profile.release]
+lto = true
+
 [workspace]


### PR DESCRIPTION
A bit of information about LTO can be found here: https://lifthrasiir.github.io/rustlog/why-is-a-rust-executable-large.html, in the "Link-time Optimization" section, together with some other neat bits of information. 

Basically, enabling LTO leads to a reduced binary size, and may very well create opportunities for performance optimizations also. The downside is a significant build time increase (it appears to be ~2x right now), but overall it seems to be worth it.

The change to Cargo.toml in this PR only enables LTO for release builds. 