### PR TITLE
CI: Support for spawning multiple microvms

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,32 @@ if os.geteuid() != 0:
     raise PermissionError("Test session needs to be run as root.")
 
 
+def test_images_s3_bucket():
+    """Auxiliary function for getting this session's bucket name."""
+    return os.environ.get(
+        ENV_TEST_IMAGES_S3_BUCKET,
+        DEFAULT_TEST_IMAGES_S3_BUCKET
+    )
+
+
+MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(test_images_s3_bucket())
+
+
+def init_microvm(root_path, cloner_path):
+    """Auxiliary function for instantiating a microvm and setting it up."""
+    microvm_id = str(uuid.uuid4())
+    fc_binary, jailer_binary = build_tools.get_firecracker_binaries(root_path)
+    vm = Microvm(
+        resource_path=root_path,
+        fc_binary_path=fc_binary,
+        jailer_binary_path=jailer_binary,
+        microvm_id=microvm_id,
+        newpid_cloner_path=cloner_path
+    )
+    vm.setup()
+    return vm
+
+
 @pytest.fixture(autouse=True, scope='session')
 def test_session_root_path():
     """Ensure and yield the testrun root directory.
@@ -193,21 +219,7 @@ def microvm(test_session_root_path, newpid_cloner_path):
 
     # Make sure the necessary binaries are there before instantiating the
     # microvm.
-    fc_binary, jailer_binary = build_tools.get_firecracker_binaries(
-        test_session_root_path
-    )
-
-    microvm_id = str(uuid.uuid4())
-
-    vm = Microvm(
-        resource_path=test_session_root_path,
-        fc_binary_path=fc_binary,
-        jailer_binary_path=jailer_binary,
-        microvm_id=microvm_id,
-        newpid_cloner_path=newpid_cloner_path
-    )
-    vm.setup()
-
+    vm = init_microvm(test_session_root_path, newpid_cloner_path)
     yield vm
     vm.kill()
 
@@ -220,27 +232,12 @@ def network_config():
     yield ipv4_generator
 
 
-@pytest.fixture
-def microvm_image_fetcher():
-    """Return a borg object that knows about fetching microvm images.
-
-    If `ENV_TEST_IMAGES_S3_BUCKET` is set in the environment, target the bucket
-    specified therein, else use the default.
-    """
-    if ENV_TEST_IMAGES_S3_BUCKET in os.environ:
-        test_images_s3_bucket = os.environ.get(ENV_TEST_IMAGES_S3_BUCKET)
-    else:
-        test_images_s3_bucket = DEFAULT_TEST_IMAGES_S3_BUCKET
-
-    return MicrovmImageS3Fetcher(test_images_s3_bucket)
-
-
 @pytest.fixture(
-    params=microvm_image_fetcher().list_microvm_images(
+    params=MICROVM_S3_FETCHER.list_microvm_images(
         capability_filter=['*']
     )
 )
-def test_microvm_any(request, microvm, microvm_image_fetcher):
+def test_microvm_any(request, microvm):
     """Yield a microvm that can have any image in the spec bucket.
 
     A test case using this fixture will run for every microvm image.
@@ -248,25 +245,109 @@ def test_microvm_any(request, microvm, microvm_image_fetcher):
     When using a pytest parameterized fixture, a test case is created for each
     parameter in the list. We generate the list dynamically based on the
     capability filter. This will result in
-    `len(microvm_image_fetcher.list_microvm_images(capability_filter=['*']))`
+    `len(MICROVM_S3_FETCHER.list_microvm_images(capability_filter=['*']))`
     test cases for each test that depends on this fixture, each receiving a
     microvm instance with a different microvm image.
     """
     # pylint: disable=redefined-outer-name
     # The fixture pattern causes a pylint false positive for that rule.
 
-    microvm_image_fetcher.get_microvm_image(request.param, microvm)
+    MICROVM_S3_FETCHER.init_vm_resources(request.param, microvm)
     yield microvm
+
+
+@pytest.fixture
+def test_multiple_microvms(
+        test_session_root_path,
+        context,
+        newpid_cloner_path
+):
+    """Yield a microvm or multiple microvms based on the context provided.
+
+    `context` is a dynamically parameterized fixture created inside the special
+    function `pytest_generate_tests` and it holds a tuple containing the name
+    of the guest image used to spawn a microvm and the number of microvms
+    to spawn.
+    """
+    # pylint: disable=redefined-outer-name
+    # The fixture pattern causes a pylint false positive for that rule.
+    microvms = []
+    (microvm_resources, how_many) = context
+
+    # When the context specifies multiple microvms, we use the first vm to
+    # populate the other ones by hardlinking its resources.
+    first_vm = init_microvm(test_session_root_path, newpid_cloner_path)
+    MICROVM_S3_FETCHER.init_vm_resources(
+        microvm_resources,
+        first_vm
+    )
+    microvms.append(first_vm)
+
+    for _ in range(how_many - 1):
+        vm = init_microvm(test_session_root_path, newpid_cloner_path)
+        MICROVM_S3_FETCHER.hardlink_vm_resources(
+            microvm_resources,
+            first_vm,
+            vm
+        )
+        microvms.append(vm)
+
+    yield microvms
+    for i in range(how_many):
+        microvms[i].kill()
+
+
+def pytest_generate_tests(metafunc):
+    """Implement customized parametrization scheme.
+
+    This is a special hook which is called by the pytest infrastructure when
+    collecting a test function. The `metafunc` contains the requesting test
+    context. Amongst other things, the `metafunc` provides the list of fixture
+    names that the calling test function is using.  If we find a fixture that
+    is called `context`, we check the calling function through the
+    `metafunc.function` field for the _pool_size attribute which we previously
+    set with a decorator. Then we create the list of parameters for this
+    fixture.
+    The parameter will be a list of tuples of the form (cap, pool_size).
+    For each parameter from the list (i.e. tuple) a different test case
+    scenario will be created.
+    """
+    if 'context' in metafunc.fixturenames:
+        # In order to create the params for the current fixture, we need the
+        # capability and the number of vms we want to spawn.
+
+        # 1. Look if the test function set the pool size through the decorator.
+        # If it did not, we set it to 1.
+        how_many = int(getattr(metafunc.function, '_pool_size', None))
+        assert how_many > 0
+
+        # 2. Check if the test function set the capability field through
+        # the decorator. If it did not, we set it to any.
+        cap = getattr(metafunc.function, '_capability', '*')
+
+        # 3. Before parametrization, get the list of images that have the
+        # desired capability. By parametrize-ing the fixture with it, we
+        # trigger tests cases for each of them.
+        image_list = MICROVM_S3_FETCHER.list_microvm_images(
+            capability_filter=[cap]
+        )
+        metafunc.parametrize(
+            'context',
+            [(item, how_many) for item in image_list],
+            ids=['{}, {} instance(s)'.format(
+                item, how_many
+            ) for item in image_list]
+        )
 
 
 TEST_MICROVM_CAP_FIXTURE_TEMPLATE = (
     "@pytest.fixture("
-    "    params=microvm_image_fetcher().list_microvm_images(\n"
+    "    params=MICROVM_S3_FETCHER.list_microvm_images(\n"
     "        capability_filter=['CAP']\n"
     "    )\n"
     ")\n"
-    "def test_microvm_with_CAP(request, microvm, microvm_image_fetcher):\n"
-    "    microvm_image_fetcher.get_microvm_image(\n"
+    "def test_microvm_with_CAP(request, microvm):\n"
+    "    MICROVM_S3_FETCHER.init_vm_resources(\n"
     "        request.param, microvm\n"
     "    )\n"
     "    yield microvm"
@@ -276,7 +357,7 @@ TEST_MICROVM_CAP_FIXTURE_TEMPLATE = (
 # capabilities present in the test microvm images bucket. `pytest` doesn't
 # provide a way to do that outright, but luckily all of python is just lists of
 # of lists and a cursor, so exec() works fine here.
-for capability in microvm_image_fetcher().enum_capabilities():
+for capability in MICROVM_S3_FETCHER.enum_capabilities():
     test_microvm_cap_fixture = (
         TEST_MICROVM_CAP_FIXTURE_TEMPLATE.replace('CAP', capability)
     )

--- a/tests/framework/decorators.py
+++ b/tests/framework/decorators.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Module for declaring decorators used throughout integration tests."""
+
+
+def test_context(cap, count=1):
+    """Set the image capability and vm count attribute for individual tests."""
+    def wrap(func):
+        setattr(func, '_capability', cap)
+        setattr(func, '_pool_size', count)
+        return func
+    return wrap

--- a/tests/framework/decorators.py
+++ b/tests/framework/decorators.py
@@ -2,6 +2,55 @@
 # SPDX-License-Identifier: Apache-2.0
 """Module for declaring decorators used throughout integration tests."""
 
+import time
+
+from framework.defs import API_USOCKET_NAME, MAX_API_CALL_DURATION_MS
+
+
+def timed_request(method):
+    """Decorate functions to monitor their duration."""
+
+    class ApiTimeoutException(Exception):
+        """A custom exception containing the details of the failed API call."""
+
+        def __init__(self, duration, method, resource, payload):
+            """Compose the error message from the API call components."""
+            super(ApiTimeoutException, self).__init__(
+                'API call exceeded maximum duration: {:.2f} ms.\n'
+                'Call: {} {} {}'.format(duration, method, resource, payload)
+            )
+
+    def timed(*args, **kwargs):
+        """Raise an exception if method's duration exceeds the max value."""
+        start = time.time()
+        result = method(*args, **kwargs)
+        duration_ms = (time.time() - start) * 1000
+
+        if duration_ms > MAX_API_CALL_DURATION_MS:
+            try:
+                # The positional arguments are:
+                # 1. The Session object
+                # 2. The URL from which we extract the resource for readability
+                resource = args[1][args[1].find(
+                    API_USOCKET_NAME)+len(API_USOCKET_NAME):]
+            except IndexError:
+                # Ignore formatting errors.
+                resource = ''
+
+            # The payload is JSON-encoded and passed as an argument.
+            payload = kwargs['json'] if 'json' in kwargs else ''
+
+            raise ApiTimeoutException(
+                duration_ms,
+                method.__name__.upper(),
+                resource,
+                payload
+            )
+
+        return result
+
+    return timed
+
 
 def test_context(cap, count=1):
     """Set the image capability and vm count attribute for individual tests."""

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -2,57 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Wrapper over an http session with timed requests."""
 
-import time
-
 import requests_unixsocket
 
-from framework.defs import API_USOCKET_NAME, MAX_API_CALL_DURATION_MS
-
-
-class ApiTimeoutException(Exception):
-    """A custom exception containing the details of the failed API call."""
-
-    def __init__(self, duration, method, resource, payload):
-        """Compose the error message from the API call components."""
-        super(ApiTimeoutException, self).__init__(
-            'API call exceeded maximum duration: {:.2f} ms.\n'
-            'Call: {} {} {}'
-            .format(duration, method, resource, payload)
-        )
-
-
-def timed_request(method):
-    """Decorate functions to monitor their duration."""
-    def timed(*args, **kwargs):
-        """Raise an exception if method's duration exceeds the max value."""
-        start = time.time()
-        result = method(*args, **kwargs)
-        duration_ms = (time.time() - start) * 1000
-
-        if duration_ms > MAX_API_CALL_DURATION_MS:
-            try:
-                # The positional arguments are:
-                # 1. The Session object
-                # 2. The URL from which we extract the resource for readability
-                resource = args[1][args[1].find(
-                    API_USOCKET_NAME)+len(API_USOCKET_NAME):]
-            except IndexError:
-                # Ignore formatting errors.
-                resource = ''
-
-            # The payload is JSON-encoded and passed as an argument.
-            payload = kwargs['json'] if 'json' in kwargs else ''
-
-            raise ApiTimeoutException(
-                duration_ms,
-                method.__name__.upper(),
-                resource,
-                payload
-            )
-
-        return result
-
-    return timed
+from framework import decorators
 
 
 class Session(requests_unixsocket.Session):
@@ -72,17 +24,17 @@ class Session(requests_unixsocket.Session):
 
         self.is_good_response = is_good_response
 
-    @timed_request
+    @decorators.timed_request
     def get(self, url, **kwargs):
         """Wrap the GET call with duration limit."""
         return super(Session, self).get(url, **kwargs)
 
-    @timed_request
+    @decorators.timed_request
     def patch(self, url, data=None, **kwargs):
         """Wrap the PATCH call with duration limit."""
         return super(Session, self).patch(url, data=data, **kwargs)
 
-    @timed_request
+    @decorators.timed_request
     def put(self, url, data=None, **kwargs):
         """Wrap the PUT call with duration limit."""
         return super(Session, self).put(url, data=data, **kwargs)

--- a/tests/framework/s3fetcher.py
+++ b/tests/framework/s3fetcher.py
@@ -72,11 +72,13 @@ class MicrovmImageS3Fetcher:
     change. In effect, the s3 bucket will only be mapped once and the s3 client
     can cache across all fixtures. This is called "the borg pattern", because
     in the Sci-Fi series "Star Trek", the borg were a people where all
-    individuals that shared the same consciousness.
+    individuals shared the same consciousness.
     """
 
-    microvm_images = None
-    microvm_images_by_cap = None
+    _microvm_images = None
+    _microvm_images_by_cap = None
+    _microvm_images_bucket = None
+    _s3 = None
 
     def __init__(
         self,
@@ -84,28 +86,27 @@ class MicrovmImageS3Fetcher:
     ):
         """Initialize fetcher shared state, s3 client, paths, and data."""
         self.__dict__ = self.__shared_state
-
-        self.s3 = boto3.client(
-            's3',
-            config=botocore.client.Config(signature_version=botocore.UNSIGNED)
-        )
-        # Will use AWS EC2 IMDS credentials if present.
-
-        self.microvm_images_bucket = microvm_images_bucket
-
-        # The Borg pattern ensures that the map_bucket() is called only once
+        # The Borg pattern ensures that the _map_bucket() is called only once
         # per test session.
-        if self.microvm_images is None:
-            self.map_bucket()
-        assert self.microvm_images and self.microvm_images_by_cap
+        if self._microvm_images is None:
+            self._microvm_images_bucket = microvm_images_bucket
 
-    def get_microvm_image(self, microvm_image_name, microvm):
-        """Populate the microvm resource path with the associated image.
+            # s3 should also be the same for each object to exploit the caching
+            # capabilities of the s3 downloading process.
+            self._s3 = boto3.client(
+                's3',
+                config=botocore.client.Config(signature_version=botocore.UNSIGNED)
+            )
+            self._map_bucket()
+        assert self._microvm_images and self._microvm_images_by_cap
+
+    def init_vm_resources(self, microvm_image_name, microvm):
+        """Populate the microvm resource path with the necessary resources.
 
         Assumes the correct microvm image structure, and copies all
         microvm image resources into the microvm resource path.
         """
-        for resource_key in self.microvm_images[microvm_image_name]:
+        for resource_key in self._microvm_images[microvm_image_name]:
             if resource_key in [
                 self.MICROVM_IMAGE_KERNEL_RELPATH,
                 self.MICROVM_IMAGE_BLOCKDEV_RELPATH
@@ -115,7 +116,6 @@ class MicrovmImageS3Fetcher:
                 continue
 
             microvm_dest_path = os.path.join(microvm.path, resource_key)
-
             if resource_key.endswith('/'):
                 # Create a new microvm_directory if one is encountered.
                 os.mkdir(microvm_dest_path)
@@ -155,8 +155,8 @@ class MicrovmImageS3Fetcher:
                     os.path.dirname(resource_local_path),
                     exist_ok=True
                 )
-                self.s3.download_file(
-                    self.microvm_images_bucket,
+                self._s3.download_file(
+                    self._microvm_images_bucket,
                     resource_rel_path,
                     resource_local_path)
 
@@ -175,6 +175,50 @@ class MicrovmImageS3Fetcher:
                 microvm.ssh_config['ssh_key_path'] = microvm_dest_path
                 os.chmod(microvm_dest_path, 400)
 
+    def hardlink_vm_resources(
+            self,
+            microvm_image_name,
+            from_microvm,
+            to_microvm
+    ):
+        """Hardlink resources from one microvm to another.
+
+        Assumes the correct microvm image structure for the source vm specified
+        by the `from_microvm` parameter and copies all necessary resources into
+        the destination microvm specified through the `to_microvm` parameter.
+        """
+        for resource_key in self._microvm_images[microvm_image_name]:
+            if resource_key in [
+                self.MICROVM_IMAGE_KERNEL_RELPATH,
+                self.MICROVM_IMAGE_BLOCKDEV_RELPATH
+            ]:
+                # Kernel and blockdev dirs already exist in the microvm's
+                # allocated resources.
+                continue
+
+            microvm_dest_path = os.path.join(to_microvm.path, resource_key)
+            microvm_source_path = os.path.join(from_microvm.path, resource_key)
+
+            if resource_key.endswith('/'):
+                # Create a new microvm_directory if one is encountered.
+                os.mkdir(microvm_dest_path)
+                continue
+
+            if not os.path.exists(microvm_dest_path):
+                os.link(microvm_source_path, microvm_dest_path)
+
+            if resource_key.endswith(self.MICROVM_IMAGE_KERNEL_FILE_SUFFIX):
+                to_microvm.kernel_file = microvm_dest_path
+
+            if resource_key.endswith(self.MICROVM_IMAGE_ROOTFS_FILE_SUFFIX):
+                to_microvm.rootfs_file = microvm_dest_path
+
+            if resource_key.endswith(self.MICROVM_IMAGE_SSH_KEY_SUFFIX):
+                # Add the key path to the config dictionary and set
+                # permissions.
+                to_microvm.ssh_config['ssh_key_path'] = microvm_dest_path
+                os.chmod(microvm_dest_path, 400)
+
     def list_microvm_images(self, capability_filter: List[str] = None):
         """Return microvm images with the specified capabilities."""
         capability_filter = capability_filter or ['*']
@@ -191,7 +235,7 @@ class MicrovmImageS3Fetcher:
         """Return a list of all the capabilities of all microvm images."""
         return [*self.microvm_images_by_cap]
 
-    def map_bucket(self):
+    def _map_bucket(self):
         """Map all the keys and tags in the s3 microvm image bucket.
 
         This allows the other methods to work on local objects.
@@ -202,14 +246,14 @@ class MicrovmImageS3Fetcher:
         Populates `self.microvm_images_by_cap` with a capability dict:
         `{capability_n: {microvm_image_folder_key_n, ...}, ...}
         """
-        self.microvm_images = {}
-        self.microvm_images_by_cap = {}
+        self._microvm_images = {}
+        self._microvm_images_by_cap = {}
         folder_key_groups_regex = re.compile(
             self.MICROVM_IMAGES_RELPATH + r'(.+?)/(.*)'
         )
 
-        for obj in self.s3.list_objects_v2(
-            Bucket=self.microvm_images_bucket,
+        for obj in self._s3.list_objects_v2(
+            Bucket=self._microvm_images_bucket,
             Prefix=self.MICROVM_IMAGES_RELPATH
         )['Contents']:
             key_groups = re.match(folder_key_groups_regex, obj['Key'])
@@ -221,19 +265,19 @@ class MicrovmImageS3Fetcher:
 
             if not resource:
                 # This is a microvm image root folder.
-                self.microvm_images[microvm_image_name] = []
-                for cap in self.get_caps(obj['Key']):
-                    if cap not in self.microvm_images_by_cap:
-                        self.microvm_images_by_cap[cap] = set()
-                    self.microvm_images_by_cap[cap].add(microvm_image_name)
+                self._microvm_images[microvm_image_name] = []
+                for cap in self._get_caps(obj['Key']):
+                    if cap not in self._microvm_images_by_cap:
+                        self._microvm_images_by_cap[cap] = set()
+                    self._microvm_images_by_cap[cap].add(microvm_image_name)
             else:
                 # This is key within a microvm image root folder.
-                self.microvm_images[microvm_image_name].append(resource)
+                self._microvm_images[microvm_image_name].append(resource)
 
-    def get_caps(self, key):
+    def _get_caps(self, key):
         """Return the set of capabilities of an s3 object key."""
-        tagging = self.s3.get_object_tagging(
-            Bucket=self.microvm_images_bucket,
+        tagging = self._s3.get_object_tagging(
+            Bucket=self._microvm_images_bucket,
             Key=key
         )
         return {

--- a/tests/framework/s3fetcher.py
+++ b/tests/framework/s3fetcher.py
@@ -45,11 +45,9 @@ class MicrovmImageS3Fetcher:
 
     # Credentials
 
-    When run on an EC2 instance, `boto3` will check for IMDS credentials if no
-    other credentials are found. This mechanism is relied upon for running test
-    sessions within an account that has access to the microvm-image-bucket. If
-    that is not the case, local credentials must be present. See `boto3`
-    documentation.
+    `boto3` is configured to not perform the signing step at all by using
+    the `signature_version=UNSIGNED` so no credentials are needed. Thus, the
+    bucket where the microVM images are stored needs to be publicly accessible.
     """
 
     MICROVM_IMAGES_RELPATH = 'img/'
@@ -63,18 +61,6 @@ class MicrovmImageS3Fetcher:
 
     CAPABILITY_KEY_PREFIX = 'capability:'
 
-    __shared_state = {}
-    """Initializing the shared state here leads to all objects sharing it.
-
-    When you instantiate this class, you get a new object every time, but the
-    object's state is the same one as the state of all other objects of this
-    class. When an object changes this shared state, all other objects see the
-    change. In effect, the s3 bucket will only be mapped once and the s3 client
-    can cache across all fixtures. This is called "the borg pattern", because
-    in the Sci-Fi series "Star Trek", the borg were a people where all
-    individuals shared the same consciousness.
-    """
-
     _microvm_images = None
     _microvm_images_by_cap = None
     _microvm_images_bucket = None
@@ -84,20 +70,13 @@ class MicrovmImageS3Fetcher:
         self,
         microvm_images_bucket
     ):
-        """Initialize fetcher shared state, s3 client, paths, and data."""
-        self.__dict__ = self.__shared_state
-        # The Borg pattern ensures that the _map_bucket() is called only once
-        # per test session.
-        if self._microvm_images is None:
-            self._microvm_images_bucket = microvm_images_bucket
-
-            # s3 should also be the same for each object to exploit the caching
-            # capabilities of the s3 downloading process.
-            self._s3 = boto3.client(
-                's3',
-                config=botocore.client.Config(signature_version=botocore.UNSIGNED)
-            )
-            self._map_bucket()
+        """Initialize S3 client, list of microvm images and S3 bucket name."""
+        self._microvm_images_bucket = microvm_images_bucket
+        self._s3 = boto3.client(
+            's3',
+            config=botocore.client.Config(signature_version=botocore.UNSIGNED)
+        )
+        self._map_bucket()
         assert self._microvm_images and self._microvm_images_by_cap
 
     def init_vm_resources(self, microvm_image_name, microvm):
@@ -225,15 +204,15 @@ class MicrovmImageS3Fetcher:
         microvm_images_with_caps = []
         for cap in capability_filter:
             if cap == '*':
-                microvm_images_with_caps.append({*self.microvm_images})
+                microvm_images_with_caps.append({*self._microvm_images})
                 continue
-            microvm_images_with_caps.append(self.microvm_images_by_cap[cap])
+            microvm_images_with_caps.append(self._microvm_images_by_cap[cap])
 
         return list(set.intersection(*microvm_images_with_caps))
 
     def enum_capabilities(self):
         """Return a list of all the capabilities of all microvm images."""
-        return [*self.microvm_images_by_cap]
+        return [*self._microvm_images_by_cap]
 
     def _map_bucket(self):
         """Map all the keys and tags in the s3 microvm image bucket.

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 
-import pytest
+from framework import decorators
 
 import host_tools.logging as log_tools
 
@@ -16,46 +16,117 @@ MAX_BOOT_TIME_US = 150000
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
+NO_OF_MICROVMS = 100
 
-@pytest.mark.timeout(120)
-def test_microvm_boottime_no_network(test_microvm_with_boottime):
+
+def test_single_microvm_boottime_no_network(test_microvm_with_boottime):
     """Check guest boottime of microvm without network."""
-    boottime_us = _test_microvm_boottime(test_microvm_with_boottime, None)
+    log_fifo, _ = _configure_vm(test_microvm_with_boottime)
+    time.sleep(0.4)
+    boottime_us = _test_microvm_boottime(log_fifo)
     print("Boot time with no network is: " + str(boottime_us) + " us")
 
 
-def test_microvm_boottime_with_network(
+@decorators.test_context('boottime', NO_OF_MICROVMS)
+def test_multiple_microvm_boottime_no_network(test_multiple_microvms):
+    """Check guest boottime without network when spawning multiple microvms."""
+    microvms = test_multiple_microvms
+    assert microvms
+    assert len(microvms) == NO_OF_MICROVMS
+    log_fifos = []
+    for i in range(NO_OF_MICROVMS):
+        log_fifo, _ = _configure_vm(microvms[i])
+        log_fifos.append(log_fifo)
+    time.sleep(0.4)
+    for i in range(NO_OF_MICROVMS):
+        boottime_us = _test_microvm_boottime(log_fifos[i])
+        print("Boot time with no network for microvm {} is: {} us".format(
+            i+1,
+            boottime_us
+        ))
+
+
+@decorators.test_context('boottime', NO_OF_MICROVMS)
+def test_multiple_microvm_boottime_with_network(
+        test_multiple_microvms,
+        network_config
+):
+    """Check guest boottime with network when spawning multiple microvms."""
+    microvms = test_multiple_microvms
+    assert microvms
+    assert len(microvms) == NO_OF_MICROVMS
+    log_fifos = []
+    _taps = []
+    for i in range(NO_OF_MICROVMS):
+        log_fifo, _tap = _configure_vm(microvms[i], {
+            "config": network_config, "iface_id": str(i)
+        })
+        log_fifos.append(log_fifo)
+        _taps.append(_tap)
+    time.sleep(0.4)
+    for i in range(NO_OF_MICROVMS):
+        boottime_us = _test_microvm_boottime(log_fifos[i])
+        print("Boot time with network for microvm {} is: {} us".format(
+            i+1,
+            boottime_us
+        ))
+
+
+def test_single_microvm_boottime_with_network(
         test_microvm_with_boottime,
         network_config
 ):
     """Check guest boottime of microvm with network."""
-    boottime_us = _test_microvm_boottime(
-        test_microvm_with_boottime,
-        network_config
-    )
+    log_fifo, _tap = _configure_vm(test_microvm_with_boottime, {
+        "config": network_config, "iface_id": "1"
+    })
+    time.sleep(0.4)
+    boottime_us = _test_microvm_boottime(log_fifo)
     print("Boot time with network configured is: " + str(boottime_us) + " us")
 
 
-def _test_microvm_boottime(
-        microvm,
-        net_config
-):
+def _test_microvm_boottime(log_fifo):
     """
     Assert that we meet the minimum boot time. Should use a microVM with the
     `boottime` capability.
     """
+    lines = log_fifo.sequential_fifo_reader(20)
+
+    boot_time_us = 0
+    for line in lines:
+        timestamps = re.findall(TIMESTAMP_LOG_REGEX, line)
+        if timestamps:
+            boot_time_us = int(timestamps[0])
+
+    assert boot_time_us > 0
+    assert boot_time_us < MAX_BOOT_TIME_US
+    return boot_time_us
+
+
+def _configure_vm(microvm, network_info=None):
+    """Auxiliary function for preparing microvm before measuring boottime."""
     microvm.spawn()
 
+    # Machine configuration specified in the SLA.
     microvm.basic_config(
-        vcpu_count=2,
-        mem_size_mib=1024
+        vcpu_count=1,
+        mem_size_mib=128
     )
-    if net_config:
-        _tap, _, _ = microvm.ssh_network_config(net_config, '1')
+    if network_info:
+        _tap, _, _ = microvm.ssh_network_config(
+            network_info["config"],
+            network_info["iface_id"]
+        )
 
     # Configure logging.
-    log_fifo_path = os.path.join(microvm.path, 'log_fifo')
-    metrics_fifo_path = os.path.join(microvm.path, 'metrics_fifo')
+    log_fifo_path = os.path.join(
+        microvm.path,
+        'log_fifo' + microvm.id.split('-')[0]
+    )
+    metrics_fifo_path = os.path.join(
+        microvm.path,
+        'metrics_fifo' + microvm.id.split('-')[0]
+    )
     log_fifo = log_tools.Fifo(log_fifo_path)
     metrics_fifo = log_tools.Fifo(metrics_fifo_path)
 
@@ -69,15 +140,4 @@ def _test_microvm_boottime(
     assert microvm.api_session.is_good_response(response.status_code)
 
     microvm.start()
-    time.sleep(0.4)
-    lines = log_fifo.sequential_fifo_reader(20)
-
-    boot_time_us = 0
-    for line in lines:
-        timestamps = re.findall(TIMESTAMP_LOG_REGEX, line)
-        if timestamps:
-            boot_time_us = int(timestamps[0])
-
-    assert boot_time_us > 0
-    assert boot_time_us < MAX_BOOT_TIME_US
-    return boot_time_us
+    return log_fifo, _tap if network_info else None


### PR DESCRIPTION
This PR introduces following changes:
* a new fixture is available `test_vm_performance` that is able to spawn multiple vms by using a dynamically parametrized fixutre `context`. The parameters are sent to this fixture by using a decorator.
* It also removes the `microvm_s3_fetcher` (which was used as a fixture but also a function). It is transformed in this PR into a global variable returning a `MicrovmS3fetcher` object given that all fixtures are using it without modifying its state. No need for a borg pattern.
* Observation: All other `test_microvm_*` fixtures could now be transformed to use the `context` fixture and we would be getting rid of the necessity to autogenerate code by doing `exec`.
