### PR TITLE
Serialize machine-config fields to correct datatypes

### DIFF
--- a/api_server/src/request/sync/machine_configuration.rs
+++ b/api_server/src/request/sync/machine_configuration.rs
@@ -53,22 +53,12 @@ impl GenerateResponse for PutMachineConfigurationOutcome {
 
 impl GenerateResponse for MachineConfiguration {
     fn generate_response(&self) -> Response {
-        let vcpu_count = match self.vcpu_count {
-            Some(v) => v.to_string(),
-            None => String::from("Uninitialized"),
-        };
-        let mem_size = match self.mem_size_mib {
-            Some(v) => v.to_string(),
-            None => String::from("Uninitialized"),
-        };
-        let ht_enabled = match self.ht_enabled {
-            Some(v) => v.to_string(),
-            None => String::from("Uninitialized"),
-        };
-        let cpu_template = match self.cpu_template {
-            Some(ref v) => v.to_string(),
-            None => String::from("Uninitialized"),
-        };
+        let vcpu_count = self.vcpu_count.unwrap_or(1);
+        let mem_size = self.mem_size_mib.unwrap_or(128);
+        let ht_enabled = self.ht_enabled.unwrap_or(false);
+        let cpu_template = self
+            .cpu_template
+            .map_or("Uninitialized".to_string(), |c| c.to_string());
 
         json_response(
             StatusCode::Ok,

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -116,13 +116,13 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
     )
     response_json = response.json()
 
-    vcpu_count = str(microvm_config_json['vcpu_count'])
+    vcpu_count = microvm_config_json['vcpu_count']
     assert response_json['vcpu_count'] == vcpu_count
 
-    ht_enabled = str(microvm_config_json['ht_enabled']).lower()
+    ht_enabled = microvm_config_json['ht_enabled']
     assert response_json['ht_enabled'] == ht_enabled
 
-    mem_size_mib = str(microvm_config_json['mem_size_mib'])
+    mem_size_mib = microvm_config_json['mem_size_mib']
     assert response_json['mem_size_mib'] == mem_size_mib
 
     cpu_template = str(microvm_config_json['cpu_template'])


### PR DESCRIPTION
This change corrects the GET /machine-config API to encode the
MachineConfiguration values using the same JSON datatypes that
Firecracker expects for input.

Tested using the Go swagger client.

This change addresses #479 