### PR TITLE
tests: auto-cleanup of temporary files resulting from unit tests

### DIFF
--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -17,3 +17,4 @@ virtio_sys = { path = "../virtio_sys" }
 
 [dev-dependencies]
 memory_model = { path = "../memory_model"}
+tempfile = ">=3.0.2"

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -634,15 +634,16 @@ impl VirtioDevice for Block {
 
 #[cfg(test)]
 mod tests {
+    extern crate tempfile;
+
+    use self::tempfile::tempfile;
+    use super::*;
+
     use libc;
-    use std::fs::OpenOptions;
-    use std::path::PathBuf;
     use std::sync::mpsc::Receiver;
     use std::thread;
     use std::time::Duration;
-    use sys_util::TempDir;
 
-    use super::*;
     use virtio::queue::tests::*;
 
     struct DummyBlock {
@@ -658,15 +659,7 @@ mod tests {
 
             let epoll_config = EpollConfig::new(0, epoll_raw_fd, sender);
 
-            let tempdir = TempDir::new("/tmp/block_test").unwrap();
-            let mut path = PathBuf::from(tempdir.as_path().unwrap());
-            path.push("disk_image");
-            let f = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .open(&path)
-                .unwrap();
+            let f: File = tempfile().unwrap();
             f.set_len(0x1000).unwrap();
 
             // Rate limiting is enabled but with a high operation rate (10 million ops/s).

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -471,6 +471,7 @@ impl Log for Logger {
 mod tests {
     extern crate tempfile;
 
+    use self::tempfile::NamedTempFile;
     use super::*;
     use log::MetadataBuilder;
 
@@ -521,10 +522,10 @@ mod tests {
 
         assert!(l.log_metrics().is_err());
 
-        let log_file_temp = tempfile::NamedTempFile::new()
-            .expect("Failed to create temporary output logging file.");
-        let metrics_file_temp = tempfile::NamedTempFile::new()
-            .expect("Failed to create temporary metrics logging file.");
+        let log_file_temp =
+            NamedTempFile::new().expect("Failed to create temporary output logging file.");
+        let metrics_file_temp =
+            NamedTempFile::new().expect("Failed to create temporary metrics logging file.");
         let log_file = String::from(log_file_temp.path().to_path_buf().to_str().unwrap());
         let metrics_file = String::from(metrics_file_temp.path().to_path_buf().to_str().unwrap());
 

--- a/logger/src/writers.rs
+++ b/logger/src/writers.rs
@@ -50,12 +50,13 @@ impl PipeLogWriter {
 mod tests {
     extern crate tempfile;
 
+    use self::tempfile::NamedTempFile;
     use super::*;
 
     #[test]
     fn test_new() {
-        let log_file_temp = tempfile::NamedTempFile::new()
-            .expect("Failed to create temporary output logging file.");
+        let log_file_temp =
+            NamedTempFile::new().expect("Failed to create temporary output logging file.");
         let good_file = String::from(log_file_temp.path().to_path_buf().to_str().unwrap());
         let res = PipeLogWriter::new(&good_file);
         assert!(res.is_ok())
@@ -63,8 +64,8 @@ mod tests {
 
     #[test]
     fn test_write() {
-        let log_file_temp = tempfile::NamedTempFile::new()
-            .expect("Failed to create temporary output logging file.");
+        let log_file_temp =
+            NamedTempFile::new().expect("Failed to create temporary output logging file.");
         let file = String::from(log_file_temp.path().to_path_buf().to_str().unwrap());
 
         let fw = PipeLogWriter::new(&file).unwrap();

--- a/sys_util/Cargo.toml
+++ b/sys_util/Cargo.toml
@@ -8,3 +8,6 @@ libc = ">=0.2.39"
 
 memory_model = { path = "../memory_model"}
 
+[dev-dependencies]
+tempfile = ">=3.0.2"
+

--- a/sys_util/src/lib.rs
+++ b/sys_util/src/lib.rs
@@ -17,7 +17,6 @@ mod guest_memory;
 mod mmap;
 mod signal;
 mod struct_util;
-mod tempdir;
 mod terminal;
 
 pub use errno::{errno_result, Error, Result};
@@ -28,7 +27,6 @@ pub use ioctl::*;
 pub use mmap::*;
 pub use signal::*;
 pub use struct_util::*;
-pub use tempdir::*;
 pub use terminal::*;
 
 pub use guest_memory::Error as GuestMemoryError;

--- a/vmm/src/device_config/drive.rs
+++ b/vmm/src/device_config/drive.rs
@@ -157,7 +157,9 @@ impl BlockDeviceConfigs {
 mod tests {
     extern crate tempfile;
 
+    use self::tempfile::NamedTempFile;
     use super::*;
+
     use api_server::request::sync::{DeviceState, DrivePermissions};
 
     #[test]
@@ -169,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_add_non_root_block_device() {
-        let dummy_file = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file = NamedTempFile::new().unwrap();
         let dummy_path = dummy_file.path().to_path_buf();
         let dummy_id = String::from("1");
         let dummy_block_device = BlockDeviceConfig {
@@ -198,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_add_one_root_block_device() {
-        let dummy_file = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file = NamedTempFile::new().unwrap();
         let dummy_path = dummy_file.path().to_path_buf();
 
         let dummy_block_device = BlockDeviceConfig {
@@ -225,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_add_two_root_block_devices_configs() {
-        let dummy_file_1 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_1 = NamedTempFile::new().unwrap();
         let dummy_path_1 = dummy_file_1.path().to_path_buf();
         let root_block_device_1 = BlockDeviceConfig {
             path_on_host: dummy_path_1,
@@ -235,7 +237,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_2 = NamedTempFile::new().unwrap();
         let dummy_path_2 = dummy_file_2.path().to_path_buf();
         let root_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
@@ -256,7 +258,7 @@ mod tests {
     #[test]
     /// Test BlockDevicesConfigs::add when you first add the root device and then the other devices
     fn test_add_root_block_device_first() {
-        let dummy_file_1 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_1 = NamedTempFile::new().unwrap();
         let dummy_path_1 = dummy_file_1.path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1,
@@ -266,7 +268,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_2 = NamedTempFile::new().unwrap();
         let dummy_path_2 = dummy_file_2.path().to_path_buf();
         let dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
@@ -276,7 +278,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_3 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_3 = NamedTempFile::new().unwrap();
         let dummy_path_3 = dummy_file_3.path().to_path_buf();
         let dummy_block_device_3 = BlockDeviceConfig {
             path_on_host: dummy_path_3,
@@ -312,7 +314,7 @@ mod tests {
     #[test]
     /// Test BlockDevicesConfigs::add when you add other devices first and then the root device
     fn test_root_block_device_add_last() {
-        let dummy_file_1 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_1 = NamedTempFile::new().unwrap();
         let dummy_path_1 = dummy_file_1.path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1,
@@ -322,7 +324,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_2 = NamedTempFile::new().unwrap();
         let dummy_path_2 = dummy_file_2.path().to_path_buf();
         let dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
@@ -332,7 +334,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_3 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_3 = NamedTempFile::new().unwrap();
         let dummy_path_3 = dummy_file_3.path().to_path_buf();
         let dummy_block_device_3 = BlockDeviceConfig {
             path_on_host: dummy_path_3,
@@ -385,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_update() {
-        let dummy_file_1 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_1 = NamedTempFile::new().unwrap();
         let dummy_path_1 = dummy_file_1.path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1,
@@ -395,7 +397,7 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = tempfile::NamedTempFile::new().unwrap();
+        let dummy_file_2 = NamedTempFile::new().unwrap();
         let dummy_path_2 = dummy_file_2.path().to_path_buf();
         let mut dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2.clone(),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1312,7 +1312,9 @@ mod tests {
 
     use std::fs::File;
 
+    use self::tempfile::NamedTempFile;
     use super::*;
+
     use api_server::request::sync::DeviceState;
     use data_model::vm::CpuFeaturesTemplate;
     use net_util::MacAddr;
@@ -1334,11 +1336,11 @@ mod tests {
     #[test]
     fn test_put_block_device() {
         let mut vmm = create_vmm_object();
-        let file = tempfile::NamedTempFile::new().unwrap();
+        let f = NamedTempFile::new().unwrap();
         // test that creating a new block device returns the correct output
         let root_block_device = BlockDeviceConfig {
             drive_id: String::from("root"),
-            path_on_host: file.path().to_path_buf(),
+            path_on_host: f.path().to_path_buf(),
             is_root_device: true,
             is_read_only: false,
             rate_limiter: None,
@@ -1356,7 +1358,7 @@ mod tests {
         // test that updating an existing block device returns the correct output
         let root_block_device = BlockDeviceConfig {
             drive_id: String::from("root"),
-            path_on_host: file.path().to_path_buf(),
+            path_on_host: f.path().to_path_buf(),
             is_root_device: true,
             is_read_only: true,
             rate_limiter: None,


### PR DESCRIPTION
Completely replaced temporary file creation inside unit tests with `NamedTempFile` and `tempfile` which automatically removes leftover files.

## Testing
```bash
cargo test --all
cargo build --release
cargo kcov --all
```