### PR TITLE
Unifying log messages triggered by flushing metrics

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -596,7 +596,7 @@ impl Logger {
         } else {
             METRICS.logger.metrics_fails.inc();
             return Err(LoggerError::LogMetricFailure(
-                "Failed to log metrics. Logger was not initialized.".to_string(),
+                "Logger was not initialized.".to_string(),
             ));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
 
         // Log the metrics before aborting.
         if let Err(e) = LOGGER.log_metrics() {
-            error!("Failed to log metrics on abort. {}:?", e);
+            error!("Failed to log metrics while panicking: {}", e);
         }
     }));
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1157,7 +1157,7 @@ impl Vmm {
 
         // Log the metrics before exiting.
         if let Err(e) = LOGGER.log_metrics() {
-            error!("Failed to log metrics on abort. {}:?", e);
+            error!("Failed to log metrics while stopping: {}", e);
         }
 
         // Exit from Firecracker using the provided exit code.
@@ -1254,7 +1254,7 @@ impl Vmm {
                             // it will write to stdout, so metric logging will interfere with
                             // console output.
                             if let Err(e) = LOGGER.log_metrics() {
-                                error!("Failed to log metrics: {}", e);
+                                error!("Failed to log metrics on timer trigger: {}", e);
                             }
                         }
                     }


### PR DESCRIPTION
* Log messages related to flushing metrics are now customized to reflect the scenario that triggered it.
* Removed "Failed to log metrics" so that it does not cause duplicate sentence inside log message.
* Also, two log messages would have a ":?" due to it being placed outside of curly braces.

Signed-off-by: Diana Popa <dpopa@amazon.com>