### PR TITLE
Allow partial specification of RateLimiter in API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
             \"host_dev_name\": \"vmtap33\",
             \"guest_mac\": \"06:00:00:00:00:01\",
             \"rx_rate_limiter\": {
-              \"bandwidth\": { \"size\": 100000000, \"refill_time\": 1000 },
-              \"ops\": { \"size\": 0, \"refill_time\": 0 }
+              \"bandwidth\": { \"size\": 100000000, \"refill_time\": 1000 }
             },
             \"state\": \"Attached\"
         }"

--- a/api_server/src/request/sync/net.rs
+++ b/api_server/src/request/sync/net.rs
@@ -85,12 +85,8 @@ mod tests {
             "state": "Attached",
             "guest_mac": "12:34:56:78:9A:bc",
             "rx_rate_limiter": {
-                "bandwidth": { "size": 0, "refill_time": 0 },
-                "ops": { "size": 0, "refill_time": 0 }
             },
             "tx_rate_limiter": {
-                "bandwidth": { "size": 0, "refill_time": 0 },
-                "ops": { "size": 0, "refill_time": 0 }
             }
         }"#;
 


### PR DESCRIPTION
# Changes

A rate limiter can be configured with bandwidth and/or ops rate
limiting capabilities.

Allow specifying just bandwidth or ops parameters when just one
is desired.

This API change/improvement is backwards compatible.

# Integration tests changes:
 - Added API tests for rate limiting.
 - Added a new 'api' capability tag to the S3 microvm resources.
 - Changed test_api.py to use the 'test_microvm_with_api' fixture.

# Note
This PR is meant to be as non-invasive/minimal as possible.
When the 'one-time burst' feature requested by customers will come in, this API code will be refactored.

# Testing done
## Unit tests
```bash
cargo fmt --all
cargo build
cargo build --release
sudo env PATH=$PATH cargo test --all
```

## Dev test
txsize=0 ; txtime=0 ; rxsize=1000000 ; rxtime=1000 ; log_path=`pwd`/out.log ;\
curl --unix-socket /tmp/kata.socket -i -X PUT "http://localhost/boot-source" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"boot_source_id\": \"string\", \"source_type\": \"LocalImage\", \"local_image\": { \"kernel_image_path\": \"/home/local/ANT/acatan/vmlinux.bin\", \"initrd_path\": \"string\" }}" ; \
curl --unix-socket /tmp/kata.socket -i -X PUT "http://localhost/drives/1" -H "acept: application/json" -H "Content-Type: application/json" -d "{ \"drive_id\": \"1\", \"path_on_host\": \"../rootfs.ext4\", \"is_root_device\": true, \"permissions\": \"rw\", \"state\": \"Attached\"}" ; \
curl --unix-socket /tmp/kata.socket -i -X PUT "http://localhost/network-interfaces/1" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"iface_id\": \"1\", \"host_dev_name\": \"vmtap34\", \"state\": \"Attached\", \"host_ip\": \"192.168.200.1\", \"rx_rate_limiter\": { \"bandwidth\": { \"size\": $rxsize, \"refill_time\": $rxtime }}, \"tx_rate_limiter\": { \"bandwidth\": { \"size\": $txsize, \"refill_time\": $txtime }}}" ; \
curl --unix-socket /tmp/kata.socket -i -X PUT "http://localhost/logger" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"path\": \"${log_path}\", \"level\": \"Info\", \"show_level\": false, \"show_log_origin\": false }" ; \
curl --unix-socket /tmp/kata.socket -i -X PUT http://a/actions/start1 -H  "accept: application/json" -H  "Content-Type: application/json" -d "{  \"action_id\": \"start1\",  \"action_type\": \"InstanceStart\"}"