### PR TITLE
MMDS lazy_static global reference

### DIFF
--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 json-patch = ">=0.2.1"
-serde = "=1.0.27"
+lazy_static = ">=1.1.0"
+serde = ">=1.0.27"
 serde_derive = "=1.0.27"
 serde_json = ">=1.0.9"
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -1,7 +1,9 @@
+extern crate json_patch;
+#[macro_use]
+extern crate lazy_static;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate json_patch;
 extern crate serde_json;
 
 extern crate fc_util;

--- a/data_model/src/mmds/mod.rs
+++ b/data_model/src/mmds/mod.rs
@@ -1,5 +1,14 @@
+use std::sync::{Arc, Mutex};
+
 use json_patch::merge;
 use serde_json::Value;
+
+lazy_static! {
+    // A static reference to a global MMDS instance. We currently use this for ease of access during
+    // prototyping. We'll consider something like passing Arc<Mutex<MMDS>> references to the
+    // appropriate threads in the future.
+    pub static ref STATIC_MMDS: Arc<Mutex<MMDS>> = Arc::new(Mutex::new(MMDS::default()));
+}
 
 /// The MMDS is the Microvm Metadata Service represented as an untyped json.
 #[derive(Clone)]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -13,6 +13,6 @@ net_sys = { path = "../net_sys" }
 sys_util = { path = "../sys_util" }
 
 [dev-dependencies]
-lazy_static = "=1.0.0"
+lazy_static = ">=1.1.0"
 pnet = "=0.21.0"
 serde_json = ">=1.0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ use clap::{App, Arg};
 use std::panic;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use api_server::request::instance_info::{InstanceInfo, InstanceState};
 use api_server::ApiServer;
-use data_model::mmds::MMDS;
+use data_model::mmds::STATIC_MMDS;
 use logger::LOGGER;
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/firecracker.socket";
@@ -70,7 +70,7 @@ fn main() {
     let shared_info = Arc::new(RwLock::new(InstanceInfo {
         state: InstanceState::Uninitialized,
     }));
-    let mmds_info = Arc::new(Mutex::new(MMDS::default()));
+    let mmds_info = STATIC_MMDS.clone();
     let (to_vmm, from_api) = channel();
     let server = ApiServer::new(
         mmds_info,


### PR DESCRIPTION
Added a global reference to a Mutex<MMDS> instance to mmds/mod.rs in the data_model crate. This is easily accessible from any file, as long as the data_model crate is imported. We'll consider switching to somet other type of handler as more things start falling into place.