### PR TITLE
Added check for required KVM capabilities

### DIFF
--- a/kvm/src/cap.rs
+++ b/kvm/src/cap.rs
@@ -5,6 +5,7 @@
 use kvm_sys::*;
 
 /// A capability the kernel's KVM interface can possibly expose.
+#[derive(Clone, Copy, Debug)]
 #[repr(u32)]
 pub enum Cap {
     Irqchip = KVM_CAP_IRQCHIP,
@@ -117,4 +118,5 @@ pub enum Cap {
     PpcEnableHcall = KVM_CAP_PPC_ENABLE_HCALL,
     CheckExtensionVm = KVM_CAP_CHECK_EXTENSION_VM,
     S390UserSigp = KVM_CAP_S390_USER_SIGP,
+    ImmediateExit = KVM_CAP_IMMEDIATE_EXIT,
 }


### PR DESCRIPTION
The main purpose of this PR is to add checks for required KVM capabilities before starting a VM. A more verbose description can be found in the commit message.

The nr_cpus/max_cpus related information is not yet used, but we should involve them in future validation logic, since the hard KVM vcpu limit is higher than the "recommended" limit, which kinda implies some performance degradation or something may happen after a certain point :-s

This provides a solution for #278. I'll create a new issue which describes some more advanced validation topics which appear to be worth doing, but are kinda out of scope right now.
