### PR TITLE
Add support for building on SELinux enabled systems

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -290,7 +290,7 @@ run_devctr() {
     docker run "${docker_args[@]}" \
         --init \
         --rm \
-        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR" \
+        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR":z \
         --env OPT_LOCAL_IMAGES_PATH="$(dirname "$CTR_MICROVM_IMAGES_DIR")" \
         --env PYTHONDONTWRITEBYTECODE=1 \
         "$DEVCTR_IMAGE" "${ctr_args[@]}"


### PR DESCRIPTION
Resolves https://github.com/firecracker-microvm/firecracker/issues/682

Adds `:z` to the volumes argument on Docker when invoking `devtool build`. This relabels the files in the mount on the host such that processes inside the container can see them. Docs are here: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
