### PR TITLE
micro_http: added support for HTTP/1.1

### DIFF
--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -7,6 +7,14 @@ pub mod ascii {
     pub const SP: u8 = b' ';
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidHttpMethod(&'static str),
+    InvalidRequest,
+    InvalidUri(&'static str),
+    InvalidHttpVersion(&'static str),
+}
+
 #[derive(Clone, PartialEq)]
 pub struct Body {
     body: Vec<u8>,
@@ -41,15 +49,29 @@ impl Method {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Version {
     Http10,
+    Http11,
 }
 
 impl Version {
     pub fn raw(&self) -> &'static [u8] {
         match self {
             Version::Http10 => b"HTTP/1.0",
+            Version::Http11 => b"HTTP/1.1",
         }
+    }
+
+    pub fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+        match bytes {
+            b"HTTP/1.0" => Ok(Version::Http10),
+            b"HTTP/1.1" => Ok(Version::Http11),
+            _ => Err(Error::InvalidHttpVersion("Cannot parse HTTP version.")),
+        }
+    }
+
+    pub fn default() -> Self {
+        Version::Http11
     }
 }

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -8,4 +8,4 @@ use common::headers;
 pub use request::{Error as RequestError, Request};
 pub use response::{Response, StatusCode};
 
-pub use common::Body;
+pub use common::{Body, Version};

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -30,9 +30,9 @@ struct StatusLine {
 }
 
 impl StatusLine {
-    fn new(status_code: StatusCode) -> Self {
+    fn new(http_version: Version, status_code: StatusCode) -> Self {
         return StatusLine {
-            http_version: Version::Http10,
+            http_version,
             status_code,
         };
     }
@@ -52,9 +52,9 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn new(status_code: StatusCode) -> Response {
+    pub fn new(http_version: Version, status_code: StatusCode) -> Response {
         return Response {
-            status_line: StatusLine::new(status_code),
+            status_line: StatusLine::new(http_version, status_code),
             headers: Headers::default(),
             body: None,
         };
@@ -94,6 +94,10 @@ impl Response {
     pub fn body(&self) -> Option<Body> {
         self.body.clone()
     }
+
+    pub fn http_version(&self) -> Version {
+        self.status_line.http_version.clone()
+    }
 }
 
 #[cfg(test)]
@@ -102,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_raw() {
-        let mut response = Response::new(StatusCode::OK);
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
         let body = String::from("This is a test");
         response.set_body(Body::new(body.clone()));
 

--- a/mmds_glue/src/lib.rs
+++ b/mmds_glue/src/lib.rs
@@ -2,10 +2,12 @@ extern crate data_model;
 extern crate micro_http;
 
 use data_model::mmds::{Error as MmdsError, MMDS};
-use micro_http::{Body, Request, RequestError, Response, StatusCode};
+use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
 
-fn build_response(status_code: StatusCode, body: Body) -> Response {
-    let mut response = Response::new(status_code);
+use std::str::from_utf8;
+
+fn build_response(http_version: Version, status_code: StatusCode, body: Body) -> Response {
+    let mut response = Response::new(http_version, status_code);
     response.set_body(body);
     response
 }
@@ -14,40 +16,49 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
     let request = Request::try_from(request_bytes);
     match request {
         Ok(request) => {
-            let uri_utf8 = request.get_uri_utf8();
-
-            // Only accept URI that start with uri_prefix.
-            // The instance metadata is available at the following uri, as specified in the
-            // official documentation:
-            // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-            let uri_prefix = "http://169.254.169.254";
-            if !uri_utf8.starts_with(uri_prefix) {
-                let error_msg = format!("Invalid URI: {}.", uri_utf8);
-                return build_response(StatusCode::BadRequest, Body::new(error_msg));
+            let uri = request.uri().get_abs_path();
+            if uri.len() == 0 {
+                return build_response(
+                    request.http_version(),
+                    StatusCode::BadRequest,
+                    Body::new("Invalid URI.".to_string()),
+                );
             }
 
-            let mmds_uri = &uri_utf8[uri_prefix.len()..];
+            // We ensure that the URI is UTF-8 when creating the request.
+            let uri_utf8 = from_utf8(uri).unwrap();
+
             // The lock can be held by one thread only, so it is safe to unwrap.
-            let response = MMDS.lock().unwrap().get_value(mmds_uri.to_string());
+            // If another thread poisened the lock, we abort the execution.
+            let response = MMDS.lock().unwrap().get_value(uri_utf8.to_string());
             match response {
                 Ok(response) => {
                     let response_body = response.join("\n");
-                    build_response(StatusCode::OK, Body::new(response_body))
+                    build_response(
+                        request.http_version(),
+                        StatusCode::OK,
+                        Body::new(response_body),
+                    )
                 }
                 Err(e) => {
                     match e {
                         MmdsError::NotFound => {
                             // NotFound
-                            let error_msg = format!("Resource not found: {}.", mmds_uri);
-                            return build_response(StatusCode::NotFound, Body::new(error_msg));
+                            let error_msg = format!("Resource not found: {}.", uri_utf8);
+                            return build_response(
+                                request.http_version(),
+                                StatusCode::NotFound,
+                                Body::new(error_msg),
+                            );
                         }
                         MmdsError::UnsupportedValueType => {
                             // InternalServerError
                             let error_msg = format!(
                                 "The resource {} has an invalid format.",
-                                mmds_uri.to_string()
+                                uri_utf8.to_string()
                             );
                             return build_response(
+                                request.http_version(),
                                 StatusCode::InternalServerError,
                                 Body::new(error_msg),
                             );
@@ -57,13 +68,20 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
             }
         }
         Err(e) => match e {
-            RequestError::InvalidHttpVersion(err_msg) => {
-                build_response(StatusCode::NotImplemented, Body::new(err_msg.to_string()))
-            }
+            RequestError::InvalidHttpVersion(err_msg) => build_response(
+                Version::default(),
+                StatusCode::NotImplemented,
+                Body::new(err_msg.to_string()),
+            ),
             RequestError::InvalidUri(err_msg) | RequestError::InvalidHttpMethod(err_msg) => {
-                build_response(StatusCode::BadRequest, Body::new(err_msg.to_string()))
+                build_response(
+                    Version::default(),
+                    StatusCode::BadRequest,
+                    Body::new(err_msg.to_string()),
+                )
             }
             RequestError::InvalidRequest => build_response(
+                Version::default(),
                 StatusCode::BadRequest,
                 Body::new("Invalid request.".to_string()),
             ),
@@ -98,56 +116,69 @@ mod tests {
 
         // Test invalid request.
         let request = b"HTTP/1.1";
-        let dummy_response = Response::new(StatusCode::BadRequest);
+        let dummy_response = Response::new(Version::Http11, StatusCode::BadRequest);
         assert!(parse_request(request).status() == dummy_response.status());
 
         // Test unsupported HTTP version.
-        let request = b"GET http://169.254.169.255/ HTTP/1.1\r\n";
-        let mut expected_response = Response::new(StatusCode::NotImplemented);
+        let request = b"GET http://169.254.169.255/ HTTP/2.0\r\n";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
         expected_response.set_body(Body::new("Unsupported HTTP version.".to_string()));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
 
         // Test invalid HTTP Method.
         let request = b"PUT http://169.254.169.255/ HTTP/1.0\r\n";
-        let mut expected_response = Response::new(StatusCode::BadRequest);
+        let mut expected_response = Response::new(Version::Http11, StatusCode::BadRequest);
         expected_response.set_body(Body::new("Unsupported HTTP method.".to_string()));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
 
-        // Test invalid URI.
-        let request = b"GET http://169.254.169.255/ HTTP/1.0\r\n";
-        let mut expected_response = Response::new(StatusCode::BadRequest);
-        expected_response.set_body(Body::new(
-            "Invalid URI: http://169.254.169.255/.".to_string(),
-        ));
+        // Test invalid (empty absolute path) URI.
+        let request = b"GET http:// HTTP/1.0\r\n";
+        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        expected_response.set_body(Body::new("Invalid URI.".to_string()));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
 
         // Test resource not found.
         let request = b"GET http://169.254.169.254/invalid HTTP/1.0\r\n";
-        let mut expected_response = Response::new(StatusCode::NotFound);
+        let mut expected_response = Response::new(Version::Http10, StatusCode::NotFound);
         expected_response.set_body(Body::new("Resource not found: /invalid.".to_string()));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
 
         // Test Ok path.
         let request = b"GET http://169.254.169.254/ HTTP/1.0\r\n";
-        let mut expected_response = Response::new(StatusCode::OK);
+        let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
         let body = "age\nname/\nphones/".to_string();
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
+
+        let request = b"GET /age HTTP/1.1\r\n";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::OK);
+        let body = "43".to_string();
+        expected_response.set_body(Body::new(body));
+        let actual_response = parse_request(request);
+
+        assert!(expected_response.status() == actual_response.status());
+        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
 
         // Test Internal Server Error.
         let data = r#"{
@@ -162,11 +193,12 @@ mod tests {
             .put_data(serde_json::from_str(data).unwrap());
 
         let request = b"GET http://169.254.169.254/age HTTP/1.0\r\n";
-        let mut expected_response = Response::new(StatusCode::InternalServerError);
+        let mut expected_response = Response::new(Version::Http10, StatusCode::InternalServerError);
         let body = format!("The resource /age has an invalid format.");
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
+        assert!(expected_response.http_version() == actual_response.http_version());
     }
 }


### PR DESCRIPTION
We now check in the request line if the HTTP version is either 1.0 or 1.1.
For parsing the request URI, we have to also accept URIs as absolute URIs
or relative URIs, where the relative URI is an absolute path.
Added get method for http_version in Request. This is to be used when
building a Response for a Request. If the request parsing failed, the
Response will have the default HTTP Version (HTTP/1.1). Exported the Version
struct publicly so it can be used when building a response.