### PR TITLE
Fix typo in kvm docs

### DIFF
--- a/kvm/src/lib.rs
+++ b/kvm/src/lib.rs
@@ -38,7 +38,7 @@ pub const MAX_KVM_CPUID_ENTRIES: usize = 80;
 
 /// A wrapper around opening and using `/dev/kvm`.
 ///
-/// The handle is used to issue system iocts.
+/// The handle is used to issue system ioctls.
 pub struct Kvm {
     kvm: File,
 }


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: I noticed a small typo in the kvm crate. This tiny patch fixes that!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
