### PR TITLE
Fix broken hyperlink in design doc

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -36,7 +36,7 @@ Firecracker virtual machine manager (VMM).
 ### Specifications
 
 Firecracker's technical specifications are available in the
-[Specifications document](SPECS.md).
+[Specifications document](../SPECIFICATION.md).
 
 ## Host Integration
 


### PR DESCRIPTION
Replace a relative link to SPECS.md with a fully-qualified link to the correct document.

Addresses #645 

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>