### PR TITLE
Remove the Non-API interface to Firecracker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,7 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 clap = "=2.27.1"
 
 api_server = { path = "api_server" }
-devices = { path = "devices" }
-net_util = { path = "net_util" }
-sys_util = { path = "sys_util" }
 vmm = { path = "vmm" }
-logger = { path = "logger" }
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,30 +2,18 @@
 extern crate clap;
 
 extern crate api_server;
-extern crate devices;
-extern crate logger;
-extern crate net_util;
-extern crate sys_util;
 extern crate vmm;
 
-use std::fs::File;
+use clap::{App, Arg};
 use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
 
-use clap::{App, Arg, SubCommand};
-
+use api_server::ApiServer;
 use api_server::request::instance_info::{InstanceInfo, InstanceState};
-use api_server::request::sync::{DeviceState, NetworkInterfaceBody};
-use api_server::{ApiRequest, ApiServer};
-use logger::Logger;
-use net_util::MacAddr;
-use sys_util::{EventFd, GuestAddress};
-use vmm::device_config::BlockDeviceConfig;
-use vmm::{CMDLINE_MAX_SIZE, CMDLINE_OFFSET, KERNEL_START_OFFSET};
-use vmm::{kernel_cmdline, KernelConfig};
 
-const DEFAULT_SUBNET_MASK: &str = "255.255.255.0";
+const DEFAULT_API_SOCK_PATH: &str = "/tmp/firecracker.socket";
+const MAX_STORED_ASYNC_REQS: usize = 100;
 
 fn main() {
     let cmd_arguments = App::new("firecracker")
@@ -36,235 +24,60 @@ fn main() {
             Arg::with_name("api_sock")
                 .long("api-sock")
                 .help("Path to unix domain socket used by the API")
-                .default_value("/tmp/firecracker.socket")
+                .default_value(DEFAULT_API_SOCK_PATH)
                 .takes_value(true),
-        )
-        .subcommand(
-            SubCommand::with_name("vmm-no-api")
-                .about("Start vmm without an API thread")
-                .arg(
-                    Arg::with_name("kernel_path")
-                        .short("k")
-                        .long("kernel-path")
-                        .help("The kernel's file path (vmlinux.bin)")
-                        .takes_value(true)
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("kernel_cmdline")
-                        .long("kernel-cmdline")
-                        .help("The kernel's command line")
-                        .default_value("console=ttyS0 noapic reboot=k panic=1 pci=off nomodules")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("mem_size")
-                        .long("mem-size")
-                        .default_value("128")
-                        .help("Virtual Machine Memory Size in MiB")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("vcpu_count")
-                        .long("vcpu-count")
-                        .default_value("1")
-                        .help("Number of VCPUs")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("root_blk_file")
-                        .short("r")
-                        .long("root-blk")
-                        .help("File to serve as root block device")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("read_only_root")
-                        .long("read-only-root")
-                        .help("Open the file backing the root block device as read-only.")
-                        .takes_value(false),
-                )
-                .arg(
-                    Arg::with_name("tap_dev_name")
-                        .long("tap-dev-name")
-                        .help("Name of existing TAP interface to use for guest Virtio net device")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("subnet_mask")
-                        .long("subnet-mask")
-                        .default_value(DEFAULT_SUBNET_MASK)
-                        .help("Subnet mask for the IP address of host interface")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("guest_mac")
-                        .long("guest-mac")
-                        .help("The MAC address of the guest network interface.")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("log_file")
-                        .short("l")
-                        .long("log-file")
-                        .help("File to serve as logging output")
-                        .takes_value(true),
-                ),
         )
         .get_matches();
 
-    let (to_vmm, from_api) = channel();
+    let bind_path = cmd_arguments
+        .value_of("api_sock")
+        .map(|s| PathBuf::from(s))
+        .unwrap();
 
     let shared_info = Arc::new(RwLock::new(InstanceInfo {
         state: InstanceState::Uninitialized,
     }));
+    let (to_vmm, from_api) = channel();
+    let server = ApiServer::new(shared_info.clone(), to_vmm, MAX_STORED_ASYNC_REQS).unwrap();
 
-    // TODO: vmm_no_api is for integration testing, need to find a more pretty solution
-    match cmd_arguments.subcommand {
-        Some(_) => {
-            vmm_no_api_handler(
-                shared_info,
-                cmd_arguments.subcommand_matches("vmm-no-api").unwrap(),
-                from_api,
-            );
-        }
-        None => {
-            // safe to unwrap since api_sock has a default value
-            let bind_path = cmd_arguments
-                .value_of("api_sock")
-                .map(|s| PathBuf::from(s))
-                .unwrap();
+    let api_event_fd = server
+        .get_event_fd_clone()
+        .expect("cannot clone API eventFD");
+    let _vmm_thread_handle = vmm::start_vmm_thread(shared_info, api_event_fd, from_api);
 
-            let server = ApiServer::new(shared_info.clone(), to_vmm, 100).unwrap();
-            let api_event_fd = server
-                .get_event_fd_clone()
-                .expect("cannot clone API eventFD");
-            let _vmm_thread_handle = vmm::start_vmm_thread(shared_info, api_event_fd, from_api);
-            server.bind_and_run(bind_path).unwrap();
-        }
-    }
+    server.bind_and_run(bind_path).unwrap();
 }
 
-fn vmm_no_api_handler(
-    instance_info: Arc<RwLock<InstanceInfo>>,
-    cmd_arguments: &clap::ArgMatches,
-    from_api: Receiver<Box<ApiRequest>>,
-) {
-    let mut vmm = vmm::Vmm::new(
-        instance_info,
-        EventFd::new().expect("cannot create eventFD"),
-        from_api,
-    ).expect("cannot create VMM");
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::time::Duration;
+    use std::{fs, thread};
 
-    // this is temporary; user will be able to customize logging subsystem through API
-    let mut l = Logger::new();
-    l.set_level(logger::Level::Info);
-    if cmd_arguments.is_present("log_file") {
-        if let Err(e) = l.init(Some(String::from(
-            cmd_arguments.value_of("log_file").unwrap(),
-        ))) {
-            eprintln!(
-                "main: Failed to initialize logging subsystem: {:?}. Trying without a file",
-                e
-            );
-            l = Logger::new();
-            l.set_level(logger::Level::Info);
-            if let Err(e) = l.init(None) {
-                panic!("main: Failed to initialize logging subsystem: {:?}", e);
-            }
-        }
-    } else {
-        if let Err(e) = l.init(None) {
-            panic!("main: Failed to initialize logging subsystem: {:?}", e);
-        }
-    }
+    #[test]
+    fn test_main() {
+        // test will be run iff the socket file does not already exist
+        if !Path::new(DEFAULT_API_SOCK_PATH).exists() {
+            thread::spawn(|| {
+                main();
+            });
 
-    // configure virtual machine from command line
-    if cmd_arguments.is_present("vcpu_count") {
-        match cmd_arguments
-            .value_of("vcpu_count")
-            .unwrap()
-            .to_string()
-            .parse::<u8>()
-        {
-            Ok(vcpu_count) => {
-                vmm.put_virtual_machine_configuration(Some(vcpu_count), None)
-                    .expect("Invalid value for vcpu_count");
+            const MAX_WAIT_ITERS: u32 = 20;
+            let mut iter_count = 0;
+            loop {
+                thread::sleep(Duration::from_secs(1));
+                if Path::new(DEFAULT_API_SOCK_PATH).exists() {
+                    break;
+                }
+                iter_count += 1;
+                if iter_count > MAX_WAIT_ITERS {
+                    fs::remove_file(DEFAULT_API_SOCK_PATH)
+                        .expect("failure in removing socket file");
+                    assert!(false);
+                }
             }
-            Err(error) => {
-                panic!("Invalid value for vcpu_count! {:?}", error);
-            }
-        };
-    }
-    if cmd_arguments.is_present("mem_size") {
-        match cmd_arguments
-            .value_of("mem_size")
-            .unwrap()
-            .to_string()
-            .parse::<usize>()
-        {
-            Ok(mem_size_mib) => {
-                vmm.put_virtual_machine_configuration(None, Some(mem_size_mib))
-                    .expect("Invalid value for mem_size!");
-            }
-            Err(error) => {
-                panic!("Invalid value for mem_size! {:?}", error);
-            }
+            fs::remove_file(DEFAULT_API_SOCK_PATH).expect("failure in removing socket file");
         }
     }
-
-    // This is a temporary fix. Block devices should be added via http requests.
-    // With the command line, we can only add one device, with default to root block device.
-    if cmd_arguments.is_present("root_blk_file") {
-        let root_block_device = BlockDeviceConfig {
-            path_on_host: PathBuf::from(cmd_arguments.value_of("root_blk_file").unwrap()),
-            is_root_device: true,
-            is_read_only: cmd_arguments.is_present("read_only_root"),
-            drive_id: String::from("1"),
-        };
-        vmm.put_block_device(root_block_device)
-            .expect("cannot add root block device.");
-    }
-
-    if let Some(value) = cmd_arguments.value_of("tap_dev_name") {
-        let host_dev_name = String::from(value);
-
-        let guest_mac = cmd_arguments
-            .value_of("guest_mac")
-            .map(|s| MacAddr::parse_str(s).expect("invalid guest MAC"));
-
-        let body = NetworkInterfaceBody {
-            iface_id: String::from("0"),
-            state: DeviceState::Attached,
-            host_dev_name,
-            guest_mac,
-        };
-
-        vmm.put_net_device(body).expect("failed adding net device.");
-    }
-
-    // configure kernel from command line
-    //we're using unwrap here because the kernel_path is mandatory for now
-    let kernel_file = File::open(cmd_arguments.value_of("kernel_path").unwrap_or_default())
-        .expect("Cannot open kernel file");
-
-    let mut cmdline = kernel_cmdline::Cmdline::new(CMDLINE_MAX_SIZE);
-    cmdline
-        .insert_str(cmd_arguments.value_of("kernel_cmdline").unwrap())
-        .expect("could not use the specified kernel cmdline");
-    let kernel_config = KernelConfig {
-        cmdline,
-        kernel_file,
-        kernel_start_addr: GuestAddress(KERNEL_START_OFFSET),
-        cmdline_addr: GuestAddress(CMDLINE_OFFSET),
-    };
-    vmm.configure_kernel(kernel_config);
-    vmm.start_instance().expect("cannot boot kernel");
-    let r = vmm.run_control(false);
-    // make sure we clean up when this loop breaks on error
-    if r.is_err() {
-        // stop() is safe to call at any moment; ignore the result
-        let _ = vmm.stop();
-    }
-    r.expect("VMM loop error!");
 }


### PR DESCRIPTION
## Changes
* removed arguments parsing related to vmm-no-api
* added unit test

## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### In-tree tests
```bash
sudo env "PATH=$PATH" pytest  functional/test_api.py # passed
```

#### Coverage
* overall 73%

Addresses #240 .