### PR TITLE
devtool: Fix test_shut_down.py hang

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -382,6 +382,7 @@ run_devctr() {
     # Finally, run the dev container
     #
     docker run "${docker_args[@]}" \
+        --init \
         --rm \
         --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR" \
         --env TEST_MICROVM_IMAGES_S3_BUCKET="$TEST_MICROVM_IMAGES_S3_BUCKET" \


### PR DESCRIPTION
Resolve #585.
 
The Docker container was being launched without a default init process to reap all zombie processes inside the container. This caused the firecracker process to hang around in a defunct state, which, in turn, caused test_shut_down.py to timeout, waiting for the firecracker PID to disappear.
Fix: now launching Docker with a default init process (`docker run --init`).

Signed-off-by: Dan Horobeanu <dhr@amazon.com>