### PR TITLE
Graceful Shutdown of Firecracker

### DIFF
--- a/tests/functional/test_shut_down.py
+++ b/tests/functional/test_shut_down.py
@@ -1,0 +1,50 @@
+"""Tests scenarios for shutting down Firecracker/VM."""
+import os
+from subprocess import run, PIPE
+
+import host_tools.network as host  # pylint: disable=import-error
+
+
+def test_reboot(test_microvm_with_ssh, network_config):
+    """Test reboot from guest kernel."""
+    test_microvm = test_microvm_with_ssh
+
+    # We don't need to monitor the memory for this test because we are
+    # just rebooting and the process dies before pmap gets the RSS.
+    test_microvm.monitor_memory = False
+
+    # Set up the microVM with 4 vCPUs, 256 MiB of RAM, 0 network ifaces, and
+    # a root file system with the rw permission. The network interfaces is
+    # added after we get an unique MAC and IP.
+    test_microvm.basic_config(vcpu_count=4, net_iface_count=0)
+    test_microvm.basic_network_config(network_config)
+    test_microvm.start()
+
+    # Get Firecracker PID so we can count the number of threads.
+    cmd = 'lsof -U | grep {} | awk \'{{print $2}}\''.format(
+        test_microvm.api_usocket_full_name
+    )
+    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
+    firecracker_pid = process.stdout.decode('utf-8').rstrip()
+
+    # Get number of threads in Firecracker
+    cmd = 'ps -o nlwp {} | tail -1 | awk \'{{print $1}}\''.format(
+        firecracker_pid
+    )
+    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
+    nr_of_threads = process.stdout.decode('utf-8').rstrip()
+    assert (int(nr_of_threads) == 6)
+
+    # Rebooting Firecracker sends an exit event and should gracefully kill.
+    # the instance.
+    ssh_connection = host.SSHConnection(test_microvm.slot.ssh_config)
+    ssh_connection.execute_command("reboot")
+
+    # TODO remove this when Firecracker is no longer a child of
+    # the testing system process.
+    os.waitpid(int(firecracker_pid), 0)
+
+    # Check that the Firecracker process does not exist
+    cmd = "ps -p {}".format(firecracker_pid)
+    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True)
+    assert (process.returncode != 0)

--- a/tests/microvm.py
+++ b/tests/microvm.py
@@ -888,13 +888,11 @@ class Microvm:
         Does not issue a stop command to the guest.
         """
         if self.is_daemonized():
-            run('kill -9 {}'.format(self.jailer_clone_pid), shell=True,
-                check=True)
+            run('kill -9 {}'.format(self.jailer_clone_pid), shell=True)
         else:
             run(
                 self.fc_stop_cmd.format(session=self.session_name),
-                shell=True,
-                check=True
+                shell=True
             )
 
     def ensure_firecracker_binary(self):


### PR DESCRIPTION
Firecracker can be gracefully shut down using the reboot command from the guest kernel. This is a first step into having an API call for shutting down Firecracker.