### PR TITLE
integration-tests: fixed test_reboot

### DIFF
--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -43,6 +43,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # the instance.
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
     ssh_connection.execute_command("reboot")
+    ssh_connection.close()
 
     while True:
         # Pytest's timeout will kill the test even if the loop doesn't exit.


### PR DESCRIPTION
In the reboot test we were opening an ssh connection, but we were
not closing it. This might lead to paramiko deadlocks.

Closed the ssh connection after running the reboot coommand.