### PR TITLE
Dumbo & MMDS docs

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -1,0 +1,231 @@
+# microVM Metadata Service
+
+The Firecracker microVM Metadata Service (MMDS) is a mutable data store which
+implements a simplified data path, made possible by the unique setting found in
+Firecracker. The MMDS consists of three major logical components: the backend,
+the data store, and the minimalist HTTP/TCP/IPv4 stack (named *Dumbo*). They
+all exist within the Firecracker process, and outside the KVM boundary; the
+first is a part of the API server, the data store is a global entity for a
+single Firecracker, and the last is a part of the device model.
+
+## The MMDS backend
+
+Users can add/update the MMDS contents via the backend, which is accessible
+through the Firecracker API. Setting the initial contents involves a `PUT`
+request to the `/mmds` API resource, with a JSON body that describes the
+desired data store structure and contents. Here's a JSON example:
+
+```json
+{
+"latest": {
+            "meta-data": {
+                "ami-id": "ami-12345678",
+                "reservation-id": "r-fea54097",
+                "local-hostname": "ip-10-251-50-12.ec2.internal",
+                "public-hostname": "ec2-203-0-113-25.compute-1.amazonaws.com",
+                "network": {
+                    "interfaces": {
+                        "macs": {
+                            "02:29:96:8f:6a:2d": {
+                                "device-number": "13345342",
+                                "local-hostname": "localhost",
+                                "subnet-id": "subnet-be9b61d"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+}
+```
+
+Queries from the guest (more on them a bit later) will be applied to this
+structure. For example, a `GET` request for
+**http://169.254.169.254/latest/meta-data/ami-id** will return a response body
+consisting of *ami-12345678*. The MMDS contents can be updated either via a
+subsequent `PUT` (that replaces them entirely), or using `PATCH` requests,
+which feed the JSON body into the merge functionality exposed by the
+`json-patch` Rust crate, based on
+[RFC 7396](https://tools.ietf.org/html/rfc7396). MMDS related API requests come
+from the host, which is considered a trusted environment, so there are no
+checks beside the kind of validation done by HTTP server and `serde-json`(the
+crate used to de/serialize JSON). Most importantly, there is currently no
+maximum size bound for MMDS contents; the users are free to provide arbitrarily
+large inputs. However, On the other hand, the HTTP server is likely to
+encounter/become a bottleneck first, which means any API resource may have
+this potential issue.
+
+## The data store
+
+This is a global data structure, currently referenced using a global variable,
+that represents the strongly-typed version of JSON-based user input describing
+the MMDS contents. It leverages the recursive
+[Value](https://docs.serde.rs/serde_json/value/enum.Value.html) type exposed by
+`serde-json`. It can only be accessed from thread-safe contexts.
+
+## Dumbo
+
+The *Dumbo* HTTP/TCP/IPv4 network stack handles guest HTTP requests heading
+towards *169.254.169.254*. Before going into *Dumbo* specifics, it's worth
+going through a brief description of the Firecracker network device model.
+Firecracker only offers Virtio-net paravirtualized devices to guests. Drivers
+running in the guest OS use ring buffers in a shared memory area to communicate
+with the device model when sending or receiving frames. The device model
+associates each guest network device with a TAP device on the host.
+Frames sent by the guest are written to the TAP fd, and frames read from the
+TAP fd are handed over to the guest.
+
+The *Dumbo* stack can be instantiated once for every network device, and is
+disabled by default. It can be enabled by setting the value of the
+`allow_mmds_requests` parameter to `true` in the API request body used to
+attach a guest network device. Once enabled, the stack taps into the
+aforementioned data path. Each frame coming from the guest is examined to
+determine whether it should be processed by *Dumbo* instead of being written to
+the TAP fd. Also, every time there is room in the ring buffer to hand over
+frames to the guest, the device model first checks whether *Dumbo* has anything
+to send; if not, it resumes getting frames from the TAP fd (when available).
+
+We chose to implement our own solution, instead of leveraging existing
+libraries/implementations, because responding to guest MMDS queries in the
+context of Firecracker is amenable to a wide swath of simplifications.
+First of all, we only need to handle `GET` requests, which require a bare-bones
+HTTP 1.1 server, without support for most headers and more advanced features
+like chunking. Also, we get to choose what subset of HTTP is used when building
+responses. Moving lower in the stack, we are dealing with TCP connections over
+what is essentially a point-to-point link, that seldom loses packets and does
+not reorder them. This means we can do away with congestion control
+(we only use flow control), complex reception logic, and support for most TCP
+options/features. At this point, the layers below (Ethernet and IPv4) don't
+involve much more than sanity checks of frame/packet contents.
+
+*Dumbo* is built using both general purpose components (which we plan to offer
+as part of one or more libraries), and Firecracker MMDS specific code. The
+former category consists of various helper modules used to process streams of
+bytes as protocol data units (Ethernet & ARP frames, IPv4 packets, and TCP
+segments), a TCP handler which listens for connections while demultiplexing
+incoming segments, a minimalist TCP connection endpoint implementation, and a
+greatly simplified HTTP 1.1 server. The Firecracker MMDS specific code is found
+in the logic which taps into the device model, and the component that parses an
+HTTP request, builds a response based on MMDS contents, and finally sends back
+a reply.
+
+### Mmds Network Stack
+
+Somewhat confusingly, this is the name of the component which taps the device
+model. It has hardcoded IP (*169.254.169.254*) and MAC (*06:01:23:45:67:01*)
+addresses. The latter is also used to respond to ARP requests. For every frame
+coming from the guest, the following steps take place:
+
+1. Apply a heuristic to determine whether the frame may contain an ARP request
+for the MMDS IP address, or an IPv4 packet heading towards the same address.
+There can be no false negatives. Frames that fail both checks are *rejected*
+(deferred to the device model for regular processing).
+1. *Reject* invalid Ethernet frames. *Reject* valid frames if their EtherType
+is neither ARP, nor IPv4.
+1. (**if EtherType == ARP**) *Reject* invalid ARP frames. *Reject* the frame if
+its target protocol address field is different from the MMDS IP address.
+Otherwise, record that an ARP request has been received (the stack only
+remembers the most recent request).
+1. (**if EtherType == IPv4**) *Reject* invalid packets. *Reject* packets if
+their destination address differs from the MMDS IP address. *Drop* (stop
+processing without deferring to the device model) packets that do not carry TCP
+segments (by looking at the protocol number field). Send the rest to the inner
+TCP handler.
+
+The current implementation does not support Ethernet 802.1Q tags, and does not
+handle IP fragmentation. Tagged Ethernet frames are most likely going to be
+deferred to the device model for processing, because the heuristics do not take
+the presence of the tag into account. Moreover, their EtherType will not appear
+to be of interest. Fragmented IP packets do not get reassembled; they are
+treated as independent packets.
+
+Whenever the guest is able to receive a frame, the device model first requests
+one from the MMDS network stack associated with the current network device.
+
+1. If an ARP request has been previously recorded, send an ARP reply and forget
+about the request.
+1. If the inner TCP handler has any packets to transmit, wrap the next one into
+a frame and send it.
+1. There are no MMDS related frames to send, so tell the device model to read
+from the TAP fd instead.
+
+### TCP handler
+
+Handles receives packets that appear to carry TCP segments. Its operation is
+described in the `dumbo` crate documentation. Each connection is associated
+with an MMDS endpoint.
+
+### MMDS endpoint
+
+This component gets the byte stream from an inner TCP connection object,
+identifies the boundaries of the next HTTP request, and parses it using an
+HttpRequest object. For each valid `GET` request, the URI is used to identify
+a key from the metadata store (like in the previous example), and a response is
+built using the Firecracker implementation of HttpResponse logic, based on the
+associated value, and sent back to the guest over the same connection. Each
+endpoint has a fixed size receive buffer, and a variable length response buffer
+(depending on the size of each response). TCP receive window semantics are used
+to ensure the guest does not overrun the receive buffer during normal operation
+(the connection has to drop segments otherwise). There can be at most one
+response pending at any given time. 
+
+Here are more details describing what happens when a segment is received by an
+MMDS endpoint (previously created when a SYN segment arrived at the TCP
+handler):
+
+1. Invoke the receive functionality of the inner connection object, and append
+any new data to the receive buffer.
+1. If no response is currently pending, attempt to identify the end of the
+first request in the receive buffer. If no such boundary can be found, and the
+buffer is full, reset the inner connection (which also causes the endpoint
+itself to be subsequently removed) because the guest exceeded the maximum
+allowed request size.
+1. If no response is pending, and we can identify a request in the receive
+buffer, parse it, free up the associated buffer space (also update the
+connection receive window), and build an HTTP response, which becomes the
+current pending response.
+1. If a FIN segment was received, and there's no pending response, call `close`
+on the inner connection. If a valid RST is received at any time, mark the
+endpoint for removal.
+
+When the TCP handler asks an MMDS endpoint for any segments to send, the
+transmission logic of the inner connection is invoked, specifying the pending
+response (when present) as the payload source.
+
+### Connection
+
+Connection objects are minimalist implementation of the TCP protocol. They are
+used to reassemble the byte stream which carries guest HTTP requests, and to
+send back segments which contain parts of the response. More details are
+available in the `dumbo` crate documentation.
+
+## Example use case: credential rotation
+
+For this example, the guest expects to find some sort of credentials (say, a
+secret access key) by issuing a `GET` request to
+*http://169.254.169.254/latest/meta-data/credentials/secret-key*. Most similar
+use cases will encompass the following sequence of steps:
+
+1. Some agent running on the host sends a `PUT` request with the initial
+contents of the MMDS, using the Firecracker API. This most likely takes place
+before the microVM starts running, but may also happen at a later time.
+Guest MMDS requests which arrive prior to contents being available receive a
+*NotFound* response.
+1. The contents are saved to the data store.
+1. The guest sends a `GET` request for the secret key, which is intercepted by
+the device model.
+1. The device model queries the data store, and gets the value associated with
+the key. 
+1. An HTTP response is assembled and sent back to the guest.
+
+After a while, the host agent decides to rotate the secret key. It does so by
+updating the data store with a new value. This can be done via a `PUT` request
+to the `/mmds` API resource, which replaces everything, or with a `PATCH`
+request that only touches the desired key. This effectively triggers the first
+two steps again.
+
+The guest reads the new secret key, going one more time through the last three
+steps. This can happen after a notification from the host agent, or discovered
+via periodic polling, or some other mechanism. Since access to the data store
+is thread safe, the guest can only receive either the old version, or the new
+version of the key, and not some intermediate state caused by the update.

--- a/dumbo/src/lib.rs
+++ b/dumbo/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(missing_docs)]
+//! Provides helper logic for parsing and writing protocol data units, and minimalist
+//! implementations of a TCP listener, a TCP connection, and a HTTP/1.1 server.
+
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
@@ -21,8 +25,12 @@ use std::ops::Index;
 pub trait ByteBuffer: Index<usize, Output = u8> {
     /// Returns the length of the buffer.
     fn len(&self) -> usize;
-    /// Reads `buf.len()` bytes into `buf`, starting at `offset`. Will panic if `offset + buf.len()
-    /// < `self.len()`.
+
+    /// Reads `buf.len()` bytes from `buf` into the inner buffer, starting at `offset`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `offset + buf.len()` < `self.len()`.
     fn read_to_slice(&self, offset: usize, buf: &mut [u8]);
 }
 

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -147,6 +147,9 @@ impl MmdsNetworkStack {
                                 METRICS.mmds.connections_created.inc();
                                 METRICS.mmds.connections_destroyed.inc();
                             }
+                            RecvEvent::EndpointDone => {
+                                METRICS.mmds.connections_destroyed.inc();
+                            }
                             _ => (),
                         },
                         Err(_) => METRICS.mmds.rx_accepted_err.inc(),

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -1,6 +1,9 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: get rid of this when splitting dumbo into public and internal parts.
+#![allow(missing_docs)]
+
 use std::convert::From;
 use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;

--- a/dumbo/src/tcp/connection.rs
+++ b/dumbo/src/tcp/connection.rs
@@ -1,6 +1,11 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module contains a minimalist TCP [`Connection`] implementation, which only supports
+//! passive open scenarios, and some auxiliary logic and data structures.
+//!
+//! [`Connection`]: struct.Connection.html
+
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize, Wrapping};
 
 // I think this is the sole use of the rand crate within Firecracker. If it's too much dependency
@@ -34,54 +39,118 @@ bitflags! {
 }
 
 bitflags! {
+    /// Represents any unusual conditions which may occur when receiving a TCP segment.
     pub struct RecvStatusFlags: u16 {
+        /// The acknowledgement number is invalid.
         const INVALID_ACK =             1 << 0;
+        /// The connection received a duplicate ACK.
         const DUP_ACK =                 1 << 1;
+        /// The connection received a data segment which does not fall within the limits of the
+        /// current receive window.
         const SEGMENT_BEYOND_RWND =     1 << 2;
+        /// The connection received a data segment, but the sequence number does not match the
+        /// next expected sequence number.
         const UNEXPECTED_SEQ =          1 << 3;
+        /// The other endpoint advertised a receive window edge which has been moved to the left.
         const REMOTE_RWND_EDGE =        1 << 4;
+        /// The other endpoint transmitted additional data after sending a `FIN`.
         const DATA_BEYOND_FIN =         1 << 5;
-        const SEQ_OUT_OF_WINDOW =       1 << 6;
-        const RESET_RECEIVED =          1 << 7;
-        const INVALID_RST =             1 << 8;
-        const INVALID_SEGMENT =         1 << 9;
-        const CONN_RESETTING =          1 << 10;
-        const INVALID_FIN =             1 << 11;
+        /// The connection received a valid `RST` segment.
+        const RESET_RECEIVED =          1 << 6;
+        /// The connection received an invalid `RST` segment.
+        const INVALID_RST =             1 << 7;
+        /// The connection received an invalid segment for its current state.
+        const INVALID_SEGMENT =         1 << 8;
+        /// The connection is resetting, and will switch to being reset after getting the
+        /// chance to transmit a `RST` segment.
+        const CONN_RESETTING =          1 << 9;
+        /// The connection received a `FIN` whose sequence number does not match the next
+        /// expected sequence number.
+        const INVALID_FIN =             1 << 10;
     }
 }
 
-// R should have the trait bound R: ByteBuffer, but bounds are ignored on type aliases. The first
-// element of the tuple is a buffer with payload data, while the second represents the sequence
-// number associated with the beginning of the buffer.
+/// Defines a segment payload source.
+///
+/// When not `None`, it contains a [`ByteBuffer`] which holds the actual data, and the sequence
+/// number associated with the first byte from the buffer.
+///
+/// [`ByteBuffer`]: ../../trait.ByteBuffer.html
+// R should have the trait bound R: ByteBuffer, but bounds are ignored on type aliases.
 pub type PayloadSource<'a, R> = Option<(&'a R, Wrapping<u32>)>;
 
+/// Describes errors which may occur during a passive open.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum PassiveOpenError {
+    /// The incoming segment is not a valid `SYN`.
     InvalidSyn,
+    /// The `SYN` segment carries an invalid `MSS` option.
     MssOption,
 }
 
+/// Describes errors which may occur when an existing connection receives a TCP segment.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RecvError {
+    /// The payload length is larger than the receive buffer size.
     BufferTooSmall,
+    /// The connection cannot receive the segment because it has been previously reset.
     ConnectionReset,
 }
 
+/// Describes errors which may occur when a connection attempts to write a segment.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum WriteNextError {
+    /// The connection cannot write the segment because it has been previously reset.
     ConnectionReset,
+    /// The write sends additional data after a `FIN` has been transmitted.
     DataAfterFin,
+    /// The remaining MSS (which can be reduced by IP and/or TCP options) is not large enough to
+    /// write the segment.
     MssRemaining,
+    /// The payload source specifies a buffer larger than [`MAX_WINDOW_SIZE`].
+    ///
+    /// [`MAX_WINDOW_SIZE`]: ../constant.MAX_WINDOW_SIZE.html
     PayloadBufTooLarge,
+    /// The payload source does not contain the first sequence number that should be sent.
     PayloadMissingSeq,
+    /// An error occurred during the actual write to the buffer.
     TcpSegment(TcpSegmentError),
 }
 
-// Represents a TCP connection which behaves as close as possible to the real thing during normal
-// operation, and takes a couple of shortcuts in exceptional cases. One thing which may not be
-// immediately obvious from the code/comments is that whenever the connection sends a RST segment,
-// it will stop working itself. This is just a design decision for our envisioned use cases;
-// improvements/changes may happen in the future.
+/// Contains the state information and implements the logic for a minimalist TCP connection.
+///
+/// One particular thing is that whenever the connection sends a `RST` segment, it will also stop
+/// working itself. This is just a design decision for our envisioned use cases;
+/// improvements/changes may happen in the future (this also goes for other aspects of the
+/// current implementation).
+///
+/// A `Connection` object can only be created via passive open, and will not recognize/use any TCP
+/// options except `MSS` during the handshake. The associated state machine is similar to how
+/// TCP normally functions, but there are some differences:
+///
+/// * Since only passive opens are supported, a `Connection` can only be instantiated in response
+///   to an incoming `SYN` segment. If the segment is valid, it will start directly in a state
+///   called `SYN_RECEIVED`. The valid events at this point are receiving a retransmission of the
+///   previous `SYN` (which does nothing), and getting the chance to write a `SYNACK`, which also
+///   moves the connection to the `SYNACK_SENT` state. Any incoming segment which is not a copy of
+///   the previous `SYN` will reset the connection.
+/// * In the `SYNACK_SENT` state, the connection awaits an `ACK` for the `SYNACK`. A
+///   retransmission of the original `SYN` moves the state back to `SYN_RECEIVED`. A valid `ACK`
+///   advances the state to `ESTABLISHED`. Any unexpected/invalid segment resets the connection.
+/// * While `ESTABLISHED`, the connection will only reset if it receives a `RST` or a `SYN`.
+///   Invalid segments are simply ignored. `FIN` handling is simplifed: when [`close`] is invoked
+///   the connection records the `FIN` sequence number, and starts setting the `FIN` flag (when
+///   possible) on outgoing segments. A `FIN` from the other endpoint is only taken into
+///   consideration if it has the next expected sequence number. When the connection has both sent
+///   and received a `FIN`, it marks itself as being done. There's no equivalent for the
+///   `TIME_WAIT` TCP state.
+///
+/// The current implementation does not do any kind of congestion control, expects segments to
+/// arrive in order, triggers a retransmission after the first duplicate `ACK`, and relies on the
+/// user to supply an opaque `u64` timestamp value when invoking send or receive functionality. The
+/// timestamps must be non-decreasing, and are mainly used for retransmission timeouts.
+///
+/// [`close`]: #method.close
 #[cfg_attr(test, derive(Clone))]
 pub struct Connection {
     // The sequence number to ACK at the next opportunity. This is 1 + the highest received
@@ -140,8 +209,16 @@ fn is_valid_syn<T: NetworkBytes>(segment: &TcpSegment<T>) -> bool {
 }
 
 impl Connection {
-    // This is called a passive open because we create the connection in response to an incoming
-    // SYN segment. The sender of the SYN is doing an active open.
+    /// Attempts to create a new `Connection` in response to an incoming `SYN` segment.
+    ///
+    /// # Arguments
+    ///
+    /// * `segment` - The incoming `SYN`.
+    /// * `local_rwnd_size` - Initial size of the local receive window.
+    /// * `rto_period` - How long the connection waits before a retransmission timeout fires for
+    ///   the first segment which has not been acknowledged yet. This uses an opaque time unit.
+    /// * `rto_count_max` - How many consecutive timeout-based retransmission may occur before
+    ///   the connection resets itself.
     pub fn passive_open<T: NetworkBytes>(
         segment: &TcpSegment<T>,
         local_rwnd_size: u32,
@@ -291,6 +368,10 @@ impl Connection {
         self.pending_ack = true;
     }
 
+    /// Closes this half of the connection.
+    ///
+    /// Subsequent calls after the first one do not have any effect. The sequence number of the
+    /// `FIN` is the first sequence number not yet sent at this point.
     #[inline]
     pub fn close(&mut self) {
         if self.send_fin.is_none() {
@@ -298,7 +379,8 @@ impl Connection {
         }
     }
 
-    /// Returns a valid configuration for a `RST` segment to be sent to the other endpoint.
+    /// Returns a valid configuration for a `RST` segment, which can be sent to the other
+    /// endpoint to signal the connection should be reset.
     #[inline]
     pub fn make_rst_config(&self) -> RstConfig {
         if self.is_established() {
@@ -308,38 +390,55 @@ impl Connection {
         }
     }
 
+    /// Specifies that a `RST` segment should be sent to the other endpoint, and then the
+    /// connection should be destroyed.
     #[inline]
     pub fn reset(&mut self) {
+        // TODO: does this interact properly with the RESETTING or smt status flag??!?!
         if !self.rst_pending() {
             self.send_rst = Some(self.make_rst_config());
         }
     }
 
+    /// Returns `true` if the connection is past the `ESTABLISHED` point.
     #[inline]
     pub fn is_established(&self) -> bool {
         self.flags_intersect(ConnStatusFlags::ESTABLISHED)
     }
 
+    /// Returns `true` if a `FIN` has been received.
     #[inline]
     pub fn fin_received(&self) -> bool {
         self.fin_received.is_some()
     }
 
+    /// Returns `true` if the connection is done communicating with the other endpoint.
+    // TODO: Maybe it would be a good idea to return true only after our FIN has also been ACKed?
+    // Otherwise, when using the TCP handler there's pretty much always going to be an ACK for the
+    // FIN that's going to trigger a gratuitous RST (best case), or can even be considered valid if
+    // a new connection is created meanwhile using the same tuple and we get very unlucky (worst
+    // case, extremely unlikely though).
     #[inline]
     pub fn is_done(&self) -> bool {
         self.is_reset() || (self.fin_received() && self.flags_intersect(ConnStatusFlags::FIN_SENT))
     }
 
+    /// Returns the first sequence number which has not been sent yet for the current window.
     #[inline]
     pub fn first_not_sent(&self) -> Wrapping<u32> {
         self.first_not_sent
     }
 
+    /// Returns the highest acknowledgement number received for the current window.
     #[inline]
     pub fn highest_ack_received(&self) -> Wrapping<u32> {
         self.highest_ack_received
     }
 
+    /// Advances the right edge of the local receive window.
+    ///
+    /// This is effectively allowing the other endpoint to send more data, because no byte can be
+    /// sent unless its sequence number falls into the receive window.
     // TODO: return the actual advance value here
     #[inline]
     pub fn advance_local_rwnd_edge(&mut self, value: u32) {
@@ -359,20 +458,25 @@ impl Connection {
         }
     }
 
+    /// Returns the right edge of the receive window advertised by the other endpoint.
     #[inline]
     pub fn remote_rwnd_edge(&self) -> Wrapping<u32> {
         self.remote_rwnd_edge
     }
 
+    /// Returns `true` if a retransmission caused by the reception of a duplicate `ACK` is pending.
     #[inline]
     pub fn dup_ack_pending(&self) -> bool {
         self.dup_ack
     }
 
-    // This function does not tell whether any data segments can/will be sent, because the
-    // Connection itself does not control the send buffer. Thus the information returned here
-    // only pertains to control segments and timeout expiry. Data segment related status will be
-    // reported by higher level components, such as an Endpoint.
+    /// Describes whether a control segment can be sent immediately, a retransmission is pending,
+    /// or there's nothing to transmit until more segments are received.
+    ///
+    /// This function does not tell whether any data segments can/will be sent, because the
+    /// Connection itself does not control the send buffer. Thus the information returned here
+    /// only pertains to control segments and timeout expiry. Data segment related status will
+    /// be reported by higher level components, which also manage the contents of the send buffer.
     #[inline]
     pub fn control_segment_or_timeout_status(&self) -> NextSegmentStatus {
         if self.synack_pending()
@@ -399,6 +503,18 @@ impl Connection {
         Ok((None, RecvStatusFlags::CONN_RESETTING | flags))
     }
 
+    /// Handles an incoming segment.
+    ///
+    /// When no errors occur, returns a pair consisting of how many
+    /// bytes (if any) were received, and whether any unusual conditions arose while processing the
+    /// segment. Since a `Connection` does not have its own internal buffer, `buf` is required to
+    /// store any data carried by incoming segments.
+    ///
+    /// # Arguments
+    ///
+    /// * `s` - The incoming segment.
+    /// * `buf` - The receive buffer where payload data (if any) from `s` is going to be written.
+    /// * `now` - An opaque timestamp representing the current moment in time.
     pub fn receive_segment<T: NetworkBytes>(
         &mut self,
         s: &TcpSegment<T>,
@@ -688,7 +804,21 @@ impl Connection {
         self.write_segment::<R>(buf, mss_reserved, seq, ack, flags_after_ns, None)
     }
 
-    // TODO: when writing doc comments, don't forget to mention the len() limit on payload_buf.
+    /// Writes a new segment (if available) to the specified buffer. The `payload_src` argument is
+    /// required because the `Connection` does not have an internal send buffer. If the payload
+    /// source is present, the data referenced therein must not amount to more than
+    /// [`MAX_WINDOW_SIZE`]. Will prioritize sendi
+    ///
+    /// # Arguments
+    ///
+    /// * `buf` - The buffer where the segment is written.
+    /// * `mss_reserved` - How much (if anything) of the MSS value has been already used at the
+    ///   lower layers (by IP options, for example). This will be zero most of the time.
+    /// * `payload_src` - References a buffer which contains data to send, and also specifies
+    ///   the sequence number associated with the first byte from that that buffer.
+    /// * `now` - An opaque timestamp representing the current moment in time.
+    ///
+    /// [`MAX_WINDOW_SIZE`]: ../constant.MAX_WINDOW_SIZE.html
     pub fn write_next_segment<'a, R: ByteBuffer + ?Sized>(
         &mut self,
         buf: &'a mut [u8],

--- a/dumbo/src/tcp/handler.rs
+++ b/dumbo/src/tcp/handler.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Exposes simple TCP over IPv4 listener functionality via the [`TcpIPv4Handler`] structure.
+//!
+//! [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
+
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
@@ -13,37 +17,63 @@ use tcp::{NextSegmentStatus, RstConfig};
 
 // TODO: This is currently IPv4 specific. Maybe change it to a more generic implementation.
 
-// When sending or receiving segments, we may encounter events such as connections being added or
-// removed, and others. The following two enums represent any such occurrences when receiving
-// or writing segments.
+/// Describes events which may occur when the handler receives packets.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RecvEvent {
+    /// The local endpoint is done communicating, and has been removed.
     EndpointDone,
+    /// An error occurred while trying to create a new `Endpoint` object, based on an incoming
+    /// `SYN` segment.
     FailedNewConnection,
+    /// A new local `Endpoint` has been successfully created.
     NewConnectionSuccessful,
+    /// Failed to add a local `Endpoint` because the handler is already at the maximum number of
+    /// concurrent connections, and there are no evictable Endpoints.
     NewConnectionDropped,
+    /// A new local `Endpoint` has been successfully created, but the handler had to make room by
+    /// evicting an older `Endpoint`.
     NewConnectionReplacing,
+    /// Nothing interesting happened regarding the state of the handler.
     Nothing,
+    /// The handler received a non-`SYN` segment which does not belong to any existing
+    /// connection.
     UnexpectedSegment,
 }
 
+/// Describes events which may occur when the handler writes packets.
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum WriteEvent {
+    /// The local `Endpoint` transitioned to being done after this segment was written.
     EndpointDone,
+    /// Nothing interesting happened.
     Nothing,
 }
 
+/// Describes errors which may be encountered by the [`receive_packet`] method from
+/// [`TcpIPv4Handler`].
+///
+/// [`receive_packet`]: struct.TcpIPv4Handler.html#method.receive_packet
+/// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RecvError {
     /// The packet has an invalid destination address.
     InvalidAddress,
+    /// The inner segment has an invalid destination port.
     InvalidPort,
+    /// The handler encountered an error while parsing the inner TCP segment.
     TcpSegment(TcpSegmentError),
 }
 
+/// Describes errors which may be encountered by the [`write_next_packet`] method from
+/// [`TcpIPv4Handler`].
+///
+/// [`write_next_packet`]: struct.TcpIPv4Handler.html#method.write_next_packet
+/// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum WriteNextError {
+    /// There was an error while writing the contents of the IPv4 packet.
     IPv4Packet(IPv4PacketError),
+    /// There was an error while writing the contents of the inner TCP segment.
     TcpSegment(TcpSegmentError),
 }
 
@@ -66,6 +96,31 @@ impl ConnectionTuple {
     }
 }
 
+/// Implements a minimalist TCP over IPv4 listener.
+///
+/// Forwards incoming TCP segments to the appropriate connection object, based on the associated
+/// tuple, or attempts to establish new connections (when receiving `SYN` segments). Aside from
+/// constructors, the handler operation is based on three methods:
+///
+/// * [`receive_packet`] examines an incoming IPv4 packet. It checks whether the destination
+///   address is correct, the attempts examine the inner TCP segment, making sure the destination
+///   port number is also correct. Then, it steers valid segments towards exiting connections,
+///   creates new connections for incoming `SYN` segments, and enqueues `RST` replies in response
+///   to any segments which cannot be associated with a connection (except other `RST` segments).
+///   On success, also describes any internal status changes triggered by the reception of the
+///   packet.
+/// * [`write_next_packet`] writes the next IPv4 packet (if available) that would be sent by the
+///   handler itself (right now it can only mean an enqueued `RST`), or one of the existing
+///   connections. On success, also describes any internal status changes triggered as the packet
+///   gets transmitted.
+/// * [`next_segment_status`] describes whether the handler can send a packet immediately, or
+///   after some retransmission timeout associated with a connection fires, or if there's nothing
+///   to send for the moment. This is used to determine whether it's appropriate to call
+///   [`write_next_packet`].
+///
+/// [`receive_packet`]: ../handler/struct.TcpIPv4Handler.html#method.receive_packet
+/// [`write_next_packet`]: ../handler/struct.TcpIPv4Handler.html#method.write_next_packet
+/// [`next_segment_status`]: ../handler/struct.TcpIPv4Handler.html#method.next_segment_status
 pub struct TcpIPv4Handler {
     local_addr: Ipv4Addr,
     local_port: u16,
@@ -76,7 +131,7 @@ pub struct TcpIPv4Handler {
     // Holds connections which are able to send segments immediately.
     active_connections: HashSet<ConnectionTuple>,
     // Remembers the closest timestamp into the future when one of the connections has to deal
-    // with a RTO trigger.
+    // with an RTO trigger.
     next_timeout: Option<(u64, ConnectionTuple)>,
     // RST segments awaiting to be sent.
     rst_queue: Vec<(ConnectionTuple, RstConfig)>,
@@ -94,8 +149,11 @@ enum RecvSegmentOutcome {
 }
 
 impl TcpIPv4Handler {
-    // Max_connections represents the maximum number of concurrent connections we are willing
-    // to accept/handle.
+    /// Creates a new `TcpIPv4Handler`.
+    ///
+    /// The handler acts as if bound to `local_addr`:`local_port`, and will accept at most
+    /// `max_connections` concurrent connections. `RST` segments generated by unexpected incoming
+    /// segments are placed in a queue which is at most `max_pending_resets` long.
     #[inline]
     pub fn new(
         local_addr: Ipv4Addr,
@@ -117,6 +175,9 @@ impl TcpIPv4Handler {
         }
     }
 
+    /// Contains logic for handling incoming segments.
+    ///
+    /// Any changes to the state if the handler are communicated through an `Ok(RecvEvent)`.
     pub fn receive_packet<T: NetworkBytes>(
         &mut self,
         packet: &IPv4Packet<T>,
@@ -290,6 +351,13 @@ impl TcpIPv4Handler {
         self.enqueue_rst_config(tuple, RstConfig::new(&s));
     }
 
+    /// Attempts to write one packet, from either the `RST` queue or one of the existing endpoints,
+    /// to `buf`.
+    ///
+    /// On success, the function returns a pair containing an `Option<NonZeroUsize>` and a
+    /// `WriteEvent`. The options represents how many bytes have been written to `buf`, or
+    /// that no packet can be send presently (when equal to `None`). The `WriteEvent` describes
+    /// whether any noteworthy state changes are associated with the write.
     pub fn write_next_packet(
         &mut self,
         buf: &mut [u8],
@@ -398,6 +466,7 @@ impl TcpIPv4Handler {
         Ok((len, event))
     }
 
+    /// Describes the status of the next segment to be sent by the handler.
     #[inline]
     pub fn next_segment_status(&self) -> NextSegmentStatus {
         if !self.active_connections.is_empty() || !self.rst_queue.is_empty() {

--- a/dumbo/src/tcp/handler.rs
+++ b/dumbo/src/tcp/handler.rs
@@ -35,6 +35,8 @@ pub enum WriteEvent {
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RecvError {
+    /// The packet has an invalid destination address.
+    InvalidAddress,
     InvalidPort,
     TcpSegment(TcpSegmentError),
 }
@@ -119,6 +121,10 @@ impl TcpIPv4Handler {
         &mut self,
         packet: &IPv4Packet<T>,
     ) -> Result<RecvEvent, RecvError> {
+        if packet.destination_address() != self.local_addr {
+            return Err(RecvError::InvalidAddress);
+        }
+
         // TODO: We skip verifying the checksum, just in case the device model relies on offloading
         // checksum computation from the guest to some other entity. Clear this up at some point!
         // (Issue #520)
@@ -476,6 +482,7 @@ mod tests {
         let mut buf = [0u8; 100];
         let mut buf2 = [0u8; 2000];
 
+        let wrong_local_addr = Ipv4Addr::new(123, 123, 123, 123);
         let local_addr = Ipv4Addr::new(169, 254, 169, 254);
         let local_port = 80;
         let remote_addr = Ipv4Addr::new(10, 0, 0, 1);
@@ -490,10 +497,11 @@ mod tests {
             NonZeroUsize::new(max_pending_resets).unwrap(),
         );
 
-        // We set the proper value of dst_addr from the start, because the TcpHandler expects this
-        // check to be made before receiving the packet.
+        // We start with a wrong destination address and destination port to check those error
+        // conditions first.
         let mut p =
-            IPv4Packet::write_header(buf.as_mut(), PROTOCOL_TCP, remote_addr, local_addr).unwrap();
+            IPv4Packet::write_header(buf.as_mut(), PROTOCOL_TCP, remote_addr, wrong_local_addr)
+                .unwrap();
 
         let seq_number = 123;
 
@@ -521,6 +529,9 @@ mod tests {
         assert_eq!(drain_packets(&mut h, remote_addr), Ok(0));
 
         let mut p = p.with_payload_len_unchecked(s_len, false);
+
+        assert_eq!(h.receive_packet(&p).unwrap_err(), RecvError::InvalidAddress);
+        p.set_destination_address(local_addr);
         assert_eq!(h.receive_packet(&p).unwrap_err(), RecvError::InvalidPort);
 
         // Let's fix the port. However, the segment is not a valid SYN, so we should get an

--- a/dumbo/src/tcp/mod.rs
+++ b/dumbo/src/tcp/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Provides functionality for handling incoming TCP connections.
+
 pub mod connection;
 mod endpoint;
 pub mod handler;
@@ -10,36 +12,41 @@ use pdu::tcp::{Flags as TcpFlags, TcpSegment};
 
 use std::num::Wrapping;
 
-/// The largest possible window size ever (requires the window scaling option).
+/// The largest possible window size (requires the window scaling option).
 pub const MAX_WINDOW_SIZE: u32 = 1_073_725_440;
 
-/// The default MSS value, used when no MSS information is carried over the initial handshake.
+/// The default maximum segment size (MSS) value, used when no MSS information is carried
+/// over the initial handshake.
 pub const MSS_DEFAULT: u16 = 536;
 
-// Describes whether a particular entity (a Connection for example) has segments to send.
+/// Describes whether a particular entity (a [`Connection`] for example) has segments to send.
+///
+/// [`Connection`]: connection/struct.Connection.html
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum NextSegmentStatus {
-    // Segments are available immediately.
+    /// At least one segment is available immediately.
     Available,
-    // There's nothing to send.
+    /// There's nothing to send.
     Nothing,
-    // A RTO will fire at the specified point in time.
+    /// A retransmission timeout (RTO) will trigger after the specified point in time.
     Timeout(u64),
 }
 
-// Represents the configuration of the sequence number and ACK fields for outgoing RST segments.
+/// Represents the configuration of the sequence number and `ACK` number fields for outgoing
+/// `RST` segments.
 #[derive(Clone, Copy)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RstConfig {
-    // The RST segment will carry the specified sequence number, and will not have the ACK flag set.
+    /// The `RST` segment will carry the specified sequence number, and will not have
+    /// the `ACK` flag set.
     Seq(u32),
-    // The RST segment will carry 0 as the sequence number, will have the ACK flag set, and the ACK
-    // number will be set to the specified value.
+    /// The `RST` segment will carry 0 as the sequence number, will have the `ACK` flag enabled,
+    /// and the `ACK` number will be set to the specified value.
     Ack(u32),
 }
 
 impl RstConfig {
-    // Creates a RstConfig in response to the specified incoming segment.
+    /// Creates a `RstConfig` in response to the given segment.
     pub fn new<T: NetworkBytes>(s: &TcpSegment<T>) -> Self {
         if s.flags_after_ns().intersects(TcpFlags::ACK) {
             // If s contains an ACK number, we use that as the sequence number of the RST.
@@ -50,8 +57,8 @@ impl RstConfig {
         }
     }
 
-    // Returns the sequence number, ACK number, and TCP flags (not counting NS) that must be set
-    // on the outgoing RST segment.
+    /// Returns the sequence number, acknowledgement number, and TCP flags (not counting `NS`) that
+    /// must be set on the outgoing `RST` segment.
     pub fn seq_ack_tcp_flags(&self) -> (u32, u32, TcpFlags) {
         match *self {
             RstConfig::Seq(seq) => (seq, 0, TcpFlags::RST),
@@ -60,17 +67,26 @@ impl RstConfig {
     }
 }
 
-// Please note this is not a connex binary relation; in other words, given two sequence numbers a
-// and b, it's sometimes possible that seq_at_or_after(a, b) || seq_at_or_after(b, a) == false. This
-// is why we can't define seq_after(a, b) as simply !seq_at_or_after(b, a).
-#[inline]
-pub fn seq_at_or_after(a: Wrapping<u32>, b: Wrapping<u32>) -> bool {
-    (a - b).0 < MAX_WINDOW_SIZE
-}
-
+/// Returns true if `a` comes after `b` in the sequence number space, relative to the maximum
+/// possible window size.
+///
+/// Please note this is not a connex binary relation; in other words, given two sequence numbers,
+/// it's sometimes possible that `seq_after(a, b) || seq_after(b, a) == false`. This is why
+/// `seq_after(a, b)` can't be defined as simply `!seq_at_or_after(b, a)`.
 #[inline]
 pub fn seq_after(a: Wrapping<u32>, b: Wrapping<u32>) -> bool {
     a != b && (a - b).0 < MAX_WINDOW_SIZE
+}
+
+/// Returns true if `a` comes after, or is at `b` in the sequence number space, relative to
+/// the maximum possible window size.
+///
+/// Please note this is not a connex binary relation; in other words, given two sequence numbers,
+/// it's sometimes possible that `seq_at_or_after(a, b) || seq_at_or_after(b, a) == false`. This
+/// is why `seq_after(a, b)` can't be defined as simply `!seq_at_or_after(b, a)`.
+#[inline]
+pub fn seq_at_or_after(a: Wrapping<u32>, b: Wrapping<u32>) -> bool {
+    (a - b).0 < MAX_WINDOW_SIZE
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds the `mmds.md` file to docs, and contains the rest of the doc comments for the public contents of the `dumbo` crate. There are no doc comments for `ns.rs` and `endpoint.rs` because these are supposed to be Firecracker internal modules. When the `dumbo` gets split, they will be not be part of the public crate(s).

There's also a commit with a couple of very small fixes.