### PR TITLE
Glibc support for Firecracker

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-target = "x86_64-unknown-linux-musl"

--- a/sys_util/src/ioctl.rs
+++ b/sys_util/src/ioctl.rs
@@ -95,38 +95,48 @@ pub const IOC_INOUT: c_uint = 3221225472;
 pub const IOCSIZE_MASK: c_uint = 1073676288;
 pub const IOCSIZE_SHIFT: c_uint = 16;
 
+#[cfg(target = "x86_64-unknown-linux-musl")]
+fn ioctl_arg(val: c_ulong) -> c_int {
+    val as u64
+}
+
+#[cfg(not(target = "x86_64-unknown-linux-musl"))]
+fn ioctl_arg(val: c_ulong) -> u64 {
+    val as u64
+}
+
 /// Run an ioctl with no arguments.
 pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
-    libc::ioctl(fd.as_raw_fd(), req as c_int, 0)
+    libc::ioctl(fd.as_raw_fd(), ioctl_arg(req), 0)
 }
 
 /// Run an ioctl with a single value argument.
 pub unsafe fn ioctl_with_val<F: AsRawFd>(fd: &F, req: c_ulong, arg: c_ulong) -> c_int {
-    libc::ioctl(fd.as_raw_fd(), req as c_int, arg)
+    libc::ioctl(fd.as_raw_fd(), ioctl_arg(req), arg)
 }
 
 /// Run an ioctl with an immutable reference.
 pub unsafe fn ioctl_with_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &T) -> c_int {
     libc::ioctl(
         fd.as_raw_fd(),
-        req as c_int,
+        ioctl_arg(req),
         arg as *const T as *const c_void,
     )
 }
 
 /// Run an ioctl with a mutable reference.
 pub unsafe fn ioctl_with_mut_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &mut T) -> c_int {
-    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *mut T as *mut c_void)
+    libc::ioctl(fd.as_raw_fd(), ioctl_arg(req), arg as *mut T as *mut c_void)
 }
 
 /// Run an ioctl with a raw pointer.
 pub unsafe fn ioctl_with_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *const T) -> c_int {
-    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *const c_void)
+    libc::ioctl(fd.as_raw_fd(), ioctl_arg(req), arg as *const c_void)
 }
 
 /// Run an ioctl with a mutable raw pointer.
 pub unsafe fn ioctl_with_mut_ptr<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: *mut T) -> c_int {
-    libc::ioctl(fd.as_raw_fd(), req as c_int, arg as *mut c_void)
+    libc::ioctl(fd.as_raw_fd(), ioctl_arg(req), arg as *mut c_void)
 }
 
 #[cfg(test)]

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -13,6 +13,7 @@ use std::result;
 
 use super::KvmContext;
 use cpuid::{c3_template, filter_cpuid, t2_template};
+use cpuid;
 use kvm::*;
 use memory_model::{GuestAddress, GuestMemory};
 use sys_util::EventFd;


### PR DESCRIPTION
This allows the standard rust toolchain to work out of the box.  This makes Firecracker much more accessible for a typical user while still retaining the ability to build for musl.