### PR TITLE
github: Add a template for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. We may close issues which do not contain this information if it may be required to help debug an issue. However, we
+are happy to re-open issues once the information is provided.
+
+---------------------------------------------------
+BUG REPORT INFORMATION
+---------------------------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Environment:**
+- Version of firecracker:
+- Host OS kernel (`uname -a`):
+- Host processor (`cat /proc/cpuinfo | grep -m 1 "model name"`):
+- Guest kernel (if applicable):
+
+**Steps to reproduce the issue:**
+
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+


### PR DESCRIPTION
The issue template will be used for all new issues created.
Among the normal stuff about the issue description, explicitly
ask users for kernel versions and CPU information.

Signed-off-by: Rolf Neugebauer <neugebar@amazon.com>