### PR TITLE
Logger: init with stdout/stderr at startup

### DIFF
--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -11,6 +11,8 @@ pub enum LoggerError {
     NeverInitialized(String),
     /// The logger does not allow reinitialization.
     AlreadyInitialized,
+    /// Attempt to initialize with one pipe and one standard output stream as destinations.
+    DifferentDestinations,
     /// Opening named pipe fails.
     OpenFIFO(std::io::Error),
     /// Writing to named pipe fails.
@@ -32,6 +34,10 @@ impl fmt::Display for LoggerError {
             LoggerError::AlreadyInitialized => {
                 format!("{}", "Reinitialization of logger not allowed.")
             }
+            LoggerError::DifferentDestinations => format!(
+                "{}",
+                "Initialization with one pipe and one standard output stream not allowed."
+            ),
             LoggerError::OpenFIFO(ref e) => {
                 format!("Failed to open pipe. Error: {}", e.description())
             }
@@ -74,6 +80,15 @@ mod tests {
         assert_eq!(
             format!("{}", LoggerError::AlreadyInitialized),
             "Reinitialization of logger not allowed."
+        );
+
+        assert_eq!(
+            format!("{:?}", LoggerError::DifferentDestinations),
+            "DifferentDestinations"
+        );
+        assert_eq!(
+            format!("{}", LoggerError::DifferentDestinations),
+            "Initialization with one pipe and one standard output stream not allowed."
         );
 
         assert!(


### PR DESCRIPTION
## Changes

Firecracker initializes its logging system with stdout/stderr when it starts, then reinitializes it with pipes 
when the user calles the `/logger` API. This way, log messages are no longer lost before the API call.

## Testing done

```bash
$ touch /tmp/firecracker.socket
$ ./target/x86_64-unknown-linux-musl/debug/firecracker --api-sock /tmp/firecracker.socket 
2018-11-13T12:54:39.598306179 [:ERROR:src/main.rs:45] Panic occurred: PanicInfo { payload: Any, message: Some(called `Result::unwrap()` on an `Err` value: Io(Os { code: 98, kind: AddrInUse, message: "Address in use" })), location: Location { file: "libcore/result.rs", line: 1009, col: 5 } }
2018-11-13T12:54:39.626277092 [:ERROR:src/main.rs:49] stack backtrace:
2018-11-13T12:54:39.626449770 [:ERROR:src/main.rs:53] Failed to log metrics on abort. Failed to log metrics. Logger was not initialized.:?
Aborted
```

Fixes #548