### PR TITLE
Use sigaction instead of signal

### DIFF
--- a/seccomp/src/seccomp.rs
+++ b/seccomp/src/seccomp.rs
@@ -199,7 +199,13 @@ extern "C" fn sigsys_handler(
 }
 
 pub fn setup_sigsys_handler() -> Result<(), sys_util::Error> {
-    return unsafe { sys_util::register_signal_handler_sigaction(libc::SIGSYS, sigsys_handler) };
+    return unsafe {
+        sys_util::register_signal_handler(
+            libc::SIGSYS,
+            sys_util::SignalHandler::Siginfo(sigsys_handler),
+            false,
+        )
+    };
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ const MAX_STORED_ASYNC_REQS: usize = 100;
 
 fn main() {
     // If the signal handler can't be set, it's OK to panic.
-    seccomp::setup_sigsys_handler().unwrap();
+    seccomp::setup_sigsys_handler().expect("Failed to register signal handler");
 
     // Start firecracker by setting up a panic hook, which will be called before
     // terminating as we're building with panic = "abort".


### PR DESCRIPTION
# Changes
Replaced `signal` with `sigaction` when registering signal handlers. `signal` is unsafe in multithreaded processes and the man page recommends `sigaction` in its stead. Note that, although simple handlers (without a returned `siginfo` structure) are supported with `sigaction` in C (the `sa_handler` field), the Rust implementation from `libc` declares only the `siginfo` member, so all handler functions need to have the header `void (int, siginfo_t, siginfo_t)`.

# Testing done
## Unit tests
```bash
cargo fmt --all
cargo build
cargo build --release
sudo env PATH=$PATH cargo test --all
sudo env PATH=$PATH cargo kcov --all
```

| File | Coverage |
|------|----------|
| signal.rs | 92.9% |
| total | 73.2% |

## Integration tests
```bash
sudo env PATH=$PATH python3 -m pytest
```
