### PR TITLE
Limit the duration of API calls in integration tests

### DIFF
--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -9,6 +9,8 @@ JAILER_BINARY_NAME = 'jailer'
 """Jailer's binary name."""
 JAILER_DEFAULT_CHROOT = '/srv/jailer'
 """The default location for the chroot."""
+MAX_API_CALL_DURATION_MS = 100
+"""Maximum accepted duration of an API call, in milliseconds."""
 MICROVM_KERNEL_RELPATH = 'kernel/'
 """Relative path to the location of the kernel file."""
 MICROVM_FSFILES_RELPATH = 'fsfiles/'

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -1,0 +1,86 @@
+"""Wrapper over an http session with timed requests."""
+
+import time
+
+import requests_unixsocket
+
+from framework.defs import API_USOCKET_NAME, MAX_API_CALL_DURATION_MS
+
+
+class ApiTimeoutException(Exception):
+    """A custom exception containing the details of the failed API call."""
+
+    def __init__(self, duration, method, resource, payload):
+        """Compose the error message from the API call components."""
+        super(ApiTimeoutException, self).__init__(
+            'API call exceeded maximum duration: {:.2f} ms.\n'
+            'Call: {} {} {}'
+            .format(duration, method, resource, payload)
+        )
+
+
+def timed_request(method):
+    """Decorate functions to monitor their duration."""
+    def timed(*args, **kwargs):
+        """Raise an exception if method's duration exceeds the max value."""
+        start = time.time()
+        result = method(*args, **kwargs)
+        duration_ms = (time.time() - start) * 1000
+
+        if duration_ms > MAX_API_CALL_DURATION_MS:
+            try:
+                # The positional arguments are:
+                # 1. The Session object
+                # 2. The URL from which we extract the resource for readability
+                resource = args[1][args[1].find(
+                    API_USOCKET_NAME)+len(API_USOCKET_NAME):]
+            except IndexError:
+                # Ignore formatting errors.
+                resource = ''
+
+            # The payload is JSON-encoded and passed as an argument.
+            payload = kwargs['json'] if 'json' in kwargs else ''
+
+            raise ApiTimeoutException(
+                duration_ms,
+                method.__name__.upper(),
+                resource,
+                payload
+            )
+
+        return result
+
+    return timed
+
+
+class Session(requests_unixsocket.Session):
+    """Wrapper over requests_unixsocket.Session limiting the call duration.
+
+    Only the API calls relevant to Firecracker (GET, PUT, PATCH) are
+    implemented.
+    """
+
+    def __init__(self):
+        """Create a Session object and set the is_good_response callback."""
+        super(Session, self).__init__()
+
+        def is_good_response(response: int):
+            """Return `True` for all HTTP 2xx response codes."""
+            return 200 <= response < 300
+
+        self.is_good_response = is_good_response
+
+    @timed_request
+    def get(self, url, **kwargs):
+        """Wrap the GET call with duration limit."""
+        return super(Session, self).get(url, **kwargs)
+
+    @timed_request
+    def patch(self, url, data=None, **kwargs):
+        """Wrap the PATCH call with duration limit."""
+        return super(Session, self).patch(url, data=data, **kwargs)
+
+    @timed_request
+    def put(self, url, data=None, **kwargs):
+        """Wrap the PUT call with duration limit."""
+        return super(Session, self).put(url, data=data, **kwargs)

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -15,12 +15,11 @@ from subprocess import run
 
 from retry import retry
 
-import requests_unixsocket
-
 import host_tools.memory as mem_tools
 import host_tools.network as net_tools
 
 from framework.defs import MICROVM_KERNEL_RELPATH, MICROVM_FSFILES_RELPATH
+from framework.http import Session
 from framework.jailer import JailerContext
 from framework.resources import Actions, BootSource, Drive, Logger, MMDS, \
     MachineConfigure, Network
@@ -217,18 +216,7 @@ class Microvm:
         """Start a microVM as a daemon or in a screen session."""
         self._jailer.setup()
         self._api_socket = self._jailer.api_socket_path()
-
-        def start_api_session():
-            """Return a unixsocket-capable http session object."""
-            def is_good_response(response: int):
-                """Return `True` for all HTTP 2xx response codes."""
-                return 200 <= response < 300
-
-            session = requests_unixsocket.Session()
-            session.is_good_response = is_good_response
-            return session
-
-        self._api_session = start_api_session()
+        self._api_session = Session()
 
         self.actions = Actions(self._api_socket, self._api_session)
         self.boot = BootSource(self._api_socket, self._api_session)


### PR DESCRIPTION
# Changes
* Added a decorator that raises a custom exception if the API call it decorates takes too long.
* Added a wrapper over `request_unixsocket.Session` that sets the custom  callback for `is_good_response` and overrides the `GET`, `PUT` and `PATCH` methods. This way, all the API calls are duration limited.
* The maximum duration of an API call is **15 ms**.

# Testing
To find out the maximum duration, I modified the decorator so as to log all the durations and ran the integration test suite 12 times on an `i3.metal` instance, then isolated the longest call (an `InstanceStart` that took 14.485731 ms).

Patch:
```diff
diff --git a/tests/framework/defs.py b/tests/framework/defs.py
index 21a2b76..1b68c15 100644
--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -3,5 +3,5 @@ API_USOCKET_URL_PREFIX = 'http+unix://'
 API_USOCKET_NAME = 'api.socket'
 FC_BINARY_NAME = 'firecracker'
 JAILER_BINARY_NAME = 'jailer'
+MAX_API_CALL_TIME_MS = 0
-MAX_API_CALL_TIME_MS = 35
 """Maximum accepted duration of an API call, in milliseconds."""
diff --git a/tests/framework/http.py b/tests/framework/http.py
index e827b1e..9016168 100644
--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -41,15 +41,12 @@ def timed_request(method):
             # The payload is JSON-encoded and passed as an argument.
             payload = kwargs['json'] if 'json' in kwargs else ''
 
+            with open('times.csv', 'a') as out:
+                out.write('{},{},{},"{}"\n'.format(duration_ms, method.__name__.upper(), resource, payload))
-            raise ApiTimeoutException(
-                duration_ms,
-                method.__name__.upper(),
-                resource,
-                payload
-            )
 
         return result
```