### PR TITLE
Add periodic logging of metrics on number of dirty pages

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -259,6 +259,7 @@ fn parse_machine_config_req<'a>(
                 mem_size_mib: None,
                 ht_enabled: None,
                 cpu_template: None,
+                log_dirty_pages: None,
             };
             Ok(empty_machine_config
                 .into_parsed_request(None, method)
@@ -982,7 +983,8 @@ mod tests {
                 \"vcpu_count\": 42,
                 \"mem_size_mib\": 1025,
                 \"ht_enabled\": true,
-                \"cpu_template\": \"T2\"
+                \"cpu_template\": \"T2\",
+                \"log_dirty_pages\": true,
               }";
         let body: Chunk = Chunk::from(json);
 
@@ -1000,6 +1002,7 @@ mod tests {
             mem_size_mib: Some(1025),
             ht_enabled: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
+            log_dirty_pages: Some(true),
         };
 
         match vm_config.into_parsed_request(None, Method::Put) {

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -435,6 +435,9 @@ definitions:
         description: Flag for enabling/disabling Hyperthreading
       cpu_template:
         $ref: "#/definitions/CpuTemplate"
+      log_dirty_pages:
+        type: boolean
+        description: Enable logging of dirty pages, and periodic generation of dirty page metrics.
 
   NetworkInterface:
     type: object

--- a/data_model/src/vm/machine_config.rs
+++ b/data_model/src/vm/machine_config.rs
@@ -35,6 +35,8 @@ pub struct VmConfig {
     pub ht_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_template: Option<CpuFeaturesTemplate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_dirty_pages: Option<bool>,
 }
 
 impl Default for VmConfig {
@@ -44,6 +46,7 @@ impl Default for VmConfig {
             mem_size_mib: Some(128),
             ht_enabled: Some(false),
             cpu_template: None,
+            log_dirty_pages: Some(false),
         }
     }
 }

--- a/kvm_sys/src/lib.rs
+++ b/kvm_sys/src/lib.rs
@@ -38,6 +38,7 @@ ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
+ioctl_ior_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
 ioctl_iow_nr!(
     KVM_SET_USER_MEMORY_REGION,
     KVMIO,

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -260,6 +260,12 @@ pub struct VcpuMetrics {
     pub failures: SharedMetric,
 }
 
+// Memory usage metrics
+#[derive(Default, Serialize)]
+pub struct MemoryMetrics {
+    pub dirty_pages: SharedMetric,
+}
+
 #[derive(Default, Serialize)]
 pub struct VmmMetrics {
     pub device_events: SharedMetric,
@@ -290,6 +296,7 @@ pub struct FirecrackerMetrics {
     pub put_api_requests: PutRequestsMetrics,
     pub seccomp: SeccompMetrics,
     pub vcpu: VcpuMetrics,
+    pub memory: MemoryMetrics,
     pub vmm: VmmMetrics,
     pub uart: SerialDeviceMetrics,
 }

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -23,9 +23,15 @@ pub enum Error {
 }
 type Result<T> = result::Result<T, Error>;
 
-struct MemoryRegion {
+pub struct MemoryRegion {
     mapping: MemoryMapping,
     guest_base: GuestAddress,
+}
+
+impl MemoryRegion {
+    pub fn size(&self) -> usize {
+        self.mapping.size()
+    }
 }
 
 fn region_end(region: &MemoryRegion) -> GuestAddress {
@@ -105,6 +111,14 @@ impl GuestMemory {
     /// Returns the size of the memory region in bytes.
     pub fn num_regions(&self) -> usize {
         self.regions.len()
+    }
+
+    pub fn map_and_fold<F, G, T>(&self, init: T, mapf: F, foldf: G) -> T
+    where
+        F: Fn((usize, &MemoryRegion)) -> T,
+        G: Fn(T, T) -> T
+    {
+        self.regions.iter().enumerate().map(mapf).fold(init, foldf)
     }
 
     /// Perform the specified action on each region's addresses.


### PR DESCRIPTION
In order to understand future opportunities for thin provisioning memory, we need to be able to measure the actual working set size of VMs. The KVM API that allows us to do this isn't ideal, so I'm interested in design feedback on the approach.

This is also my first Rust code ever, so code feedback is welcome too.