### PR TITLE
Fix hyperlink to public URI for a GitHub issue

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ Not at the moment.
 
 ### I tried using an initrd for boot but it doesn't seem to be used. Is initrd supported?
 Right now, initrd is not supported in Firecracker. You can track issue
-[#228](https://github.com/aws/PRIVATE-firecracker/issues/208) for news on this
+[#228](https://github.com/firecracker-microvm/firecracker/issues/208) for news on this
 topic.
 
 ### Firecracker is not showing any output on the console.

--- a/mmds/src/data_store.rs
+++ b/mmds/src/data_store.rs
@@ -37,7 +37,7 @@ impl Mmds {
 
     pub fn put_data(&mut self, data: Value) {
         // TODO: we should add a data validator and only accept Strings, arrays & dictionaries
-        // https://github.com/aws/PRIVATE-firecracker/issues/401
+        // https://github.com/firecracker-microvm/firecracker/issues/401
         self.data_store = data;
         self.is_initialized = true;
     }


### PR DESCRIPTION
The FAQ has a link a GitHub issue in what looks like a previous, private incarnation of this repo. Link to the [current URI](https://github.com/firecracker-microvm/firecracker/issues/208) of that issue instead.