### PR TITLE
Fixed testrun.sh package manager selection

### DIFF
--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -144,13 +144,10 @@ acquire_pkg_installer() {
     declare acquired_installer=false
     for installer in "${SUPPORTED_INSTALLERS[@]}"; do
         if check_cmd $installer; then
-            if $acquired_installer; then
-                err "Found more than one supported package manager."
-            else
-                export PKG_INSTALLER=$installer
-                record_global_symbol PKG_INSTALLER
-                acquired_installer=true
-            fi
+            export PKG_INSTALLER=$installer
+            record_global_symbol PKG_INSTALLER
+            acquired_installer=true
+            break
         fi
     done
 


### PR DESCRIPTION
Whenever testrun.sh detected more than one package manager, it got confused and refused to  proceed. This no longer happens, as we simply use the first package manager we detect.

