### PR TITLE
tests: added integration test for CPU Topology

### DIFF
--- a/tests/functional/test_cpu_features.py
+++ b/tests/functional/test_cpu_features.py
@@ -1,0 +1,114 @@
+import time
+
+import pytest
+
+from ssh_connection import SSHConnection
+
+
+def check_cpu_topology(test_microvm, expected_cpu_topology):
+    """
+    Different topologies can be tested the same way once the microvm is started.
+    This is a wrapper function for calling lscpu and checking if the command
+    returns the expected cpu topology.
+    """
+
+    ssh_connection = SSHConnection(test_microvm.slot.ssh_config)
+
+    # Execute the lscpu command to check the guest topology
+    _, stdout, stderr = ssh_connection.execute_command("lscpu")
+    assert (stderr.read().decode("utf-8") == '')
+    # Read Line by line the stdout of lscpu to check the relevant information
+    # regarding the CPU topology
+    while True:
+        line = stdout.readline()
+        if line != '':
+            [key, value] = list(map(lambda x: x.strip(), line.split(':')))
+            if key in expected_cpu_topology.keys():
+                assert value == expected_cpu_topology[key],\
+                    "%s does not have the expected value" % key
+        else:
+            break
+
+    ssh_connection.close()
+
+
+@pytest.mark.timeout(500)
+def test_2vcpu_ht_disabled(test_microvm_with_ssh):
+    test_microvm = test_microvm_with_ssh
+
+    # Set number of vcpu = 2 and ht_enabled=false
+    response = test_microvm.api_session.put(
+        test_microvm.microvm_cfg_url,
+        json={
+            'vcpu_count': 2,
+            'ht_enabled': False,
+        }
+    )
+    assert(test_microvm.api_session.is_good_response(response.status_code))
+
+    # Add the root filesystem
+    response = test_microvm.api_session.put(
+        test_microvm.blk_cfg_url + '/rootfs',
+        json={
+            'drive_id': 'rootfs',
+            'path_on_host': test_microvm.slot.rootfs_file,
+            'is_root_device': True,
+            'permissions': 'rw',
+            'state': 'Attached'
+        }
+    )
+    assert(test_microvm.api_session.is_good_response(response.status_code))
+
+    response = test_microvm.api_session.put(
+        test_microvm.boot_cfg_url,
+        json={
+            'boot_source_id': '1',
+            'source_type': 'LocalImage',
+            'local_image': {'kernel_image_path': test_microvm.slot.kernel_file}
+        }
+    )
+    assert(test_microvm.api_session.is_good_response(response.status_code))
+
+    # Configure the tap device and add the network interface
+    tap_name=test_microvm.slot.make_tap(ip="192.168.241.1/30")
+    # We have to make sure that the microvm will be in the same
+    # subnet as the tap device. The IP of the microvm is computed from the
+    # mac address. To set the IP of the microvm to 192.168.241.2, we
+    # need to set the mac to XX:XX:C0:A8:F1:02, where the first 2 bytes
+    # are ignored and the next 4 bytes form the IP
+    iface_id = "1"
+    test_microvm.api_session.put(
+        "{}/{}".format(test_microvm.net_cfg_url, iface_id),
+        json={
+            "iface_id": iface_id,
+            "host_dev_name": tap_name,
+            "guest_mac": "06:00:C0:A8:F1:02",
+            "state": "Attached"
+        }
+    )
+
+    # we can now update the ssh_config dictionary with the IP of the VM
+    test_microvm.slot.ssh_config['hostname'] = "192.168.241.2"
+
+    # Start the microvm.
+    response = test_microvm.api_session.put(
+        test_microvm.actions_url + '/1',
+        json={'action_id': '1', 'action_type': 'InstanceStart'}
+    )
+    assert(test_microvm.api_session.is_good_response(response.status_code))
+
+    # Wait for the microvm to start.
+    time.sleep(1)
+    # Check that the Instance Start was successful
+    response = test_microvm.api_session.get(test_microvm.actions_url + '/1')
+    assert (test_microvm.api_session.is_good_response(response.status_code))
+
+    expected_cpu_topology = {
+        "CPU(s)": "2",
+        "On-line CPU(s) list": "0,1",
+        "Thread(s) per core": "1",
+        "Core(s) per socket": "2",
+        "Socket(s)": "1",
+        "NUMA node(s)": "1"
+    }
+    check_cpu_topology(test_microvm, expected_cpu_topology)

--- a/tests/microvm_image.py
+++ b/tests/microvm_image.py
@@ -65,6 +65,7 @@ class MicrovmImageS3Fetcher:
     MICROVM_IMAGE_BLOCKDEV_RELPATH = 'fsfiles/'
     MICROVM_IMAGE_KERNEL_FILE_SUFFIX = r'vmlinux.bin'
     MICROVM_IMAGE_ROOTFS_FILE_SUFFIX = r'rootfs.ext4'
+    MICROVM_IMAGE_SSH_KEY_SUFFIX = r'.id_rsa'
     CAPABILITY_KEY_PREFIX = 'capability:'
 
     __shared_state = {}
@@ -154,6 +155,12 @@ class MicrovmImageS3Fetcher:
 
             if resource_key.endswith(self.MICROVM_IMAGE_ROOTFS_FILE_SUFFIX):
                 microvm_slot.rootfs_file = slot_dest_path
+
+            if resource_key.endswith(self.MICROVM_IMAGE_SSH_KEY_SUFFIX):
+                # Add the key path to the config dictionary and set permissions.
+                microvm_slot.ssh_config['ssh_key_path'] = slot_dest_path
+                os.chmod(slot_dest_path, 400)
+
 
     def list_microvm_images(self, capability_filter: List[str]=['*']):
         """

--- a/tests/ssh_connection.py
+++ b/tests/ssh_connection.py
@@ -1,0 +1,41 @@
+import paramiko
+from paramiko import SSHClient
+import os
+
+
+class SSHConnection:
+    """
+    SSHConnection hides the complexity of sending commands to the microVM
+    via ssh.
+
+    This class should be instantiated as part of the ssh fixture with the
+    the hostname obtained from the MAC address, the username for logging into
+    the image and the path of the ssh key.
+
+    The ssh config dictionary contains the following fields:
+    * hostname
+    * username
+    * ssh_key_path
+
+    This translates in a ssh connection as follows:
+    ssh -i ssh_key_path username@hostname
+    """
+
+    def __init__(self, ssh_config):
+        self.ssh_client = SSHClient()
+        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        assert (os.path.exists(ssh_config['ssh_key_path']))
+        self.ssh_client.connect(
+            ssh_config['hostname'],
+            look_for_keys=False,
+            username=ssh_config['username'],
+            key_filename=ssh_config['ssh_key_path']
+        )
+
+    def execute_command(self, cmd_string):
+        """Executes the command passed as a string in the ssh context"""
+        return self.ssh_client.exec_command(cmd_string)
+
+    def close(self):
+        """Closes the SSH connection"""
+        self.ssh_client.close()

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -44,6 +44,7 @@ declare -ra PYTHON_DEPS=( \
      pytest pytest-timeout \
      boto3 \
      requests requests-unixsocket \
+     paramiko \
 )
 
 declare -r RUSTUP_URL=https://sh.rustup.rs
@@ -57,6 +58,8 @@ declare -ra KCOV_APT_GET_DEPS=(\
     gcc g++ cmake \
     binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev \
 )
+
+declare -ra PYTHON_SSH_YUM_DEPS=(python3-devel)
 
 declare -ra GCC_STATIC_YUM_DEPS=(glibc-static)
 # Some tests will build static binaries for use in systems without user space.
@@ -278,6 +281,14 @@ create_python3_venv() {
 }
 
 install_python3_deps() {
+    if [ $PKG_MANAGER == "yum" ]; then
+        say "Setup: Installed python-devel."
+        declare deps="${PYTHON_SSH_YUM_DEPS[@]}"
+        ensure $PKG_MANAGER install -q -y $deps >/dev/null 2>&1
+        say "Setup: Installed python-devel."
+    fi
+    # It looks like on Debian and Ubuntu python-devel -static is included by default.
+
     ensure python3 -m pip install -q "${PYTHON_DEPS[@]}"
     say "Setup: Installed python3 dependencies."
 }


### PR DESCRIPTION
This is the first test from the integration tests that uses ssh
to login into the microvm. For this purpose, a new class was
added to handle the ssh connection and passing commands (SSHConnection).

Also, the microvms with the "capability:ssh" need to have an SSH
configuration file and an ssh key in the fsfiles S3 directory. The path
of these files are saved as fields in the MicrovmSlot and used to
connect to the microvm.

The first test added is testing a microvm with 2 vCPUs and
hyperthreading disabled. It uses lscpu to get the configuration
of the guest and matches it with the expected topology.