### PR TITLE
docs: add docs to clarify Firecracker's direction

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,33 @@
+# Firecracker Charter
+
+## Mission
+
+Enable secure, multi-tenant, minimal-overhead execution of container and
+serverless workloads.
+
+## Tenets
+
+These tenets guide Firecracker's development:
+
+1. **Built-In Security**: We provide compute security barriers that enable
+   multitenant workloads, and cannot be mistakenly disabled by customers.
+   Customer workloads are simultaneously considered sacred (shall not be
+   touched) and malicious (shall be defended against).
+1. **Light-weight Virtualization**: We focus on transient or stateless workloads
+   over long-running or persistent workloads. Firecracker's hardware resources
+   overhead is known and guaranteed.
+1. **Minimalist in Features**: If it's not clearly required for our mission, we
+   won't build it. We maintain a single implementation per capability.
+1. **Compute Oversubscription**: All of the hardware compute resources exposed
+   by Firecracker to guests can be securely oversubscribed.
+
+## Contributions & Governance 
+
+All contributions must align with this charter and follow Firecracker's
+[contribution process](CONTRIBUTE.md).
+
+Only Firecracker [maintainers](MAINTAINERS.md) may merge contributions into the
+master branch and create Firecracker releases. Maintainers are also subject to
+the mission and tenets outlined herein. Anyone may submit and review
+contributions.
+

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,71 @@
+# Contributions Welcome
+
+Firecracker welcomes external contributions that further the mission defined in
+[the Firecracker Charter](CHARTER.md) and that align with the tenets therein.
+
+If you're just looking for quick feedback for an idea or proposal, open an
+[issue](https://github.com/firecracker-microvm/firecracker/issues) or chat with
+us on the [Firecracker Slack workgroup](https://firecracker-microvm.slack.com).
+
+Follow the [contribution workflow](#contribution-workflow) for submitting your
+changes to the Firecracker codebase. If you want to receive high-level but still
+commit-based feedback for a contribution, follow the
+[request for comments](#request-for-comments) steps instead.
+
+## Contribution Workflow
+
+Firecracker uses the “fork-and-pull” development model. Follow these steps if
+you want to merge your changes to Firecracker:
+
+1. Within your fork of 
+   [Firecracker](https://github.com/firecracker-microvm/firecracker), create a
+   branch for your contribution. Use a meaningful name.
+1. Create your contribution, meeting all
+   [contribution quality standards](#contribution-quality-standards)
+1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
+   against the master branch of the Firecracker repository.
+1. Add two reviewers to your pull request (a maintainer will do that for you if
+   you're new). Work with your reviewers to address any comments and obtain a
+   minimum of 2 approvals, at least one of which must be provided by
+   [a maintainer](MAINTAINERS.md).
+   To update your pull request amend existing commits whenever applicable and
+   then push the new changes to your pull request branch.
+1. Once the pull request is approved, one of the maintainers will merge it.
+
+## Request for Comments
+
+If you just want to receive feedback for a contribution proposal, open an “RFC”
+(“Request for Comments”) pull request:
+
+1. On your fork of 
+   [Firecracker](https://github.com/firecracker-microvm/firecracker), create a
+   branch for the contribution you want feedback on. Use a meaningful name.
+1. Create your proposal based on the existing codebase.
+1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
+   against the master branch of the Firecracker repository. Prefix your pull
+   request name with `[RFC]`.
+1. Discuss your proposal with the community on the pull request page (or on any
+   other channel). Add the conclusion(s) of this discussion to the pull request
+   page.
+
+## Contribution Quality Standards
+
+Most quality and style standards are enforced automatically during integration
+testing. Your contribution needs to meet the following standards:
+
+- Separate each **logical change** into its own commit.
+- Each commit must pass all unit & code style tests, and the full pull request
+  must pass all integration tests. See [tests/README.md](tests/README.md) for
+  information on how to run tests.
+- Unit test coverage must _increase_ the overall project code coverage.
+- Include integration tests for any new functionality in your pull request.
+- Document all your public functions.
+- Add a descriptive message for each commit. Follow
+  [commit message best practices](https://github.com/erlang/otp/wiki/writing-good-commit-messages).
+- Document your pull requests. Include the reasoning behind each change, and
+  the testing done.
+- Acknowledge Firecracker's [Apache 2.0 license](LICENSE.md) and certify that no
+  part of your contribution contravenes this license by signing off on all your
+  commits with `git -s`. Ensure that every file in your pull request has a
+  header referring to the repository license file.
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Maintainers
+
+Firecracker is maintained by a dedicated team within Amazon:
+
+- Alex Agache <aagch@amazon.com>
+- Adrian Catangiu <acatan@amazon.com>
+- Alexandra Iordache <aghecen@amazon.com>
+- Anthony Liguori <aliguori@amazon.com>
+- Dan Horobeanu <dhr@amazon.com>
+- Diana Popa <dpopa@amazon.com>
+- Andreea Florescu <fandree@amazon.com>
+

--- a/SECURITY-POLICY.md
+++ b/SECURITY-POLICY.md
@@ -1,0 +1,20 @@
+# Security Problem Policy
+
+Once the Firecracker [maintainers](MAINTAINERS.md) become aware (or are made
+aware) of a security vulnerability, they will immediately assess it. Based on
+impact and complexity, they will determine an embargo period (if externally
+reported, the period will be agreed upon with the external party).
+
+During the embargo period, maintainers will prioritize developing a fix over
+other activities. Within this period, maintainers may also notify a limited
+number of trusted parties via a pre-disclosure list, providing them with
+technical information, a risk assessment, and early access to a fix.
+
+The external customers are included in this group based on the scale of their
+Firecracker usage in production. The pre-disclosure list may also contain
+significant external security contributors that can join the effort to fix the
+vulnerability during the embargo period.
+
+At the end of the embargo period, maintainers will publicly release information
+about the vulnerability together with the Firecracker patches that mitigate it.
+

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,50 @@
+# Specification
+
+The specifications below quantify Firecracker's promise to enable
+minimal-overhead execution of container and serverless workloads. These
+specifications are enforced by integration tests (that run for each PR and
+master branch merge).
+
+On an I3.metal instance¹, with hyperthreading disabled and given host system
+resources are available (e.g., there are enough free CPU cycles, there is enough
+RAM, etc.), customers can rely on the following:
+
+1. **Stability:** The Firecracker virtual machine manager starts (up to API
+   socket availability) within `8 CPU ms`² and never crashes/halts/terminates
+   for internal reasons once started. _Note_: The wall-clock time has a large
+   standard deviation, spanning `6 ms to 60 ms`, with typical durations around
+   `12 ms`.
+1. **Failure Information:** When failures occur due to external circumstances,
+   they are logged³ by the Firecracker process.
+1. **API Stability:** The API socket is always available and the API conforms
+   to the in-tree [Open API specification](api_server/swagger/firecracker). API
+   failures are logged in the Firecracker log.
+1. **Overhead:** For a Firecracker virtual machine manager running a microVM
+   with `2 CPUs and 256 MiB of RAM`, and a guest OS with the Firecracker-tuned
+   kernel:
+   - Firecracker's virtual machine manager threads always have a memory
+     overhead `<= 5 MiB`;
+   - It takes `<= 125 ms` to go from receiving the Firecracker InstanceStart API
+     call to the start of the Linux guest user-space `/sbin/init` process.
+   - The compute-only guest CPU performance is `> 95%` of the equivalent
+     bare-metal performance. _`[integration test pending]`_
+1. **IO Performance:** With a host CPU core dedicated to the Firecracker device
+   emulation thread,
+   - the guest achieves up to `14.5 Gbps` network throughput by using `<= 80%`
+     of the host CPU core for emulation. _`[integration test pending]`_
+   - the guest achieves up to `1 GiB/s` storage throughput by using `<= 70%`
+     the host CPU cores for emulation. _`[integration test pending]`_
+1. **Telemetry:** Firecracker emits logs and metrics to the named pipes passed
+   to the logging API. Any logs and metrics emitted while their respective
+   pipes are full will be lost. Any such events will be signaled through the
+   `lost-logs` and `lost-metrics` counters.
+
+¹ I3.metal instances: [https://aws.amazon.com/ec2/instance-types/i3/](https://aws.amazon.com/ec2/instance-types/i3/)
+
+² CPU ms are actual ms of a user space thread's on-CPU runtime; useful for
+  getting consistent measurements for some performance metrics.
+
+³ No logs are currently produced in the span of time between the `jailer`
+  process start-up and the logging system initialization in the `firecracker`
+  process.
+


### PR DESCRIPTION
The added documents collectivly define Firecracker's direction, development,
and maintainers.

Signed-off-by: Radu Weiss <raduweis@amazon.com>