### PR TITLE
Fixed regs::tests::segments_and_regs()

### DIFF
--- a/x86_64/src/regs.rs
+++ b/x86_64/src/regs.rs
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(0xfffff, sregs.tr.limit);
         assert_eq!(0, sregs.tr.avl);
         assert_eq!(X86_CR0_PE, sregs.cr0);
-        assert_eq!(EFER_LME, sregs.efer);
+        assert_eq!(EFER_LME | EFER_LMA, sregs.efer);
     }
 
     #[test]


### PR DESCRIPTION
Fixed a test that would otherwise fail because of the latest changes from regs.rs.