### PR TITLE
Refactor memory monitor as coroutine

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -114,6 +114,10 @@ class Microvm:
                 shell=True
             )
 
+        # Clean up memory monitor
+        if self.monitor_memory:
+            self.memory_monitor_fut.cancel()
+
     @property
     def api_session(self):
         """Return the api session associated with this microVM."""
@@ -322,7 +326,7 @@ class Microvm:
         assert self._api_session.is_good_response(response.status_code)
 
         if self.monitor_memory:
-            mem_tools.threaded_memory_monitor(
+            self.memory_monitor_fut = mem_tools.spawn_memory_monitor(
                 mem_size_mib,
                 self._jailer_clone_pid
             )

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -1,31 +1,28 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Utilities for measuring memory utilization for a process."""
-import time
+import asyncio
 
 from subprocess import run, CalledProcessError, PIPE
-from threading import Thread
 
 
 MAX_MEMORY = 5 * 1024
 MEMORY_COP_TIMEOUT = 1
 
 
-def threaded_memory_monitor(mem_size_mib, pid):
-    """Spawns a thread that monitors memory consumption of a process.
+def spawn_memory_monitor(mem_size_mib, pid):
+    """Spawns a coroutine that monitors memory consumption of a process.
 
-    If at some point the memory used exceeds mem_size_mib, the calling thread
-    will trigger error.
+    If at some point the memory used exceeds mem_size_mib, an exception
+    will be raised.
+
+    Returns an asyncio.Future associated with the montioring coroutine
     """
-    memory_cop_thread = Thread(target=_memory_cop, args=(
-        mem_size_mib,
-        pid
-    ))
-    memory_cop_thread.start()
+    return asyncio.ensure_future(_memory_cop(mem_size_mib, pid))
 
 
-def _memory_cop(mem_size_mib, pid):
-    """Thread for monitoring memory consumption of some pid.
+async def _memory_cop(mem_size_mib, pid):
+    """Coroutine for monitoring memory consumption of some pid.
 
     `pmap` is used to compute the memory overhead. If it exceeds
     the maximum value, the process exits immediately, failing any running
@@ -33,7 +30,6 @@ def _memory_cop(mem_size_mib, pid):
     """
     pmap_cmd = 'pmap -xq {}'.format(pid)
     while True:
-        mem_total = 0
         try:
             pmap_out = run(
                 pmap_cmd,
@@ -41,37 +37,44 @@ def _memory_cop(mem_size_mib, pid):
                 check=True,
                 stdout=PIPE
             ).stdout.decode('utf-8').split('\n')
-        except CalledProcessError:
-            break
-        for line in pmap_out:
-            tokens = line.split()
-            if not tokens:
-                # This should occur when Firecracker exited cleanly and
-                # `pmap` isn't writing anything to `stdout` anymore.
-                # However, in the current state of things, Firecracker
-                # (at least sometimes) remains as a zombie, and `pmap`
-                # always outputs, even though memory consumption is 0.
-                break
-            try:
-                total_size = int(tokens[1])
-                rss = int(tokens[2])
-            except ValueError:
-                # This line doesn't contain memory related information.
-                continue
-            if total_size == mem_size_mib * 1024:
-                # This is the guest's memory region.
-                # TODO Check for the address of the guest's memory instead.
-                continue
-            mem_total += rss
+        except CalledProcessError as e:
+            print('Memory cop failed calling  \'{}\''.format(pmap_cmd))
+            raise(e)
 
-        if mem_total > MAX_MEMORY:
-            print('ERROR! Memory usage exceeded limit: {}'
-                  .format(mem_total))
-            exit(-1)
-
-        if not mem_total:
-            # Until we have a reliable way to a) kill Firecracker, b) know
-            # Firecracker is dead, this will have to do.
+        if not pmap_out:
+            # This should occur when Firecracker exited cleanly and
+            # `pmap` isn't writing anything to `stdout` anymore.
+            # However, in the current state of things, Firecracker
+            # (at least sometimes) remains as a zombie, and `pmap`
+            # always outputs, even though memory consumption is 0.
             return
 
-        time.sleep(MEMORY_COP_TIMEOUT)
+        mem_total = sum([rss for rss in _pmap_rss_streamer(pmap_out, mem_size_mib)])
+        if mem_total > MAX_MEMORY:
+            raise MemoryError(
+                'ERROR! Memory usage exceeded limit: {}/{} for pid: {}'.format(
+                    mem_total, MAX_MEMORY, pid,
+                )
+            )
+
+        await asyncio.sleep(MEMORY_COP_TIMEOUT)
+
+
+def _pmap_rss_streamer(pmap_out, mem_size_mib):
+    """Parses pmap output yielding RSS memory amounts
+    """
+    for line in pmap_out:
+        tokens = line.split()
+        try:
+            total_size = int(tokens[1])
+            rss = int(tokens[2])
+        except ValueError:
+            # This line doesn't contain memory related information.
+            continue
+
+        if total_size == mem_size_mib * 1024:
+            # This is the guest's memory region.
+            # TODO Check for the address of the guest's memory instead.
+            continue
+
+        yield rss


### PR DESCRIPTION
Allows memory monitor errors to propagate to the main
thread vs. the prior threaded model.

Closes #521 

Description of changes:
- Replace memory monitor thread with coroutine version.
- Move pmap output parsing to separate function
- Add memory montior teardown to `Microvm.kill()`