### PR TITLE
kvm: get rid of redundant Copy/Clone

### DIFF
--- a/vmm/src/vm_control.rs
+++ b/vmm/src/vm_control.rs
@@ -40,7 +40,7 @@ impl VmRequest {
     /// received this `VmRequest`.
     pub fn execute(&self, vm: &VmFd) -> VmResponse {
         match self {
-            &VmRequest::RegisterIoevent(ref evt, addr, datamatch) => {
+            &VmRequest::RegisterIoevent(ref evt, ref addr, datamatch) => {
                 match vm.register_ioevent(evt, addr, datamatch) {
                     Ok(_) => VmResponse::Ok,
                     Err(e) => VmResponse::Err(e),


### PR DESCRIPTION
The `IoEventAdress` is uselessly moved around by
being copied when calling `register_io_event`.
Coverage also improves.

Signed-off-by: Diana Popa <dpopa@amazon.com>