### PR TITLE
cpuid: check if hyperthreading is available on host

### DIFF
--- a/tests/microvm.py
+++ b/tests/microvm.py
@@ -324,6 +324,7 @@ class Microvm:
         self,
         vcpu_count: int=2,
         mem_size_mib: int=256,
+        ht_enabled: bool=True,
         net_iface_count: int=1
     ):
         """
@@ -339,15 +340,14 @@ class Microvm:
 
         responses = []
 
+        """
+        Running Firecracker microvms with hyperthreading disabled when the host has hyperthreading
+        generates a panic. Until we change the host AMI to disable hyperthreading, we need to set
+        ht_enabled=true for Firecracker to start.
+        """
         response = self.api_session.put(
             self.microvm_cfg_url,
-            json={'vcpu_count': vcpu_count}
-        )
-        responses.append(response)
-
-        response = self.api_session.put(
-            self.microvm_cfg_url,
-            json={'mem_size_mib': mem_size_mib}
+            json={'vcpu_count': vcpu_count, 'mem_size_mib': mem_size_mib, 'ht_enabled': ht_enabled}
         )
         responses.append(response)
 

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -255,7 +255,7 @@ mod tests {
         let mut vm = Vm::new(&kvm).unwrap();
         let mut vcpu = Vcpu::new(0, &mut vm).unwrap();
         assert_eq!(vcpu.get_cpuid(), vm.fd.get_supported_cpuid());
-        assert!(cpuid::filter_cpuid(0, 1, true, &mut vcpu.cpuid).is_ok());
+        assert!(cpuid::filter_cpuid(0, 2, true, &mut vcpu.cpuid).is_ok());
         // Test using the T2 template
         cpuid::set_cpuid_template(CpuFeaturesTemplate::T2, &mut vcpu.cpuid);
         assert!(vcpu.fd.set_cpuid2(&vcpu.cpuid).is_ok());

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -10,5 +10,6 @@ libc = ">=0.2.39"
 data_model = { path = "../data_model" }
 kvm_sys = { path = "../kvm_sys" }
 kvm = { path = "../kvm" }
+logger = { path = "../logger" }
 memory_model = { path = "../memory_model"}
 sys_util = { path = "../sys_util" }

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -3,10 +3,13 @@
 // found in the LICENSE file.
 
 extern crate byteorder;
+extern crate libc;
+
 extern crate data_model;
 extern crate kvm;
 extern crate kvm_sys;
-extern crate libc;
+#[macro_use]
+extern crate logger;
 extern crate memory_model;
 extern crate sys_util;
 


### PR DESCRIPTION
... before enabling/disabling it.

When the host has logical cpus as hyperthreads, but the client
disables hyperhtreads through the API, we will panic and firecracker
should crash after logging an error. The reason behind panic-ing
is that on the host the hyperthreads of the same core are not
co-scheduled. We want to make sure that the client is aware that
hyperthreading on the host cannot be disabled by Firecracker, but
it has to be disabled before running Firecracker with ht_enabled
set to false.

When the host has logical cpus as full cores, but the client
enables hyperthreading, we will log a warning and continue with the
execution because there is no security issue involved here, but rather
the topology of the guest will report full cores as hyperhtreads.

Signed-off-by: Andreea Florescu <fandree@amazon.com>