### PR TITLE
Add periodic logging of metrics on number of dirty pages

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -260,6 +260,7 @@ fn parse_machine_config_req<'a>(
                 mem_size_mib: None,
                 ht_enabled: None,
                 cpu_template: None,
+                log_dirty_pages: None,
             };
             Ok(empty_machine_config
                 .into_parsed_request(None, method)
@@ -978,7 +979,8 @@ mod tests {
                 \"vcpu_count\": 42,
                 \"mem_size_mib\": 1025,
                 \"ht_enabled\": true,
-                \"cpu_template\": \"T2\"
+                \"cpu_template\": \"T2\",
+                \"log_dirty_pages\": true
               }";
         let body: Chunk = Chunk::from(json);
 
@@ -996,6 +998,7 @@ mod tests {
             mem_size_mib: Some(1025),
             ht_enabled: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
+            log_dirty_pages: Some(true),
         };
 
         match vm_config.into_parsed_request(None, Method::Put) {

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -16,12 +16,13 @@ impl GenerateHyperResponse for VmConfig {
         let cpu_template = self
             .cpu_template
             .map_or("Uninitialized".to_string(), |c| c.to_string());
+        let log_dirty_pages = self.log_dirty_pages.unwrap_or(false);
 
         json_response(
             StatusCode::Ok,
             format!(
-                "{{ \"vcpu_count\": {:?}, \"mem_size_mib\": {:?},  \"ht_enabled\": {:?},  \"cpu_template\": {:?} }}",
-                vcpu_count, mem_size, ht_enabled, cpu_template
+                "{{ \"vcpu_count\": {:?}, \"mem_size_mib\": {:?},  \"ht_enabled\": {:?},  \"cpu_template\": {:?}, \"log_dirty_pages\": {:?} }}",
+                vcpu_count, mem_size, ht_enabled, cpu_template, log_dirty_pages
             ),
         )
     }
@@ -44,6 +45,7 @@ impl IntoParsedRequest for VmConfig {
                     && self.mem_size_mib.is_none()
                     && self.cpu_template.is_none()
                     && self.ht_enabled.is_none()
+                    && self.log_dirty_pages.is_none()
                 {
                     return Err(String::from("Empty request."));
                 }
@@ -69,6 +71,7 @@ mod tests {
             mem_size_mib: Some(1024),
             ht_enabled: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
+            log_dirty_pages: Some(false),
         };
         let (sender, receiver) = oneshot::channel();
         assert!(
@@ -84,6 +87,7 @@ mod tests {
             mem_size_mib: None,
             ht_enabled: None,
             cpu_template: None,
+            log_dirty_pages: None,
         };
         assert!(
             uninitialized

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -156,7 +156,8 @@ mod tests {
             "vcpu_count": 1,
             "mem_size_mib": 128,
             "ht_enabled": false,
-            "cpu_template": "Uninitialized"
+            "cpu_template": "Uninitialized",
+            "log_dirty_pages": false
         }"#;
         let vm_config_json: serde_json::Value = serde_json::from_str(vm_config_json).unwrap();
         assert_eq!(get_body(hyper_resp).unwrap(), vm_config_json);

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -435,6 +435,9 @@ definitions:
         description: Flag for enabling/disabling Hyperthreading
       cpu_template:
         $ref: "#/definitions/CpuTemplate"
+      log_dirty_pages:
+        type: boolean
+        description: Enable logging of dirty pages, and periodic generation of dirty page metrics.
 
   NetworkInterface:
     type: object

--- a/kvm_sys/src/lib.rs
+++ b/kvm_sys/src/lib.rs
@@ -38,6 +38,7 @@ ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
+ioctl_iow_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
 ioctl_iow_nr!(
     KVM_SET_USER_MEMORY_REGION,
     KVMIO,

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -260,6 +260,12 @@ pub struct VcpuMetrics {
     pub failures: SharedMetric,
 }
 
+// Memory usage metrics
+#[derive(Default, Serialize)]
+pub struct MemoryMetrics {
+    pub dirty_pages: SharedMetric,
+}
+
 #[derive(Default, Serialize)]
 pub struct VmmMetrics {
     pub device_events: SharedMetric,
@@ -290,6 +296,7 @@ pub struct FirecrackerMetrics {
     pub put_api_requests: PutRequestsMetrics,
     pub seccomp: SeccompMetrics,
     pub vcpu: VcpuMetrics,
+    pub memory: MemoryMetrics,
     pub vmm: VmmMetrics,
     pub uart: SerialDeviceMetrics,
 }

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -23,9 +23,15 @@ pub enum Error {
 }
 type Result<T> = result::Result<T, Error>;
 
-struct MemoryRegion {
+pub struct MemoryRegion {
     mapping: MemoryMapping,
     guest_base: GuestAddress,
+}
+
+impl MemoryRegion {
+    pub fn size(&self) -> usize {
+        self.mapping.size()
+    }
 }
 
 fn region_end(region: &MemoryRegion) -> GuestAddress {
@@ -105,6 +111,14 @@ impl GuestMemory {
     /// Returns the size of the memory region in bytes.
     pub fn num_regions(&self) -> usize {
         self.regions.len()
+    }
+
+    pub fn map_and_fold<F, G, T>(&self, init: T, mapf: F, foldf: G) -> T
+    where
+        F: Fn((usize, &MemoryRegion)) -> T,
+        G: Fn(T, T) -> T,
+    {
+        self.regions.iter().enumerate().map(mapf).fold(init, foldf)
     }
 
     /// Perform the specified action on each region's addresses.

--- a/vmm/src/vmm_config/machine_config.rs
+++ b/vmm/src/vmm_config/machine_config.rs
@@ -35,6 +35,8 @@ pub struct VmConfig {
     pub ht_enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_template: Option<CpuFeaturesTemplate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_dirty_pages: Option<bool>,
 }
 
 impl Default for VmConfig {
@@ -44,6 +46,7 @@ impl Default for VmConfig {
             mem_size_mib: Some(128),
             ht_enabled: Some(false),
             cpu_template: None,
+            log_dirty_pages: Some(false),
         }
     }
 }


### PR DESCRIPTION
In order to understand future opportunities for thin provisioning memory, we need to be able to measure the actual working set size of VMs. The KVM API that allows us to do this isn't ideal, so I'm interested in design feedback on the approach.

This is also my first Rust code ever, so code feedback is welcome too.

Updated with CR feedback from other PR for this change. I couldn't find a way to update that PR to diff to my fork instead of a branch.

This passes all the tests I can get working on my desktop. I'm going to do more extensive testing on a metal instance soon.