### PR TITLE
Some non-breaking tweaks to `micro_http`

### DIFF
--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -40,9 +40,9 @@ pub struct Body {
 
 impl Body {
     /// Creates a new `Body` from a `String` input.
-    pub fn new(body: String) -> Self {
+    pub fn new<T: Into<Vec<u8>>>(body: T) -> Self {
         Body {
-            body: body.into_bytes(),
+            body: body.into(),
         }
     }
 

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -12,17 +12,10 @@ use headers::Headers;
 // Splits the bytes in a pair containing the bytes before the separator and after the separator.
 // The separator is not included in the return values.
 fn split(bytes: &[u8], separator: u8) -> (&[u8], &[u8]) {
-    for index in 0..bytes.len() {
-        if bytes[index] == separator {
-            if index + 1 < bytes.len() {
-                return (&bytes[..index], &bytes[index + 1..]);
-            } else {
-                return (&bytes[..index], &[]);
-            }
-        }
+    match bytes.iter().position(|byte| *byte == separator) {
+        Some(index) => (&bytes[..index], &bytes[index + 1..]),
+        None        => (&[], bytes)
     }
-
-    return (&[], bytes);
 }
 
 /// Wrapper over HTTP URIs.
@@ -60,24 +53,25 @@ impl<'a> Uri<'a> {
     /// Returns an empty byte array when the host or the path are empty/invalid.
     ///
     pub fn get_abs_path(&self) -> &'a str {
-        let http_scheme_prefix = "http://";
-        if self.slice.starts_with(http_scheme_prefix) {
-            if self.slice.len() == http_scheme_prefix.len() {
+        const HTTP_SCHEME_PREFIX: &str = "http://";
+
+        if self.slice.starts_with(HTTP_SCHEME_PREFIX) {
+            let without_scheme = &self.slice[HTTP_SCHEME_PREFIX.len()..];
+            if without_scheme.len() == 0 {
                 return "";
             }
             // The host in this case includes the port and contains the bytes after http:// up to
             // the next '/'.
-            let (host, _) = split(&self.slice.as_bytes()[http_scheme_prefix.len()..], b'/');
-            if host.len() == 0 {
-                return "";
+            match without_scheme.bytes().position(|byte| byte == b'/') {
+                Some(len) => &without_scheme[len..],
+                None      => ""
             }
-            let path_start_index = http_scheme_prefix.len() + host.len();
-            return &self.slice[path_start_index..];
         } else {
             if self.slice.starts_with("/") {
                 return &self.slice;
             }
-            return "";
+
+            ""
         }
     }
 }
@@ -91,11 +85,10 @@ struct RequestLine<'a> {
 
 impl<'a> RequestLine<'a> {
     fn remove_trailing_cr(version: &[u8]) -> &[u8] {
-        if version.len() > 1 && version[version.len() - 1] == CR {
-            return &version[..version.len() - 1];
+        match version.last() {
+            Some(&CR) => &version[..version.len() - 1],
+            _         => version
         }
-
-        version
     }
 
     fn parse_request_line(request_line: &[u8]) -> (&[u8], &[u8], &[u8]) {

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -27,7 +27,7 @@ pub enum StatusCode {
 }
 
 impl StatusCode {
-    fn raw(&self) -> &'static [u8] {
+    fn raw(&self) -> &'static [u8; 3] {
         match self {
             StatusCode::OK => b"200",
             StatusCode::BadRequest => b"400",
@@ -139,11 +139,11 @@ mod tests {
     #[test]
     fn test_write_response() {
         let mut response = Response::new(Version::Http10, StatusCode::OK);
-        let body = String::from("This is a test");
-        response.set_body(Body::new(body.clone()));
+        let body = "This is a test";
+        response.set_body(Body::new(body));
 
         assert!(response.status() == StatusCode::OK);
-        assert_eq!(response.body().unwrap(), Body::new(body.clone()));
+        assert_eq!(response.body().unwrap(), Body::new(body));
         assert_eq!(response.http_version(), Version::Http10);
 
         // Headers can be in either order.


### PR DESCRIPTION
+ `Body::new()` works for generic `T: Into<Vec<u8>>`, this will convert `String`s without allocation like before, but also adds some convenience when you have a `Vec<u8>`, `&str`, or `&[u8]`.
+ Made some code in `request.rs` more declarative. It's shorter, intent I think is clearer to read, and it should be faster in at least one instance.
    + Side note: the `if index + 1 < bytes.len() {` branching in `fn split` was completely unnecessary. `index + 1` for the last byte is equal to length, thus `&bytes[index + 1..]` will produce an empty slice without panics.
+ `StatusCode::raw()` returns `&[u8; 3]` instead of `&[u8]`, since it's always 3 bytes we can save a word on stack here and there.
