### PR TITLE
[RFC] Add a vmm action for flushing the metrics

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -595,7 +595,7 @@ impl Logger {
             }
         } else {
             METRICS.logger.metrics_fails.inc();
-            return Err(LoggerError::LogMetricFailure(
+            return Err(LoggerError::NeverInitialized(
                 "Failed to log metrics. Logger was not initialized.".to_string(),
             ));
         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -65,6 +65,7 @@ use fc_util::now_cputime_us;
 use kernel::cmdline as kernel_cmdline;
 use kernel::loader as kernel_loader;
 use kvm::*;
+use logger::error::LoggerError;
 use logger::{Level, Metric, LOGGER, METRICS};
 use memory_model::{GuestAddress, GuestMemory};
 use sys_util::{register_signal_handler, EventFd, Killable, Terminal};
@@ -206,6 +207,9 @@ pub enum VmmAction {
     ConfigureLogger(LoggerConfig, OutcomeSender),
     /// Get the configuration of the microVM. The action response is sent using the `OutcomeSender`.
     GetVmConfiguration(OutcomeSender),
+    /// Flush the metrics. This action can only be called after the logger has been configured.
+    /// The response is sent using the `OutcomeSender`.
+    FlushMetrics(OutcomeSender),
     /// Add a new block device or update one that already exists using the `BlockDeviceConfig` as
     /// input. This action can only be called before the microVM has booted. The response
     /// is sent using the `OutcomeSender`.
@@ -750,6 +754,23 @@ impl Vmm {
 
     fn configure_kernel(&mut self, kernel_config: KernelConfig) {
         self.kernel_config = Some(kernel_config);
+    }
+
+    fn flush_metrics(&mut self) -> std::result::Result<VmmData, VmmActionError> {
+        if let Err(e) = LOGGER.log_metrics() {
+            if let LoggerError::NeverInitialized(s) = e {
+                return Err(VmmActionError::Logger(
+                    ErrorKind::User,
+                    LoggerConfigError::FlushMetrics(s),
+                ));
+            } else {
+                return Err(VmmActionError::Logger(
+                    ErrorKind::Internal,
+                    LoggerConfigError::FlushMetrics(e.to_string()),
+                ));
+            }
+        }
+        Ok(VmmData::Empty)
     }
 
     fn init_guest_memory(&mut self) -> std::result::Result<(), StartMicrovmError> {
@@ -1587,6 +1608,9 @@ impl Vmm {
             }
             VmmAction::ConfigureLogger(logger_description, sender) => {
                 Vmm::send_response(self.init_logger(logger_description), sender);
+            }
+            VmmAction::FlushMetrics(sender) => {
+                Vmm::send_response(self.flush_metrics(), sender);
             }
             VmmAction::GetVmConfiguration(sender) => {
                 Vmm::send_response(

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -43,13 +43,16 @@ pub struct LoggerConfig {
 pub enum LoggerConfigError {
     /// Cannot initialize the logger due to bad user input.
     InitializationFailure(String),
+    /// Cannot flush the metrics.
+    FlushMetrics(String),
 }
 
 impl Display for LoggerConfigError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use self::LoggerConfigError::*;
         match *self {
-            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg),
+            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
+            FlushMetrics(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
         }
     }
 }


### PR DESCRIPTION
At any time, the user can call the `FlushMetrics` api command for
getting the values of the metrics at that moment. The action can only be
called after the logger has been initialized (i.e a FIFO has been
provided as the destination for the metrics).

```
curl --unix-socket /tmp/firecracker.socket -i      
-X PUT "http://localhost/actions"      
-H  "accept: application/json"      
-H  "Content-Type: application/json"      
-d "{  
     \"action_type\": \"FlushMetrics\"
}"
```
You will get an error saying `  "fault_message": "Failed to log metrics. Logger was not initialized."
` if the logger has not been initialized beforehand. Othewise, you should see the json related metrics on the screen.
## Obs
* This is an RFC. After design is confirmed, I will update documentation, write unit tests and integration tests for it.
* Partially fixes #573.
