### PR TITLE
Disable check for immediate_exit & remove console=ttyS0

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,7 +56,8 @@ use vstate::{Vcpu, Vm};
 pub const KERNEL_START_OFFSET: usize = 0x200000;
 pub const CMDLINE_OFFSET: usize = 0x20000;
 pub const CMDLINE_MAX_SIZE: usize = KERNEL_START_OFFSET - CMDLINE_OFFSET;
-pub const DEFAULT_KERNEL_CMDLINE: &str = "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules";
+pub const DEFAULT_KERNEL_CMDLINE: &str =
+    "noapic reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0";
 const VCPU_RTSIG_OFFSET: u8 = 0;
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR consists of two commits, which do the following:
* The first removes the check which determines whether the immediate_exit KVM capability is present. We'll defer merging #304 until users no longer require the use of older kernels, and it will be re-enabled by default at that point.
* The second eliminates the option "console=ttyS0" from the default kernel command line. This significantly reduces the number of VM exits during boot (which were mainly caused by serial port accesses), and thus lowers the effective boot time by tens of ms. We also add the "8250.nr_uarts=0" option, which skips even more serial port related initialization time.
