### PR TITLE
vmm: removed noapic from default kernel cmdline

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -25,7 +25,7 @@ If you have no output in the console, most likely you will have to update the
 kernel command line. By default, Firecracker starts with the serial console
 disabled for boot time performance reasons. Example of a kernel valid command
 line that enables the serial console:
-`console=ttyS0 noapic reboot=k panic=1 pci=off nomodules`, which goes in the
+`console=ttyS0 reboot=k panic=1 pci=off nomodules`, which goes in the
 `boot_args` field of the `/boot-source` Firecracker API resource.
 
 `Q3:`

--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ curl --unix-socket /tmp/firecracker.socket -i \
    instances.
 1. Firecracker is started without the serial console for performance reasons.
    You can use the following boot_args if you need the serial console:
-   `console=ttyS0 noapic reboot=k panic=1 pci=off nomodules`  
+   `console=ttyS0 reboot=k panic=1 pci=off nomodules`  
 1. Firecracker uses default values for the following parameters:
     1. Kernel Command Line:
-       `noapic reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0`. This can be
+       `reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0`. This can be
        changed via the `/boot-source`.
     1. Number of vCPUs: 1. Default Memory Size: 128 MiB. Hyperthreading is
        disabled. CPU Template: None.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -63,7 +63,7 @@ pub const KERNEL_START_OFFSET: usize = 0x200000;
 pub const CMDLINE_OFFSET: usize = 0x20000;
 pub const CMDLINE_MAX_SIZE: usize = KERNEL_START_OFFSET - CMDLINE_OFFSET;
 pub const DEFAULT_KERNEL_CMDLINE: &str =
-    "noapic reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0";
+    "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0";
 const VCPU_RTSIG_OFFSET: u8 = 0;
 
 // TODO: Maybe configure this parameter via the API.


### PR DESCRIPTION
Using noapic decreases the performance of applications using
timers.

Signed-off-by: Andreea Florescu <fandree@amazon.com>