### PR TITLE
yaml: renamed CPUTemplate to CpuTemplate

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -663,7 +663,7 @@ fn describe(sync: bool, method: &Method, path: &String, body: &String) -> String
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_model::vm::CPUFeaturesTemplate;
+    use data_model::vm::CpuFeaturesTemplate;
     use fc_util::LriHashMap;
     use futures::sync::oneshot;
     use hyper::header::{ContentType, Headers};
@@ -1060,7 +1060,7 @@ mod tests {
             vcpu_count: Some(42),
             mem_size_mib: Some(1025),
             ht_enabled: Some(true),
-            cpu_template: Some(CPUFeaturesTemplate::T2),
+            cpu_template: Some(CpuFeaturesTemplate::T2),
         };
 
         match mcb.into_parsed_request(Method::Put) {

--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -107,7 +107,7 @@ impl IntoParsedRequest for MachineConfiguration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_model::vm::CPUFeaturesTemplate;
+    use data_model::vm::CpuFeaturesTemplate;
 
     #[test]
     fn test_generate_response_put_machine_configuration_error() {
@@ -153,7 +153,7 @@ mod tests {
             vcpu_count: Some(8),
             mem_size_mib: Some(1024),
             ht_enabled: Some(true),
-            cpu_template: Some(CPUFeaturesTemplate::T2),
+            cpu_template: Some(CpuFeaturesTemplate::T2),
         };
         let (sender, receiver) = oneshot::channel();
         assert!(

--- a/api_server/swagger/firecracker-beta.yaml
+++ b/api_server/swagger/firecracker-beta.yaml
@@ -263,7 +263,7 @@ definitions:
         type: string
         description: Kernel boot arguments
 
-  CPUTemplate:
+  CpuTemplate:
     type: string
     description:
       The CPU Template defines a set of flags to be disabled from the microvm so that
@@ -389,7 +389,7 @@ definitions:
         type: boolean
         description: Flag for enabling/disabling Hyperthreading
       cpu_template:
-        $ref: "#/definitions/CPUTemplate"
+        $ref: "#/definitions/CpuTemplate"
 
   NetworkInterface:
     type: object

--- a/data_model/src/vm/machine_config.rs
+++ b/data_model/src/vm/machine_config.rs
@@ -9,7 +9,7 @@ pub struct MachineConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ht_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_template: Option<CPUFeaturesTemplate>,
+    pub cpu_template: Option<CpuFeaturesTemplate>,
 }
 
 impl Default for MachineConfiguration {
@@ -24,16 +24,16 @@ impl Default for MachineConfiguration {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub enum CPUFeaturesTemplate {
+pub enum CpuFeaturesTemplate {
     C3,
     T2,
 }
 
-impl fmt::Display for CPUFeaturesTemplate {
+impl fmt::Display for CpuFeaturesTemplate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CPUFeaturesTemplate::C3 => write!(f, "C3"),
-            CPUFeaturesTemplate::T2 => write!(f, "T2"),
+            CpuFeaturesTemplate::C3 => write!(f, "C3"),
+            CpuFeaturesTemplate::T2 => write!(f, "T2"),
         }
     }
 }

--- a/data_model/src/vm/mod.rs
+++ b/data_model/src/vm/mod.rs
@@ -1,4 +1,4 @@
 pub mod machine_config;
 
-pub use vm::machine_config::CPUFeaturesTemplate;
+pub use vm::machine_config::CpuFeaturesTemplate;
 pub use vm::machine_config::MachineConfiguration;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1306,7 +1306,7 @@ pub fn start_vmm_thread(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_model::vm::CPUFeaturesTemplate;
+    use data_model::vm::CpuFeaturesTemplate;
 
     fn create_vmm_object() -> Vmm {
         let shared_info = Arc::new(RwLock::new(InstanceInfo {
@@ -1388,7 +1388,7 @@ mod tests {
             vcpu_count: Some(1),
             mem_size_mib: Some(0),
             ht_enabled: Some(false),
-            cpu_template: Some(CPUFeaturesTemplate::T2),
+            cpu_template: Some(CpuFeaturesTemplate::T2),
         };
         assert_eq!(
             vmm.put_virtual_machine_configuration(machine_config)
@@ -1421,7 +1421,7 @@ mod tests {
             vcpu_count: Some(2),
             mem_size_mib: None,
             ht_enabled: Some(true),
-            cpu_template: Some(CPUFeaturesTemplate::T2),
+            cpu_template: Some(CpuFeaturesTemplate::T2),
         };
         assert!(
             vmm.put_virtual_machine_configuration(machine_config)
@@ -1429,7 +1429,7 @@ mod tests {
         );
         assert_eq!(vmm.vm_config.vcpu_count, Some(2));
         assert_eq!(vmm.vm_config.ht_enabled, Some(true));
-        assert_eq!(vmm.vm_config.cpu_template, Some(CPUFeaturesTemplate::T2));
+        assert_eq!(vmm.vm_config.cpu_template, Some(CpuFeaturesTemplate::T2));
     }
 
     #[test]

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -211,7 +211,7 @@ impl Vcpu {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data_model::vm::CPUFeaturesTemplate;
+    use data_model::vm::CpuFeaturesTemplate;
 
     #[test]
     fn create_vm() {
@@ -257,10 +257,10 @@ mod tests {
         assert_eq!(vcpu.get_cpuid(), vm.fd.get_supported_cpuid());
         assert!(cpuid::filter_cpuid(0, 1, true, &mut vcpu.cpuid).is_ok());
         // Test using the T2 template
-        cpuid::set_cpuid_template(CPUFeaturesTemplate::T2, &mut vcpu.cpuid);
+        cpuid::set_cpuid_template(CpuFeaturesTemplate::T2, &mut vcpu.cpuid);
         assert!(vcpu.fd.set_cpuid2(&vcpu.cpuid).is_ok());
         // Test using the C3 template
-        cpuid::set_cpuid_template(CPUFeaturesTemplate::C3, &mut vcpu.cpuid);
+        cpuid::set_cpuid_template(CpuFeaturesTemplate::C3, &mut vcpu.cpuid);
         assert!(vcpu.fd.set_cpuid2(&vcpu.cpuid).is_ok());
     }
 

--- a/x86_64/src/cpuid/mod.rs
+++ b/x86_64/src/cpuid/mod.rs
@@ -1,7 +1,7 @@
 use std::result;
 
 use cpuid::cpu_leaf::*;
-use data_model::vm::CPUFeaturesTemplate;
+use data_model::vm::CpuFeaturesTemplate;
 use kvm::CpuId;
 
 mod cpu_leaf;
@@ -44,11 +44,11 @@ fn str_to_u32(string: &str) -> u32 {
         | (str_bytes[3] as u32);
 }
 
-pub fn set_cpuid_template(template: CPUFeaturesTemplate, kvm_cpuid: &mut CpuId) {
+pub fn set_cpuid_template(template: CpuFeaturesTemplate, kvm_cpuid: &mut CpuId) {
     let entries = kvm_cpuid.mut_entries_slice();
     match template {
-        CPUFeaturesTemplate::T2 => t2_template::set_cpuid_entries(entries),
-        CPUFeaturesTemplate::C3 => c3_template::set_cpuid_entries(entries),
+        CpuFeaturesTemplate::T2 => t2_template::set_cpuid_entries(entries),
+        CpuFeaturesTemplate::C3 => c3_template::set_cpuid_entries(entries),
     }
 }
 
@@ -231,7 +231,7 @@ mod tests {
             _ => assert!(false),
         };
 
-        set_cpuid_template(CPUFeaturesTemplate::T2, &mut kvm_cpuid);
+        set_cpuid_template(CpuFeaturesTemplate::T2, &mut kvm_cpuid);
 
         let entries = kvm_cpuid.mut_entries_slice();
         // TODO: This should be tested as part of the CI; only check that the function result is ok


### PR DESCRIPTION
Apparently there is a problem with the go swagger codegenerator
if the definitions are not in strict InitialCamelCase.

Signed-off-by: Andreea Florescu <fandree@amazon.com>