### PR TITLE
Fix typo in prod-host-setup docs

### DIFF
--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -14,7 +14,7 @@ To set up the jailer correctly, you'll need to:
 
 - Create a dedicated non-privilaged POSIX user and group to run Firecracker
   under. Use the created POSIX user and group IDs in Jailer's ``--uid <uid>``
-  and ``--guid <gid>`` flags, respectively. This will run the Firecracker as
+  and ``--gid <gid>`` flags, respectively. This will run the Firecracker as
   the created non-privileged user and group. All file system resources used for
   Firecracker should be owned by this user and group. Apply least privilege to
   the resource files owned by this user and group to prevent other accounts from


### PR DESCRIPTION
Changes `--guid` to `--gid`.

Signed-off-by: Nicolas Mesa <nicolasmesa@gmail.com>
Issue #, if available:

Description of changes:

The jailer expects a [`--gid` argument](https://github.com/firecracker-microvm/firecracker/blob/master/jailer/src/lib.rs#L139-L140) but the docs said `--guid`. This PR fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
