### PR TITLE
vmm: removed NetworkInterfaceBody

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -20,7 +20,7 @@ use sys_util::EventFd;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 use vmm::vmm_config::instance_info::InstanceInfo;
 use vmm::vmm_config::logger::LoggerConfig;
-use vmm::vmm_config::net::NetworkInterfaceBody;
+use vmm::vmm_config::net::NetworkInterfaceConfig;
 use vmm::VmmAction;
 
 fn build_response_base<B: Into<hyper::Body>>(
@@ -297,7 +297,7 @@ fn parse_netif_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<'a
         1 if method == Method::Put => {
             METRICS.put_api_requests.network_count.inc();
 
-            Ok(serde_json::from_slice::<NetworkInterfaceBody>(body)
+            Ok(serde_json::from_slice::<NetworkInterfaceConfig>(body)
                 .map_err(|e| {
                     METRICS.put_api_requests.network_fails.inc();
                     Error::SerdeJson(e)
@@ -1038,7 +1038,7 @@ mod tests {
         let body: Chunk = Chunk::from(json);
 
         // PUT
-        let netif = NetworkInterfaceBody {
+        let netif = NetworkInterfaceConfig {
             iface_id: net_id.clone(),
             state: DeviceState::Attached,
             host_dev_name: String::from("foo"),
@@ -1046,6 +1046,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            tap: None,
         };
 
         match netif.into_parsed_request(Some(net_id), Method::Put) {

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -234,6 +234,11 @@ mod tests {
             NetworkInterfaceError::UpdateNotAllowedPostBoot,
         );
         check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::NetworkConfig(
+            ErrorKind::User,
+            NetworkInterfaceError::HostDeviceNameInUse(String::from("tap_name")),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
 
         // Tests for MicrovmStart Errors.
         // RegisterBlockDevice, RegisterNetDevice, and LegacyIOBus cannot be tested because the

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -40,6 +40,12 @@ pub struct Tap {
     if_name: [u8; 16usize],
 }
 
+impl PartialEq for Tap {
+    fn eq(&self, other: &Tap) -> bool {
+        return self.if_name == other.if_name;
+    }
+}
+
 // Returns a byte vector representing the contents of a null terminated C string which
 // contains if_name.
 fn build_terminated_if_name(if_name: &str) -> Result<Vec<u8>> {

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -178,7 +178,8 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
         guest_mac='06:00:00:00:00:01'
     )
     assert not test_microvm.api_session.is_good_response(response.status_code)
-    assert "Cannot open TAP device. Invalid name/permissions." in response.text
+    assert "The host device name {} is already in use.".\
+        format(second_if_name) in response.text
 
     # Updates to a network interface with an available name are allowed.
     iface_id = '1'


### PR DESCRIPTION
Previously, we had a NetworkInterfaceConfig that contained the
NetworkInterfaceBody. The only additional field of the
NetworkInterfaceConfig was the tap device.

Renamed the NetworkInterfaceBody to NetworkInterfaceConfig.

Added the tap field to NetworkInterfaceConfig. This field cannot
and should not be serialized or deserialized because it is created
using the field `host_dev_name`.

Reworked the update and create of the NetworkInterfaceConfig. Added
validate functions for both actions. Also, checked if the host_dev_name
is in use before trying to open the Tap, so we can return a meaningful
error in that case.

Coverage: **78.4%**