### PR TITLE
CI: run unit tests sequentially

### DIFF
--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -24,8 +24,8 @@ CARGO_UNITTEST_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, "test")
 def test_unittests(test_session_root_path):
     """Run unit and doc tests from all crates using default target."""
     run(
-        'CARGO_TARGET_DIR={} RUST_BACKTRACE=1 cargo test --all --no-fail-fast'
-        .format(
+        'CARGO_TARGET_DIR={} RUST_TEST_THREADS=1 RUST_BACKTRACE=1 cargo test '
+        '--all --no-fail-fast'.format(
             os.path.join(test_session_root_path, CARGO_UNITTEST_REL_PATH),
         ),
         shell=True,
@@ -36,7 +36,7 @@ def test_unittests(test_session_root_path):
 def test_gnutests(test_session_root_path):
     """Run unit and doc tests from all crates using GNU target."""
     run(
-        'CARGO_TARGET_DIR={} RUST_BACKTRACE=1 cargo test '
+        'CARGO_TARGET_DIR={} RUST_TEST_THREADS=1 RUST_BACKTRACE=1 cargo test '
         '--target x86_64-unknown-linux-gnu --all --no-fail-fast'.format(
             os.path.join(test_session_root_path, CARGO_UNITTEST_REL_PATH),
         ),


### PR DESCRIPTION
By default, `cargo test` runs the tests in parallel. Official
recommended solution is to use environment variable `RUN_TEST_THREADS`
to specify the number of threads used to run the tests. Since we are
opening `/dev/kvm` in multiple unit tests, we need this in order to
avoid race conditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
