### PR TITLE
Improve error readability: part 1

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -252,8 +252,8 @@ mod tests {
         // Tests for MicrovmStart Errors.
         // RegisterBlockDevice, RegisterNetDevice, and LegacyIOBus cannot be tested because the
         // device manager is a private module in the vmm crate.
-        // ConfigureVm, Vcpu, VcpuConfigure, and VmConfigure cannot be tested because vstate is a
-        // private module in the vmm crate.
+        // ConfigureVm, Vcpu and VcpuConfigure cannot be tested because vstate is a private module
+        // in the vmm crate.
         let vmm_resp =
             VmmActionError::StartMicrovm(ErrorKind::User, StartMicrovmError::MicroVMAlreadyRunning);
         check_error_response(vmm_resp, StatusCode::BadRequest);

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -70,7 +70,7 @@ pub fn filter_cpuid(
     kvm_cpuid: &mut CpuId,
 ) -> Result<()> {
     let entries = kvm_cpuid.mut_entries_slice();
-    let max_addr_cpu = get_max_addressable_lprocessors(cpu_count).unwrap() as u32;
+    let max_addr_cpu = get_max_addressable_lprocessors(cpu_count)? as u32;
 
     let bstr = get_brand_string();
 

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -130,7 +130,9 @@ impl Bus {
     pub fn read(&self, addr: u64, data: &mut [u8]) -> bool {
         if let Some((offset, dev)) = self.get_device(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
-            dev.lock().unwrap().read(offset, data);
+            dev.lock()
+                .expect("Failed to acquire device lock")
+                .read(offset, data);
             true
         } else {
             false
@@ -143,7 +145,9 @@ impl Bus {
     pub fn write(&self, addr: u64, data: &[u8]) -> bool {
         if let Some((offset, dev)) = self.get_device(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
-            dev.lock().unwrap().write(offset, data);
+            dev.lock()
+                .expect("Failed to acquire device lock")
+                .write(offset, data);
             true
         } else {
             false

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -101,13 +101,18 @@ impl fmt::Display for Error {
         use self::Error::*;
 
         match *self {
-            Canonicalize(ref path, ref io_err) => {
-                write!(f, "Failed to canonicalize path {:?}: {:?}", path, io_err)
-            }
+            Canonicalize(ref path, ref io_err) => write!(
+                f,
+                "{}",
+                format!("Failed to canonicalize path {:?}: {}", path, io_err).replace("\"", "")
+            ),
             CgroupInheritFromParent(ref path, ref filename) => write!(
                 f,
-                "Failed to inherit cgroups configurations from file {} in path {:?}",
-                filename, path
+                "{}",
+                format!(
+                    "Failed to inherit cgroups configurations from file {} in path {:?}",
+                    filename, path
+                ).replace("\"", "")
             ),
             CgroupLineNotFound(ref proc_mounts, ref controller) => write!(
                 f,
@@ -122,30 +127,44 @@ impl fmt::Display for Error {
             ChangeDevNetTunOwner(ref err) => {
                 write!(f, "Failed to change owner for /dev/net/tun: {}", err)
             }
-            Chroot(ref err) => write!(f, "Failed to chroot into the new jail folder: {}", err),
+            ChdirNewRoot(ref err) => write!(f, "Failed to chdir into chroot directory: {}", err),
             CloseNetNsFd(ref err) => write!(f, "Failed to close netns fd: {}", err),
             CloseDevNullFd(ref err) => write!(f, "Failed to close /dev/null fd: {}", err),
-            Copy(ref file, ref path, ref err) => {
-                write!(f, "Failed to copy {:?} to {:?}: {}", file, path, err)
-            }
-            CreateDir(ref path, ref err) => {
-                write!(f, "Failed to create directory {:?}: {:?}", path, err)
-            }
+            Copy(ref file, ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to copy {:?} to {:?}: {}", file, path, err).replace("\"", "")
+            ),
+            CreateDir(ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to create directory {:?}: {}", path, err).replace("\"", "")
+            ),
             CStringParsing(_) => write!(f, "Encountered interior \\0 while parsing a string"),
             Dup2(ref err) => write!(f, "Failed to duplicate fd: {}", err),
-            Exec(ref err) => write!(f, "Failed to exec into Firecracker: {:?}", err),
-            FileName(ref path) => write!(f, "Failed to extract filename from path {:?}", path),
-            FileOpen(ref path, ref err) => {
-                write!(f, "Failed to open file {:?}: error {:?}", path, err)
-            }
+            Exec(ref err) => write!(f, "Failed to exec into Firecracker: {}", err),
+            FileName(ref path) => write!(
+                f,
+                "{}",
+                format!("Failed to extract filename from path {:?}", path).replace("\"", "")
+            ),
+            FileOpen(ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to open file {:?}: {}", path, err).replace("\"", "")
+            ),
             FromBytesWithNul(ref bytes) => {
                 write!(f, "Failed to decode string from byte array: {:?}", bytes)
             }
-            GetOldFdFlags(ref err) => write!(f, "Failed to get flags from fs: {}", err),
+            GetOldFdFlags(ref err) => write!(f, "Failed to get flags from fd: {}", err),
             Gid(ref gid) => write!(f, "Invalid gid: {}", gid),
             InvalidInstanceId(ref err) => write!(f, "Invalid instance ID: {}", err),
             MissingArgument(ref arg) => write!(f, "Missing argument: {}", arg),
-            MissingParent(ref path) => write!(f, "File {:?} doesn't have a parent", path),
+            MissingParent(ref path) => write!(
+                f,
+                "{}",
+                format!("File {:?} doesn't have a parent", path).replace("\"", "")
+            ),
             MkdirOldRoot(ref err) => write!(
                 f,
                 "Failed to create the jail root directory before pivoting root: {}",
@@ -164,24 +183,34 @@ impl fmt::Display for Error {
                 "Failed to change the propagation type to private: {}",
                 err
             ),
-            NotAFile(ref path) => write!(f, "{:?} is not a file", path),
+            NotAFile(ref path) => write!(
+                f,
+                "{}",
+                format!("{:?} is not a file", path).replace("\"", "")
+            ),
             NumaNode(ref node) => write!(f, "Invalid numa node: {}", node),
             OpenDevKvm(ref err) => write!(f, "Failed to open /dev/kvm: {}", err),
             OpenDevNull(ref err) => write!(f, "Failed to open /dev/null: {}", err),
-            OsStringParsing(ref path, _) => {
-                write!(f, "Failed to parse path {:?} into an OsString", path)
-            }
+            OsStringParsing(ref path, _) => write!(
+                f,
+                "{}",
+                format!("Failed to parse path {:?} into an OsString", path).replace("\"", "")
+            ),
             PivotRoot(ref err) => write!(f, "Failed to pivot root: {}", err),
-            ReadLine(ref path, ref err) => {
-                write!(f, "Failed to read line from {:?}: {:?}", path, err)
-            }
-            ReadToString(ref path, ref err) => {
-                write!(f, "Failed to read file {:?} into a string: {:?}", path, err)
-            }
+            ReadLine(ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to read line from {:?}: {}", path, err).replace("\"", "")
+            ),
+            ReadToString(ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to read file {:?} into a string: {}", path, err).replace("\"", "")
+            ),
             RegEx(ref err) => write!(f, "Regex failed: {:?}", err),
             RmOldRootDir(ref err) => write!(f, "Failed to remove old jail root directory: {}", err),
             SeccompLevel(ref err) => write!(f, "Failed to parse seccomp level: {:?}", err),
-            SetCurrentDir(ref err) => write!(f, "Failed to change current directory: {:?}", err),
+            SetCurrentDir(ref err) => write!(f, "Failed to change current directory: {}", err),
             SetNetNs(ref err) => write!(f, "Failed to join network namespace: netns: {}", err),
             SetSid(ref err) => write!(f, "Failed to daemonize: setsid: {}", err),
             Uid(ref uid) => write!(f, "Invalid uid: {}", uid),
@@ -193,13 +222,17 @@ impl fmt::Display for Error {
             UnshareNewNs(ref err) => {
                 write!(f, "Failed to unshare into new mount namespace: {}", err)
             }
-            UnixListener(ref err) => write!(f, "Failed to bind to the Unix socket: {:?}", err),
+            UnixListener(ref err) => write!(f, "Failed to bind to the Unix socket: {}", err),
             UnsetCloexec(ref err) => write!(
                 f,
                 "Failed to unset the O_CLOEXEC flag on the socket fd: {}",
                 err
             ),
-            Write(ref path, ref err) => write!(f, "Failed to write to {:?}: {:?}", path, err),
+            Write(ref path, ref err) => write!(
+                f,
+                "{}",
+                format!("Failed to write to {:?}: {}", path, err).replace("\"", "")
+            ),
         }
     }
 }
@@ -371,4 +404,255 @@ fn to_cstring<T: AsRef<Path>>(path: T) -> Result<CString> {
         .into_string()
         .map_err(|e| Error::OsStringParsing(path.as_ref().to_path_buf(), e))?;
     CString::new(path_str).map_err(Error::CStringParsing)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let path = PathBuf::from("/foo");
+        let file_str = "/foo/bar";
+        let file_path = PathBuf::from(file_str);
+        let proc_mounts = "/proc/mounts";
+        let controller = "sysfs";
+        let id = "foobar";
+        let err42 = sys_util::Error::new(42);
+        let err_regex = regex::Error::Syntax(id.to_string());
+        let err_parse = i8::from_str_radix("129", 10).unwrap_err();
+        let err2_str = "No such file or directory (os error 2)";
+
+        assert_eq!(
+            format!(
+                "{}",
+                Error::Canonicalize(path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to canonicalize path /foo: {}", err2_str)
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CgroupInheritFromParent(path.clone(), file_str.to_string())
+            ),
+            "Failed to inherit cgroups configurations from file /foo/bar in path /foo",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CgroupLineNotFound(proc_mounts.to_string(), controller.to_string())
+            ),
+            "sysfs configurations not found in /proc/mounts",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CgroupLineNotUnique(proc_mounts.to_string(), controller.to_string())
+            ),
+            "Found more than one cgroups configuration line in /proc/mounts for sysfs",
+        );
+        assert_eq!(
+            format!("{}", Error::ChangeDevNetTunOwner(err42.clone())),
+            "Failed to change owner for /dev/net/tun: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::ChdirNewRoot(err42.clone())),
+            "Failed to chdir into chroot directory: Errno 42"
+        );
+        assert_eq!(
+            format!("{}", Error::CloseNetNsFd(err42.clone())),
+            "Failed to close netns fd: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::CloseDevNullFd(err42.clone())),
+            "Failed to close /dev/null fd: Errno 42",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::Copy(
+                    file_path.clone(),
+                    path.clone(),
+                    io::Error::from_raw_os_error(2)
+                )
+            ),
+            format!("Failed to copy /foo/bar to /foo: {}", err2_str)
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CreateDir(path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to create directory /foo: {}", err2_str)
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CStringParsing(CString::new(b"f\0oo".to_vec()).unwrap_err())
+            ),
+            "Encountered interior \\0 while parsing a string",
+        );
+        assert_eq!(
+            format!("{}", Error::Dup2(err42.clone())),
+            "Failed to duplicate fd: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::Exec(io::Error::from_raw_os_error(2))),
+            format!("Failed to exec into Firecracker: {}", err2_str)
+        );
+        assert_eq!(
+            format!("{}", Error::FileName(file_path.clone())),
+            "Failed to extract filename from path /foo/bar",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::FileOpen(file_path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to open file /foo/bar: {}", err2_str)
+        );
+        assert_eq!(
+            format!("{}", Error::FromBytesWithNul(b"/\0")),
+            "Failed to decode string from byte array: [47, 0]",
+        );
+        assert_eq!(
+            format!("{}", Error::GetOldFdFlags(err42.clone())),
+            "Failed to get flags from fd: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::Gid(id.to_string())),
+            "Invalid gid: foobar",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::InvalidInstanceId(validators::Error::InvalidChar('a', 1))
+            ),
+            "Invalid instance ID: invalid char (a) at position 1",
+        );
+        assert_eq!(
+            format!("{}", Error::MissingArgument(id)),
+            "Missing argument: foobar",
+        );
+        assert_eq!(
+            format!("{}", Error::MissingParent(file_path.clone())),
+            "File /foo/bar doesn't have a parent",
+        );
+        assert_eq!(
+            format!("{}", Error::MkdirOldRoot(err42.clone())),
+            "Failed to create the jail root directory before pivoting root: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::MknodDevNetTun(err42.clone())),
+            "Failed to create /dev/net/tun via mknod inside the jail: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::MountBind(err42.clone())),
+            "Failed to bind mount the jail root directory: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::MountPropagationPrivate(err42.clone())),
+            "Failed to change the propagation type to private: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::NotAFile(file_path.clone())),
+            "/foo/bar is not a file",
+        );
+        assert_eq!(
+            format!("{}", Error::NumaNode(id.to_string())),
+            "Invalid numa node: foobar",
+        );
+        assert_eq!(
+            format!("{}", Error::OpenDevKvm(err42.clone())),
+            "Failed to open /dev/kvm: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::OpenDevNull(err42.clone())),
+            "Failed to open /dev/null: Errno 42",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::OsStringParsing(file_path.clone(), file_path.clone().into_os_string())
+            ),
+            "Failed to parse path /foo/bar into an OsString",
+        );
+        assert_eq!(
+            format!("{}", Error::PivotRoot(err42.clone())),
+            "Failed to pivot root: Errno 42",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::ReadLine(file_path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to read line from /foo/bar: {}", err2_str)
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::ReadToString(file_path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to read file /foo/bar into a string: {}", err2_str)
+        );
+        assert_eq!(
+            format!("{}", Error::RegEx(err_regex.clone())),
+            format!("Regex failed: {:?}", err_regex),
+        );
+        assert_eq!(
+            format!("{}", Error::RmOldRootDir(err42.clone())),
+            "Failed to remove old jail root directory: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::SeccompLevel(err_parse.clone())),
+            "Failed to parse seccomp level: ParseIntError { kind: Overflow }",
+        );
+        assert_eq!(
+            format!("{}", Error::SetCurrentDir(io::Error::from_raw_os_error(2))),
+            format!("Failed to change current directory: {}", err2_str),
+        );
+        assert_eq!(
+            format!("{}", Error::SetNetNs(err42.clone())),
+            "Failed to join network namespace: netns: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::SetSid(err42.clone())),
+            "Failed to daemonize: setsid: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::Uid(id.to_string())),
+            "Invalid uid: foobar",
+        );
+        assert_eq!(
+            format!("{}", Error::UmountOldRoot(err42.clone())),
+            "Failed to unmount the old jail root: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::UnexpectedKvmFd(42)),
+            "Unexpected value for the /dev/kvm fd: 42",
+        );
+        assert_eq!(
+            format!("{}", Error::UnexpectedListenerFd(42)),
+            "Unexpected value for the socket listener fd: 42",
+        );
+        assert_eq!(
+            format!("{}", Error::UnshareNewNs(err42.clone())),
+            "Failed to unshare into new mount namespace: Errno 42",
+        );
+        assert_eq!(
+            format!("{}", Error::UnixListener(io::Error::from_raw_os_error(2))),
+            format!("Failed to bind to the Unix socket: {}", err2_str),
+        );
+        assert_eq!(
+            format!("{}", Error::UnsetCloexec(err42.clone())),
+            "Failed to unset the O_CLOEXEC flag on the socket fd: Errno 42",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::Write(file_path, io::Error::from_raw_os_error(2))
+            ),
+            format!("Failed to write to /foo/bar: {}", err2_str),
+        );
+    }
 }

--- a/jailer/src/uuid.rs
+++ b/jailer/src/uuid.rs
@@ -68,7 +68,7 @@ pub fn validate(mut input: &str) -> Result<()> {
             }
             _ => {
                 return Err(UUIDError::InvalidChar(
-                    input[index..].chars().next().unwrap(),
+                    input[index..].chars().next().unwrap_or('\0'),
                 ))
             }
         }

--- a/mmds/src/lib.rs
+++ b/mmds/src/lib.rs
@@ -43,7 +43,10 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
 
             // The lock can be held by one thread only, so it is safe to unwrap.
             // If another thread poisoned the lock, we abort the execution.
-            let response = MMDS.lock().unwrap().get_value(uri.to_string());
+            let response = MMDS
+                .lock()
+                .expect("Failed to build MMDS response due to poisoned lock")
+                .get_value(uri.to_string());
             match response {
                 Ok(response) => {
                     let response_body = response.join("\n");

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -421,7 +421,7 @@ impl RateLimiter {
             // safe to unwrap: timer is definitely Some() since we have a bucket.
             self.timer_fd
                 .as_mut()
-                .unwrap()
+                .expect("Failed to consume rate limiter token due to invalid timer fd")
                 .set_state(TIMER_REFILL_STATE, SetTimeFlags::Default);
             self.timer_active = true;
         }
@@ -499,7 +499,7 @@ impl Default for RateLimiter {
     /// Default RateLimiter is a no-op limiter with infinite budget.
     fn default() -> Self {
         // Safe to unwrap since this will not attempt to create timer_fd.
-        RateLimiter::new(0, None, 0, 0, None, 0).unwrap()
+        RateLimiter::new(0, None, 0, 0, None, 0).expect("Failed to build default RateLimiter")
     }
 }
 

--- a/src/bin/jailer.rs
+++ b/src/bin/jailer.rs
@@ -7,10 +7,13 @@ extern crate clap;
 extern crate fc_util;
 extern crate jailer;
 
-fn main() -> jailer::Result<()> {
-    jailer::run(
+fn main() {
+    match jailer::run(
         jailer::clap_app().get_matches(),
         (chrono::Utc::now().timestamp_nanos() / 1000) as u64,
         fc_util::now_cputime_us(),
-    )
+    ) {
+        Ok(()) => (),
+        Err(error) => eprintln!("Jailer error: {}", error),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
     let bind_path = cmd_arguments
         .value_of("api_sock")
         .map(|s| PathBuf::from(s))
-        .unwrap();
+        .expect("Missing argument: api_sock");
 
     let mut instance_id = String::from(DEFAULT_INSTANCE_ID);
     let mut seccomp_level = 0;
@@ -87,7 +87,8 @@ fn main() {
     let mut is_jailed = false;
 
     if let Some(s) = cmd_arguments.value_of("context") {
-        let context = serde_json::from_str::<FirecrackerContext>(s).unwrap();
+        let context =
+            serde_json::from_str::<FirecrackerContext>(s).expect("Invalid context format");
         is_jailed = context.jailed;
         instance_id = context.id;
         seccomp_level = context.seccomp_level;
@@ -101,7 +102,8 @@ fn main() {
     }));
     let mmds_info = MMDS.clone();
     let (to_vmm, from_api) = channel();
-    let server = ApiServer::new(mmds_info, shared_info.clone(), to_vmm).unwrap();
+    let server =
+        ApiServer::new(mmds_info, shared_info.clone(), to_vmm).expect("Cannot create API server");
 
     let api_event_fd = server
         .get_event_fd_clone()

--- a/x86_64/src/interrupts.rs
+++ b/x86_64/src/interrupts.rs
@@ -37,7 +37,9 @@ fn get_klapic_reg(klapic: &kvm_lapic_state, reg_offset: usize) -> u32 {
     };
     let mut reader = Cursor::new(sliceu8);
     // Following call can't fail if the offsets defined above are correct.
-    reader.read_u32::<LittleEndian>().unwrap()
+    reader
+        .read_u32::<LittleEndian>()
+        .expect("Failed to read klapic register")
 }
 
 fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
@@ -48,7 +50,9 @@ fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
     };
     let mut writer = Cursor::new(sliceu8);
     // Following call can't fail if the offsets defined above are correct.
-    writer.write_u32::<LittleEndian>(value).unwrap()
+    writer
+        .write_u32::<LittleEndian>(value)
+        .expect("Failed to write klapic register")
 }
 
 fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {


### PR DESCRIPTION
## Changes
* replaced several occurrences of `unwrap()` with `expect()`. This will produce an explanatory message on panics that will speed up panic diagnosis.
* replaced other occurrences of `unwrap()` with error propagation for better error handling.
* added appropriate messages for jailer errors, which are diverse and can be confusing, especially with the jailer not having a logger.

This PR only addresses a part of the `unwrap()`s in the code base. More TBD.

Partially addresses #593