### PR TITLE
Enforce seccomp filtering in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ dependencies = [
  "logger 0.1.0",
  "mmds 0.1.0",
  "net_util 0.1.0",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/dumbo/Cargo.toml
+++ b/dumbo/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 [dependencies]
 bitflags = ">=1.0.4"
 byteorder = ">=1.2.1"
-rand = ">=0.5.5"
 
 fc_util = { path = "../fc_util" }
 logger = { path = "../logger" }

--- a/dumbo/src/lib.rs
+++ b/dumbo/src/lib.rs
@@ -4,7 +4,6 @@
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
-extern crate rand;
 
 extern crate fc_util;
 extern crate logger;

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -40,7 +40,7 @@ class JailerContext:
             chroot_base=JAILER_DEFAULT_CHROOT,
             netns=None,
             daemonize=True,
-            seccomp_level=0
+            seccomp_level=2
     ):
         """Set up jailer fields.
 


### PR DESCRIPTION
Apply tight seccomp filters to Firecracker in the integration tests to prevent unauthorized syscalls from being introduced.