### PR TITLE
Add async start function to Microvm

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -10,6 +10,7 @@ destroy microvms.
 - Use the Firecracker Open API spec to populate Microvm API resource URLs.
 """
 
+import asyncio
 import os
 import re
 from subprocess import run, PIPE
@@ -399,3 +400,15 @@ class Microvm:
         """
         response = self.actions.put(action_type='InstanceStart')
         assert self._api_session.is_good_response(response.status_code)
+
+    def start_async(self):
+        """Start the microvm without blocking.
+        """
+        asyncio.ensure_future(self._start_async())
+
+    async def _start_async(self):
+        """Thin async wrapper for start()
+
+        External callers should use `start_async()`
+        """
+        self.start()


### PR DESCRIPTION
Add support for non-blocking Microvm starts in tests

Closes #623 

Description of changes:
- Add a non-blocking version of `start()`, `start_async()`, to the Microvm class
