### PR TITLE
getting-started.md: Fix kernel version check

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,7 +240,10 @@ or run Firecracker as `root` (via `sudo`).
 You can check your KVM setup with:
 
 ```bash
-[ -r /dev/kvm ] && [ -w /dev/kvm ] && [ $(uname -r) \> 4.14 ] && echo "OK" || echo "FAIL"
+[ -r /dev/kvm ] && [ -w /dev/kvm ]           \
+  && [ "$(uname -r | cut -d. -f1)" -ge 4 ]   \
+  && [ "$(uname -r | cut -d. -f2)" -ge 14 ]  \
+  && echo "OK" || echo "FAIL"
 ```
 
 Note: if you've just added your user to the `kvm` group via `usermod`, don't


### PR DESCRIPTION
The example code for checking the host kernel version was yielding some
false positives. Fixed it.

Signed-off-by: Dan Horobeanu <dhr@amazon.com>