### PR TITLE
Fixed kvm_set_sregs issue

### DIFF
--- a/x86_64/src/regs.rs
+++ b/x86_64/src/regs.rs
@@ -167,6 +167,7 @@ const X86_CR0_PE: u64 = 0x1;
 const X86_CR0_PG: u64 = 0x80000000;
 const X86_CR4_PAE: u64 = 0x20;
 
+const EFER_LMA: u64 = 0x400;
 const EFER_LME: u64 = 0x100;
 
 const BOOT_GDT_OFFSET: usize = 0x500;
@@ -225,7 +226,7 @@ fn configure_segments_and_sregs(mem: &GuestMemory, sregs: &mut kvm_sregs) -> Res
 
     /* 64-bit protected mode */
     sregs.cr0 |= X86_CR0_PE;
-    sregs.efer |= EFER_LME;
+    sregs.efer |= EFER_LME | EFER_LMA;
 
     Ok(())
 }


### PR DESCRIPTION
We weren't properly setting up CPU registers before trying to boot, and newer versions of the kernel/KVM are less permissive abut such omissions. This version of the PR was also created to trigger the CI system.