### PR TITLE
Have the logger as a global static variable

### DIFF
--- a/vmm/src/api_logger_config.rs
+++ b/vmm/src/api_logger_config.rs
@@ -1,28 +1,26 @@
 use std::result;
 
 use api_server::request::sync::{APILoggerDescription, APILoggerError, APILoggerLevel};
-use logger::{Level, Logger};
+use logger::{Level, LOGGER};
 
 type Result<T> = result::Result<T, APILoggerError>;
 
 pub fn init_logger(api_logger: APILoggerDescription) -> Result<()> {
-    //there are 3 things we need to get out: the level, whether to show it and whether to show the origin of the log
-    let mut logger = Logger::new();
     let level = from_api_level(api_logger.level);
 
     if let Some(val) = level {
-        logger.set_level(val);
+        LOGGER.set_level(val);
     }
 
     if let Some(val) = api_logger.show_log_origin {
-        logger.set_include_origin(val, val);
+        LOGGER.set_include_origin(val, val);
     }
 
     if let Some(val) = api_logger.show_level {
-        logger.set_include_level(val);
+        LOGGER.set_include_level(val);
     }
 
-    if let Err(ref e) = logger.init(Some(api_logger.path)) {
+    if let Err(ref e) = LOGGER.init(Some(api_logger.path)) {
         return Err(APILoggerError::InitializationFailure(e.to_string()));
     } else {
         Ok(())

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -201,9 +201,9 @@ pub struct EpollEvent {
     event_fd: EventFd,
 }
 
-//This should handle epoll related business from now on. A glaring shortcoming of the current
-//design is the liberal passing around of raw_fds, and duping of file descriptors. This issue
-//will be solved when we also implement device removal.
+// This should handle epoll related business from now on. A glaring shortcoming of the current
+// design is the liberal passing around of raw_fds, and duping of file descriptors. This issue
+// will be solved when we also implement device removal.
 pub struct EpollContext {
     epoll_raw_fd: RawFd,
     stdin_index: u64,


### PR DESCRIPTION
It would be great if the logger was accessible through a global static variable, because it would be much easier to invoke functionalities which go beyond the scope of simply logging messages through the macros exported from the `log` crate.  This PR brings the necessary changes for this goal. More details are available in the individual commit messages.