### PR TITLE
Preallocate Cmdline internal String

### DIFF
--- a/kernel/src/cmdline/mod.rs
+++ b/kernel/src/cmdline/mod.rs
@@ -82,7 +82,7 @@ impl Cmdline {
     pub fn new(capacity: usize) -> Cmdline {
         assert_ne!(capacity, 0);
         Cmdline {
-            line: String::new(),
+            line: String::with_capacity(capacity),
             capacity: capacity,
         }
     }


### PR DESCRIPTION
Initializes the internal String buffer inside of Cmdline with the given capacity