### PR TITLE
getting-started: Only warn on nested virtualization

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,12 +44,12 @@ the basic requirements to run Firecracker.</summary>
 err=""; \
 [ "$(uname) $(uname -m)" = "Linux x86_64" ] \
   || err="ERROR: your system is not Linux x86_64."; \
-dmesg | grep -i "hypervisor detected" \
-  && err="$err\nERROR: you are running in a virtual machine."; \
 [ -r /dev/kvm ] && [ -w /dev/kvm ] \
   || err="$err\nERROR: /dev/kvm is innaccessible."; \
 (( $(uname -r | cut -d. -f1)*1000 + $(uname -r | cut -d. -f2) >= 4014 )) \
   || err="$err\nERROR: your kernel version ($(uname -r)) is too old."; \
+dmesg | grep -i "hypervisor detected" \
+  && echo "WARNING: you are running in a virtual machine. Firecracker is not well tested under nested virtualization."; \
 [ -z "$err" ] && echo "Your system looks ready for Firecracker!" || echo -e "$err"
 ```
 


### PR DESCRIPTION
# Description of changes:
In the getting started guide, the BASH snippet recommended to check the basic host requirements was issuing an ERROR, if it detected a nested virtualization environment. Downgraded that to a warning, since reports came in that Firecracker was successfully run on GCE, with L2 KVM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
