### PR TITLE
test_boottime.py: fixed time extraction regex

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -13,7 +13,7 @@ import host_tools.logging as log_tools
 MAX_BOOT_TIME_US = 150000
 # TODO: Keep a `current` boot time in S3 and validate we don't regress
 # Regex for obtaining boot time from some string.
-TIMESTAMP_LOG_REGEX = r'Guest-boot-time\ \=\ (\d+)'
+TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
The regex used to find the boot time in the log was failing for boot
times lower than 100ms. Fixed it.