### PR TITLE
CI: fix test_style.py

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -281,8 +281,8 @@ class Microvm:
                 .stdout.decode('utf-8')
             screen_pid = re.search(r'([0-9]+)\.{}'.format(self._session_name),
                                    out).group(1)
-            self._jailer_clone_pid = open('/proc/{}/task/{}/children'
-                                          .format(screen_pid, screen_pid)
+            self._jailer_clone_pid = open('/proc/{0}/task/{0}/children'
+                                          .format(screen_pid)
                                           ).read().strip()
 
         # Wait for the jailer to create resources needed.

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -88,19 +88,13 @@ class SSHConnection:
 class NoMoreIPsError(Exception):
     """No implementation required."""
 
-    pass
-
 
 class InvalidIPCount(Exception):
     """No implementation required."""
 
-    pass
-
 
 class SingletonReinitializationError(Exception):
     """No implementation required."""
-
-    pass
 
 
 class UniqueIPv4Generator:

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -38,7 +38,6 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
     The result is extracted from the index.json created by kcov after a
     coverage run.
     """
-
     exclude_pattern = (
         '${CARGO_HOME:-$HOME/.cargo/},'
         'build/,'

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -11,7 +11,6 @@ import host_tools.network as net_tools
 
 def test_api_happy_start(test_microvm_with_api):
     """Test a regular microvm API start sequence."""
-
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -24,7 +23,6 @@ def test_api_happy_start(test_microvm_with_api):
 
 def test_api_put_update_pre_boot(test_microvm_with_api):
     """Test that PUT updates are allowed before the microvm boots."""
-
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -634,7 +632,7 @@ def test_api_actions(test_microvm_with_api):
 
 
 def _drive_patch(test_microvm):
-    """Helper function to exercise drive patch test scenarios."""
+    """Exercise drive patch test scenarios."""
     # Patches without mandatory fields are not allowed.
     response = test_microvm.drive.patch(
         drive_id='scratch'

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -56,7 +56,7 @@ def test_2vcpu_ht_disabled(test_microvm_with_ssh, network_config):
 
 
 def _check_cpu_topology(test_microvm, expected_cpu_topology):
-    """"Perform common microvm setup for different CPU topology tests.
+    """Perform common microvm setup for different CPU topology tests.
 
     This is a wrapper function for calling lscpu and checking if the
     command returns the expected cpu topology.
@@ -81,13 +81,13 @@ def _check_cpu_topology(test_microvm, expected_cpu_topology):
 
 
 def test_brand_string(test_microvm_with_ssh, network_config):
-    """
-    For Intel CPUs, the guest brand string should be:
+    """Ensure good formatting for the guest band string.
+
+    * For Intel CPUs, the guest brand string should be:
         Intel(R) Xeon(R) Processor @ {host frequency}
     where {host frequency} is the frequency reported by the host CPUID
     (e.g. 4.01GHz)
-
-    For non-Intel CPUs, the guest brand string should be:
+    * For non-Intel CPUs, the guest brand string should be:
         Intel(R) Xeon(R) Processor
     """
     cif = open('/proc/cpuinfo', 'r')

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -57,7 +57,7 @@ def test_rescan(test_microvm_with_ssh, network_config):
 
 
 def test_non_partuuid_boot(test_microvm_with_ssh, network_config):
-    """"Test the output reported by blockdev when booting from /dev/vda."""
+    """Test the output reported by blockdev when booting from /dev/vda."""
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -1,8 +1,10 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests the format of human readable logs by checking response of the API
-config calls."""
+"""Tests the format of human readable logs.
 
+It checks the response of the API configuration calls and the logs that show
+up in the configured logging FIFO.
+"""
 import os
 import re
 
@@ -16,7 +18,8 @@ LOG_LEVELS = ["ERROR", "WARN", "INFO", "DEBUG"]
 
 
 def to_formal_log_level(log_level):
-    """
+    """Convert a pretty-print log level into the related log level code.
+
     Turns a pretty formatted log level (i.e Warning) into the one actually
     being logged (i.e WARN).
     :param log_level: pretty formatted log level
@@ -34,13 +37,15 @@ def to_formal_log_level(log_level):
 
 
 def check_log_message(log_str, instance_id, level, show_level, show_origin):
-    """Parse the string representing the logs and look for the parts
-     that should be there.
-     The log line should look lie this:
+    """Ensure correctness of the logged message.
+
+    Parse the string representing the logs and look for the parts
+    that should be there.
+    The log line should look lie this:
          YYYY-MM-DDTHH:MM:SS.NNNNNNNNN [ID:LEVEL:FILE:LINE] MESSAGE
-     where LEVEL and FILE:LINE are both optional.
-     e.g.:
-        2018-09-09T12:52:00.123456789 [MYID:WARN:/path/to/file.rs:52] warning
+    where LEVEL and FILE:LINE are both optional.
+    e.g.:
+    `2018-09-09T12:52:00.123456789 [MYID:WARN:/path/to/file.rs:52] warning`
     """
     (timestamp, tag, _) = log_str.split(' ')[:3]
     timestamp = timestamp[:-10]

--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -338,7 +338,6 @@ def _check_rx_rate_limiting(test_microvm, guest_ips):
 
 def _start_iperf_on_guest(test_microvm, hostname):
     """Start iperf in server mode through an SSH connection."""
-
     test_microvm.ssh_config['hostname'] = hostname
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
@@ -377,15 +376,13 @@ def _start_local_iperf(netns_cmd_prefix):
 
 
 def _run_local_iperf(iperf_cmd):
-    """Runs a client related iperf command locally."""
-
+    """Execute a client related iperf command locally."""
     process = run(iperf_cmd, shell=True, stdout=PIPE)
     return process.stdout.decode('utf-8')
 
 
 def _get_difference(current, previous):
-    """Returns the percentage delta between the arguments."""
-
+    """Return the percentage delta between the arguments."""
     if current == previous:
         return 0
     try:

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -40,9 +40,9 @@ def _test_microvm_boottime(
         microvm,
         net_config
 ):
-    """
-    Assert that we meet the minimum boot time. Should use a microVM with the
-    `boottime` capability.
+    """Assert that we meet the minimum boot time.
+
+    TODO: Should use a microVM with the `boottime` capability.
     """
     microvm.spawn()
 

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""
-Tests that ensure the process startup time up to socket bind is within spec.
-"""
+"""Test that the process startup time up to socket bind is within spec."""
 
 import json
 import os
@@ -17,7 +15,6 @@ MAX_STARTUP_TIME_CPU_US = 8000
 
 def test_startup_time(test_microvm_with_api):
     """Check the startup time for jailer and Firecracker up to socket bind."""
-
     microvm = test_microvm_with_api
     microvm.spawn()
 

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -13,9 +13,8 @@ import host_tools.cargo_build as host  # pylint:disable=import-error
 
 @pytest.fixture
 def tmp_basic_jailer(test_session_root_path):
-    """
+    """Build `demo_basic_jailer`, required for the basic seccomp tests.
 
-    Build `demo_basic_jailer`, required for the basic seccomp tests.
     :return: The paths of the built binary.
     """
     binaries_srcdir = os.path.normpath(


### PR DESCRIPTION
The `pylint` and `pydocstyle` are successful even when errors are
reported since `find` does not fail if the `exec` fails. We are now
using `xargs` as a workaround. Another improved is that warnings will also be treated  as errors.
Also, the "*.py" files have been modified to pass the tests.
## Test correctness
* Check that pylint fails indeed => rename t`est_python_style` to `testPython_style` and then
```sudo env "PATH=$PATH" ./testrun.sh -r integration_tests/build/test_style.py```.
* Check that pydostyle fails => comment out the code section related to the pylint test =>
```sudo env "PATH=$PATH" ./testrun.sh -r integration_tests/build/test_style.py``` fails

FIxes #572.