### PR TITLE
Vmm unittests

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2207,6 +2207,15 @@ mod tests {
     }
 
     #[test]
+    fn test_init_devices() {
+        let mut vmm = create_vmm_object(InstanceState::Uninitialized);
+        vmm.default_kernel_config();
+        assert!(vmm.init_guest_memory().is_ok());
+
+        assert!(vmm.init_devices().is_ok());
+    }
+
+    #[test]
     fn test_rescan() {
         let mut vmm = create_vmm_object(InstanceState::Uninitialized);
         vmm.default_kernel_config();


### PR DESCRIPTION
Added tests in vmm/src/lib.rs.
As part of this PR. I also renamed is_instance_running to is_instance_initialized because that's what the function actually does.
Also, refactored the unit tests so we have less duplicated code.

The following functions could also be tested, but were excluded because they will need refactoring:
* rescan
* update_drive_handler
* check_patch_payload_post_boot

Coverage in vmm/src/lib.rs
Before: 32.8%
Now: 39.1%