### PR TITLE
Switch from TRACE to INFO

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -518,7 +518,7 @@ impl hyper::server::Service for ApiServerHttpService {
 
                         let b_str = String::from_utf8_lossy(&b.to_vec()).to_string();
                         let path_dbg = path.clone();
-                        trace!("Sent {}", describe(false, &method_copy, &path, &b_str));
+                        info!("Sent {}", describe(false, &method_copy, &path, &b_str));
 
                         // We have to explicitly spawn a future that will handle the outcome of the
                         // async request.
@@ -538,7 +538,7 @@ impl hyper::server::Service for ApiServerHttpService {
                                             match outcome {
                                                 AsyncOutcome::Ok(timestamp) => {
                                                     async_body.set_timestamp(timestamp);
-                                                    trace!(
+                                                    info!(
                                                         "Received Success on {}",
                                                         describe(
                                                             false,
@@ -555,7 +555,7 @@ impl hyper::server::Service for ApiServerHttpService {
                                                     )
                                                 }
                                                 AsyncOutcome::Error(msg) => {
-                                                    trace!(
+                                                    info!(
                                                         "Received Error on {}",
                                                         describe(
                                                             false,
@@ -610,7 +610,7 @@ impl hyper::server::Service for ApiServerHttpService {
                         let path_copy_err = path_copy.clone();
                         let method_copy_err = method_copy.clone();
 
-                        trace!("Sent {}", describe(true, &method_copy, &path, &b_str));
+                        info!("Sent {}", describe(true, &method_copy, &path, &b_str));
 
                         // Sync requests don't receive a response until the outcome is returned.
                         // Once more, this just registers a closure to run when the result is
@@ -618,14 +618,14 @@ impl hyper::server::Service for ApiServerHttpService {
                         Either::B(
                             outcome_receiver
                                 .map(move |x| {
-                                    trace!(
+                                    info!(
                                         "Received Success on {}",
                                         describe(true, &method_copy, &path_copy, &b_str)
                                     );
                                     x.generate_response()
                                 })
                                 .map_err(move |_| {
-                                    trace!(
+                                    info!(
                                         "Received Error on {}",
                                         describe(
                                             true,

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -400,7 +400,7 @@ impl Logger {
 impl Log for Logger {
     // test whether a log level is enabled for the current module
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() as usize <= self.level_info.code() || metadata.level() == Level::Trace
+        metadata.level() as usize <= self.level_info.code()
     }
 
     fn log(&self, record: &Record) {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -892,7 +892,7 @@ impl Vmm {
 
     /// make sure to check Result of this function and call self.stop() in case of Err
     pub fn start_instance(&mut self) -> Result<()> {
-        trace!("VMM received instance start command");
+        info!("VMM received instance start command");
         self.check_health()?;
 
         // unwrap() to crash if the other thread poisoned this lock
@@ -925,7 +925,7 @@ impl Vmm {
     }
 
     pub fn stop(&mut self) -> Result<()> {
-        trace!("VMM received instance stop command");
+        info!("VMM received instance stop command");
         // unwrap() to crash if the other thread poisoned this lock
         let mut shared_info = self.shared_info.write().unwrap();
         shared_info.state = InstanceState::Halting;


### PR DESCRIPTION
The TRACE! level was enabled by default for metrics logging purposes and that lead to unbound output given that the logger captures all messages from all crates.
I removed having the trace level treated specially and the messages signaling special events have now the info! level and logging output decreased considerably. See below:
```
2018-06-14T11:32:34.493234880 [INFO:api_server/src/http_service.rs:541] Received Success on asynchronous Put request "/actions/start" with body "{  \n            \"action_id\": \"start\",  \n            \"action_type\": \"InstanceStart\"\n         }"
{"utc_timestamp_ms":1528994014493,"api_server":{"async_missed_actions_count":0,"async_outcome_fails":0,"async_vmm_send_timeout_count":0,"instance_info_fails":0,"sync_outcome_fails":0,"sync_vmm_send_timeout_count":0},"block":{"activate_fails":0,"cfg_fails":0,"event_fails":0,"execute_fails":0,"invalid_reqs_count":0,"flush_count":0,"queue_event_count":1519,"rate_limiter_event_count":0,"read_count":46393344,"write_count":3887104},"get_api_requests":{"action_info_count":0,"actions_count":0,"actions_fails":0,"instance_info_count":0,"machine_cfg_count":0,"machine_cfg_fails":0},"i8042":{"error_count":0,"missed_read_count":0,"missed_write_count":0,"read_count":0,"reset_count":0,"write_count":0},"net":{"activate_fails":0,"cfg_fails":0,"event_fails":0,"rx_bytes_count":0,"rx_packets_count":0,"rx_event_rate_limiter_count":0,"rx_fails":0,"rx_queue_event_count":0,"rx_tap_event_count":0,"tx_bytes_count":0,"tx_packets_count":0,"tx_rate_limiter_event_count":0,"tx_fails":0,"tx_queue_event_count":0},"put_api_requests":{"actions_count":1,"actions_fails":0,"boot_source_count":1,"boot_source_fails":0,"drive_fails":0,"drive_count":1,"logger_count":1,"logger_fails":0,"machine_cfg_count":0,"machine_cfg_fails":0,"network_count":0,"network_fails":0},"vcpu":{"eagain":0,"eintr":0,"exit_io_in":15525,"exit_io_out":17146,"exit_mmio_read":1517,"exit_mmio_write":1519,"failures":0},"vmm":{"device_events":1519},"uart":{"error_count":0,"flush_count":15358,"missed_read_count":0,"missed_write_count":0,"read_count":84,"write_count":15358}}
```
