### PR TITLE
RESTful API: action_id leftover in .yaml

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -326,10 +326,6 @@ definitions:
       Variant wrapper containing the real action.
       The timestamp field is read-only, trying to update/change it with an API call will fail.
     properties:
-      action_id:
-        type: string
-        minLength: 1
-        maxLength: 64
       action_type:
         description: Enumeration indicating what type of action is contained in the payload
         type: string


### PR DESCRIPTION
Found a leftover line in `InstanceActionInfo` properties containing the `action_id`