### PR TITLE
Jailer last-minute enhancements

### DIFF
--- a/jailer/src/env.rs
+++ b/jailer/src/env.rs
@@ -20,7 +20,7 @@ pub struct Env {
 impl Env {
     pub fn new(args: JailerArgs) -> Result<Self> {
         let exec_file_name = args.exec_file_name()?;
-        let cgroup = Cgroup::new(args.id, exec_file_name)?;
+        let cgroup = Cgroup::new(args.id, args.numa_node, exec_file_name)?;
 
         let mut chroot_dir = PathBuf::from(&args.chroot_base_dir);
 

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -40,6 +40,7 @@ pub enum Error {
     NotAFile(PathBuf),
     NotAFolder(PathBuf),
     NotAlphanumeric(String),
+    NumaNode(String),
     OpenDevKvm(sys_util::Error),
     OpenDevNetTun(sys_util::Error),
     ReadLine(PathBuf, io::Error),
@@ -57,6 +58,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 pub struct JailerArgs<'a> {
     id: &'a str,
+    numa_node: u32,
     exec_file_path: PathBuf,
     chroot_base_dir: PathBuf,
     uid: u32,
@@ -66,6 +68,7 @@ pub struct JailerArgs<'a> {
 impl<'a> JailerArgs<'a> {
     pub fn new(
         id: &'a str,
+        node: &str,
         exec_file: &str,
         chroot_base: &str,
         uid: &str,
@@ -77,6 +80,9 @@ impl<'a> JailerArgs<'a> {
                 return Err(Error::NotAlphanumeric(id.to_string()));
             }
         }
+
+        let numa_node = node.parse::<u32>()
+            .map_err(|_| Error::NumaNode(String::from(node)))?;
 
         let exec_file_path =
             canonicalize(exec_file).map_err(|e| Error::Canonicalize(PathBuf::from(exec_file), e))?;
@@ -105,6 +111,7 @@ impl<'a> JailerArgs<'a> {
 
         Ok(JailerArgs {
             id,
+            numa_node,
             exec_file_path,
             chroot_base_dir,
             uid,

--- a/src/bin/jailer.rs
+++ b/src/bin/jailer.rs
@@ -20,10 +20,17 @@ fn main() -> jailer::Result<()> {
     // Initially, the uid and gid params had default values, but it turns out that it's quite
     // easy to shoot yourself in the foot by not setting proper permissions when preparing the
     // contents of the jail, so I think their values should be provided explicitly.
-    let cmd_arguments = App::new("firejailer")
+    let cmd_arguments = App::new("jailer")
         .version(crate_version!())
         .author(crate_authors!())
         .about("Jail a microVM.")
+        .arg(
+            Arg::with_name("numa_node")
+                .long("node")
+                .help("NUMA node to assign this microVM to.")
+                .required(true)
+                .takes_value(true),
+        )
         .arg(
             Arg::with_name("id")
                 .long("id")
@@ -65,6 +72,7 @@ fn main() -> jailer::Result<()> {
     // All arguments are either mandatory, or have default values, so the unwraps should not fail.
     let args = JailerArgs::new(
         cmd_arguments.value_of("id").unwrap(),
+        cmd_arguments.value_of("numa_node").unwrap(),
         cmd_arguments.value_of("exec_file").unwrap(),
         cmd_arguments.value_of("chroot_base").unwrap(),
         cmd_arguments.value_of("uid").unwrap(),


### PR DESCRIPTION
This PR contains the following:
- We no longer expect to find all three cgroups of interest (cpu, cpuset, and pids) mounted at the same location. Instead, the jailer will now detect partial or individual such mounts, found when parsing `/proc/mounts`, and remember the set of distinct paths. Finally, cgroups subfolders are created for each identified path, and the current PID is added to the respective `tasks` files.
- The base folder for chroot jails is no longer hardcoded to `/srv/jailer`. Instead, we use that as a default path, but will also accept a different path via the optional `--chroot-base-dir` command line parameter.
- The id provided as a parameter to the jailer has to be an alphanumeric string.
- The logic responsible for clearing the FD_CLOEXEC flag for the UDS listener has been improved.
- Small fixes/corrections here and there.