### PR TITLE
Minimal implementation of HTTP/1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ api_server = { path = "api_server" }
 data_model = { path = "data_model" }
 jailer = { path = "jailer" }
 logger = { path = "logger"}
+micro_http = { path = "micro_http" }
 seccomp = { path = "seccomp" }
 vmm = { path = "vmm" }
 

--- a/micro_http/Cargo.toml
+++ b/micro_http/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "micro_http"
+version = "0.1.0"
+authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
+
+[dependencies]

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use ascii::{COLON, CRLF, SP};
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum Header {
+    ContentLength,
+    ContentType,
+}
+
+impl Header {
+    fn raw(&self) -> &'static [u8] {
+        match self {
+            Header::ContentLength => b"Content-Length",
+            Header::ContentType => b"Content-Type",
+        }
+    }
+}
+
+pub struct Headers {
+    headers: HashMap<Header, String>,
+}
+
+impl Headers {
+    pub fn default() -> Headers {
+        return Headers {
+            headers: HashMap::new(),
+        };
+    }
+
+    pub fn add(&mut self, header: Header, value: String) {
+        self.headers.insert(header, value);
+    }
+
+    pub fn raw(&self) -> Vec<u8> {
+        let mut response = Vec::new();
+
+        for (key, val) in &self.headers {
+            let header = [key.raw(), COLON, SP, val.clone().as_bytes(), CRLF].concat();
+            response = [response, header].concat()
+        }
+
+        return response;
+    }
+}
+
+pub enum MediaType {
+    PlainText,
+}
+
+impl MediaType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MediaType::PlainText => "text/plain",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        assert!(Headers::default().headers == HashMap::new());
+    }
+
+    #[test]
+    fn test_add_headers() {
+        let mut headers = Headers::default();
+
+        headers.add(Header::ContentType, "text/plain".to_string());
+        headers.add(Header::ContentLength, "120".to_string());
+
+        assert!(headers.headers.contains_key(&Header::ContentType));
+        assert_eq!(
+            headers.headers.get(&Header::ContentType).unwrap(),
+            &"text/plain".to_string()
+        );
+        assert!(headers.headers.contains_key(&Header::ContentLength));
+        assert_eq!(
+            headers.headers.get(&Header::ContentLength).unwrap(),
+            &"120".to_string()
+        );
+
+        // Test that adding a Header with the same key, updates the value.
+        headers.add(Header::ContentLength, "130".to_string());
+        assert_eq!(
+            headers.headers.get(&Header::ContentLength).unwrap(),
+            &"130".to_string()
+        );
+    }
+}

--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -1,0 +1,54 @@
+pub mod headers;
+
+pub mod ascii {
+    pub const CRLF: &[u8] = b"\r\n";
+    pub const COLON: &[u8] = b":";
+    pub const LF: &[u8] = b"\n";
+    pub const SP: &[u8] = b" ";
+}
+
+pub struct Body {
+    body: Vec<u8>,
+}
+
+impl Body {
+    pub fn new(body: String) -> Self {
+        Body {
+            body: body.into_bytes(),
+        }
+    }
+
+    pub fn raw(&self) -> &[u8] {
+        return self.body.as_slice();
+    }
+
+    pub fn len(&self) -> usize {
+        return self.body.len();
+    }
+}
+
+#[derive(PartialEq)]
+pub enum Method {
+    Get,
+}
+
+impl Method {
+    pub fn raw(&self) -> &'static [u8] {
+        match self {
+            Method::Get => b"GET",
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum Version {
+    Http10,
+}
+
+impl Version {
+    pub fn raw(&self) -> &'static [u8] {
+        match self {
+            Version::Http10 => b"HTTP/1.0",
+        }
+    }
+}

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -1,0 +1,9 @@
+mod common;
+mod request;
+mod response;
+
+use common::ascii;
+use common::headers;
+
+pub use request::Request;
+pub use response::Response;

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -1,0 +1,266 @@
+use common::{Body, Method, Version};
+use headers::Headers;
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidRequest,
+}
+
+#[derive(PartialEq)]
+struct RequestLine {
+    method: Method,
+    uri: String,
+    http_version: Version,
+}
+
+impl RequestLine {
+    fn try_from(byte_stream: &[u8]) -> Result<Self, Error> {
+        let method_len = helpers::request_line::check_method(byte_stream)?;
+        let version_len = helpers::request_line::check_http_version(byte_stream)?;
+
+        let request_uri =
+            helpers::request_line::get_request_uri(byte_stream, method_len, version_len)?;
+
+        Ok(RequestLine {
+            http_version: Version::Http10,
+            method: Method::Get,
+            uri: request_uri,
+        })
+    }
+}
+
+#[allow(unused)]
+pub struct Request {
+    request_line: RequestLine,
+    headers: Headers,
+    body: Option<Body>,
+}
+
+impl Request {
+    /// Parses a byte slice into a HTTP Request.
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Line: "GET SP Request-uri SP HTTP/1.0 CRLF" - Mandatory </br>
+    ///     * Request Headers "<headers> CRLF"- Optional </br>
+    ///     * Entity Body - Optional </br>
+    /// The request headers and the entity body is not parsed and None is returned because
+    /// these are not used by the MMDS server.
+    /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0.
+    ///
+    /// # Errors
+    /// The function returns InvalidRequest when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::Request;
+    ///
+    /// let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n");
+    ///
+    pub fn try_from(byte_stream: &[u8]) -> Result<Self, Error> {
+        // The first line of the request is the Request Line. The line ending is LF.
+        let lf_pos = helpers::request::get_first_lf(byte_stream)?;
+
+        // The Request Line should include the trailing LF.
+        let request_line = RequestLine::try_from(&byte_stream[0..=lf_pos])?;
+        // We ignore the Headers and Entity body because we don't need them for MMDS requests.
+        Ok(Request {
+            request_line,
+            headers: Headers::default(),
+            body: None,
+        })
+    }
+}
+
+mod helpers {
+    use super::{Error, Method, Version};
+    use ascii::{CRLF, LF, SP};
+
+    // Module used for grouping functions that parse a Request.
+    pub mod request {
+        use super::*;
+
+        // Helper function that returns the first position of the LF character in a u8 slice.
+        // Returns Error::InvalidRequest if LF is not found.
+        pub fn get_first_lf(byte_stream: &[u8]) -> Result<usize, Error> {
+            for i in 0..byte_stream.len() {
+                if byte_stream[i] == LF[0] {
+                    return Ok(i);
+                }
+            }
+            return Err(Error::InvalidRequest);
+        }
+    }
+
+    // Module used for grouping functions that parse a RequestLine.
+    pub mod request_line {
+        use super::*;
+        use std;
+
+        // Checks that the HTTP method is correct (only GET is supported).
+        // When the method is correct, returns the length of the method + 1, where the additional 1
+        // is the length of SP character.
+        pub fn check_method(byte_stream: &[u8]) -> Result<usize, Error> {
+            // The first 3 characters from the request line should be the method.
+            // We only support GET requests. Check that the first three letters are GET, followed
+            // by SP.
+            let request_line_prefix = [Method::Get.raw(), SP].concat();
+
+            if byte_stream.starts_with(request_line_prefix.as_slice()) {
+                return Ok(request_line_prefix.len());
+            }
+
+            return Err(Error::InvalidRequest);
+        }
+
+        // Checks that the HTTP version is 1.0. When the version is correct, it returns the length
+        // of the suffix defined as "SP HTTP_Version CRLF/LF".
+        pub fn check_http_version(byte_stream: &[u8]) -> Result<usize, Error> {
+            let http_version = Version::Http10.raw();
+
+            let line_suffix_with_crlf = [SP, http_version.clone(), CRLF].concat();
+            let line_suffix_with_lf = [SP, http_version, LF].concat();
+
+            if byte_stream.ends_with(line_suffix_with_crlf.as_slice()) {
+                return Ok(line_suffix_with_crlf.len());
+            }
+
+            if byte_stream.ends_with(line_suffix_with_lf.as_slice()) {
+                return Ok(line_suffix_with_lf.len());
+            }
+
+            return Err(Error::InvalidRequest);
+        }
+
+        // Returns the request URI.
+        // The prefix should be GET SP and the suffix one of SP HTTP/1.0 CRLF or SP HTTP/1.0 LF.
+        // TODO: we need some validation of the URI.
+        pub fn get_request_uri(
+            byte_stream: &[u8],
+            prefix_len: usize,
+            suffix_len: usize,
+        ) -> Result<String, Error> {
+            if prefix_len + suffix_len >= byte_stream.len() {
+                return Err(Error::InvalidRequest);
+            }
+
+            match std::str::from_utf8(&byte_stream[prefix_len..(byte_stream.len() - suffix_len)]) {
+                Ok(request_uri) => Ok(String::from(request_uri)),
+                Err(_) => Err(Error::InvalidRequest),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::helpers::request_line::{check_http_version, check_method, get_request_uri};
+    use super::*;
+
+    impl PartialEq for Request {
+        fn eq(&self, other: &Request) -> bool {
+            // Ignore the other fields of Request for now because they are not used.
+            return self.request_line == other.request_line;
+        }
+    }
+
+    #[test]
+    fn test_check_http_method() {
+        let request_line = b"GET http://localhost/home HTTP/1.0\r\n";
+        match check_method(request_line) {
+            Ok(len) => assert_eq!(len, 4),
+            Err(_) => assert!(false),
+        };
+
+        let request_line = b"PUT http://localhost/home HTTP/1.0\r\n";
+        assert!(check_method(request_line).is_err());
+
+        assert!(check_method(b"").is_err());
+    }
+
+    #[test]
+    fn test_check_http_version() {
+        // Test CRLF ending for Request Line.
+        let request_line = b"GET http://localhost/home HTTP/1.0\r\n";
+        let expected_http_version = b" HTTP/1.0\r\n";
+        match check_http_version(request_line) {
+            Ok(val) => assert_eq!(val, expected_http_version.len()),
+            Err(_) => assert!(false),
+        };
+
+        // Test LF ending for Request Line.
+        let request_line = b"GET http://localhost/home HTTP/1.0\n";
+        let expected_http_version = b" HTTP/1.0\n";
+        match check_http_version(request_line) {
+            Ok(val) => assert_eq!(val, expected_http_version.len()),
+            Err(_) => assert!(false),
+        };
+
+        // Test Invalid HTTP version.
+        let request_line = b"GET http://localhost/home HTTP/1.1\n";
+        match check_http_version(request_line) {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(e, Error::InvalidRequest),
+        };
+
+        assert!(check_http_version(b"").is_err());
+    }
+
+    #[test]
+    fn test_get_request_uri() {
+        let request_line = b"GET http://localhost/home HTTP/1.0\r\n";
+        let prefix = b"GET ";
+        let suffix = b" HTTP/1.0\r\n";
+        let request_uri = String::from("http://localhost/home");
+
+        match get_request_uri(request_line, prefix.len(), suffix.len()) {
+            Ok(req_uri) => assert_eq!(req_uri, request_uri),
+            Err(_) => assert!(false),
+        };
+
+        assert!(get_request_uri(request_line, 50, 50).is_err());
+    }
+
+    #[test]
+    fn test_into_request_line() {
+        let expected_request_line = RequestLine {
+            http_version: Version::Http10,
+            method: Method::Get,
+            uri: String::from("http://localhost/home"),
+        };
+
+        let request_line = b"GET http://localhost/home HTTP/1.0\r\n";
+        match RequestLine::try_from(request_line) {
+            Ok(request) => assert!(request == expected_request_line),
+            Err(_) => assert!(false),
+        };
+
+        // Test for invalid method.
+        let request_line = b"PUT http://localhost/home HTTP/1.0\r\n";
+        assert!(RequestLine::try_from(request_line).is_err());
+
+        // Test for invalid uri.
+        let request_line = b"GET  HTTP/1.0\r\n";
+        assert!(RequestLine::try_from(request_line).is_err());
+
+        // Test for invalid HTTP version.
+        let request_line = b"GET http://localhost/home HTTP/2.0\r\n";
+        assert!(RequestLine::try_from(request_line).is_err());
+    }
+
+    #[test]
+    fn test_into_request() {
+        let expected_request = Request {
+            request_line: RequestLine {
+                http_version: Version::Http10,
+                method: Method::Get,
+                uri: String::from("http://localhost/home"),
+            },
+            body: None,
+            headers: Headers::default(),
+        };
+        let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n \
+                                     Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT";
+        assert!(Request::try_from(request_bytes) == Ok(expected_request));
+    }
+}

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -1,0 +1,118 @@
+use ascii::SP;
+use common::{Body, Version};
+use headers::{Header, Headers, MediaType};
+
+#[allow(dead_code)]
+pub enum StatusCode {
+    OK,
+    BadRequest,
+    NotFound,
+    InternalServerError,
+    NotImplemented,
+}
+
+impl StatusCode {
+    fn raw(&self) -> &'static [u8] {
+        match self {
+            StatusCode::OK => b"200",
+            StatusCode::BadRequest => b"400",
+            StatusCode::NotFound => b"404",
+            StatusCode::InternalServerError => b"500",
+            StatusCode::NotImplemented => b"501",
+        }
+    }
+}
+
+struct StatusLine {
+    http_version: Version,
+    status_code: StatusCode,
+}
+
+impl StatusLine {
+    fn new(status_code: StatusCode) -> Self {
+        return StatusLine {
+            http_version: Version::Http10,
+            status_code,
+        };
+    }
+
+    fn raw(&mut self) -> Vec<u8> {
+        let http_version = self.http_version.raw();
+        let status_code = self.status_code.raw();
+
+        return [http_version, SP, status_code, SP].concat();
+    }
+}
+
+pub struct Response {
+    status_line: StatusLine,
+    headers: Headers,
+    body: Option<Body>,
+}
+
+impl Response {
+    pub fn new(status_code: StatusCode) -> Response {
+        return Response {
+            status_line: StatusLine::new(status_code),
+            headers: Headers::default(),
+            body: None,
+        };
+    }
+
+    pub fn set_body(&mut self, body: Body) {
+        self.headers
+            .add(Header::ContentLength, body.len().to_string());
+        self.headers.add(
+            Header::ContentType,
+            String::from(MediaType::PlainText.as_str()),
+        );
+        self.body = Some(body);
+    }
+
+    fn body_raw(&self) -> &[u8] {
+        match self.body {
+            Some(ref body) => body.raw(),
+            None => &[],
+        }
+    }
+
+    pub fn raw(&mut self) -> Vec<u8> {
+        let status_line = self.status_line.raw();
+        let headers = self.headers.raw();
+        let body = self.body_raw();
+
+        let response = [status_line, headers, body.to_owned()].concat();
+
+        return response;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raw() {
+        let mut response = Response::new(StatusCode::OK);
+        let body = String::from("This is a test");
+        response.set_body(Body::new(body.clone()));
+
+        // Headers can be in either order.
+        let content_type = "Content-Type: text/plain\r\n";
+        let content_length = format!("Content-Length: {}\r\n", body.len());
+
+        let expected_response_1 = format!(
+            "HTTP/1.0 200 {}{}This is a test",
+            content_length, content_type
+        );
+        let expected_response_2 = format!(
+            "HTTP/1.0 200 {}{}This is a test",
+            content_type, content_length
+        );
+
+        assert!(
+            response.raw() == expected_response_1.into_bytes()
+                || response.raw() == expected_response_2.into_bytes()
+        );
+    }
+}


### PR DESCRIPTION
micro_http is to be used by MMDS and has the following restrictions:
* supported method: GET.
* supported protocol version: HTTP/1.0
* available status codes: 200, 400, 500 and 501.
* for incoming requests, only the request line is parsed. The request line contains the method, request URI and HTTP version. Everything else is ignored.
* when creating responses, the only headers set are Content-Length and Content-Type.
* supported media type: "text/plain". All entity bodies are assumed to be text/plain.

Coverage of micro_http crate: 93.9%
