### PR TITLE
CI: exclude autogenerated files from coverage

### DIFF
--- a/tests/build/test_coverage.py
+++ b/tests/build/test_coverage.py
@@ -16,7 +16,7 @@ import pytest
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 
-COVERAGE_TARGET_PCT = 65.0
+COVERAGE_TARGET_PCT = 72.0
 # TODO: Put the coverage in s3 and update it automatically.
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')
@@ -41,7 +41,13 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
         'tests/,'
         'usr/lib/gcc,'
         'lib/x86_64-linux-gnu/,'
-        'pnet'
+        'pnet,'
+        # The following files/directories are auto-generated
+        'bootparam.rs,'
+        'elf.rs,'
+        'mpspec.rs,'
+        'msr_index.rs,'
+        '_sys'
     )
     exclude_region = '\'mod tests {\''
 


### PR DESCRIPTION
We don't have all autogenerated files in _sys crates.
As a temporary solution, we exclude them by name. Also, exclude
all the files in _sys crates.

Signed-off-by: Andreea Florescu <fandree@amazon.com>