### PR TITLE
Unit tests for legacy device manager

### DIFF
--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -73,7 +73,7 @@ pub struct MMIODeviceManager {
 }
 
 impl MMIODeviceManager {
-    /// Create a new DeviceManager.
+    /// Create a new DeviceManager handling mmio devices (virtio net, block).
     pub fn new(guest_mem: GuestMemory, mmio_base: u64) -> MMIODeviceManager {
         MMIODeviceManager {
             guest_mem: guest_mem,


### PR DESCRIPTION
## Changes
* ```pub type Result``` does not need to be pub
* added comments to function similar to the mmio device manager
* added unit tests => kcov now reports **98.2% for vmm/src/device_manager/legacy.rs**

## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Build tests
```bash
cargo fmt —all
cargo build # no warning
cargo build —release
sudo env "PATH=$PATH" cargo test --all
sudo env "PATH=$PATH" cargo kcov --all #71.6%
```