### PR TITLE
Some non-breaking tweaks to `micro_http`

### DIFF
--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -40,10 +40,8 @@ pub struct Body {
 
 impl Body {
     /// Creates a new `Body` from a `String` input.
-    pub fn new(body: String) -> Self {
-        Body {
-            body: body.into_bytes(),
-        }
+    pub fn new<T: Into<Vec<u8>>>(body: T) -> Self {
+        Body { body: body.into() }
     }
 
     /// Returns the body as an `u8 slice`.

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -27,7 +27,7 @@ pub enum StatusCode {
 }
 
 impl StatusCode {
-    fn raw(&self) -> &'static [u8] {
+    fn raw(&self) -> &'static [u8; 3] {
         match self {
             StatusCode::OK => b"200",
             StatusCode::BadRequest => b"400",
@@ -139,11 +139,11 @@ mod tests {
     #[test]
     fn test_write_response() {
         let mut response = Response::new(Version::Http10, StatusCode::OK);
-        let body = String::from("This is a test");
-        response.set_body(Body::new(body.clone()));
+        let body = "This is a test";
+        response.set_body(Body::new(body));
 
         assert!(response.status() == StatusCode::OK);
-        assert_eq!(response.body().unwrap(), Body::new(body.clone()));
+        assert_eq!(response.body().unwrap(), Body::new(body));
         assert_eq!(response.http_version(), Version::Http10);
 
         // Headers can be in either order.


### PR DESCRIPTION
+ `Body::new()` works for generic `T: Into<Vec<u8>>`, this will convert `String`s without allocation like before, but also adds some convenience when you have a `Vec<u8>`, `&str`, or `&[u8]`.
+ Made some code in `request.rs` more declarative. It's shorter, intent I think is clearer to read, and it should be faster in at least one instance.
    + Side note: the `if index + 1 < bytes.len() {` branching in `fn split` was completely unnecessary. `index + 1` for the last byte is equal to length, thus `&bytes[index + 1..]` will produce an empty slice without panics.
+ `StatusCode::raw()` returns `&[u8; 3]` instead of `&[u8]`, since it's always 3 bytes we can save a word on stack here and there.

(Replacing #688)