### PR TITLE
Jailer: set default seccomp level to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `PUT` requests on `/mmds` always return 204 on success.
 - `PUT` operations on `/network-interfaces` API resources no longer accept 
   the previously required `state` parameter.
+- The jailer starts with `--seccomp-level=2` (was previously 0) by default.
 
 ## [0.11.0]
 

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -314,7 +314,7 @@ pub fn clap_app<'a, 'b>() -> App<'a, 'b> {
 ")
                 .required(false)
                 .takes_value(true)
-                .default_value("0")
+                .default_value("2")
                 .possible_values(&["0", "1", "2"]),
         )
 }


### PR DESCRIPTION
Changes the default seccomp level when starting Firecracker via the jailer to 2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.