### PR TITLE
Add API Call for Setting the CPU Template

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -218,6 +218,7 @@ fn parse_machine_config_req<'a>(
                 vcpu_count: None,
                 mem_size_mib: None,
                 ht_enabled: None,
+                cpu_template: None,
             };
             Ok(empty_machine_config
                 .into_parsed_request(method)
@@ -516,6 +517,7 @@ impl hyper::server::Service for ApiServerHttpService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use data_model::vm::CPUFeaturesTemplate;
     use fc_util::LriHashMap;
     use futures::sync::oneshot;
     use hyper::header::{ContentType, Headers};
@@ -890,7 +892,8 @@ mod tests {
         let json = "{
                 \"vcpu_count\": 42,
                 \"mem_size_mib\": 1025,
-                \"ht_enabled\": true
+                \"ht_enabled\": true,
+                \"cpu_template\": \"T2\"
               }";
         let body: Chunk = Chunk::from(json);
 
@@ -911,6 +914,7 @@ mod tests {
             vcpu_count: Some(42),
             mem_size_mib: Some(1025),
             ht_enabled: Some(true),
+            cpu_template: Some(CPUFeaturesTemplate::T2),
         };
 
         match mcb.into_parsed_request(Method::Put) {

--- a/data_model/src/vm/machine_config.rs
+++ b/data_model/src/vm/machine_config.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MachineConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -6,6 +8,8 @@ pub struct MachineConfiguration {
     pub mem_size_mib: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ht_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_template: Option<CPUFeaturesTemplate>,
 }
 
 impl Default for MachineConfiguration {
@@ -14,6 +18,20 @@ impl Default for MachineConfiguration {
             vcpu_count: Some(1),
             mem_size_mib: Some(128),
             ht_enabled: Some(false),
+            cpu_template: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum CPUFeaturesTemplate {
+    T2,
+}
+
+impl fmt::Display for CPUFeaturesTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CPUFeaturesTemplate::T2 => write!(f, "T2"),
         }
     }
 }

--- a/data_model/src/vm/mod.rs
+++ b/data_model/src/vm/mod.rs
@@ -1,3 +1,4 @@
 pub mod machine_config;
 
+pub use vm::machine_config::CPUFeaturesTemplate;
 pub use vm::machine_config::MachineConfiguration;

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -147,6 +147,37 @@ def test_api_put_update_pre_boot(test_microvm_any):
     """ Valid updates to the network `host_dev_name` are allowed. """
     assert(test_microvm.api_session.is_good_response(response.status_code))
 
+def test_api_put_machine_config(test_microvm_any):
+    """Tests various scenarios for PUT on /machine_config that cannot be covered by the unit tests"""
+
+    """ Test invalid vcpu count < 0 """
+    test_microvm = test_microvm_any
+    response = test_microvm.api_session.put(
+        test_microvm.microvm_cfg_url,
+        json = {'vcpu_count': '-2'}
+    )
+    assert response.status_code == 400
+
+    """ Test invalid mem_size_mib < 0 """
+    response = test_microvm.api_session.put(
+        test_microvm.microvm_cfg_url,
+        json = {'mem_size_mib': '-2'}
+    )
+    assert response.status_code == 400
+
+    """ Test invalid type for ht_enabled flag """
+    response = test_microvm.api_session.put(
+        test_microvm.microvm_cfg_url,
+        json = {'ht_enabled': 'random_string'}
+    )
+    assert response.status_code == 400
+
+    """ Test invalid CPU template """
+    response = test_microvm.api_session.put(
+        test_microvm.microvm_cfg_url,
+        json = {'cpu_template': 'random_string'}
+    )
+    assert response.status_code == 400
 
 def test_api_put_update_post_boot(test_microvm_any):
     """ Tests that PUT updates are rejected after the microvm boots. """

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -7,7 +7,8 @@ authors = ["The Chromium OS Authors"]
 byteorder = "=1.2.1"
 libc = ">=0.2.39"
 
-memory_model = { path = "../memory_model"}
+data_model = { path = "../data_model" }
 kvm_sys = { path = "../kvm_sys" }
 kvm = { path = "../kvm" }
+memory_model = { path = "../memory_model"}
 sys_util = { path = "../sys_util" }

--- a/x86_64/src/cpuid.rs
+++ b/x86_64/src/cpuid.rs
@@ -1,6 +1,7 @@
-use kvm::CpuId;
-
 use std::result;
+
+use data_model::vm::CPUFeaturesTemplate;
+use kvm::CpuId;
 
 // Basic CPUID Information
 mod leaf_0x1 {
@@ -168,10 +169,6 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     VcpuCountOverflow,
-}
-
-pub enum CPUFeaturesTemplate {
-    T2,
 }
 
 /// This function is used for setting leaf 01H EBX[23-16]

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 extern crate byteorder;
+extern crate data_model;
 extern crate kvm;
 extern crate kvm_sys;
 extern crate libc;


### PR DESCRIPTION
## Changes
Added the cpu template to MachineConfiguration struct.
The default value for the cpu_template is none thus firecracker
starts without a template.

The function for configuring the vcpu needs most of the fields
from the MachineConfiguration (except mem_size_mib), so instead of
passing them individually, just use the whole struct.

## Testing Done
sudo ./testrun.sh -p apt-get => Passed
Coverage (74.5% same as before this PR)
Tested that the same features are exposed to users as before.
