### PR TITLE
[RFC] mmds: configure the net interface for MMDS req

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -1478,6 +1478,7 @@ mod tests {
             guest_mac: Some(MacAddr::parse_str("12:34:56:78:9a:BC").unwrap()),
             rx_rate_limiter: None,
             tx_rate_limiter: None,
+            allow_mmds_requests: false,
         };
 
         match netif.into_parsed_request("bar") {

--- a/api_server/src/request/sync/net.rs
+++ b/api_server/src/request/sync/net.rs
@@ -22,6 +22,15 @@ pub struct NetworkInterfaceBody {
     pub rx_rate_limiter: Option<RateLimiterDescription>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_rate_limiter: Option<RateLimiterDescription>,
+    #[serde(default = "default_allow_mmds_requests")]
+    pub allow_mmds_requests: bool,
+}
+
+// Serde does not allow specifying a default value for a field
+// that is not required. The workaround is to specify a function
+// that returns the value.
+fn default_allow_mmds_requests() -> bool {
+    false
 }
 
 impl NetworkInterfaceBody {
@@ -54,6 +63,7 @@ mod tests {
             guest_mac: Some(MacAddr::parse_str("12:34:56:78:9A:BC").unwrap()),
             rx_rate_limiter: None,
             tx_rate_limiter: None,
+            allow_mmds_requests: false,
         };
 
         assert!(netif.clone().into_parsed_request("bar").is_err());
@@ -78,6 +88,7 @@ mod tests {
             guest_mac: Some(MacAddr::parse_str("12:34:56:78:9A:BC").unwrap()),
             rx_rate_limiter: Some(RateLimiterDescription::default()),
             tx_rate_limiter: Some(RateLimiterDescription::default()),
+            allow_mmds_requests: true,
         };
 
         // This is the json encoding of the netif variable.
@@ -89,7 +100,8 @@ mod tests {
             "rx_rate_limiter": {
             },
             "tx_rate_limiter": {
-            }
+            },
+            "allow_mmds_requests": true
         }"#;
 
         let x = serde_json::from_str(jstr).expect("deserialization failed.");

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -468,6 +468,14 @@ definitions:
       host_dev_name:
         type: string
         description: Host level path for the guest network interface
+      allow_mmds_requests:
+        type: boolean
+        description:
+          If this field is set, the device model will reply to HTTP GET
+          requests sent to the MMDS address via this interface. In this case,
+          both ARP requests for 169.254.169.254 and TCP segments heading to the
+          same address are intercepted by the device model, and do not reach
+          the associated TAP device.
       rx_rate_limiter:
         $ref: "#/definitions/RateLimiter"
       tx_rate_limiter:

--- a/vmm/src/device_config/net.rs
+++ b/vmm/src/device_config/net.rs
@@ -57,6 +57,10 @@ impl NetworkInterfaceConfig {
     pub fn guest_mac(&self) -> Option<&MacAddr> {
         self.body.guest_mac.as_ref()
     }
+
+    pub fn allow_mmds_requests(&self) -> bool {
+        self.body.allow_mmds_requests
+    }
 }
 
 pub struct NetworkInterfaceConfigs {
@@ -133,6 +137,7 @@ mod tests {
             guest_mac: Some(mac),
             rx_rate_limiter: Some(RateLimiterDescription::default()),
             tx_rate_limiter: Some(RateLimiterDescription::default()),
+            allow_mmds_requests: false,
         }
     }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -754,6 +754,8 @@ impl Vmm {
                 cfg.tx_rate_limiter.as_ref(),
             ).map_err(Error::CreateRateLimiter)?;
 
+            let allow_mmds_requests = cfg.allow_mmds_requests();
+
             if let Some(tap) = cfg.take_tap() {
                 let net_box = Box::new(
                     devices::virtio::Net::new_with_tap(
@@ -762,6 +764,7 @@ impl Vmm {
                         epoll_config,
                         rx_rate_limiter,
                         tx_rate_limiter,
+                        allow_mmds_requests,
                     ).map_err(Error::CreateNetDevice)?,
                 );
 
@@ -1695,6 +1698,7 @@ mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
+            allow_mmds_requests: false,
         };
         match vmm.put_net_device(network_interface) {
             Ok(outcome) => assert!(outcome == SyncOkStatus::Created),
@@ -1710,6 +1714,7 @@ mod tests {
                 guest_mac: Some(mac),
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
+                allow_mmds_requests: false,
             };
             match vmm.put_net_device(network_interface) {
                 Ok(outcome) => assert!(outcome == SyncOkStatus::Updated),


### PR DESCRIPTION
Added field allow_mmds_requests to the network config API request.
Only the interfaces that have this field set to true will intercept
MMDS requests.

This is an RFC mostly because I just added on top of the spaghetti code that we already have around network interfaces. We should make this properly, but we will probably not have time in this milestone.

Also, I want some feedback on the swagger definition.