### PR TITLE
Remove FIRECRACKER_IS_JAILED

### DIFF
--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -16,7 +16,6 @@ tokio-io = "=0.1.5"
 
 data_model = { path = "../data_model" }
 fc_util = { path = "../fc_util" }
-jailer = { path = "../jailer" }
 logger = { path = "../logger" }
 sys_util = { path = "../sys_util" }
 vmm = { path = "../vmm" }

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -11,11 +11,6 @@ extern crate fc_util;
 pub mod mmds;
 pub mod vm;
 
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
-
-// ATOMIC_BOOL_INIT = false
-pub static FIRECRACKER_IS_JAILED: AtomicBool = ATOMIC_BOOL_INIT;
-
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FirecrackerContext {

--- a/kvm/Cargo.toml
+++ b/kvm/Cargo.toml
@@ -7,8 +7,6 @@ authors = ["The Chromium OS Authors"]
 byteorder = "=1.2.1"
 libc = ">=0.2.39"
 
-data_model = { path = "../data_model" }
-jailer = { path = "../jailer" }
 kvm_sys = { path = "../kvm_sys" }
 memory_model = { path = "../memory_model" }
 sys_util = { path = "../sys_util" }


### PR DESCRIPTION
Removed the aforementioned global variable and reworked existing logic to accomodate this change. When Firecracker is jailed, some parameters are propagated from main.rs to the appropriate places in the implementation of `struct Kvm`, and that of `ApiServer`, in order to distinguish between having to create resources, and reusing a fd already opened by the jailer.