### PR TITLE
Expose host CPUID brand string frequency v2

### DIFF
--- a/tests/functional/test_cpu_features.py
+++ b/tests/functional/test_cpu_features.py
@@ -1,4 +1,5 @@
 from host_tools.network import SSHConnection
+import re
 
 
 def check_cpu_topology(test_microvm, expected_cpu_topology):
@@ -74,3 +75,53 @@ def test_2vcpu_ht_disabled(test_microvm_with_ssh, network_config):
         "NUMA node(s)": "1"
     }
     check_cpu_topology(test_microvm, expected_cpu_topology)
+
+
+def test_brand_string(test_microvm_with_ssh, network_config):
+    """
+    For Intel CPUs, the guest brand string should be:
+        Intel(R) Xeon(R) Processor @ {host frequency}
+    where {host frequency} is the frequency reported by the host CPUID
+    (e.g. 4.01GHz)
+
+    For non-Intel CPUs, the host and guest brand strings should be the same
+    """
+    cif = open('/proc/cpuinfo', 'r')
+    host_brand_string = None
+    while True:
+        line = cif.readline()
+        if line == '':
+            break
+        mo = re.search("^model name\\s+:\\s+(.+)$", line)
+        if mo:
+            host_brand_string = mo.group(1)
+            break
+    cif.close()
+    assert(host_brand_string is not None)
+
+    test_microvm = test_microvm_with_ssh
+    test_microvm.basic_config(vcpu_count=1, net_iface_count=0)
+    test_microvm.basic_network_config(network_config)
+    test_microvm.start()
+
+    ssh_connection = SSHConnection(test_microvm.slot.ssh_config)
+
+    guest_cmd = "cat /proc/cpuinfo | grep 'model name' | head -1"
+    _, stdout, stderr = ssh_connection.execute_command(guest_cmd)
+    assert (stderr.read().decode("utf-8") == '')
+
+    mo = re.search("^model name\\s+:\\s+(.+)$", stdout.readline().rstrip())
+    assert(not (mo is None))
+    guest_brand_string = mo.group(1)
+    assert(len(guest_brand_string) > 0)
+
+    expected_guest_brand_string = host_brand_string
+    if host_brand_string.startswith("Intel"):
+        expected_guest_brand_string = "Intel(R) Xeon(R) Processor"
+        mo = re.search("[.0-9]+[MG]Hz", host_brand_string)
+        if mo:
+            expected_guest_brand_string += " @ " + mo.group(0)
+
+    assert(guest_brand_string == expected_guest_brand_string)
+
+

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -12,3 +12,8 @@ kvm_sys = { path = "../kvm_sys" }
 kvm = { path = "../kvm" }
 memory_model = { path = "../memory_model" }
 sys_util = { path = "../sys_util" }
+
+
+[build-dependencies]
+cc = "1.0"
+

--- a/x86_64/build.rs
+++ b/x86_64/build.rs
@@ -1,0 +1,10 @@
+extern crate cc;
+
+fn main() {
+    cc::Build::new()
+        .compiler("gcc")
+        .flag("-nostdlib")
+        .flag("-nodefaultlibs")
+        .file("src/cpuid/host_cpuid.c")
+        .compile("x86_64_c");
+}

--- a/x86_64/src/cpuid/brand_string.rs
+++ b/x86_64/src/cpuid/brand_string.rs
@@ -1,0 +1,303 @@
+use super::host_cpuid;
+use std::cmp;
+use std::mem;
+use std::ptr;
+use std::str;
+
+pub const BRAND_STRING_MIN_LEAF: u32 = 0x80000002;
+pub const BRAND_STRING_MAX_LEAF: u32 = 0x80000004;
+pub const BRAND_STRING_LEAF_COUNT: u32 = BRAND_STRING_MAX_LEAF - BRAND_STRING_MIN_LEAF + 1;
+
+pub const BRAND_STRING_MAX_LEN: usize =
+    BRAND_STRING_LEAF_COUNT as usize * mem::size_of::<BrandStringRegs>();
+
+#[derive(Debug)]
+pub enum Error {
+    BrandStringNotSupported,
+    FreqNotFound,
+}
+
+// Defining our own regs structure here, since we'll be relying on
+// precise struct sizing. Also, technically, the registers used by
+// the brand string leaves are a subset of the CPUID registers.
+#[repr(C)]
+pub struct BrandStringRegs {
+    pub eax: u32,
+    pub ebx: u32,
+    pub ecx: u32,
+    pub edx: u32,
+}
+
+/// A CPUID brand string wrapper, providing some efficient manipulation
+/// primitives. This is achieved by bypassing the O(n) indexing, heap
+/// allocation, and the unicode checks done by std::string::String.
+///
+pub struct BrandString {
+    bytes: [u8; BRAND_STRING_MAX_LEN],
+    len: usize,
+}
+
+impl BrandString {
+    /// Creates an empty brand string (0-initialized)
+    ///
+    fn new() -> Self {
+        Self {
+            bytes: [0; BRAND_STRING_MAX_LEN],
+            len: 0,
+        }
+    }
+
+    /// Creates a brand string, initialized from the CPUID leaves
+    /// 0x80000002 through 0x80000004, of the host CPU
+    ///
+    pub fn from_host_cpuid() -> Result<Self, Error> {
+        let mut this = Self::new();
+        let mut cpuid_regs = host_cpuid(0x80000000);
+
+        if cpuid_regs.eax < BRAND_STRING_MAX_LEAF {
+            return Err(Error::BrandStringNotSupported);
+        }
+
+        for i in 0..BRAND_STRING_LEAF_COUNT {
+            cpuid_regs = host_cpuid(BRAND_STRING_MIN_LEAF + i);
+            let this_regs = this.borrow_mut_regs_for_leaf(BRAND_STRING_MIN_LEAF + i);
+            this_regs.eax = cpuid_regs.eax;
+            this_regs.ebx = cpuid_regs.ebx;
+            this_regs.ecx = cpuid_regs.ecx;
+            this_regs.edx = cpuid_regs.edx;
+        }
+
+        this.len = this.bytes.len();
+        while this.bytes[this.len - 1] == 0 && this.len > 0 {
+            this.len -= 1;
+        }
+
+        Ok(this)
+    }
+
+    /// Creates a (custom) brand string, initialized from src
+    /// If src.len() exceeds BRAND_STRING_MAX_LEN, the brand string
+    /// will contain only the fist BRAND_STRING_MAX_LEN-1 chars from src
+    /// (the brand string needs to be NULL-terminated)
+    ///
+    pub fn from_str(src: &str) -> Self {
+        let mut this = Self::new();
+
+        this.len = cmp::min(src.len(), BRAND_STRING_MAX_LEN - 1);
+        unsafe {
+            ptr::copy_nonoverlapping(src.as_ptr(), this.bytes.as_mut_ptr(), this.len);
+        }
+        this
+    }
+
+    /// Provides a raw, register-level view into the brand string.
+    /// The register values are the those that would be set by
+    /// calling CPUID with EAX=leaf, on a CPU with self as brand string
+    ///
+    /// Note: this transformation is provided only for the caller's
+    /// convenience. No data is copied.
+    #[inline]
+    pub fn borrow_regs_for_leaf(&self, leaf: u32) -> &BrandStringRegs {
+        if leaf < BRAND_STRING_MIN_LEAF || leaf > BRAND_STRING_MAX_LEAF {
+            panic!("Invalid CPUID brand string leaf: {}", leaf);
+        }
+        unsafe {
+            mem::transmute::<*const u8, &BrandStringRegs>(self.bytes.as_ptr().offset(
+                ((leaf - BRAND_STRING_MIN_LEAF) * mem::size_of::<BrandStringRegs>() as u32)
+                    as isize,
+            ))
+        }
+    }
+
+    /// Same as borrow_regs_for_leaf(), but providing a mutable reference
+    /// to the inner registers.
+    #[inline]
+    pub fn borrow_mut_regs_for_leaf(&mut self, leaf: u32) -> &mut BrandStringRegs {
+        if leaf < BRAND_STRING_MIN_LEAF || leaf > BRAND_STRING_MAX_LEAF {
+            panic!("Invalid CPUID brand string leaf: {}", leaf);
+        }
+        unsafe {
+            mem::transmute::<*mut u8, &mut BrandStringRegs>(self.bytes.as_mut_ptr().offset(
+                ((leaf - BRAND_STRING_MIN_LEAF) * mem::size_of::<BrandStringRegs>() as u32)
+                    as isize,
+            ))
+        }
+    }
+
+    /// Appends src to the brand string.
+    /// If there isn't enough room to append src, this operation silently fails,
+    /// and the brand string remains unchanged.
+    ///
+    pub fn push_str(&mut self, src: &str) {
+        if src.len() > self.bytes.len() - 1 - self.len {
+            // No room to push all of src. Fail silently
+            return;
+        }
+        unsafe {
+            ptr::copy_nonoverlapping(
+                src.as_ptr(),
+                self.bytes.as_mut_ptr().offset(self.len as isize),
+                src.len(),
+            );
+        }
+        self.len += src.len();
+    }
+
+    /// Checks if src is a prefix of the brand string
+    ///
+    pub fn starts_with(&self, src: &str) -> bool {
+        if src.len() > BRAND_STRING_MAX_LEN - 1 {
+            return false;
+        }
+        self.bytes[..src.len()] == src.as_bytes()[..src.len()]
+    }
+
+    /// Searches the brand string for the CPU frequency data
+    /// it may contain (e.g. 4.01GHz), and, if found,
+    /// returns it as a str slice.
+    /// No data is copied; the returned value is an immutable view
+    /// into the brand string buffer.
+    ///
+    pub fn borrow_freq_str(&self) -> Result<&str, Error> {
+        let mut it = self
+            .bytes
+            .iter()
+            .rev()
+            .skip(self.bytes.len() - self.len)
+            .enumerate();
+        let mut freq_start = 0_usize;
+        let mut freq_end = 0_usize;
+
+        while freq_start == 0 {
+            match it.next() {
+                Some((i, &b'z')) => freq_end = self.len - i - 1,
+                Some((_, _)) => continue,
+                None => break,
+            }
+            match it.next() {
+                Some((_, &b'H')) => {}
+                Some((_, _)) => continue,
+                None => break,
+            }
+            match it.next() {
+                Some((_, &ch)) => {
+                    if ch != b'M' && ch != b'G' {
+                        continue;
+                    }
+                }
+                None => break,
+            }
+            while let Some((i, &ch)) = it.next() {
+                if ch == b'.' || (ch >= b'0' && ch <= b'9') {
+                    freq_start = self.len - i - 1;
+                    continue;
+                }
+                break;
+            }
+        }
+
+        if freq_start == 0 {
+            return Err(Error::FreqNotFound);
+        }
+
+        unsafe { Ok(str::from_utf8_unchecked(&self.bytes[freq_start..=freq_end])) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn test_brand_string() {
+        #[inline]
+        fn str_to_u32(src: &str) -> u32 {
+            assert!(src.len() >= 4);
+            unsafe { ptr::read(src.as_ptr() as *const u32) }
+        }
+
+        const TEST_STR: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        let mut bstr = BrandString::from_str(TEST_STR);
+
+        // Test the immutable bitwise casts
+        //
+        {
+            for i in 0_usize..=1_usize {
+                let leaf_regs = bstr.borrow_regs_for_leaf(BRAND_STRING_MIN_LEAF + i as u32);
+                let eax_offs = mem::size_of::<BrandStringRegs>() * i
+                    + &leaf_regs.eax as *const _ as usize
+                    - leaf_regs as *const _ as usize;
+                let ebx_offs = mem::size_of::<BrandStringRegs>() * i
+                    + &leaf_regs.ebx as *const _ as usize
+                    - leaf_regs as *const _ as usize;
+                let ecx_offs = mem::size_of::<BrandStringRegs>() * i
+                    + &leaf_regs.ecx as *const _ as usize
+                    - leaf_regs as *const _ as usize;
+                let edx_offs = mem::size_of::<BrandStringRegs>() * i
+                    + &leaf_regs.edx as *const _ as usize
+                    - leaf_regs as *const _ as usize;
+                assert_eq!(
+                    leaf_regs.eax,
+                    str_to_u32(&TEST_STR[eax_offs..(eax_offs + 4)])
+                );
+                assert_eq!(
+                    leaf_regs.ebx,
+                    str_to_u32(&TEST_STR[ebx_offs..(ebx_offs + 4)])
+                );
+                assert_eq!(
+                    leaf_regs.ecx,
+                    str_to_u32(&TEST_STR[ecx_offs..(ecx_offs + 4)])
+                );
+                assert_eq!(
+                    leaf_regs.edx,
+                    str_to_u32(&TEST_STR[edx_offs..(edx_offs + 4)])
+                );
+            }
+        }
+
+        // Test mutable bitwise casting and finding the frequency substring
+        //
+        {
+            let mut_leaf_regs = bstr.borrow_mut_regs_for_leaf(BRAND_STRING_MIN_LEAF + 1);
+            mut_leaf_regs.ebx = str_to_u32("5.20");
+            mut_leaf_regs.ecx = str_to_u32("GHz ");
+        }
+        {
+            assert_eq!(bstr.borrow_freq_str().unwrap(), "5.20GHz");
+        }
+
+        // Test BrandString::starts_with()
+        //
+        assert_eq!(bstr.starts_with("012345"), true);
+        assert_eq!(bstr.starts_with("01234X"), false);
+        assert_eq!(bstr.starts_with("X01234"), false);
+
+        // Test BrandString::push_str()
+        //
+        bstr = BrandString::new();
+        bstr.push_str("Hello");
+        bstr.push_str(", world!");
+        assert!(bstr.starts_with("Hello, world!"));
+
+        // Test BrandString::from_host_cpuid() and borrow_regs_for_leaf()
+        //
+        match BrandString::from_host_cpuid() {
+            Ok(bstr) => {
+                for i in 0..BRAND_STRING_LEAF_COUNT {
+                    let leaf_regs = bstr.borrow_regs_for_leaf(BRAND_STRING_MIN_LEAF + i);
+                    let host_regs = host_cpuid(BRAND_STRING_MIN_LEAF + i);
+                    assert_eq!(leaf_regs.eax, host_regs.eax);
+                    assert_eq!(leaf_regs.ebx, host_regs.ebx);
+                    assert_eq!(leaf_regs.ecx, host_regs.ecx);
+                    assert_eq!(leaf_regs.edx, host_regs.edx);
+                }
+            }
+            Err(Error::BrandStringNotSupported) => {
+                let host_regs = host_cpuid(0x80000000);
+                assert!(host_regs.eax >= BRAND_STRING_MAX_LEAF);
+            }
+            Err(_) => assert!(false),
+        }
+    }
+}

--- a/x86_64/src/cpuid/c3_template.rs
+++ b/x86_64/src/cpuid/c3_template.rs
@@ -1,5 +1,4 @@
 use cpuid::cpu_leaf::*;
-use cpuid::str_to_u32;
 use kvm_sys::kvm_cpuid_entry2;
 
 pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
@@ -77,26 +76,6 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::PREFETCH_SHIFT);
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::LZCNT_SHIFT);
                 entry.edx &= !(1 << leaf_0x80000001::edx::PDPE1GB_SHIFT);
-            }
-            0x80000002 => {
-                // set this leaf to "Intel(R) Xeon(R)"
-                entry.eax = str_to_u32("etnI");
-                entry.ebx = str_to_u32(")R(l");
-                entry.ecx = str_to_u32("oeX ");
-                entry.edx = str_to_u32(")R(n");
-            }
-            0x80000003 => {
-                // set this leaf to " Processor"
-                entry.eax = str_to_u32("orP ");
-                entry.ebx = str_to_u32("ssec");
-                entry.ecx = str_to_u32("  ro");
-                entry.edx = 0;
-            }
-            0x80000004 => {
-                entry.eax = 0;
-                entry.ebx = 0;
-                entry.ecx = 0;
-                entry.edx = 0;
             }
 
             _ => (),

--- a/x86_64/src/cpuid/host_cpuid.c
+++ b/x86_64/src/cpuid/host_cpuid.c
@@ -1,0 +1,27 @@
+#ifdef __x86_64__
+
+#include <stdint.h>
+
+void x86_64_cpuid_host_cpuid(
+    uint32_t leaf,
+    uint32_t *eax,
+    uint32_t *ebx,
+    uint32_t *ecx,
+    uint32_t *edx
+) {
+    asm volatile(
+
+        "cpuid"
+
+        /* out */ :
+            "=a" (*eax),
+            "=b" (*ebx),
+            "=c" (*ecx),
+            "=d" (*edx)
+        /* in */ :
+            "a" (leaf) /* place leaf in EAX */
+        /* clobber */ : 
+    );
+}
+
+#endif

--- a/x86_64/src/cpuid/t2_template.rs
+++ b/x86_64/src/cpuid/t2_template.rs
@@ -1,5 +1,4 @@
 use cpuid::cpu_leaf::*;
-use cpuid::str_to_u32;
 use kvm_sys::kvm_cpuid_entry2;
 
 pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
@@ -69,26 +68,6 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
             0x80000001 => {
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::PREFETCH_SHIFT);
                 entry.edx &= !(1 << leaf_0x80000001::edx::PDPE1GB_SHIFT);
-            }
-            0x80000002 => {
-                // set this leaf to "Intel(R) Xeon(R)"
-                entry.eax = str_to_u32("etnI");
-                entry.ebx = str_to_u32(")R(l");
-                entry.ecx = str_to_u32("oeX ");
-                entry.edx = str_to_u32(")R(n");
-            }
-            0x80000003 => {
-                // set this leaf to " Processor"
-                entry.eax = str_to_u32("orP ");
-                entry.ebx = str_to_u32("ssec");
-                entry.ecx = str_to_u32("  ro");
-                entry.edx = 0;
-            }
-            0x80000004 => {
-                entry.eax = 0;
-                entry.ebx = 0;
-                entry.ecx = 0;
-                entry.edx = 0;
             }
 
             _ => (),


### PR DESCRIPTION
Added the host CPUID brand string frequency to the (emulated) vCPU brand
string. Also moved brand string emulation from the vCPU templates to
cpuid::filter_cpuid(). If needed, any template will have a chance to
override this default behaviour.