### PR TITLE
api: update firecracker.yaml swagger definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- The `path_on_host` property in the drive specification is now marked as *mandatory*.
+- PATCH drive only allows patching/changing the `path_on_host` property.
+
 ## [0.9.0]
 
 ### Added

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -134,7 +134,7 @@ paths:
         description: Guest drive properties
         required: true
         schema:
-          $ref: "#/definitions/Drive"
+          $ref: "#/definitions/PartialDrive"
       responses:
         204:
           description: Drive updated
@@ -289,6 +289,7 @@ definitions:
     type: object
     required:
       - drive_id
+      - path_on_host
       - is_root_device
       - is_read_only
     properties:
@@ -422,6 +423,18 @@ definitions:
         $ref: "#/definitions/RateLimiter"
       state:
         $ref: "#/definitions/DeviceState"
+
+  PartialDrive:
+    type: object
+    required:
+      - drive_id
+      - path_on_host
+    properties:
+      drive_id:
+        type: string
+      path_on_host:
+        type: string
+        description: Host level path for the guest drive
 
   RateLimiter:
     type: object


### PR DESCRIPTION
Added `path_on_host` as mandatory for `Drive` specification.
Added `PartialDrive` as the spec used for PATCH-ing Drives.
PATCH on drives only allows changing `path_on_host`.