### PR TITLE
memory_model: completed documentation

### DIFF
--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-//! Track memory regions that are mapped to the guest VM.
+//! Track memory regions that are mapped to the guest microVM.
 
 use std::io::{Read, Write};
 use std::result;
@@ -15,13 +15,20 @@ use guest_address::GuestAddress;
 use mmap::{self, MemoryMapping};
 use DataInit;
 
+/// Errors associated with handling guest memory regions.
 #[derive(Debug)]
 pub enum Error {
+    /// Failure in finding a guest address in any memory regions mapped by this guest.
     InvalidGuestAddress(GuestAddress),
+    /// Failure in accessing the memory located at some address.
     MemoryAccess(GuestAddress, mmap::Error),
+    /// Failure in creating an anonymous shared mapping.
     MemoryMappingFailed(mmap::Error),
+    /// Failure in initializing guest memory.
     MemoryNotInitialized,
+    /// Two of the memory regions are overlapping.
     MemoryRegionOverlap,
+    /// No memory regions were provided for initializing the guest memory.
     NoMemoryRegions,
 }
 type Result<T> = result::Result<T, Error>;
@@ -142,7 +149,7 @@ impl GuestMemory {
         Ok(())
     }
     /// Writes a slice to guest memory at the specified guest address.
-    /// Returns the number of bytes written.  The number of bytes written can
+    /// Returns the number of bytes written. The number of bytes written can
     /// be less than the length of the slice if there isn't enough room in the
     /// memory region.
     ///

--- a/memory_model/src/lib.rs
+++ b/memory_model/src/lib.rs
@@ -5,6 +5,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+//! Provides a wrapper for allocating, handling and interacting with the guest memory regions.
+
+#![warn(missing_docs)]
+
 extern crate libc;
 extern crate sys_util;
 
@@ -17,7 +21,7 @@ extern crate sys_util;
 /// Implementing this trait guarantees that it is safe to instantiate the struct with random data.
 pub unsafe trait DataInit: Copy + Send + Sync {}
 
-// All intrinsic types and arrays of intrinsic types are DataInit.  They are just numbers.
+// All intrinsic types and arrays of intrinsic types are DataInit. They are just numbers.
 macro_rules! array_data_init {
     ($T:ty, $($N:expr)+) => {
         $(


### PR DESCRIPTION
* Generate documentation in `html` format:
```bash
cd memory_model
cargo doc --open
```
* Running the documentation tests sample will fail due to the musl ioctls signature.
* Added #![warn(missing_docs)] to lib.rs and there are no warnings.
* Solves item from #609.