### PR TITLE
add python3-dev as a dependency on Ubuntu

### DIFF
--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -61,7 +61,7 @@ declare -ra KCOV_APT_GET_DEPS=(\
 )
 
 declare -ra PYTHON_SSH_YUM_DEPS=(python3-devel)
-declare -ra PYTHON_SSH_APT_DEPS=(libssl-dev)
+declare -ra PYTHON_SSH_APT_DEPS=(libssl-dev python3-dev)
 
 declare -ra GCC_STATIC_YUM_DEPS=(glibc-static)
 # Some tests will build static binaries for use in systems without user space.


### PR DESCRIPTION
On Ubuntu, `pip install cryptography` fails without `python3-dev` installed.

Fixes #437