### PR TITLE
swagger: Mark is_root_device and is_read_only as required properties o…

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -342,6 +342,8 @@ definitions:
     type: object
     required:
       - drive_id
+      - is_root_device
+      - is_read_only
     properties:
       drive_id:
         type: string


### PR DESCRIPTION
…n Drive objects

If these fields are not marked as required, then generated clients may
attempt to PUT Drive objects lacking these fields, e.g.

{
    "drive_id": "2",
    "path_on_host": "/path/to/drive.img"
}

This is not accepted by firecracker, which returns

 "fault_message": "missing field `is_root_device` at line 1 column 159"

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

Tested by generating a Go API client and confirming that `is_root_device` and `is_read_only` are no longer marked as optional.