### PR TITLE
Make firecracker check requirements before it starts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ logger = { path = "logger"}
 mmds = { path = "mmds" }
 vmm = { path = "vmm" }
 fc_util = { path = "fc_util" }
-
+libc = ">=0.2.39"
 [dev-dependencies]
 tempfile = ">=3.0.2"
 

--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -50,6 +50,7 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_eventfd2,
     libc::SYS_epoll_create1,
     libc::SYS_getrandom,
+    libc::SYS_uname,
 ];
 
 // See /usr/include/x86_64-linux-gnu/sys/epoll.h


### PR DESCRIPTION
Hi,
Reading issue https://github.com/firecracker-microvm/firecracker/issues/685, and pull request https://github.com/firecracker-microvm/firecracker/pull/686, I thought would be helpful to have firecracker check KVM and Kernel requirements before it starts.
