### PR TITLE
micro_http: added documentation

### DIFF
--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -6,9 +6,12 @@ use std::io::{Error as WriteError, Write};
 
 use ascii::{COLON, CR, LF, SP};
 
+/// Wrapper over an HTTP Header type.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum Header {
+    /// Header `Content-Length`.
     ContentLength,
+    /// Header `Content-Type`.
     ContentType,
 }
 
@@ -21,22 +24,26 @@ impl Header {
     }
 }
 
+/// Wrapper over the list of headers associated with a Request/Response.
 #[derive(Debug)]
 pub struct Headers {
     headers: HashMap<Header, String>,
 }
 
 impl Headers {
+    /// By default Requests are created with no headers.
     pub fn default() -> Headers {
         return Headers {
             headers: HashMap::new(),
         };
     }
 
+    /// Adds a new header to the list.
     pub fn add(&mut self, header: Header, value: String) {
         self.headers.insert(header, value);
     }
 
+    /// Writes the headers to `buf` using the HTTP specification.
     pub fn write_all<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
         for (key, val) in &self.headers {
             buf.write_all(key.raw())?;
@@ -52,11 +59,14 @@ impl Headers {
     }
 }
 
+/// Wrapper over supported Media Types.
 pub enum MediaType {
+    /// Media Type: "text/plain".
     PlainText,
 }
 
 impl MediaType {
+    /// Returns a static string representation of the object.
     pub fn as_str(&self) -> &'static str {
         match self {
             MediaType::PlainText => "text/plain",

--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -10,41 +10,68 @@ pub mod ascii {
     pub const SP: u8 = b' ';
 }
 
+/// Errors associated with parsing the HTTP Request from a u8 slice.
 #[derive(Debug, PartialEq)]
 pub enum RequestError {
+    /// The HTTP Method is not supported or it is invalid.
     InvalidHttpMethod(&'static str),
+    /// Cannot parse the Request Line due to invalid input.
     InvalidRequest,
+    /// Request URI is invalid.
     InvalidUri(&'static str),
+    /// The HTTP Version in the Request is not supported or it is invalid.
     InvalidHttpVersion(&'static str),
 }
 
+/// The Body associated with an HTTP Request or Response.
+///
+/// ## Examples
+/// ```
+/// extern crate micro_http;
+/// use micro_http::Body;
+/// let body = Body::new("This is a test body.".to_string());
+/// assert_eq!(body.raw(), b"This is a test body.");
+/// assert_eq!(body.len(), 20);
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Body {
     body: Vec<u8>,
 }
 
 impl Body {
+    /// Creates a new `Body` from a `String` input.
     pub fn new(body: String) -> Self {
         Body {
             body: body.into_bytes(),
         }
     }
 
+    /// Returns the body as an `u8 slice`.
     pub fn raw(&self) -> &[u8] {
         return self.body.as_slice();
     }
 
+    /// Returns the length of the `Body`.
     pub fn len(&self) -> usize {
         return self.body.len();
     }
 }
 
+/// Supported HTTP Methods.
 #[derive(Debug, PartialEq)]
 pub enum Method {
+    /// GET Method.
     Get,
 }
 
 impl Method {
+    /// Returns a `Method` object if the parsing of `bytes` is successful.
+    ///
+    /// The method is case sensitive. A call to try_from with the input b"get" will return
+    /// an error, but when using the input b"GET", it returns Method::Get.
+    ///
+    /// # Errors
+    /// Returns `RequestError` if the method specified by `bytes` is unsupported.
     pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         match bytes {
             b"GET" => Ok(Method::Get),
@@ -52,6 +79,7 @@ impl Method {
         }
     }
 
+    /// Returns an `u8 slice` corresponding to the Method.
     pub fn raw(&self) -> &'static [u8] {
         match self {
             Method::Get => b"GET",
@@ -59,13 +87,28 @@ impl Method {
     }
 }
 
+/// Supported HTTP Versions.
+///
+/// # Examples
+/// ```
+/// extern crate micro_http;
+/// use micro_http::Version;
+/// let version = Version::try_from(b"HTTP/1.1");
+/// assert!(version.is_ok());
+///
+/// let version = Version::try_from(b"http/1.1");
+/// assert!(version.is_err());
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Version {
+    /// HTTP/1.0
     Http10,
+    /// HTTP/1.1
     Http11,
 }
 
 impl Version {
+    /// HTTP Version as an `u8 slice`.
     pub fn raw(&self) -> &'static [u8] {
         match self {
             Version::Http10 => b"HTTP/1.0",
@@ -73,6 +116,14 @@ impl Version {
         }
     }
 
+    /// Creates a new HTTP Version from an `u8 slice`.
+    ///
+    /// The supported versions are HTTP/1.0 and HTTP/1.1.
+    /// The version is case sensitive and the accepted input is upper case.
+    ///
+    /// # Errors
+    /// Returns a `RequestError` when the version is not supported.
+    ///
     pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         match bytes {
             b"HTTP/1.0" => Ok(Version::Http10),
@@ -83,6 +134,7 @@ impl Version {
         }
     }
 
+    /// Returns the default HTTP version = HTTP/1.1.
     pub fn default() -> Self {
         Version::Http11
     }

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -1,10 +1,67 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
+#![warn(missing_docs)]
+//! Minimal implementation of the [HTTP/1.0](https://tools.ietf.org/html/rfc1945)
+//! and [HTTP/1.1](https://www.ietf.org/rfc/rfc2616.txt) protocols.
+//!
+//! HTTP/1.1 has a mandatory header **Host**, but as this crate is only used
+//! for parsing MMDS requests, this header (if present) is ignored.
+//!
+//! This HTTP implementation is stateless thus it does not support chunking or
+//! compression.
+//!
+//! ## Supported Headers
+//! The **micro_http** crate does not have support for parsing **Request**
+//! headers.
+//!
+//! The **Response** does not have a public interface for adding headers, but whenever
+//! a write to the **Body** is made, the headers **ContentLength** and **MediaType**
+//! are automatically updated.
+//!
+//! ### Media Types
+//! The only supported media type is **text/plain**.
+//!
+//! ## Supported Methods
+//! The only supported HTTP Method is **GET**.
+//!
+//! ## Supported Status Codes
+//! The supported status codes are:
+//!
+//! - OK - 200
+//! - Bad Request - 400
+//! - Not Found - 404
+//! - Internal Server Error - 500
+//! - Not Implemented - 501
+//!
+//! ## Example for parsing an HTTP Request from a slice
+//! ```
+//! extern crate micro_http;
+//! use micro_http::{Request, Version};
+//!
+//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n").unwrap();
+//! assert_eq!(http_request.http_version(), Version::Http10);
+//! assert_eq!(http_request.uri().get_abs_path(), "/home");
+//! ```
+//!
+//! ## Example for creating an HTTP Response
+//! ```
+//! extern crate micro_http;
+//! use micro_http::{Body, Response, StatusCode, Version};
+//!
+//! let mut response = Response::new(Version::Http10, StatusCode::OK);
+//! let body = String::from("This is a test");
+//! response.set_body(Body::new(body.clone()));
+//!
+//! assert!(response.status() == StatusCode::OK);
+//! assert_eq!(response.body().unwrap(), Body::new(body));
+//! assert_eq!(response.http_version(), Version::Http10);
+//!
+//! let mut response_buf: [u8; 77] = [0; 77];
+//! assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+//! ```
 mod common;
 mod request;
 mod response;
-
 use common::ascii;
 use common::headers;
 

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -25,6 +25,9 @@ fn split(bytes: &[u8], separator: u8) -> (&[u8], &[u8]) {
     return (&[], bytes);
 }
 
+/// Wrapper over HTTP URIs.
+///
+/// The `Uri` can not be used directly and it is only accessible from an HTTP Request.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Uri<'a> {
     slice: &'a str,
@@ -44,6 +47,8 @@ impl<'a> Uri<'a> {
         Ok(Uri::new(utf8_slice))
     }
 
+    /// Returns the absolute path of the `Uri`.
+    ///
     /// URIs can be represented in absolute form or relative form. The absolute form includes
     /// the HTTP scheme, followed by the absolute path as follows:
     /// "http:" "//" host [ ":" port ] [ abs_path ]
@@ -120,6 +125,7 @@ impl<'a> RequestLine<'a> {
     }
 }
 
+/// Wrapper over an HTTP Request.
 #[allow(unused)]
 #[derive(Debug)]
 pub struct Request<'a> {
@@ -130,13 +136,15 @@ pub struct Request<'a> {
 
 impl<'a> Request<'a> {
     /// Parses a byte slice into a HTTP Request.
+    ///
     /// The byte slice is expected to have the following format: </br>
     ///     * Request Line: "GET SP Request-uri SP HTTP/1.0 CRLF" - Mandatory </br>
     ///     * Request Headers "<headers> CRLF"- Optional </br>
     ///     * Entity Body - Optional </br>
     /// The request headers and the entity body is not parsed and None is returned because
     /// these are not used by the MMDS server.
-    /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0.
+    /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0
+    /// or HTTP/1.1.
     ///
     /// # Errors
     /// The function returns InvalidRequest when parsing the byte stream fails.
@@ -148,7 +156,7 @@ impl<'a> Request<'a> {
     /// use micro_http::Request;
     ///
     /// let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n");
-    ///
+    /// ```
     pub fn try_from(byte_stream: &'a [u8]) -> Result<Self, RequestError> {
         // The first line of the request is the Request Line. The line ending is LF.
         let (request_line, _) = split(byte_stream, LF);
@@ -166,10 +174,14 @@ impl<'a> Request<'a> {
         })
     }
 
+    /// Returns the `Uri` from the parsed `Request`.
+    ///
+    /// The return value can be used to get the absolute path of the URI.
     pub fn uri(&self) -> &Uri {
         &self.request_line.uri
     }
 
+    /// Returns the HTTP `Version` of the `Request`.
     pub fn http_version(&self) -> Version {
         self.request_line.http_version
     }


### PR DESCRIPTION
Documented the public interface of micro_http.

## Testing Done
Added `#![warn(missing_docs)]` to lib.rs and there are no warnings.
Ran the documentation examples.