### PR TITLE
fix firecracker build on fedora 28 (selinux)

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -290,7 +290,7 @@ run_devctr() {
     docker run "${docker_args[@]}" \
         --init \
         --rm \
-        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR" \
+        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR:z" \
         --env OPT_LOCAL_IMAGES_PATH="$(dirname "$CTR_MICROVM_IMAGES_DIR")" \
         --env PYTHONDONTWRITEBYTECODE=1 \
         "$DEVCTR_IMAGE" "${ctr_args[@]}"


### PR DESCRIPTION
fixed selinux issue by relabeling the volume
on docker run command

see this issue:
https://github.com/firecracker-microvm/firecracker/issues/682#issuecomment-442486560