### PR TITLE
Add periodic logging of dirty pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ##  [Unreleased]
 
+### Added
+- The `/logger` API has a new field called `options`. This is an array of
+  strings that specify additional logging configurations. The only supported
+  value is `LogDirtyPages`.
+- When the `LogDirtyPages` option is configured via `PUT /logger`, a new metric
+  called `memory.dirty_pages` is computed as the number of pages dirtied by the
+  guest since the last time the metric was flushed. 
+
 ### Changed
 
 - `PUT` requests on `/mmds` always return 204 on success.

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -28,6 +28,8 @@ impl IntoParsedRequest for LoggerConfig {
 mod tests {
     use super::*;
 
+    use serde_json::Value;
+
     #[test]
     fn test_into_parsed_request() {
         let desc = LoggerConfig {
@@ -36,6 +38,7 @@ mod tests {
             level: None,
             show_level: None,
             show_log_origin: None,
+            options: Value::Array(vec![]),
         };
         format!("{:?}", desc);
         assert!(&desc.clone().into_parsed_request(None, Method::Put).is_ok());

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -409,6 +409,10 @@ definitions:
       show_log_origin:
         type: boolean
         description: Whether or not to include the file path and line number of the log's origin.
+      options:
+        type: array
+        items: string
+        description: Additional logging options. Only "LogDirtyPages" is supported.
 
   MachineConfiguration:
     type: object

--- a/kvm_gen/src/lib.rs
+++ b/kvm_gen/src/lib.rs
@@ -41,6 +41,7 @@ ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 ioctl_io_nr!(KVM_GET_VCPU_MMAP_SIZE, KVMIO, 0x04);
 ioctl_io_nr!(KVM_CREATE_VCPU, KVMIO, 0x41);
+ioctl_iow_nr!(KVM_GET_DIRTY_LOG, KVMIO, 0x42, kvm_dirty_log);
 ioctl_iow_nr!(
     KVM_SET_USER_MEMORY_REGION,
     KVMIO,

--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -16,6 +16,8 @@ pub enum LoggerError {
     AlreadyInitialized,
     /// Attempt to initialize with one pipe and one standard output stream as destinations.
     DifferentDestinations,
+    /// Invalid logger option specified.
+    InvalidLogOption(String),
     /// Opening named pipe fails.
     OpenFIFO(std::io::Error),
     /// Writing to named pipe fails.
@@ -41,6 +43,7 @@ impl fmt::Display for LoggerError {
                 "{}",
                 "Initialization with one pipe and one standard output stream not allowed."
             ),
+            LoggerError::InvalidLogOption(ref s) => format!("Invalid log option: {}", s),
             LoggerError::OpenFIFO(ref e) => {
                 format!("Failed to open pipe. Error: {}", e.description())
             }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -24,8 +24,8 @@
 //! use std::ops::Deref;
 //!
 //! fn main() {
-//!     // Initialize the logger. if there is not path to a FIFO provided the `LOGGER` logs both
-//!     // the human readable content and metrics to stdout and stderr depending on the log level.
+//!     // Initialize the logger. If there is no path to a FIFO provided, the `LOGGER` logs the
+//!     // human readable content to stdout and stderr depending on the log level.
 //!     if let Err(e) = LOGGER.deref().init("MY-INSTANCE", None, None, vec![]) {
 //!         println!("Could not initialize the log subsystem: {:?}", e);
 //!         return;
@@ -201,10 +201,12 @@ enum Destination {
     Pipe,
 }
 
-// Logging options.
+/// Enum representing logging options that can be activated from the API.
+///
 #[derive(PartialEq)]
 #[repr(usize)]
-enum LogOption {
+pub enum LogOption {
+    /// Enable KVM dirty page tracking and a metric that counts dirty pages.
     LogDirtyPages = 1,
 }
 
@@ -420,6 +422,12 @@ impl Logger {
         if self.level_info.writer() != Destination::Pipe as usize {
             self.level_info.set_writer(get_default_destination(level));
         }
+    }
+
+    /// Returns the configured flags for the logger.
+    ///
+    pub fn flags(&self) -> usize {
+        self.flags.load(Ordering::Relaxed)
     }
 
     /// Creates the first portion (to the left of the separator)

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -364,6 +364,13 @@ pub struct VmmMetrics {
     pub panic_count: SharedMetric,
 }
 
+/// Memory usage metrics.
+#[derive(Default, Serialize)]
+pub struct MemoryMetrics {
+    /// Number of pages dirtied since the last call to `KVM_GET_DIRTY_LOG`.
+    pub dirty_pages: SharedMetric,
+}
+
 // The sole purpose of this struct is to produce an UTC timestamp when an instance is serialized.
 #[derive(Default)]
 struct SerializeToUtcTimestampMs;
@@ -404,6 +411,8 @@ pub struct FirecrackerMetrics {
     pub vmm: VmmMetrics,
     /// Metrics related to the UART device.
     pub uart: SerialDeviceMetrics,
+    /// Memory usage metrics.
+    pub memory: MemoryMetrics,
 }
 
 lazy_static! {

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -33,9 +33,17 @@ pub enum Error {
 }
 type Result<T> = result::Result<T, Error>;
 
-struct MemoryRegion {
+/// Tracks a mapping of anonymous memory in the current process and the corresponding base address
+/// in the guest's memory space.
+pub struct MemoryRegion {
     mapping: MemoryMapping,
     guest_base: GuestAddress,
+}
+
+impl MemoryRegion {
+    pub fn size(&self) -> usize {
+        self.mapping.size()
+    }
 }
 
 fn region_end(region: &MemoryRegion) -> GuestAddress {
@@ -43,7 +51,7 @@ fn region_end(region: &MemoryRegion) -> GuestAddress {
     region.guest_base.unchecked_add(region.mapping.size())
 }
 
-/// Tracks a memory region and where it is mapped in the guest.
+/// Tracks all memory regions allocated for the guest in the current process.
 #[derive(Clone)]
 pub struct GuestMemory {
     regions: Arc<Vec<MemoryRegion>>,
@@ -338,7 +346,7 @@ impl GuestMemory {
         })
     }
 
-    /// Convert a GuestAddress into a pointer in the address space of this
+    /// Converts a GuestAddress into a pointer in the address space of this
     /// process. This should only be necessary for giving addresses to the
     /// kernel, as with vhost ioctls. Normal reads/writes to guest memory should
     /// be done through `write_from_memory`, `read_obj_from_addr`, etc.
@@ -364,6 +372,45 @@ impl GuestMemory {
             // bounds.
             Ok(unsafe { mapping.as_ptr().offset(offset as isize) } as *const u8)
         })
+    }
+
+    /// Applies two functions, specified as callbacks, on the inner memory regions.
+    ///
+    /// # Arguments
+    /// * `init` - Starting value of the accumulator for the `foldf` function.
+    /// * `mapf` - "Map" function, applied to all the inner memory regions. It returns an array of
+    ///            the same size as the memory regions array, containing the function's results
+    ///            for each region.
+    /// * `foldf` - "Fold" function, applied to the array returned by `mapf`. It acts as an
+    ///             operator, applying itself to the `init` value and to each subsequent elemnent
+    ///             in the array returned by `mapf`.
+    ///
+    /// # Examples
+    ///
+    /// * Compute the total size of all memory mappings in KB by iterating over the memory regions
+    ///   and dividing their sizes to 1024, then summing up the values in an accumulator.
+    ///
+    /// ```
+    /// # use memory_model::{GuestAddress, GuestMemory};
+    /// # fn test_map_fold() -> Result<(), ()> {
+    ///     let start_addr1 = GuestAddress(0x0);
+    ///     let start_addr2 = GuestAddress(0x400);
+    ///     let mem = GuestMemory::new(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+    ///     let total_size = mem.map_and_fold(
+    ///         0,
+    ///         |(_, region)| region.size() / 1024,
+    ///         |acc, size| acc + size
+    ///     );
+    ///     println!("Total memory size = {} KB", total_size);
+    ///     Ok(())
+    /// # }
+    /// ```
+    pub fn map_and_fold<F, G, T>(&self, init: T, mapf: F, foldf: G) -> T
+    where
+        F: Fn((usize, &MemoryRegion)) -> T,
+        G: Fn(T, T) -> T,
+    {
+        self.regions.iter().enumerate().map(mapf).fold(init, foldf)
     }
 
     fn do_in_region<F, T>(&self, guest_addr: GuestAddress, cb: F) -> Result<T>
@@ -523,5 +570,21 @@ mod tests {
         // Check that a bad address returns an error.
         let bad_addr = GuestAddress(0x123456);
         assert!(mem.get_host_address(bad_addr).is_err());
+    }
+
+    #[test]
+    fn test_map_fold() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x400);
+        let mem = GuestMemory::new(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+
+        assert_eq!(
+            mem.map_and_fold(
+                0,
+                |(_, region)| region.size() / 1024,
+                |acc, size| acc + size
+            ),
+            3
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 
 fn main() {
     LOGGER
-        .init(&"", None, None)
+        .init(&"", None, None, vec![])
         .expect("Failed to register logger");
 
     // If the signal handler can't be set, it's OK to panic.
@@ -220,6 +220,7 @@ mod tests {
                 "TEST-ID",
                 Some(log_file_temp.path().to_str().unwrap().to_string()),
                 Some(metrics_file_temp.path().to_str().unwrap().to_string()),
+                vec![],
             ).expect("Could not initialize logger.");
 
         // Cause some controlled panic and see if a backtrace shows up in the log,

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -204,7 +204,8 @@ class Logger:
             metrics_fifo=None,
             level=None,
             show_level=None,
-            show_log_origin=None
+            show_log_origin=None,
+            options=None
     ):
         """Compose the json associated to this type of API request."""
         datax = {}
@@ -218,6 +219,8 @@ class Logger:
             datax['show_level'] = show_level
         if show_log_origin is not None:
             datax['show_log_origin'] = show_log_origin
+        if options is not None:
+            datax['options'] = options
         return datax
 
 

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -1,7 +1,11 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate serde_json;
+
 use std::fmt::{Display, Formatter, Result};
+
+use self::serde_json::Value;
 
 /// Enum used for setting the log level.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -36,6 +40,13 @@ pub struct LoggerConfig {
     /// When enabled, the logger will append the origin of the log entry.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_log_origin: Option<bool>,
+    /// Additional logging options.
+    #[serde(default = "default_log_options")]
+    pub options: Value,
+}
+
+fn default_log_options() -> Value {
+    Value::Array(vec![])
 }
 
 /// Errors associated with actions on the `LoggerConfig`.

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 extern crate devices;
+extern crate logger;
 extern crate sys_util;
 extern crate x86_64;
 
@@ -14,12 +15,14 @@ use std::result;
 use super::KvmContext;
 use cpuid::{c3_template, filter_cpuid, t2_template};
 use kvm::*;
+use logger::{LogOption, LOGGER};
 use memory_model::{GuestAddress, GuestMemory, GuestMemoryError};
 use sys_util::EventFd;
 use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig};
 use x86_64::{interrupts, regs};
 
 pub const KVM_TSS_ADDRESS: usize = 0xfffbd000;
+const KVM_MEM_LOG_DIRTY_PAGES: u32 = 0x1;
 
 /// Errors associated with the wrappers over KVM ioctls.
 #[derive(Debug)]
@@ -93,13 +96,19 @@ impl Vm {
         }
         guest_mem.with_regions(|index, guest_addr, size, host_addr| {
             info!("Guest memory starts at {:x?}", host_addr);
+
+            let flags = if LOGGER.flags() & LogOption::LogDirtyPages as usize > 0 {
+                KVM_MEM_LOG_DIRTY_PAGES
+            } else {
+                0
+            };
             // Safe because the guest regions are guaranteed not to overlap.
             self.fd.set_user_memory_region(
                 index as u32,
                 guest_addr.offset() as u64,
                 size as u64,
                 host_addr as u64,
-                0,
+                flags,
             )
         })?;
         self.guest_mem = Some(guest_mem);


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: This PR is a re-submission of #551.

## Changes
* Added a new `options` parameter for logging configuration. This should be used as a list of logging options sent to Firecracker. Currently there's only 1 valid option: `LogDirtyPages`.
* Added logging flags in the logger implementation. They are the "inner" representation of the `options` from the API. `LogDirtyPages` translates into a logging flag that, in turn, sets the `KVM_MEM_LOG_DIRTY_PAGES` flag when initializing memory in kvm and gets the dirty page bitmap via `KVM_GET_DIRTY_LOG` into a new metric when flushing metrics.
* Added the functions written by @marcbrooker to retrieve the dirty page bitmap and hooked them up to the logging options.
* Completed documentation in `kvm/src/lib.rs`.
* Added unit & integration tests. The integration test is not super relevant because metrics flush every 60 s and the test shouldn't block while waiting for them. With something like #642, this test should be rewritten. Unit tests in the `kvm` crate verify the dirty page logging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
