### PR TITLE
Cpuid ht from api

### DIFF
--- a/api/swagger/firecracker-beta.yaml
+++ b/api/swagger/firecracker-beta.yaml
@@ -170,7 +170,7 @@ paths:
     get:
       summary: Get the machine configuration of the VM.
       description: Get the machine configuration of the VM. When called before the PUT operation, it will return
-                   the default values for the vCPU count (=1) and the memory size (=128 MiB).
+                   the default values for the vCPU count (=1), memory size (=128 MiB) and Hyperthreading is enabled.
       responses:
         200:
           description: OK
@@ -184,7 +184,9 @@ paths:
     put:
       summary: Updates the Virtual Machine Configuration with the specified input.
                The Machine Configuration has default values for the vCPU count (=1) and the memory size (=256 MiB).
-               May fail if update is not possible.
+               When Hyperthreading is enabled, the vCPU count has to be either 1 or an even number. When Hyperthreading
+               is disabled, there are no restrictions regarding the vCPU count.
+               If one of the parameters does not have a correct value, the update fails and no fields are updated.
       operationId: putMachineConfiguration
       parameters:
       - name: body
@@ -361,8 +363,8 @@ definitions:
   MachineConfiguration:
     type: object
     description:
-      Machine Configuration descriptor by which you can specify the number of vCPU of one machine with vcpu_count
-      and the memory size in MiB with mem_size_mib
+      Machine Configuration descriptor by which you can specify the number of vCPU of one machine with vcpu_count,
+      the memory size in MiB with mem_size_mib and whether Hyperthreading is enabled/disabled with hyperthreading_enable
     properties:
       vcpu_count:
         type: integer
@@ -370,6 +372,9 @@ definitions:
       mem_size_mib:
         type: integer
         description: Memory size of VM
+      hyperthreading_enable:
+        type: bool
+        description: Flag for enabling/disabling Hyperthreading
 
   NetworkInterface:
     type: object

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -210,6 +210,7 @@ fn parse_machine_config_req<'a>(
             let empty_machine_config = MachineConfiguration {
                 vcpu_count: None,
                 mem_size_mib: None,
+                ht_enabled: None,
             };
             Ok(empty_machine_config
                 .into_parsed_request(method)
@@ -866,7 +867,8 @@ mod tests {
         let path_tokens: Vec<&str> = path[1..].split_terminator('/').collect();
         let json = "{
                 \"vcpu_count\": 42,
-                \"mem_size_mib\": 1025
+                \"mem_size_mib\": 1025,
+                \"ht_enabled\": true
               }";
         let body: Chunk = Chunk::from(json);
 
@@ -886,6 +888,7 @@ mod tests {
         let mcb = MachineConfiguration {
             vcpu_count: Some(42),
             mem_size_mib: Some(1025),
+            ht_enabled: Some(true),
         };
 
         match mcb.into_parsed_request(Method::Put) {

--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -23,7 +23,7 @@ impl GenerateResponse for PutMachineConfigurationError {
                 StatusCode::BadRequest,
                 json_fault_message(
                     "The vCPU number is invalid! The vCPU number can only \
-                     be 1 or an even number.",
+                     be 1 or an even number when hyperthreading is enabled.",
                 ),
             ),
             InvalidMemorySize => json_response(
@@ -77,12 +77,16 @@ impl GenerateResponse for MachineConfiguration {
             Some(v) => v.to_string(),
             None => String::from("Uninitialized"),
         };
+        let ht_enabled = match self.ht_enabled {
+            Some(v) => v.to_string(),
+            None => String::from("Uninitialized"),
+        };
 
         json_response(
             StatusCode::Ok,
             format!(
-                "{{ \"vcpu_count\": {:?}, \"mem_size_mib\": {:?} }}",
-                vcpu_count, mem_size
+                "{{ \"vcpu_count\": {:?}, \"mem_size_mib\": {:?},  \"ht_enabled\": {:?} }}",
+                vcpu_count, mem_size, ht_enabled
             ),
         )
     }
@@ -152,6 +156,7 @@ mod tests {
         let body = MachineConfiguration {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
+            ht_enabled: Some(true),
         };
         let (sender, receiver) = oneshot::channel();
         assert!(
@@ -165,6 +170,7 @@ mod tests {
         let uninitialized = MachineConfiguration {
             vcpu_count: None,
             mem_size_mib: None,
+            ht_enabled: None,
         };
         assert!(
             uninitialized

--- a/data_model/src/vm/machine_config.rs
+++ b/data_model/src/vm/machine_config.rs
@@ -4,6 +4,8 @@ pub struct MachineConfiguration {
     pub vcpu_count: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mem_size_mib: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ht_enabled: Option<bool>,
 }
 
 impl Default for MachineConfiguration {
@@ -11,6 +13,7 @@ impl Default for MachineConfiguration {
         MachineConfiguration {
             vcpu_count: Some(1),
             mem_size_mib: Some(128),
+            ht_enabled: Some(true),
         }
     }
 }


### PR DESCRIPTION
## Changes
* Changed put_machine_configuration function to receive as parameter the MachineConfiguration object directly. Previously it received vcpu_count and mem_size_mib separately because the MachineConfigurationBody was defined in another crate. As part of this commit, also added a unit test for this method.
* Removed the num_cpus crate. The function that replaces the functionality of num_cpus::get() is added for now in vmm/src/lib.rs, but I will move it to x86_64/src/lib.rs after my other PR (#284) is merged.
* Add ht_enabled field to the MachineConfiguration. Hyperthreading can be enabled/disable via the API with a PUT on /machine-config. As all the other fields, this one is also optional. By default hyperthreading is enabled.

## Testing Done
### Build Time
The usual + Added a unit test for put_machine_configuration.
Code Coverage = 73.9% (before it was 73.6%)

### CI Like
**2 vcpus, hyperthreading enabled**
> lscpu 
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                2
On-line CPU(s) list:   0,1
Thread(s) per core:    2
Core(s) per socket:    1
Socket(s):             1
NUMA node(s):          1

> lscpu | grep "ht" 
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss **ht** syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon rep_good nopl xtopology nonstop_tsc eagerfpu pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt arat

**2 vcpus, hyperthread disabled**
> lscpu     
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                2
On-line CPU(s) list:   0,1
Thread(s) per core:    1
Core(s) per socket:    1
Socket(s):             2
NUMA node(s):          1

> lscpu | grep "ht"
nada de nada
