### PR TITLE
Replace unsafe unwraps with proper error handling

### DIFF
--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -126,6 +126,7 @@ impl Bus {
     /// Returns true on success, otherwise `data` is untouched.
     pub fn read(&self, addr: u64, data: &mut [u8]) -> bool {
         if let Some((offset, dev)) = self.get_device(addr) {
+            // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock().unwrap().read(offset, data);
             true
         } else {
@@ -138,6 +139,7 @@ impl Bus {
     /// Returns true on success, otherwise `data` is untouched.
     pub fn write(&self, addr: u64, data: &[u8]) -> bool {
         if let Some((offset, dev)) = self.get_device(addr) {
+            // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock().unwrap().write(offset, data);
             true
         } else {

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -17,7 +17,7 @@ mod bus;
 pub mod legacy;
 pub mod virtio;
 
-pub use self::bus::{Bus, BusDevice};
+pub use self::bus::{Bus, BusDevice, Error as BusError};
 
 pub type DeviceEventT = u16;
 

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -273,12 +273,12 @@ impl BusDevice for MmioDevice {
                     self.device
                         .activate(
                             mem,
-                            interrupt_evt.try_clone().unwrap(),
+                            interrupt_evt.try_clone().expect("Failed to clone eventfd"),
                             self.interrupt_status.clone(),
                             self.queues.clone(),
                             self.queue_evts.split_off(0),
                         )
-                        .unwrap();
+                        .expect("Failed to activate device");
                     self.device_activated = true;
                 }
             }

--- a/fc_util/src/lri_hash_map.rs
+++ b/fc_util/src/lri_hash_map.rs
@@ -26,9 +26,10 @@ where
 
     // This should only be called when the LriHashMap is full.
     fn make_room_for_new_key(&mut self) {
-        // Being full should imply list len > 0.
+        // Being full should imply list len > 0. Otherwise, something is very wrong and unwrap()
+        // should panic.
         let old_key = self.keys_ordered_by_insertion_time.pop_back().unwrap();
-        // If old_key was in the list, it should also be in the map.
+        // If old_key was in the list, it should also be in the map, therefore unwrap() is safe.
         self.hash_map.remove(&old_key).unwrap();
     }
 
@@ -45,7 +46,7 @@ where
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         let key_already_present = self.contains_key(&k);
         if self.keys_ordered_by_insertion_time.len() == self.capacity && !key_already_present {
-            self.make_room_for_new_key()
+            self.make_room_for_new_key();
         }
 
         self.do_insert(k, v, key_already_present)

--- a/sys_util/src/guest_memory.rs
+++ b/sys_util/src/guest_memory.rs
@@ -18,6 +18,7 @@ pub enum Error {
     InvalidGuestAddress(GuestAddress),
     MemoryAccess(GuestAddress, mmap::Error),
     MemoryMappingFailed(mmap::Error),
+    MemoryNotInitialized,
     MemoryRegionOverlap,
     NoMemoryRegions,
     RegionOperationFailed,

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -6,6 +6,7 @@ use sys_util::{self, EventFd, Terminal};
 
 #[derive(Debug)]
 pub enum Error {
+    BusError(devices::BusError),
     EventFd(sys_util::Error),
     StdinHandle(sys_util::Error),
 }
@@ -51,7 +52,7 @@ impl LegacyDeviceManager {
     pub fn register_devices(&mut self) -> Result<()> {
         self.io_bus
             .insert(self.stdio_serial.clone(), 0x3f8, 0x8)
-            .unwrap();
+            .map_err(|err| Error::BusError(err))?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -60,7 +61,7 @@ impl LegacyDeviceManager {
                 0x2f8,
                 0x8,
             )
-            .unwrap();
+            .map_err(|err| Error::BusError(err))?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -69,7 +70,7 @@ impl LegacyDeviceManager {
                 0x3e8,
                 0x8,
             )
-            .unwrap();
+            .map_err(|err| Error::BusError(err))?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -78,12 +79,14 @@ impl LegacyDeviceManager {
                 0x2e8,
                 0x8,
             )
-            .unwrap();
+            .map_err(|err| Error::BusError(err))?;
         self.stdin_handle
             .lock()
             .set_raw_mode()
             .map_err(|e| Error::StdinHandle(e))?;
-        self.io_bus.insert(self.i8042.clone(), 0x064, 0x1).unwrap();
+        self.io_bus
+            .insert(self.i8042.clone(), 0x064, 0x1)
+            .map_err(|err| Error::BusError(err))?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Changes

* propagate errors for proper handling
* log errors where propagation isn't an option
* add explanatory comments to "safe" `unwrap()`s where necessary
* leave `unwrap()`s with convincing explanations unchanged

Addresses #132

## Analysis of the remaining `unwrap()`s

|Source directory | Source File | # of occurrences | Reasoning |
|-------|----------|------------------|----------|
|api_server/src | http_service.rs | 3 | explanatory comments for safe unwraps, unit tests|
|api_server/src/request/async | mod.rs | 3 | unit tests|
|api_server/src/request/sync | net.rs | 2 | unit tests|
|devices/src/legacy | i8042.rs | 2 | unit tests|
|devices/src/legacy | serial.rs.rs | 12 | unit tests|
|devices/src/virtio | block.rs | 69 | explanatory comments for safe unwraps, unit tests|
|devices/src/virtio | mmio.rs | 10 | explanatory comments for safe unwraps, unit tests|
|devices/src/virtio | net.rs | 23 | explanatory comments for safe unwraps, unit tests|
|devices/src/virtio | queue.rs | 20 | explanatory comments for safe unwraps, unit tests|
|fc_util/src | lri_hash_map.rs | 1 | unit tests|
|kernel_loader/src | lib.rs | 8 | unit tests|
|kvm/src | lib.rs | 78 | unit tests|
|logger/src | lib.rs | 6 | unit tests|
|logger/src | writers.rs | 5 | unit tests|
|memory_model/src | volatile_memory.rs | 10 | unit tests|
|net_util/src | lib.rs | 1 | unit tests|
|net_util/src | mac.rs | 1 | unit tests|
|net_util/src | tap.rs | 38 | unit tests|
|src | main.rs | 3 | panic by design if unwrap fails|
|sys_util/src | eventfd.rs | 6 | unit tests|
|sys_util/src | guest_memory.rs | 26 | unit tests|
|sys_util/src | mmap.rs | 34 | unit tests|
|sys_util/src | signal.rs | 1 | unit tests|
|sys_util/src | struct_util.rs | 2 | unit tests|
|sys_util/src | tempdir.rs | 6 | explanatory comments for safe unwraps, unit tests|
|sys_util/src | terminal.rs | 1 | unit tests|
|vmm/src | api_logger_config.rs | 2 | unit tests|
|vmm/src | kernel_cmdline.rs | 1 | unit tests|
|vmm/src | lib.rs | 35 | explanatory comments for safe unwraps, panic by design if unwrap fails, unit tests|
|vmm/src | vstate.rs | 23 | explanatory comments for safe unwraps, unit tests|
|vmm/src/device_config | drive.rs | 8 | unit tests|
|vmm/src/device_manager | legacy.rs | 2 | unit tests|
|vmm/src/device_manager | mmio.rs | 9 | unit tests|
|x86_64/src | interrupts.rs | 2 | explanatory comments for safe unwraps|
|x86_64/src | mptable.rs | 19 | unit tests|
|x86_64/src | regs.rs | 4 | unit tests|

## Analysis of `expect()`s

|srcdir|src file|# of occurrences|reasoning|
|------|--------|----------------|---------|
|api_server/src/request/sync|net.rs|3|unit tests|
|kvm/src|lib.rs|10|unit tests|
|net_util/src|mac.rs|2|unit tests|
|src|main.rs|3|panic by design if expect fails, unit tests|
|sys_util/src|signal.rs|1|unit tests|
|vmm/src|kernel_cmdline.rs|1|unit tests|
|vmm/src|lib.rs|18|panic by design if expect fails|
|vmm/src|vstate.rs|12|unit tests|


# Testing done

```bash
cargo fmt --all
cargo build
cargo build --release
sudo env "PATH=$PATH" cargo test --all # all passed
sudo env PATH=$PATH python3 -m pytest # all passed, coverage 73.3%
```