### PR TITLE
sys_util: fixing test_a_tty unit test

### DIFF
--- a/sys_util/src/terminal.rs
+++ b/sys_util/src/terminal.rs
@@ -135,14 +135,8 @@ mod tests {
         assert!(stdin.set_raw_mode().is_ok());
         assert!(stdin.set_canon_mode().is_ok());
         assert!(stdin.set_non_block(true).is_ok());
-        //trying to read 3 bytes in non-blocking mode will give error as there is nothing to read
-        let mut out = [0u8; 3];
-        assert!(stdin.read_raw(&mut out[..]).is_err());
         let mut out = [0u8; 0];
-        assert_eq!(stdin.read_raw(&mut out[..]).unwrap(), 0);
-        assert!(stdin.set_non_block(false).is_ok());
-        // trying to read more than 0 would block the terminal
-        assert_eq!(stdin.read_raw(&mut out[..]).unwrap(), 0);
+        assert!(stdin.read_raw(&mut out[..]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Changes
* removed asserts inside the test_a_tty unit test that would try to  read fixed bytes from stdin
* given that the unit tests are run in parallel and that some of them output stuff, the test_a_tty test would basically exercise random scenarios
## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Build tests
```bash
cargo fmt —all
cargo build # no warning
cargo build —release
sudo env "PATH=$PATH" cargo test --all
sudo env "PATH=$PATH" cargo kcov —all #71.5%
```