### PR TITLE
MMDS: get data by path

### DIFF
--- a/data_model/src/mmds/mod.rs
+++ b/data_model/src/mmds/mod.rs
@@ -8,6 +8,12 @@ pub struct MMDS {
     is_initialized: bool,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    NotFound,
+    UnsupportedValueType,
+}
+
 impl Default for MMDS {
     fn default() -> Self {
         MMDS {
@@ -27,6 +33,8 @@ impl MMDS {
     }
 
     pub fn put_data(&mut self, data: Value) {
+        // TODO: we should add a data validator and only accept Strings, arrays & dictionaries
+        // https://github.com/aws/PRIVATE-firecracker/issues/401
         self.data_store = data;
         self.is_initialized = true;
     }
@@ -41,10 +49,104 @@ impl MMDS {
         }
         return self.data_store.to_string();
     }
+
+    // Helper function for getting all the keys from Value::Object.
+    // Returns a Vec<String> with all keys. If the key corresponds to a
+    // dictionary, a "/" is appended to the key name.
+    // If the `dict` is Value::Null, Error::NotFound is thrown.
+    // If the `dict` is not a dictionary, a Vec with the value corresponding to
+    // the key is returned.
+    fn get_keys(dict: &Value) -> Result<Vec<String>, Error> {
+        if dict.is_null() {
+            return Err(Error::NotFound);
+        }
+
+        let mut ret = Vec::new();
+        match dict.as_object() {
+            Some(map) => {
+                // When the object is a map, push all the keys in the Vec.
+                for key in map.keys() {
+                    let mut key = key.clone();
+                    if dict[&key].is_object() {
+                        key.push_str("/");
+                    }
+
+                    ret.push(key);
+                }
+                return Ok(ret);
+            }
+            None => {
+                // When the object is not a map, return the value.
+                match dict.as_str() {
+                    Some(val) => {
+                        ret.push(val.to_string());
+                        return Ok(ret);
+                    }
+                    None => return Err(Error::UnsupportedValueType),
+                };
+            }
+        };
+    }
+
+    // Helper function for converting a Value to String by following the IMDS specs.
+    // The only supported Value is String. Throws UnsupportedValueType when the type of the
+    // Value is not String.
+    fn get_value_as_string(val: &Value) -> Result<String, Error> {
+        if val.is_null() {
+            return Err(Error::NotFound);
+        }
+
+        if val.is_object() {
+            return Ok(String::new());
+        }
+
+        match val.as_str() {
+            Some(value) => Ok(value.to_string()),
+            None => Err(Error::UnsupportedValueType),
+        }
+    }
+
+    /// This function replicates the behavior of the Instance Metadata Service
+    /// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+    /// When the path ends with / there are two cases:
+    /// 1. For a (key, value) pair where the value is a dictionary, it will return all the keys
+    /// in the dictionary.
+    /// 2. For a (key, value) pair where the value is a simple type (bool, string, number),
+    /// it will return the value.
+    ///
+    /// When the path does not end with / there are also two cases to cover:
+    /// 1. The value corresponding to that path is a dictionary, the function returns
+    /// an empty string.
+    /// 2. The value corresponding to that path is a simple type, the function returns the value.
+    ///
+    /// When the path is not found, a NotFound error is returned.
+    pub fn get_value(&self, path: String) -> Result<Vec<String>, Error> {
+        // The pointer function splits the input by "/". With a trailing "/", pointer does not
+        // know how to get the object.
+        let value = match path.ends_with('/') {
+            true => self.data_store.pointer(&path.as_str()[..(path.len() - 1)]),
+            false => self.data_store.pointer(path.as_str()),
+        };
+
+        match value {
+            Some(val) => {
+                // If path ends with /, return all keys in Value::Object
+                if path.ends_with("/") {
+                    MMDS::get_keys(val)
+                } else {
+                    match MMDS::get_value_as_string(val) {
+                        Ok(value) => Ok(vec![value]),
+                        Err(e) => Err(e),
+                    }
+                }
+            }
+            None => return Err(Error::NotFound),
+        }
+    }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use serde_json;
 
@@ -65,5 +167,111 @@ mod test {
         mmds.patch_data(serde_json::from_str(patch_json).unwrap());
         mmds_json = "{\"meta-data\":{\"iam\":\"dummy\"},\"user-data\":\"10\"}";
         assert_eq!(mmds.get_data_str(), mmds_json);
+    }
+
+    #[test]
+    fn test_get_value() {
+        let mut mmds = MMDS::default();
+        let data = r#"{
+            "name": {
+                "first": "John",
+                "second": "Doe"
+            },
+            "age": "43",
+            "phones": {
+                "home": {
+                    "RO": "+40 1234567",
+                    "UK": "+44 1234567"
+                },
+                "mobile": "+44 2345678"
+            }
+        }"#;
+
+        let data_store: Value = serde_json::from_str(data).unwrap();
+        mmds.put_data(data_store);
+
+        // Test invalid path.
+        match mmds.get_value("/invalid_path".to_string()) {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(e, Error::NotFound),
+        };
+        match mmds.get_value("/invalid_path/".to_string()) {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(e, Error::NotFound),
+        };
+
+        // Test path ends with /; Value is a dictionary.
+        match mmds.get_value("/phones/".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec!["home/", "mobile"]),
+            Err(e) => assert!(false),
+        };
+        match mmds.get_value("/phones/home/".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec!["RO", "UK"]),
+            Err(_) => assert!(false),
+        };
+
+        // Test path ends with /; Value is a String.
+        match mmds.get_value("/phones/mobile/".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec!["+44 2345678"]),
+            Err(_) => assert!(false),
+        };
+
+        // Test path does NOT end with /; Value is a dictionary.
+        match mmds.get_value("/phones".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec![""]),
+            Err(_) => assert!(false),
+        };
+
+        // Test path does NOT end with /; Value is a String.
+        match mmds.get_value("/phones/mobile".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec!["+44 2345678"]),
+            Err(_) => assert!(false),
+        };
+    }
+
+    #[test]
+    fn test_get_element_from_array() {
+        let mut mmds = MMDS::default();
+        let data = r#"{
+            "phones": [
+                "+40 1234567",
+                "+44 1234567"
+            ]
+        }"#;
+
+        let data_store: Value = serde_json::from_str(data).unwrap();
+        mmds.put_data(data_store);
+
+        // Test path does NOT end with /; Value is a String.
+        match mmds.get_value("/phones/0".to_string()) {
+            Ok(ret) => assert_eq!(ret, vec!["+40 1234567"]),
+            Err(_) => assert!(false),
+        };
+    }
+
+    #[test]
+    fn test_invalid_types() {
+        let mut mmds = MMDS::default();
+        let data = r#"{
+            "name": {
+                "first": "John",
+                "second": "Doe"
+            },
+            "age": 43
+        }"#;
+
+        let data_store: Value = serde_json::from_str(data).unwrap();
+        // TODO: This should fail; we should only accept String types
+        mmds.put_data(data_store);
+
+        match mmds.get_value("/age".to_string()) {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(e, Error::UnsupportedValueType),
+        };
+
+        match mmds.get_value("/age/".to_string()) {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(e, Error::UnsupportedValueType),
+        };
     }
 }


### PR DESCRIPTION
The method get_data_by_path is to be used when the gues sends
an HTTP request to 169.254.169.254/${PATH}. The path is split
by "/" and the tokens are searched in the data store. If the
path does not match an object in the data store, NotFound Error
is thrown. Also, if one object does not have the type Value::String
or Value::Object, UnsupportedValueType Error is thrown.

The method returns a Vec of Strings with variable length:
- 0 if trying to list as a directory a file
- 1 if trying to get the value of one key
- x, where x is the number of keys in a sub-dictionary specified
  by path.

For more details, check the public Instance meta-data Service
documentation:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

Signed-off-by: Andreea Florescu <fandree@amazon.com>