### PR TITLE
vmm: add instrumentation for measuring guest boot time

### DIFF
--- a/fc_util/Cargo.toml
+++ b/fc_util/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-time = "0.1.39"
+time = ">=0.1.39"
 timerfd = "1.0"
 
 logger = { path = "../logger" }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -11,7 +11,7 @@ log = { version = "0.4", features = ["std"] }
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-time = "0.1.34"
+time = ">=0.1.39"
 
 [dev-dependencies]
 tempfile = ">=3.0.2"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -9,6 +9,7 @@ epoll = "=2.1.0"
 scopeguard = "=0.3.3"
 serde = "=1.0.27"
 serde_json = ">=1.0.9"
+time = ">=0.1.39"
 timerfd = ">=1.0"
 
 api_server = { path = "../api_server" }


### PR DESCRIPTION
A timestamp is taken on receiving the `StartInstance` API request.

Guest boot-time is the time passed from `StartInstance` to running
the guest userspace `init`. To measure this time we depend on the
guest `init`, or another process, to write a magic value to a magic
IO port.

The magic IO port used is `0x03f0` which is the first io port address
in the range reserved for the Floppy Disk Controller. This port was
chosen since we do not support or plan on supporting a Floppy Disk
Controller.

The magic value of `123` was pseudo-randomly chosen.

On every write of `123` to the `0x3f0` io port, the time difference
between the io-write trap and the `StartInstance` timestamp is
printed in the Firecracker log at the warn level using format:
```
Guest-boot-time = {:>6} us {} ms
```