### PR TITLE
api: spawn API server in a new thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 clap = "=2.27.1"
 
 api_server = { path = "api_server" }
+sys_util = { path = "sys_util" }
 vmm = { path = "vmm" }
 
 [profile.release]

--- a/sys_util/src/lib.rs
+++ b/sys_util/src/lib.rs
@@ -9,9 +9,9 @@ extern crate memory_model;
 
 #[macro_use]
 pub mod ioctl;
+pub mod eventfd;
 
 mod errno;
-mod eventfd;
 mod guest_address;
 mod guest_memory;
 mod mmap;


### PR DESCRIPTION
# Changes
* fire the API server in a new thread instead of the main thread to handle API thread `panic!`s better
* use `Arc` instead of `Rc` for the API server's `EventFd` because it's now being sent to another thread and `Rc` is not thread safe

Fixes #128

# Testing done

## Unit tests

```bash
cargo fmt --all
cargo build
cargo build --release
sudo env "PATH=$PATH" cargo test --all # all passed
sudo env PATH=$PATH python3 -m pytest # all passed, coverage 73.4%
```
## Custom panic test

```diff
diff --git a/api_server/src/http_service.rs b/api_server/src/http_service.rs
index 3261812..c3c2671 100644
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -256,6 +256,9 @@ fn parse_request<'a>(
     path: &'a str,
     body: &Chunk,
 ) -> Result<'a, ParsedRequest> {
+
+    panic!("test panic");
+
     // Commenting this out for now.
     /*
     if cfg!(debug_assertions) {

```

```bash
$ sudo rm -f /tmp/firecracker.socket && sudo target/x86_64-unknown-linux-musl/debug/firecracker --api-sock /tmp/firecracker.socket
$ sudo curl --unix-socket /tmp/firecracker.socket -i -X GET "http://localhost/"  -H "Content-Type: application/json"

thread '<unnamed>' panicked at 'test panic', api_server/src/http_service.rs:260:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread 'main' panicked at 'The API thread has panicked: Any', libcore/result.rs:945:5
```

## Integration tests

```bash
$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/boot-source -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ 
           "boot_source_id": "alinux_kernel",
           "source_type": "LocalImage", 
           "local_image": 
                { 
                    "kernel_image_path": "$PWD/resources/kernels/vmlinux_login_network.bin" 
                }
        }'
HTTP/1.1 201 Created
Content-Length: 0
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/machine-config -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "vcpu_count": 4, "mem_size_mib": 256}'
HTTP/1.1 204 No Content
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/drives/root -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ 
            "drive_id": "root",
            "path_on_host": "$PWD/resources/amis/ami-fea26484.ext4", 
            "is_root_device": true, 
            "permissions": "rw", 
            "state": "Attached"
         }'
HTTP/1.1 201 Created
Content-Length: 0
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/drives/read_only_drive -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ 
            "drive_id": "read_only_drive",
            "path_on_host": "$PWD/rootfs.ext4", 
            "is_root_device": false, 
            "permissions": "ro", 
            "state": "Attached"
         }'
HTTP/1.1 201 Created
Content-Length: 0
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/network-interfaces/1 -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ 
            "iface_id": "1", 
            "host_dev_name": "vmtap33", 
            "guest_mac": "06:00:00:00:00:01", 
            "state": "Attached" 
        }'
HTTP/1.1 201 Created
Content-Length: 0
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X PUT http://localhost/actions/start -H 'accept: application/json' -H 'Content-Type: application/json' -d '{  
            "action_id": "start",  
            "action_type": "InstanceStart"
         }'
HTTP/1.1 201 Created
Content-Length: 0
Date: Mon, 21 May 2018 13:08:25 GMT

$ curl --unix-socket /tmp/firecracker.socket -i -X GET http://localhost/actions/start -H 'accept: application/json'
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Date: Mon, 21 May 2018 13:08:25 GMT

{"action_id":"start","action_type":"InstanceStart","timestamp":0}
```