### PR TITLE
Allow setting up multiple network-interfaces with autogenerated MAC

### DIFF
--- a/vmm/src/device_config/net.rs
+++ b/vmm/src/device_config/net.rs
@@ -69,7 +69,7 @@ impl NetworkInterfaceConfigs {
                 return Ok(SyncOkStatus::Updated);
             }
 
-            if device_config.guest_mac() == cfg.guest_mac() {
+            if cfg.guest_mac().is_some() && device_config.guest_mac() == cfg.guest_mac() {
                 return Err(SyncError::GuestMacAddressInUse);
             }
         }


### PR DESCRIPTION
## Changes
When configuring network-interfaces through the API, the 'guest_mac'
field is optional. Omitting this field results in the MAC address
of the guest network-interface to be autogenerated.

This patch fixes an issue where trying to configure more than one
network-interface with autogenerated MAC addresses would fail.

## Testing
### Build Time
#### Prerequisite
```bash
## add the necessary musl target to the active toolchain
rustup target add x86_64-unknown-linux-musl
```
#### Build tests
```bash
cargo build # no warning
cargo build —release # no warning
sudo env "PATH=$PATH" cargo test --all #no warning
```
### Integration Testing
Create tap on host
```bash
ip tuntap add name vmtap33 mode tap
ifconfig vmtap33 192.168.241.1/24 up
ip tuntap add name vmtap34 mode tap
ifconfig vmtap33 192.168.242.1/24 up
```

Run Firecracker
```bash
rm -f /tmp/firecracker.socket && \
target/x86_64-unknown-linux-musl/debug/firecracker --api-sock=/tmp/firecracker.socket
```

Now try to boot up a machine:
```bash
curl --unix-socket /tmp/firecracker.socket -i  \
     -X PUT "http://localhost/boot-source" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
           \"boot_source_id\": \"alinux_kernel\",
           \"source_type\": \"LocalImage\", 
           \"local_image\": 
                { 
                    \"kernel_image_path\": \"${kernel_path}\" 
                }
        }"

curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/machine-config" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ \"vcpu_count\": 4, \"mem_size_mib\": 256}"

# Add root block device
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/drives/root" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{ 
            \"drive_id\": \"root\",
            \"path_on_host\": \"${rootfs_path}\", 
            \"is_root_device\": true, 
            \"permissions\": \"rw\", 
            \"state\": \"Attached\"
         }"

# Add network interfaces
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/network-interfaces/1" \
     -H "accept: application/json" -H "Content-Type: application/json" \
     -d "{
            \"iface_id\": \"1\",
            \"host_dev_name\": \"vmtap33\",
            \"state\": \"Attached\",
            \"host_ip\": \"192.168.241.1\"
         }"
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/network-interfaces/2" \
     -H "accept: application/json" -H "Content-Type: application/json" \
     -d "{
            \"iface_id\": \"2\",
            \"host_dev_name\": \"vmtap34\",
            \"state\": \"Attached\",
            \"host_ip\": \"192.168.242.1\"
         }"

# Start the instance
curl --unix-socket /tmp/firecracker.socket -i \
     -X PUT "http://localhost/actions/start" \
     -H  "accept: application/json" \
     -H  "Content-Type: application/json" \
     -d "{  
            \"action_id\": \"start\",  
            \"action_type\": \"InstanceStart\"
         }"

# Get the response of starting the instance
curl --unix-socket /tmp/firecracker.socket -i \
     -X GET "http://localhost/actions/start" \
     -H "accept: application/json"

```
Verify interfaces
```bash
# login: ...
root@u408d5cb7e82359d64def:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 3a:7a:26:c8:3d:fc brd ff:ff:ff:ff:ff:ff
3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 72:68:7d:e0:1c:19 brd ff:ff:ff:ff:ff:ff
```