### PR TITLE
Fixed empty PUT request handling for machine_config

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -902,15 +902,14 @@ mod tests {
                 .is_err()
         );
 
-        // FIXME #236
-        // A non-machine configuration json body should cause this request to fail the parsing
-        // stage, but it doesn't because the implementation is incomplete. Commenting it out until
-        // it's fixed.
-        // assert!(parse_machine_config_req(
-        //    &path_tokens,
-        //    &path,
-        //    Method::Put,
-        //    &Chunk::from("{\"foo\": \"bar\"}")).is_err());
+        assert!(
+            parse_machine_config_req(
+                &path_tokens,
+                &path,
+                Method::Put,
+                &Chunk::from("{\"foo\": \"bar\"}")
+            ).is_err()
+        );
 
         assert!(
             parse_machine_config_req(

--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -18,7 +18,7 @@ impl GenerateResponse for PutMachineConfigurationError {
     fn generate_response(&self) -> Response {
         use self::PutMachineConfigurationError::*;
 
-        match *self {
+        match self {
             InvalidVcpuCount => json_response(
                 StatusCode::BadRequest,
                 json_fault_message(
@@ -28,7 +28,7 @@ impl GenerateResponse for PutMachineConfigurationError {
             ),
             InvalidMemorySize => json_response(
                 StatusCode::BadRequest,
-                json_fault_message("The memory size (MiB) is invalid!"),
+                json_fault_message("The memory size (MiB) is invalid."),
             ),
         }
     }
@@ -80,10 +80,15 @@ impl IntoParsedRequest for MachineConfiguration {
                 SyncRequest::GetMachineConfiguration(sender),
                 receiver,
             )),
-            Method::Put => Ok(ParsedRequest::Sync(
-                SyncRequest::PutMachineConfiguration(self, sender),
-                receiver,
-            )),
+            Method::Put => {
+                if self.vcpu_count.is_none() && self.mem_size_mib.is_none() {
+                    return Err(String::from("Empty request."));
+                }
+                Ok(ParsedRequest::Sync(
+                    SyncRequest::PutMachineConfiguration(self, sender),
+                    receiver,
+                ))
+            }
             _ => Ok(ParsedRequest::Dummy),
         }
     }


### PR DESCRIPTION
A BadRequest response is now sent back every time a PUT machine_config request with an empty JSON body is received.

Testing done:

* started Firecracker using `SOCKET=/tmp/firecracker.socket rm -f $SOCKET && target/x86_64-unknown-linux-musl/debug/firecracker $SOCKET`
* ran `curl --unix-socket /tmp/firecracker.socket -i -X PUT "http://localhost/machine-config" -H "accept: application/json" -H "Content-Type: application/json" -d "{}"` and got:
```
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sun, 20 May 2018 21:43:19 GMT

{
  "fault_message": "Empty request."
}
```
* ran `curl --unix-socket /tmp/firecracker.socket -i -X PUT "http://localhost/machine-config" -H "accept: application/json" -H "Content-Type:application/json" -d "{ \"vcpu_count\": null, \"mem_size_mib\": null}"` and got the same:
```
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sun, 20 May 2018 21:43:33 GMT

{
  "fault_message": "Empty request."
}
```

This PR fixes #236. It's worth mentioning that sending a request without a body (as opposed to a valid, but empty JSON body) also return a BadRequest response, but with a message that suggests a serde parse error; for example when running `curl --unix-socket /tmp/firecracker.socket -i -X PUT "http://localhost/machine-config" -H "accept: application/json" -H "Content-Type:application/json"` (notice there's no more `-d` parameter), I get:
```
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sun, 20 May 2018 21:50:55 GMT

{
  "fault_message": "EOF while parsing a value at line 1 column 0"
}
```
We might want to unify the contents at some point (but this is not a super trivial fix), and the `api_server` crate could use some refactoring anyway.