### PR TITLE
Update to Rust 2018

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -116,7 +116,8 @@ fn parse_actions_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<
                 .map_err(|e| {
                     METRICS.put_api_requests.actions_fails.inc();
                     Error::SerdeJson(e)
-                })?.into_parsed_request(None, method)
+                })?
+                .into_parsed_request(None, method)
                 .map_err(|msg| {
                     METRICS.put_api_requests.actions_fails.inc();
                     Error::Generic(StatusCode::BadRequest, msg)
@@ -148,7 +149,8 @@ fn parse_boot_source_req<'a>(
                 .map_err(|e| {
                     METRICS.put_api_requests.boot_source_fails.inc();
                     Error::SerdeJson(e)
-                })?.into_parsed_request(None, method)
+                })?
+                .into_parsed_request(None, method)
                 .map_err(|s| {
                     METRICS.put_api_requests.boot_source_fails.inc();
                     Error::Generic(StatusCode::BadRequest, s)
@@ -217,7 +219,8 @@ fn parse_drives_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<'
                     METRICS.patch_api_requests.drive_fails.inc();
                     Error::SerdeJson(e)
                 })?,
-            }.into_parsed_request(Some(id_from_path.to_string()), method)
+            }
+            .into_parsed_request(Some(id_from_path.to_string()), method)
             .map_err(|s| {
                 METRICS.patch_api_requests.drive_fails.inc();
                 Error::Generic(StatusCode::BadRequest, s)
@@ -239,7 +242,8 @@ fn parse_logger_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<'
                 .map_err(|e| {
                     METRICS.put_api_requests.logger_fails.inc();
                     Error::SerdeJson(e)
-                })?.into_parsed_request(None, method)
+                })?
+                .into_parsed_request(None, method)
                 .map_err(|s| {
                     METRICS.put_api_requests.logger_fails.inc();
                     Error::Generic(StatusCode::BadRequest, s)
@@ -280,7 +284,8 @@ fn parse_machine_config_req<'a>(
                 .map_err(|e| {
                     METRICS.put_api_requests.machine_cfg_fails.inc();
                     Error::SerdeJson(e)
-                })?.into_parsed_request(None, method)
+                })?
+                .into_parsed_request(None, method)
                 .map_err(|s| {
                     METRICS.put_api_requests.machine_cfg_fails.inc();
                     Error::Generic(StatusCode::BadRequest, s)
@@ -307,7 +312,8 @@ fn parse_netif_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<'a
                 .map_err(|e| {
                     METRICS.put_api_requests.network_fails.inc();
                     Error::SerdeJson(e)
-                })?.into_parsed_request(Some(id_from_path.to_string()), method)
+                })?
+                .into_parsed_request(Some(id_from_path.to_string()), method)
                 .map_err(|s| {
                     METRICS.put_api_requests.network_fails.inc();
                     Error::Generic(StatusCode::BadRequest, s)
@@ -537,7 +543,8 @@ impl hyper::server::Service for ApiServerHttpService {
                                         describe(&method_copy, &path_copy, &b_str)
                                     );
                                     x.generate_response()
-                                }).map_err(move |_| {
+                                })
+                                .map_err(move |_| {
                                     info!(
                                         "Received Error on {}",
                                         describe(&method_copy_err, &path_copy_err, &b_str_err)
@@ -605,12 +612,14 @@ mod tests {
             .fold(Vec::new(), |mut acc, chunk| {
                 acc.extend_from_slice(&*chunk);
                 Ok::<_, hyper::Error>(acc)
-            }).and_then(move |value| Ok(value));
+            })
+            .and_then(move |value| Ok(value));
 
         String::from_utf8_lossy(
             &ret.wait()
                 .expect("Couldn't convert request body into String due to Future polling failure"),
-        ).into()
+        )
+        .into()
     }
 
     fn get_dummy_serde_error() -> serde_json::Error {

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -95,7 +95,8 @@ impl ApiServer {
                 UnixListener::from_listener(
                     unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd) },
                     &handle,
-                ).map_err(Error::Io)?
+                )
+                .map_err(Error::Io)?
             }
         };
 
@@ -133,7 +134,8 @@ impl ApiServer {
                 // We have to adjust the future item and error, to fit spawn()'s definition.
                 handle.spawn(connection.map(|_| ()).map_err(|_| ()));
                 Ok(())
-            }).map_err(Error::Io);
+            })
+            .map_err(Error::Io);
 
         // This runs forever, unless an error is returned somewhere within f (but nothing happens
         // for errors which might arise inside the connections we spawn from f, unless we explicitly

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -139,13 +139,11 @@ mod tests {
 
             let result: Result<ActionBody, serde_json::Error> = serde_json::from_str(json);
             assert!(result.is_ok());
-            assert!(
-                result
-                    .unwrap()
-                    .into_parsed_request(None, Method::Put)
-                    .unwrap()
-                    .eq(&req)
-            );
+            assert!(result
+                .unwrap()
+                .into_parsed_request(None, Method::Put)
+                .unwrap()
+                .eq(&req));
         }
 
         {
@@ -157,13 +155,11 @@ mod tests {
             let req: ParsedRequest = ParsedRequest::Sync(VmmAction::StartMicroVm(sender), receiver);
             let result: Result<ActionBody, serde_json::Error> = serde_json::from_str(json);
             assert!(result.is_ok());
-            assert!(
-                result
-                    .unwrap()
-                    .into_parsed_request(None, Method::Put)
-                    .unwrap()
-                    .eq(&req)
-            );
+            assert!(result
+                .unwrap()
+                .into_parsed_request(None, Method::Put)
+                .unwrap()
+                .eq(&req));
         }
     }
 }

--- a/api_server/src/request/boot_source.rs
+++ b/api_server/src/request/boot_source.rs
@@ -39,12 +39,11 @@ mod tests {
             boot_args: Some(String::from("foobar")),
         };
         let (sender, receiver) = oneshot::channel();
-        assert!(
-            body.into_parsed_request(None, Method::Put)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::ConfigureBootSource(same_body, sender),
-                    receiver
-                )))
-        )
+        assert!(body
+            .into_parsed_request(None, Method::Put)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::ConfigureBootSource(same_body, sender),
+                receiver
+            ))))
     }
 }

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -169,11 +169,9 @@ mod tests {
         let patch_payload = PatchDrivePayload {
             fields: Value::Object(payload_map),
         };
-        assert!(
-            patch_payload
-                .into_parsed_request(None, Method::Patch)
-                .is_err()
-        );
+        assert!(patch_payload
+            .into_parsed_request(None, Method::Patch)
+            .is_err());
 
         // PATCH with missing path_on_host field.
         let mut payload_map = Map::<String, Value>::new();
@@ -235,18 +233,13 @@ mod tests {
         };
         let (sender, receiver) = oneshot::channel();
 
-        assert!(
-            pdp.clone()
-                .into_parsed_request(Some("foo".to_string()), Method::Patch)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::UpdateBlockDevicePath(
-                        "foo".to_string(),
-                        "dummy".to_string(),
-                        sender
-                    ),
-                    receiver
-                )))
-        );
+        assert!(pdp
+            .clone()
+            .into_parsed_request(Some("foo".to_string()), Method::Patch)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::UpdateBlockDevicePath("foo".to_string(), "dummy".to_string(), sender),
+                receiver
+            ))));
 
         assert!(
             pdp.into_parsed_request(None, Method::Put) == Err(String::from("Invalid method PUT!"))
@@ -286,12 +279,11 @@ mod tests {
             rate_limiter: None,
         };
         let (sender, receiver) = oneshot::channel();
-        assert!(
-            desc.into_parsed_request(Some(String::from("foo")), Method::Put)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::InsertBlockDevice(same_desc, sender),
-                    receiver
-                )))
-        );
+        assert!(desc
+            .into_parsed_request(Some(String::from("foo")), Method::Put)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::InsertBlockDevice(same_desc, sender),
+                receiver
+            ))));
     }
 }

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -43,14 +43,12 @@ mod tests {
         format!("{:?}", desc);
         assert!(&desc.clone().into_parsed_request(None, Method::Put).is_ok());
         let (sender, receiver) = oneshot::channel();
-        assert!(
-            &desc
-                .clone()
-                .into_parsed_request(None, Method::Put)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::ConfigureLogger(desc, sender),
-                    receiver
-                )))
-        );
+        assert!(&desc
+            .clone()
+            .into_parsed_request(None, Method::Put)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::ConfigureLogger(desc, sender),
+                receiver
+            ))));
     }
 }

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -74,32 +74,27 @@ mod tests {
             cpu_template: Some(CpuFeaturesTemplate::T2),
         };
         let (sender, receiver) = oneshot::channel();
-        assert!(
-            body.clone()
-                .into_parsed_request(None, Method::Put)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::SetVmConfiguration(body, sender),
-                    receiver
-                )))
-        );
+        assert!(body
+            .clone()
+            .into_parsed_request(None, Method::Put)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::SetVmConfiguration(body, sender),
+                receiver
+            ))));
         let uninitialized = VmConfig {
             vcpu_count: None,
             mem_size_mib: None,
             ht_enabled: None,
             cpu_template: None,
         };
-        assert!(
-            uninitialized
-                .clone()
-                .into_parsed_request(None, Method::Get)
-                .is_ok()
-        );
-        assert!(
-            uninitialized
-                .clone()
-                .into_parsed_request(None, Method::Patch)
-                .is_err()
-        );
+        assert!(uninitialized
+            .clone()
+            .into_parsed_request(None, Method::Get)
+            .is_ok());
+        assert!(uninitialized
+            .clone()
+            .into_parsed_request(None, Method::Patch)
+            .is_err());
 
         match uninitialized.into_parsed_request(None, Method::Put) {
             Ok(_) => assert!(false),

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -130,7 +130,8 @@ mod tests {
             .fold(vec![], |mut acc, chunk| {
                 acc.extend_from_slice(&chunk);
                 Ok(acc)
-            }).and_then(|v| String::from_utf8(v).map_err(|_| ()));
+            })
+            .and_then(|v| String::from_utf8(v).map_err(|_| ()));
         serde_json::from_str::<Value>(body.wait().unwrap().as_ref())
     }
 

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -66,11 +66,9 @@ mod tests {
             String::from("bar"),
             "12:34:56:78:9A:BC",
         );
-        assert!(
-            netif
-                .into_parsed_request(Some(String::from("bar")), Method::Put)
-                .is_err()
-        );
+        assert!(netif
+            .into_parsed_request(Some(String::from("bar")), Method::Put)
+            .is_err());
 
         let (sender, receiver) = oneshot::channel();
         let netif = get_dummy_netif(
@@ -84,14 +82,12 @@ mod tests {
             String::from("bar"),
             "12:34:56:78:9A:BC",
         );
-        assert!(
-            netif
-                .into_parsed_request(Some(String::from("foo")), Method::Put)
-                .eq(&Ok(ParsedRequest::Sync(
-                    VmmAction::InsertNetworkDevice(netif_clone, sender),
-                    receiver
-                )))
-        );
+        assert!(netif
+            .into_parsed_request(Some(String::from("foo")), Method::Put)
+            .eq(&Ok(ParsedRequest::Sync(
+                VmmAction::InsertNetworkDevice(netif_clone, sender),
+                receiver
+            ))));
     }
 
     #[test]

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -41,17 +41,13 @@ mod tests {
             id: String::from("foo"),
             guest_cid: 42,
         };
-        assert!(
-            vsock
-                .clone()
-                .into_parsed_request(Some(String::from("bar")), Method::Put)
-                .is_err()
-        );
-        assert!(
-            vsock
-                .clone()
-                .into_parsed_request(Some(String::from("foo")), Method::Put)
-                .is_ok()
-        );
+        assert!(vsock
+            .clone()
+            .into_parsed_request(Some(String::from("bar")), Method::Put)
+            .is_err());
+        assert!(vsock
+            .clone()
+            .into_parsed_request(Some(String::from("foo")), Method::Put)
+            .is_ok());
     }
 }

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -243,10 +243,9 @@ mod tests {
 
         let mut bus = Bus::new();
         let mut data = [1, 2, 3, 4];
-        assert!(
-            bus.insert(Arc::new(Mutex::new(DummyDevice)), 0x10, 0x10)
-                .is_ok()
-        );
+        assert!(bus
+            .insert(Arc::new(Mutex::new(DummyDevice)), 0x10, 0x10)
+            .is_ok());
         assert!(bus.write(0x10, &mut data));
         let bus_clone = bus.clone();
         assert!(bus.read(0x10, &mut data));

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -127,7 +127,8 @@ fn build_device_id(disk_image: &File) -> result::Result<String, Error> {
         blk_metadata.st_dev(),
         blk_metadata.st_rdev(),
         blk_metadata.st_ino()
-    ).to_owned();
+    )
+    .to_owned();
     Ok(device_id)
 }
 
@@ -577,7 +578,8 @@ impl VirtioDevice for Block {
                 epoll::EPOLL_CTL_ADD,
                 queue_evt_raw_fd,
                 epoll::Event::new(epoll::EPOLLIN, self.epoll_config.q_avail_token),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 METRICS.block.activate_fails.inc();
                 ActivateError::EpollCtl(e)
             })?;
@@ -588,7 +590,8 @@ impl VirtioDevice for Block {
                     epoll::EPOLL_CTL_ADD,
                     rate_limiter_rawfd,
                     epoll::Event::new(epoll::EPOLLIN, self.epoll_config.rate_limiter_token),
-                ).map_err(|e| {
+                )
+                .map_err(|e| {
                     METRICS.block.activate_fails.inc();
                     ActivateError::EpollCtl(e)
                 })?;

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -271,7 +271,8 @@ impl BusDevice for MmioDevice {
                             self.interrupt_status.clone(),
                             self.queues.clone(),
                             self.queue_evts.split_off(0),
-                        ).expect("Failed to activate device");
+                        )
+                        .expect("Failed to activate device");
                     self.device_activated = true;
                 }
             }

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -627,7 +627,8 @@ impl Net {
         // Set offload flags to match the virtio features below.
         tap.set_offload(
             net_gen::TUN_F_CSUM | net_gen::TUN_F_UFO | net_gen::TUN_F_TSO4 | net_gen::TUN_F_TSO6,
-        ).map_err(Error::TapSetOffload)?;
+        )
+        .map_err(Error::TapSetOffload)?;
 
         let vnet_hdr_size = vnet_hdr_len() as i32;
         tap.set_vnet_hdr_size(vnet_hdr_size)
@@ -829,7 +830,8 @@ impl VirtioDevice for Net {
                 epoll::EPOLL_CTL_ADD,
                 tap_raw_fd,
                 epoll::Event::new(epoll::EPOLLIN, self.epoll_config.rx_tap_token),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 METRICS.net.activate_fails.inc();
                 ActivateError::EpollCtl(e)
             })?;
@@ -839,7 +841,8 @@ impl VirtioDevice for Net {
                 epoll::EPOLL_CTL_ADD,
                 rx_queue_raw_fd,
                 epoll::Event::new(epoll::EPOLLIN, self.epoll_config.rx_queue_token),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 METRICS.net.activate_fails.inc();
                 ActivateError::EpollCtl(e)
             })?;
@@ -849,7 +852,8 @@ impl VirtioDevice for Net {
                 epoll::EPOLL_CTL_ADD,
                 tx_queue_raw_fd,
                 epoll::Event::new(epoll::EPOLLIN, self.epoll_config.tx_queue_token),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 METRICS.net.activate_fails.inc();
                 ActivateError::EpollCtl(e)
             })?;
@@ -860,7 +864,8 @@ impl VirtioDevice for Net {
                     epoll::EPOLL_CTL_ADD,
                     rx_rate_limiter_rawfd,
                     epoll::Event::new(epoll::EPOLLIN, self.epoll_config.rx_rate_limiter_token),
-                ).map_err(ActivateError::EpollCtl)?;
+                )
+                .map_err(ActivateError::EpollCtl)?;
             }
 
             if tx_rate_limiter_rawfd != -1 {
@@ -869,7 +874,8 @@ impl VirtioDevice for Net {
                     epoll::EPOLL_CTL_ADD,
                     tx_rate_limiter_rawfd,
                     epoll::Event::new(epoll::EPOLLIN, self.epoll_config.tx_rate_limiter_token),
-                ).map_err(ActivateError::EpollCtl)?;
+                )
+                .map_err(ActivateError::EpollCtl)?;
             }
 
             return Ok(());
@@ -942,7 +948,8 @@ mod tests {
                             u64::max_value(),
                             None,
                             1000,
-                        ).unwrap(),
+                        )
+                        .unwrap(),
                     ),
                     Some(
                         RateLimiter::new(
@@ -952,10 +959,12 @@ mod tests {
                             u64::max_value(),
                             None,
                             1000,
-                        ).unwrap(),
+                        )
+                        .unwrap(),
                     ),
                     true,
-                ).unwrap(),
+                )
+                .unwrap(),
                 epoll_raw_fd,
                 _receiver,
             }
@@ -1282,7 +1291,8 @@ mod tests {
                 tha,
                 sha,
                 ethernet::ETHERTYPE_ARP,
-            ).ok()
+            )
+            .ok()
             .unwrap();
             // Set its length to hold an ARP request.
             let mut eth_frame_complete =

--- a/devices/src/virtio/vhost/vsock.rs
+++ b/devices/src/virtio/vhost/vsock.rs
@@ -192,7 +192,8 @@ impl VirtioDevice for Vsock {
                             queue.used_ring,
                             queue.avail_ring,
                             None,
-                        ).map_err(Error::VhostSetVringAddr)?;
+                        )
+                        .map_err(Error::VhostSetVringAddr)?;
                     vsock_fd
                         .set_vring_base(queue_index, 0)
                         .map_err(Error::VhostSetVringBase)?;
@@ -229,7 +230,8 @@ impl VirtioDevice for Vsock {
                     epoll::EPOLL_CTL_ADD,
                     queue_evt_raw_fd,
                     epoll::Event::new(epoll::EPOLLIN, self.epoll_config.get_queue_evt_token()),
-                ).map_err(ActivateError::EpollCtl)?;
+                )
+                .map_err(ActivateError::EpollCtl)?;
 
                 return Ok(());
             }

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -208,7 +208,8 @@ impl MmdsNetworkStack {
             self.remote_mac_addr,
             self.mac_addr,
             ETHERTYPE_ARP,
-        ).map_err(WriteArpReplyError::Ethernet)?;
+        )
+        .map_err(WriteArpReplyError::Ethernet)?;
 
         let arp_len = EthIPv4ArpFrame::write_reply(
             eth_unsized
@@ -220,7 +221,8 @@ impl MmdsNetworkStack {
             self.ipv4_addr,
             self.remote_mac_addr,
             dst_ipv4,
-        ).map_err(WriteArpReplyError::Arp)?
+        )
+        .map_err(WriteArpReplyError::Arp)?
         .len();
 
         Ok(Some(
@@ -235,7 +237,8 @@ impl MmdsNetworkStack {
             self.remote_mac_addr,
             self.mac_addr,
             ETHERTYPE_IPV4,
-        ).map_err(WritePacketError::Ethernet)?;
+        )
+        .map_err(WritePacketError::Ethernet)?;
 
         let (maybe_len, event) = self
             .tcp_handler
@@ -253,7 +256,8 @@ impl MmdsNetworkStack {
                     eth_unsized
                         .with_payload_len_unchecked(packet_len.get())
                         .len(),
-                ).unwrap(),
+                )
+                .unwrap(),
             ));
         }
         Ok(None)

--- a/dumbo/src/pdu/arp.rs
+++ b/dumbo/src/pdu/arp.rs
@@ -417,7 +417,8 @@ mod tests {
             spa,
             tha,
             tpa,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).is_ok());
 
         // Now we start writing invalid requests. We've already tried with an invalid operation.
@@ -434,7 +435,8 @@ mod tests {
             spa,
             tha,
             tpa,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).unwrap_err(),
             Error::HType
@@ -452,7 +454,8 @@ mod tests {
             spa,
             tha,
             tpa,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).unwrap_err(),
             Error::PType
@@ -470,7 +473,8 @@ mod tests {
             spa,
             tha,
             tpa,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).unwrap_err(),
             Error::HLen
@@ -488,7 +492,8 @@ mod tests {
             spa,
             tha,
             tpa,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             EthIPv4ArpFrame::request_from_bytes(&a[..ETH_IPV4_FRAME_LEN]).unwrap_err(),
             Error::PLen

--- a/dumbo/src/pdu/tcp.rs
+++ b/dumbo/src/pdu/tcp.rs
@@ -461,7 +461,8 @@ impl<'a, T: NetworkBytesMut> TcpSegment<'a, T> {
             mss_option,
             mss_remaining,
             payload,
-        )?.finalize(src_port, dst_port, compute_checksum))
+        )?
+        .finalize(src_port, dst_port, compute_checksum))
     }
 
     /// Writes an incomplete TCP segment, which is missing the `source port`, `destination port`,
@@ -684,7 +685,8 @@ mod tests {
                 mss_left,
                 payload,
                 Some((src_addr, dst_addr)),
-            ).unwrap();
+            )
+            .unwrap();
 
             assert_eq!(p.source_port(), src_port);
             assert_eq!(p.destination_port(), dst_port);
@@ -741,7 +743,8 @@ mod tests {
                 mss_left,
                 Some((c.as_ref(), c.len())),
                 Some((src_addr, dst_addr)),
-            ).unwrap()
+            )
+            .unwrap()
             .len();
 
             assert_eq!(len, mss_left as usize);
@@ -801,7 +804,8 @@ mod tests {
                 mss_left,
                 payload,
                 Some((src_addr, dst_addr)),
-            ).unwrap_err(),
+            )
+            .unwrap_err(),
             Error::SliceTooShort
         );
 
@@ -819,7 +823,8 @@ mod tests {
                 0,
                 payload,
                 Some((src_addr, dst_addr)),
-            ).unwrap_err(),
+            )
+            .unwrap_err(),
             Error::MssRemaining
         );
     }

--- a/dumbo/src/tcp/connection.rs
+++ b/dumbo/src/tcp/connection.rs
@@ -264,10 +264,11 @@ impl Connection {
     // We send a FIN control segment if every data byte up to the self.send_fin sequence number
     // has been ACKed by the other endpoint, and no FIN has been previously sent.
     fn can_send_first_fin(&self) -> bool {
-        !self.fin_sent() && match self.send_fin {
-            Some(fin_seq) if fin_seq == self.highest_ack_received => true,
-            _ => false,
-        }
+        !self.fin_sent()
+            && match self.send_fin {
+                Some(fin_seq) if fin_seq == self.highest_ack_received => true,
+                _ => false,
+            }
     }
 
     // Returns the window size which should be written to an outgoing segment. This is going to be
@@ -647,7 +648,8 @@ impl Connection {
                 .checked_sub(mss_reserved)
                 .ok_or_else(|| WriteNextError::MssRemaining)?,
             payload,
-        ).map_err(WriteNextError::TcpSegment)?;
+        )
+        .map_err(WriteNextError::TcpSegment)?;
 
         if flags_after_ns.intersects(TcpFlags::ACK) {
             self.pending_ack = false;
@@ -971,7 +973,8 @@ pub(crate) mod tests {
                 self.mss.checked_sub(self.mss_reserved).unwrap(),
                 payload,
                 None,
-            ).unwrap()
+            )
+            .unwrap()
         }
 
         pub fn write_syn<'a>(&self, buf: &'a mut [u8]) -> TcpSegment<'a, &'a mut [u8]> {

--- a/dumbo/src/tcp/endpoint.rs
+++ b/dumbo/src/tcp/endpoint.rs
@@ -269,10 +269,11 @@ impl Endpoint {
     }
 
     pub fn next_segment_status(&self) -> NextSegmentStatus {
-        let can_send_new_data = !self.response_buf.is_empty() && seq_after(
-            self.connection.remote_rwnd_edge(),
-            self.connection.first_not_sent(),
-        );
+        let can_send_new_data = !self.response_buf.is_empty()
+            && seq_after(
+                self.connection.remote_rwnd_edge(),
+                self.connection.first_not_sent(),
+            );
 
         if can_send_new_data || self.connection.dup_ack_pending() {
             NextSegmentStatus::Available

--- a/dumbo/src/tcp/handler.rs
+++ b/dumbo/src/tcp/handler.rs
@@ -317,12 +317,14 @@ impl TcpIPv4Handler {
                 None,
                 0,
                 None,
-            ).map_err(WriteNextError::TcpSegment)?
+            )
+            .map_err(WriteNextError::TcpSegment)?
             .finalize(
                 self.local_port,
                 tuple.remote_port,
                 Some((self.local_addr, tuple.remote_addr)),
-            ).len();
+            )
+            .len();
 
             packet
                 .inner_mut()
@@ -356,7 +358,8 @@ impl TcpIPv4Handler {
                             self.local_port,
                             tuple.remote_port,
                             Some((self.local_addr, tuple.remote_addr)),
-                        ).len(),
+                        )
+                        .len(),
                     None => continue,
                 }
             };
@@ -512,7 +515,8 @@ mod tests {
                 100,
                 None,
                 None,
-            ).unwrap();
+            )
+            .unwrap();
             s.len()
         };
 

--- a/dumbo/src/tcp/mod.rs
+++ b/dumbo/src/tcp/mod.rs
@@ -96,7 +96,8 @@ mod tests {
             100,
             None,
             None,
-        ).unwrap();
+        )
+        .unwrap();
 
         // The ACK flag isn't set, and the payload length is 0.
         let cfg = RstConfig::new(&s);

--- a/jailer/src/env.rs
+++ b/jailer/src/env.rs
@@ -287,7 +287,8 @@ impl Env {
                 .arg(format!(
                     "--context={}",
                     serde_json::to_string(&context).expect("Failed to serialize context")
-                )).stdin(Stdio::inherit())
+                ))
+                .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
                 .uid(self.uid())
@@ -367,7 +368,8 @@ mod tests {
             ),
             0,
             0,
-        ).expect("This new environment should be created successfully.");
+        )
+        .expect("This new environment should be created successfully.");
 
         let mut chroot_dir = PathBuf::from(chroot_base);
         chroot_dir.push(Path::new(exec_file).file_name().unwrap());
@@ -384,71 +386,67 @@ mod tests {
             make_args(node, id, exec_file, uid, gid, chroot_base, None, false),
             0,
             0,
-        ).expect("This another new environment should be created successfully.");
+        )
+        .expect("This another new environment should be created successfully.");
         assert!(!another_good_env.daemonize);
 
         // Not fine - invalid node.
-        assert!(
-            Env::new(
-                make_args("zzz", id, exec_file, uid, gid, chroot_base, None, true),
-                0,
-                0,
-            ).is_err()
-        );
+        assert!(Env::new(
+            make_args("zzz", id, exec_file, uid, gid, chroot_base, None, true),
+            0,
+            0,
+        )
+        .is_err());
 
         // Not fine - invalid id.
-        assert!(
-            Env::new(
-                make_args(
-                    node,
-                    "/ad./sa12",
-                    exec_file,
-                    uid,
-                    gid,
-                    chroot_base,
-                    None,
-                    true
-                ),
-                0,
-                0
-            ).is_err()
-        );
+        assert!(Env::new(
+            make_args(
+                node,
+                "/ad./sa12",
+                exec_file,
+                uid,
+                gid,
+                chroot_base,
+                None,
+                true
+            ),
+            0,
+            0
+        )
+        .is_err());
 
         // Not fine - inexistent (hopefully) exec_file.
-        assert!(
-            Env::new(
-                make_args(
-                    node,
-                    id,
-                    "/this!/file!/should!/not!/exist!/",
-                    uid,
-                    gid,
-                    chroot_base,
-                    None,
-                    true
-                ),
-                0,
-                0
-            ).is_err()
-        );
+        assert!(Env::new(
+            make_args(
+                node,
+                id,
+                "/this!/file!/should!/not!/exist!/",
+                uid,
+                gid,
+                chroot_base,
+                None,
+                true
+            ),
+            0,
+            0
+        )
+        .is_err());
 
         // Not fine - invalid uid.
-        assert!(
-            Env::new(
-                make_args(node, id, exec_file, "zzz", gid, chroot_base, None, true),
-                0,
-                0
-            ).is_err()
-        );
+        assert!(Env::new(
+            make_args(node, id, exec_file, "zzz", gid, chroot_base, None, true),
+            0,
+            0
+        )
+        .is_err());
 
         // Not fine - invalid gid.
-        assert!(
-            Env::new(
-                make_args(node, id, exec_file, uid, "zzz", chroot_base, None, true),
-                0,
-                0
-            ).is_err()
-        );
+        assert!(Env::new(
+            make_args(node, id, exec_file, uid, "zzz", chroot_base, None, true),
+            0,
+            0
+        )
+        .is_err());
 
         // The chroot-base-dir param is not validated by Env::new, but rather in run, when we
         // actually attempt to create the folder structure (the same goes for netns).

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -112,7 +112,8 @@ impl fmt::Display for Error {
                 format!(
                     "Failed to inherit cgroups configurations from file {} in path {:?}",
                     filename, path
-                ).replace("\"", "")
+                )
+                .replace("\"", "")
             ),
             CgroupLineNotFound(ref proc_mounts, ref controller) => write!(
                 f,
@@ -368,7 +369,8 @@ pub fn run(args: ArgMatches, start_time_us: u64, start_time_cpu_us: u64) -> Resu
             .parent()
             .ok_or(Error::MissingParent(env.chroot_dir().to_path_buf()))?
             .join(SOCKET_FILE_NAME),
-    ).map_err(|e| Error::UnixListener(e))?;
+    )
+    .map_err(|e| Error::UnixListener(e))?;
 
     let listener_fd = listener.as_raw_fd();
     if listener_fd != LISTENER_FD {

--- a/kvm/src/lib.rs
+++ b/kvm/src/lib.rs
@@ -994,8 +994,8 @@ mod tests {
         let mem = GuestMemory::new(&mem_vec).unwrap();
         let vm = kvm.create_vm().unwrap();
 
-        assert!(
-            mem.with_regions(
+        assert!(mem
+            .with_regions(
                 |index, guest_addr, size, host_addr| vm.set_user_memory_region(
                     index as u32,
                     guest_addr.offset() as u64,
@@ -1003,8 +1003,8 @@ mod tests {
                     host_addr as u64,
                     0,
                 )
-            ).is_err()
-        );
+            )
+            .is_err());
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -1303,7 +1303,8 @@ mod tests {
                 host_addr as u64,
                 KVM_MEM_LOG_DIRTY_PAGES,
             )
-        }).expect("Cannot configure guest memory");
+        })
+        .expect("Cannot configure guest memory");
         mem.write_slice_at_addr(&code, load_addr)
             .expect("Writing code to memory failed");
 

--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -68,12 +68,11 @@ mod tests {
 
     #[test]
     fn test_formatting() {
-        assert!(
-            format!(
-                "{:?}",
-                LoggerError::NeverInitialized(String::from("Bad Log Path Provided"))
-            ).contains("NeverInitialized")
-        );
+        assert!(format!(
+            "{:?}",
+            LoggerError::NeverInitialized(String::from("Bad Log Path Provided"))
+        )
+        .contains("NeverInitialized"));
         assert_eq!(
             format!(
                 "{}",
@@ -97,12 +96,11 @@ mod tests {
             "Initialization with one pipe and one standard output stream not allowed."
         );
 
-        assert!(
-            format!(
-                "{:?}",
-                LoggerError::LogWrite(std::io::Error::new(ErrorKind::Interrupted, "write"))
-            ).contains("LogWrite")
-        );
+        assert!(format!(
+            "{:?}",
+            LoggerError::LogWrite(std::io::Error::new(ErrorKind::Interrupted, "write"))
+        )
+        .contains("LogWrite"));
         assert_eq!(
             format!(
                 "{}",
@@ -111,12 +109,11 @@ mod tests {
             "Failed to write logs. Error: write"
         );
 
-        assert!(
-            format!(
-                "{:?}",
-                LoggerError::LogFlush(std::io::Error::new(ErrorKind::Interrupted, "flush"))
-            ).contains("LogFlush")
-        );
+        assert!(format!(
+            "{:?}",
+            LoggerError::LogFlush(std::io::Error::new(ErrorKind::Interrupted, "flush"))
+        )
+        .contains("LogFlush"));
         assert_eq!(
             format!(
                 "{}",
@@ -125,12 +122,11 @@ mod tests {
             "Failed to flush logs. Error: flush"
         );
 
-        assert!(
-            format!(
-                "{:?}",
-                LoggerError::MutexLockFailure(String::from("Mutex lock"))
-            ).contains("MutexLockFailure")
-        );
+        assert!(format!(
+            "{:?}",
+            LoggerError::MutexLockFailure(String::from("Mutex lock"))
+        )
+        .contains("MutexLockFailure"));
         assert_eq!(
             format!(
                 "{}",
@@ -139,12 +135,11 @@ mod tests {
             "Mutex lock"
         );
 
-        assert!(
-            format!(
-                "{:?}",
-                LoggerError::LogMetricFailure("Failure in the logging of the metrics.".to_string())
-            ).contains("LogMetricFailure")
-        );
+        assert!(format!(
+            "{:?}",
+            LoggerError::LogMetricFailure("Failure in the logging of the metrics.".to_string())
+        )
+        .contains("LogMetricFailure"));
         assert_eq!(
             format!(
                 "{}",

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -648,7 +648,8 @@ impl Logger {
                             self.metrics_fifo_guard()
                                 .as_mut()
                                 .expect("Failed to write to fifo due to poisoned lock"),
-                        ).map_err(|e| {
+                        )
+                        .map_err(|e| {
                             METRICS.logger.missed_metrics_count.inc();
                             e
                         })?;
@@ -777,7 +778,8 @@ mod tests {
                     None,
                     None,
                     vec![Value::String("foobar".to_string())]
-                ).err()
+                )
+                .err()
             ),
             "Some(NeverInitialized(\"Could not set option flags: Invalid log option: foobar\"))"
         );
@@ -797,14 +799,14 @@ mod tests {
         let metrics_file = String::from(metrics_file_temp.path().to_path_buf().to_str().unwrap());
 
         // Assert that initialization with pipes works after initializing with stdout/stderr.
-        assert!(
-            l.init(
+        assert!(l
+            .init(
                 TEST_INSTANCE_ID,
                 Some(log_file.clone()),
                 Some(metrics_file),
                 vec![Value::String("LogDirtyPages".to_string())]
-            ).is_ok()
-        );
+            )
+            .is_ok());
 
         info!("info");
         warn!("warning");
@@ -839,17 +841,15 @@ mod tests {
         let log_file = String::from(log_file_temp.path().to_path_buf().to_str().unwrap());
 
         // Assert that initialization with one pipe and stdout/stderr is not allowed.
-        assert!(
-            l.init(TEST_INSTANCE_ID, Some(log_file.clone()), None, vec![])
-                .is_err()
-        );
+        assert!(l
+            .init(TEST_INSTANCE_ID, Some(log_file.clone()), None, vec![])
+            .is_err());
 
         // Exercise the case when there is an error in opening file.
         STATE.store(UNINITIALIZED, Ordering::SeqCst);
-        assert!(
-            l.init("TEST-ID", Some(String::from("")), None, vec![])
-                .is_err()
-        );
+        assert!(l
+            .init("TEST-ID", Some(String::from("")), None, vec![])
+            .is_err());
         let res = l.init(
             "TEST-ID",
             Some(log_file.clone()),

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -512,7 +512,8 @@ mod tests {
             addr,
             &mut File::open(Path::new("/dev/zero")).unwrap(),
             mem::size_of::<u32>(),
-        ).unwrap();
+        )
+        .unwrap();
         let value: u32 = gm.read_obj_from_addr(addr).unwrap();
         assert_eq!(value, 0);
 

--- a/memory_model/src/mmap.rs
+++ b/memory_model/src/mmap.rs
@@ -381,24 +381,18 @@ mod tests {
         let mem_map = MemoryMapping::new(5).unwrap();
         assert!(mem_map.write_obj(!0u32, 1).is_ok());
         let mut file = File::open(Path::new("/dev/zero")).unwrap();
-        assert!(
-            mem_map
-                .read_to_memory(2, &mut file, mem::size_of::<u32>())
-                .is_err()
-        );
+        assert!(mem_map
+            .read_to_memory(2, &mut file, mem::size_of::<u32>())
+            .is_err());
 
-        assert!(
-            mem_map
-                .read_to_memory(1, &mut file, mem::size_of::<u32>())
-                .is_ok()
-        );
+        assert!(mem_map
+            .read_to_memory(1, &mut file, mem::size_of::<u32>())
+            .is_ok());
 
         let mut f = tempfile().unwrap();
-        assert!(
-            mem_map
-                .read_to_memory(1, &mut f, mem::size_of::<u32>())
-                .is_err()
-        );
+        assert!(mem_map
+            .read_to_memory(1, &mut f, mem::size_of::<u32>())
+            .is_err());
         format!(
             "{:?}",
             mem_map.read_to_memory(1, &mut f, mem::size_of::<u32>())
@@ -407,16 +401,12 @@ mod tests {
         assert_eq!(mem_map.read_obj::<u32>(1).unwrap(), 0);
 
         let mut sink = Vec::new();
-        assert!(
-            mem_map
-                .write_from_memory(1, &mut sink, mem::size_of::<u32>())
-                .is_ok()
-        );
-        assert!(
-            mem_map
-                .write_from_memory(2, &mut sink, mem::size_of::<u32>())
-                .is_err()
-        );
+        assert!(mem_map
+            .write_from_memory(1, &mut sink, mem::size_of::<u32>())
+            .is_ok());
+        assert!(mem_map
+            .write_from_memory(2, &mut sink, mem::size_of::<u32>())
+            .is_err());
         format!(
             "{:?}",
             mem_map.write_from_memory(2, &mut sink, mem::size_of::<u32>())

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -320,7 +320,8 @@ impl<'de> Deserialize<'de> for RateLimiter {
                     ops.size,
                     ops.one_time_burst,
                     ops.refill_time,
-                ).map_err(de::Error::custom)
+                )
+                .map_err(de::Error::custom)
             }
         }
         const FIELDS: &'static [&'static str] = &["bandwidth", "ops"];

--- a/seccomp/src/lib.rs
+++ b/seccomp/src/lib.rs
@@ -1194,18 +1194,18 @@ mod tests {
                     (
                         0,
                         vec![SeccompRule::new(
-                            vec![
-                                SeccompCondition::new(1, SeccompCmpOp::MaskedEq(0b100), 36)
-                                    .unwrap(),
-                            ],
+                            vec![SeccompCondition::new(1, SeccompCmpOp::MaskedEq(0b100), 36)
+                                .unwrap()],
                             SeccompAction::Allow,
                         )],
                     ),
                 ),
-            ].into_iter()
+            ]
+            .into_iter()
             .collect(),
             SeccompAction::Trap,
-        ).unwrap();
+        )
+        .unwrap();
         let instructions = vec![
             BPF_STMT(0x20, 0),
             BPF_JUMP(0x15, 1, 0, 1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,12 +68,14 @@ fn main() {
                 .help("Path to unix domain socket used by the API")
                 .default_value(DEFAULT_API_SOCK_PATH)
                 .takes_value(true),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("context")
                 .long("context")
                 .help("Additional parameters sent to Firecracker.")
                 .takes_value(true),
-        ).get_matches();
+        )
+        .get_matches();
 
     let bind_path = cmd_arguments
         .value_of("api_sock")
@@ -221,7 +223,8 @@ mod tests {
                 Some(log_file_temp.path().to_str().unwrap().to_string()),
                 Some(metrics_file_temp.path().to_str().unwrap().to_string()),
                 vec![],
-            ).expect("Could not initialize logger.");
+            )
+            .expect("Could not initialize logger.");
 
         // Cause some controlled panic and see if a backtrace shows up in the log,
         // as it's supposed to.

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -138,10 +138,12 @@ mod tests {
     fn test_register_signal_handler() {
         unsafe {
             // testing bad value
-            assert!(
-                register_signal_handler(SIGRTMAX(), SignalHandler::Siginfo(handle_signal), true)
-                    .is_err()
-            );
+            assert!(register_signal_handler(
+                SIGRTMAX(),
+                SignalHandler::Siginfo(handle_signal),
+                true
+            )
+            .is_err());
             format!(
                 "{:?}",
                 register_signal_handler(SIGRTMAX(), SignalHandler::Siginfo(handle_signal), true)
@@ -149,10 +151,12 @@ mod tests {
             assert!(
                 register_signal_handler(0, SignalHandler::Siginfo(handle_signal), true).is_ok()
             );
-            assert!(
-                register_signal_handler(libc::SIGSYS, SignalHandler::Siginfo(handle_signal), false)
-                    .is_ok()
-            );
+            assert!(register_signal_handler(
+                libc::SIGSYS,
+                SignalHandler::Siginfo(handle_signal),
+                false
+            )
+            .is_ok());
         }
     }
 

--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -16,21 +16,6 @@ SUCCESS_CODE = 0
 @pytest.mark.timeout(120)
 def test_rust_style():
     """Fail if there's misbehaving Rust style in this repo."""
-    # Install rustfmt if it's not available yet.
-    rustfmt_check = run(
-        'rustup component list | grep --silent "rustfmt.*(installed)"',
-        shell=True
-    )
-    if not rustfmt_check.returncode == SUCCESS_CODE:
-        run(
-            'rustup component add rustfmt-preview'
-            '>/dev/null 2>&1',
-            shell=True,
-            check=True
-        )
-        # rustfmt-preview is used with the current state of things.
-        # See github.com/rust-lang-nursery/rustfmt for information.
-
     # Check that the output is empty.
     process = run(
         'cargo fmt --all -- --check',

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update \
 RUN mkdir "$TMP_BUILD_DIR" \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y \
         && rustup target add x86_64-unknown-linux-musl \
+        && rustup component add rustfmt \
         && cd "$TMP_BUILD_DIR" \
             && cargo install cargo-kcov \
             && cargo kcov --print-install-kcov-sh | sh \

--- a/tools/devtool
+++ b/tools/devtool
@@ -49,9 +49,6 @@
 #   This will run the entire integration test battery. The testing system is
 #   based on pytest (http://pytest.org).
 #
-# Updating the container image:
-#   Run `./devtool update`.
-#
 # Opening a shell prompt inside the development container:
 #   Run `./devtool shell`.
 #
@@ -74,7 +71,9 @@
 #     would help with reproducible builds (in addition to pinning Cargo.lock)
 
 # Development container image (name:tag)
-DEVCTR_IMAGE="fcuvm/dev:latest"
+# This should be updated whenever we upgrade the development container.
+# (Yet another step on our way to reproducible builds.)
+DEVCTR_IMAGE="fcuvm/dev:v2"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"
@@ -196,8 +195,14 @@ ensure_devctr() {
 
     # Check if we have the container image available locally. Attempt to
     # download it, if we don't.
-    [[ $(docker images -q "$DEVCTR_IMAGE" | wc -l) -gt 0 ]] || cmd_update
-    ok_or_die "Error pulling docker image. Aborting."
+    [[ $(docker images -q "$DEVCTR_IMAGE" | wc -l) -gt 0 ]] || {
+        say "About to pull docker image $DEVCTR_IMAGE"
+        get_user_confirmation || die "Aborted."
+
+        docker pull "${DEVCTR_IMAGE}"
+
+        ok_or_die "Error pulling docker image. Aborting."
+    }
 }
 
 # Check if /dev/kvm exists. Exit if it doesn't.
@@ -338,9 +343,6 @@ cmd_help() {
     echo "        Run the Firecracker integration tests."
     echo "        The Firecracker testing system is based on pytest. All arguments after --"
     echo "        will be passed through to pytest."
-    echo ""
-    echo "    update"
-    echo "        Pull the latest Docker image used to build and test Firecracker."
     echo ""
 }
 
@@ -516,32 +518,6 @@ cmd_shell() {
     return $ret
 }
 
-
-# `$0 update` - download the latest dev container image
-# Please see `$0 help` for more information.
-#
-cmd_update() {
-    confirmed=false
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -h|--help)          { cmd_help; exit 1;     } ;;
-            -y|--yes)           { confirmed=true;       } ;;
-            *)
-                die "Unknown argument: $1. Use --help for help."
-        esac
-        shift
-    done
-
-    ensure_docker
-
-    [ $confirmed = true ] || {
-        say "About to pull docker image $DEVCTR_IMAGE"
-        get_user_confirmation || die "Aborted."
-    }
-
-    say "Updating ${DEVCTR_IMAGE} ..."
-    docker pull "${DEVCTR_IMAGE}"
-}
 
 main() {
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -330,6 +330,11 @@ cmd_help() {
     echo "        --debug             Build the debug binaries. This is the default."
     echo "        --release           Build the release binaries."
     echo ""
+    echo "    fmt"
+    echo "        Auto-format all Rust source files, to match the Firecracker requirements."
+    echo "        This should be used as the last step in every commit, to ensure that the"
+    echo "        Rust style tests pass."
+    echo ""
     echo "    help"
     echo "        Display this help message."
     echo ""
@@ -360,7 +365,7 @@ cmd_build() {
             "-h"|"--help")  { cmd_help; exit 1;     } ;;
             "--debug")      { profile="debug";      } ;;
             "--release")    { profile="release";    } ;;
-            "--")           { break;                } ;;
+            "--")           { shift; break;         } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
             ;;
@@ -413,7 +418,7 @@ cmd_test() {
     while [ $# -gt 0 ]; do
         case "$1" in
             "-h"|"--help")      { cmd_help; exit 1; } ;;
-            "--")               { break;            } ;;
+            "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
             ;;
@@ -516,6 +521,34 @@ cmd_shell() {
     fi
 
     return $ret
+}
+
+
+# Auto-format all source code, to match the Firecracker requirements. For the
+# moment, this is just a wrapper over `cargo fmt --all`
+# Example: `devtool fmt`
+#
+cmd_fmt() {
+
+    # Parse any command line args.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "-h"|"--help")      { cmd_help; exit 1; } ;;
+            *)
+                die "Unknown argument: $1. Please use --help for help."
+            ;;
+        esac
+        shift
+    done
+
+    ensure_devctr
+
+    say "Applying rustfmt ..."
+    run_devctr \
+        --user "$(id -u):$(id -g)" \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        -- \
+        cargo fmt --all
 }
 
 

--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -604,7 +604,8 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
                 libc::SYS_writev,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
             ),
-        ].into_iter()
+        ]
+        .into_iter()
         .collect(),
         SeccompAction::Trap,
     )?)
@@ -628,50 +629,46 @@ mod tests {
     fn test_advanced_seccomp() {
         // Sets up context with additional rules required by the test.
         let mut context = super::default_context().unwrap();
-        assert!(
-            context
-                .add_rules(
-                    libc::SYS_exit,
-                    None,
-                    vec![seccomp::SeccompRule::new(
-                        vec![],
-                        seccomp::SeccompAction::Allow,
-                    )],
-                ).is_ok()
-        );
-        assert!(
-            context
-                .add_rules(
-                    libc::SYS_rt_sigprocmask,
-                    None,
-                    vec![seccomp::SeccompRule::new(
-                        vec![],
-                        seccomp::SeccompAction::Allow,
-                    )],
-                ).is_ok()
-        );
-        assert!(
-            context
-                .add_rules(
-                    libc::SYS_set_tid_address,
-                    None,
-                    vec![seccomp::SeccompRule::new(
-                        vec![],
-                        seccomp::SeccompAction::Allow,
-                    )],
-                ).is_ok()
-        );
-        assert!(
-            context
-                .add_rules(
-                    libc::SYS_sigaltstack,
-                    None,
-                    vec![seccomp::SeccompRule::new(
-                        vec![],
-                        seccomp::SeccompAction::Allow,
-                    )],
-                ).is_ok()
-        );
+        assert!(context
+            .add_rules(
+                libc::SYS_exit,
+                None,
+                vec![seccomp::SeccompRule::new(
+                    vec![],
+                    seccomp::SeccompAction::Allow,
+                )],
+            )
+            .is_ok());
+        assert!(context
+            .add_rules(
+                libc::SYS_rt_sigprocmask,
+                None,
+                vec![seccomp::SeccompRule::new(
+                    vec![],
+                    seccomp::SeccompAction::Allow,
+                )],
+            )
+            .is_ok());
+        assert!(context
+            .add_rules(
+                libc::SYS_set_tid_address,
+                None,
+                vec![seccomp::SeccompRule::new(
+                    vec![],
+                    seccomp::SeccompAction::Allow,
+                )],
+            )
+            .is_ok());
+        assert!(context
+            .add_rules(
+                libc::SYS_sigaltstack,
+                None,
+                vec![seccomp::SeccompRule::new(
+                    vec![],
+                    seccomp::SeccompAction::Allow,
+                )],
+            )
+            .is_ok());
 
         assert!(seccomp::setup_seccomp(seccomp::SeccompLevel::Advanced(context)).is_ok());
     }

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -74,7 +74,8 @@ impl LegacyDeviceManager {
                 ))),
                 0x2f8,
                 0x8,
-            ).map_err(|err| Error::BusError(err))?;
+            )
+            .map_err(|err| Error::BusError(err))?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -82,7 +83,8 @@ impl LegacyDeviceManager {
                 ))),
                 0x3e8,
                 0x8,
-            ).map_err(|err| Error::BusError(err))?;
+            )
+            .map_err(|err| Error::BusError(err))?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -90,7 +92,8 @@ impl LegacyDeviceManager {
                 ))),
                 0x2e8,
                 0x8,
-            ).map_err(|err| Error::BusError(err))?;
+            )
+            .map_err(|err| Error::BusError(err))?;
         self.stdin_handle
             .lock()
             .set_raw_mode()

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -134,7 +134,8 @@ impl MMIODeviceManager {
             .insert(
                 "virtio_mmio.device",
                 &format!("{}K@0x{:08x}:{}", MMIO_LEN / 1024, self.mmio_base, self.irq),
-            ).map_err(Error::Cmdline)?;
+            )
+            .map_err(Error::Cmdline)?;
         let ret = self.mmio_base;
         self.mmio_base += MMIO_LEN;
         self.irq += 1;
@@ -240,11 +241,9 @@ mod tests {
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
 
-        assert!(
-            device_manager
-                .register_device(dummy_box, &mut cmdline, None)
-                .is_ok()
-        );
+        assert!(device_manager
+            .register_device(dummy_box, &mut cmdline, None)
+            .is_ok());
     }
 
     #[test]
@@ -306,7 +305,8 @@ mod tests {
                         device_manager.mmio_base,
                         device_manager.irq
                     ),
-                ).unwrap_err(),
+                )
+                .unwrap_err(),
         );
         assert_eq!(
             format!("{}", e),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -403,7 +403,8 @@ impl EpollContext {
             epoll::EPOLL_CTL_DEL,
             libc::STDIN_FILENO,
             epoll::Event::new(epoll::EPOLLIN, self.stdin_index),
-        ).map_err(Error::EpollFd);
+        )
+        .map_err(Error::EpollFd);
         self.dispatch_table[self.stdin_index as usize] = None;
 
         Ok(())
@@ -419,7 +420,8 @@ impl EpollContext {
             epoll::EPOLL_CTL_ADD,
             fd.as_raw_fd(),
             epoll::Event::new(epoll::EPOLLIN, dispatch_index),
-        ).map_err(Error::EpollFd)?;
+        )
+        .map_err(Error::EpollFd)?;
         self.dispatch_table.push(Some(token));
 
         Ok(EpollEvent { dispatch_index, fd })
@@ -434,7 +436,8 @@ impl EpollContext {
             epoll::EPOLL_CTL_DEL,
             epoll_event.fd.as_raw_fd(),
             epoll::Event::new(epoll::EPOLLIN, epoll_event.dispatch_index),
-        ).map_err(Error::EpollFd)?;
+        )
+        .map_err(Error::EpollFd)?;
         self.dispatch_table[epoll_event.dispatch_index as usize] = None;
 
         Ok(())
@@ -570,7 +573,8 @@ impl Vmm {
                 // non-blocking & close on exec
                 TimerFd::new_custom(ClockId::Monotonic, true, true).map_err(Error::TimerFd)?,
                 EpollDispatch::WriteMetrics,
-            ).expect("Cannot add write metrics TimerFd to epoll.");
+            )
+            .expect("Cannot add write metrics TimerFd to epoll.");
 
         let block_device_configs = BlockDeviceConfigs::new();
         let kvm = KvmContext::new(kvm_fd)?;
@@ -670,7 +674,8 @@ impl Vmm {
                         " root=PARTUUID={}",
                         //The unwrap is safe as we are firstly checking that partuuid is_some().
                         drive_config.get_partuuid().unwrap()
-                    )).map_err(|e| StartMicrovmError::KernelCmdline(e.to_string()))?;
+                    ))
+                    .map_err(|e| StartMicrovmError::KernelCmdline(e.to_string()))?;
                 if drive_config.is_read_only {
                     kernel_config
                         .cmdline
@@ -689,14 +694,16 @@ impl Vmm {
                     drive_config.is_read_only,
                     epoll_config,
                     drive_config.rate_limiter.take(),
-                ).map_err(StartMicrovmError::CreateBlockDevice)?,
+                )
+                .map_err(StartMicrovmError::CreateBlockDevice)?,
             );
             device_manager
                 .register_device(
                     block_box,
                     &mut kernel_config.cmdline,
                     Some(drive_config.drive_id.clone()),
-                ).map_err(StartMicrovmError::RegisterBlockDevice)?;
+                )
+                .map_err(StartMicrovmError::RegisterBlockDevice)?;
         }
 
         Ok(())
@@ -728,7 +735,8 @@ impl Vmm {
                         rx_rate_limiter,
                         tx_rate_limiter,
                         allow_mmds_requests,
-                    ).map_err(StartMicrovmError::CreateNetDevice)?,
+                    )
+                    .map_err(StartMicrovmError::CreateNetDevice)?,
                 );
 
                 device_manager
@@ -822,12 +830,14 @@ impl Vmm {
                         memory_model::GuestMemoryError::MemoryNotInitialized,
                     ))?,
                 &self.kvm,
-            ).map_err(|e| StartMicrovmError::ConfigureVm(e))?;
+            )
+            .map_err(|e| StartMicrovmError::ConfigureVm(e))?;
         self.vm
             .setup_irqchip(
                 &self.legacy_device_manager.com_evt_1_3,
                 &self.legacy_device_manager.com_evt_2_4,
-            ).map_err(|e| StartMicrovmError::ConfigureVm(e))?;
+            )
+            .map_err(|e| StartMicrovmError::ConfigureVm(e))?;
         self.vm
             .create_pit()
             .map_err(|e| StartMicrovmError::ConfigureVm(e))?;
@@ -906,7 +916,8 @@ impl Vmm {
                                 VCPU_RTSIG_OFFSET,
                                 sys_util::SignalHandler::Siginfo(handle_signal),
                                 true,
-                            ).expect("Failed to register vcpu signal handler");
+                            )
+                            .expect("Failed to register vcpu signal handler");
                         }
 
                         vcpu_thread_barrier.wait();
@@ -1001,7 +1012,8 @@ impl Vmm {
                             METRICS.vcpu.failures.inc();
                             error!("Failed signaling vcpu exit event: {:?}", e);
                         }
-                    }).map_err(StartMicrovmError::VcpuSpawn)?,
+                    })
+                    .map_err(StartMicrovmError::VcpuSpawn)?,
             );
         }
 
@@ -1013,12 +1025,14 @@ impl Vmm {
                 setup_seccomp(SeccompLevel::Advanced(
                     default_syscalls::default_context()
                         .map_err(|e| StartMicrovmError::SeccompFilters(e))?,
-                )).map_err(|e| StartMicrovmError::SeccompFilters(e))?;
+                ))
+                .map_err(|e| StartMicrovmError::SeccompFilters(e))?;
             }
             SECCOMP_LEVEL_BASIC => {
                 setup_seccomp(seccomp::SeccompLevel::Basic(
                     default_syscalls::ALLOWED_SYSCALLS,
-                )).map_err(|e| StartMicrovmError::SeccompFilters(e))?;
+                ))
+                .map_err(|e| StartMicrovmError::SeccompFilters(e))?;
             }
             SECCOMP_LEVEL_NONE | _ => {}
         }
@@ -1059,7 +1073,8 @@ impl Vmm {
             kernel_config.cmdline_addr,
             cmdline_cstring.to_bytes().len() + 1,
             vcpu_count,
-        ).map_err(|e| StartMicrovmError::ConfigureSystem(e))?;
+        )
+        .map_err(|e| StartMicrovmError::ConfigureSystem(e))?;
         Ok(entry_addr)
     }
 
@@ -1264,7 +1279,8 @@ impl Vmm {
                                         .lock()
                                         .expect(
                                             "Failed to process stdin event due to poisoned lock",
-                                        ).queue_input_bytes(&out[..count])
+                                        )
+                                        .queue_input_bytes(&out[..count])
                                         .map_err(Error::Serial)?;
                                 }
                             }
@@ -1632,7 +1648,8 @@ impl Vmm {
                 Some(api_logger.log_fifo),
                 Some(api_logger.metrics_fifo),
                 options,
-            ).map(|_| VmmData::Empty)
+            )
+            .map(|_| VmmData::Empty)
             .map_err(|e| {
                 VmmActionError::Logger(
                     ErrorKind::User,
@@ -1774,7 +1791,8 @@ pub fn start_vmm_thread(
                 from_api,
                 seccomp_level,
                 kvm_fd,
-            ).expect("Cannot create VMM.");
+            )
+            .expect("Cannot create VMM.");
             match vmm.run_control() {
                 Ok(()) => {
                     info!("Gracefully terminated VMM control loop");
@@ -1785,7 +1803,8 @@ pub fn start_vmm_thread(
                     vmm.stop(1)
                 }
             }
-        }).expect("VMM thread spawn failed.")
+        })
+        .expect("VMM thread spawn failed.")
 }
 
 #[cfg(test)]
@@ -1933,7 +1952,8 @@ mod tests {
             from_api,
             seccomp::SECCOMP_LEVEL_ADVANCED,
             None,
-        ).expect("Cannot Create VMM");
+        )
+        .expect("Cannot Create VMM");
         return vmm;
     }
 
@@ -1967,11 +1987,10 @@ mod tests {
             rate_limiter: None,
         };
         assert!(vmm.insert_block_device(root_block_device.clone()).is_ok());
-        assert!(
-            vmm.block_device_configs
-                .config_list
-                .contains(&root_block_device)
-        );
+        assert!(vmm
+            .block_device_configs
+            .config_list
+            .contains(&root_block_device));
 
         // Test that updating a block device returns the correct output.
         let root_block_device = BlockDeviceConfig {
@@ -1983,11 +2002,10 @@ mod tests {
             rate_limiter: None,
         };
         assert!(vmm.insert_block_device(root_block_device.clone()).is_ok());
-        assert!(
-            vmm.block_device_configs
-                .config_list
-                .contains(&root_block_device)
-        );
+        assert!(vmm
+            .block_device_configs
+            .config_list
+            .contains(&root_block_device));
 
         // Test insert second drive with the same path fails.
         let root_block_device = BlockDeviceConfig {
@@ -2423,10 +2441,9 @@ mod tests {
         let mut device_manager =
             MMIODeviceManager::new(guest_mem.clone(), x86_64::get_32bit_gap_start() as u64);
         assert!(vmm.attach_block_devices(&mut device_manager).is_ok());
-        assert!(
-            vmm.get_kernel_cmdline_str()
-                .contains("root=PARTUUID=0eaa91a0-01")
-        );
+        assert!(vmm
+            .get_kernel_cmdline_str()
+            .contains("root=PARTUUID=0eaa91a0-01"));
 
         // Use Case 3: Root Block Device is not added at all.
         let mut vmm = create_vmm_object(InstanceState::Uninitialized);
@@ -2440,10 +2457,9 @@ mod tests {
         };
 
         // Test that creating a new block device returns the correct output.
-        assert!(
-            vmm.insert_block_device(non_root_block_device.clone())
-                .is_ok()
-        );
+        assert!(vmm
+            .insert_block_device(non_root_block_device.clone())
+            .is_ok());
         assert!(vmm.init_guest_memory().is_ok());
         assert!(vmm.guest_memory.is_some());
 
@@ -2458,25 +2474,21 @@ mod tests {
         assert!(!vmm.get_kernel_cmdline_str().contains("root=/dev/vda"));
 
         // Test that the non root device is attached.
-        assert!(
-            device_manager
-                .get_address(&non_root_block_device.drive_id)
-                .is_some()
-        );
+        assert!(device_manager
+            .get_address(&non_root_block_device.drive_id)
+            .is_some());
 
         // Test partial update of block devices.
         let new_block = NamedTempFile::new().unwrap();
         let path = String::from(new_block.path().to_path_buf().to_str().unwrap());
-        assert!(
-            vmm.set_block_device_path("not_root".to_string(), path)
-                .is_ok()
-        );
+        assert!(vmm
+            .set_block_device_path("not_root".to_string(), path)
+            .is_ok());
 
         // Test partial update of block device fails due to invalid file.
-        assert!(
-            vmm.set_block_device_path("not_root".to_string(), String::from("dummy_path"))
-                .is_err()
-        );
+        assert!(vmm
+            .set_block_device_path("not_root".to_string(), String::from("dummy_path"))
+            .is_err());
     }
 
     #[test]
@@ -2524,34 +2536,30 @@ mod tests {
         let mut vmm = create_vmm_object(InstanceState::Uninitialized);
 
         // Test invalid kernel path.
-        assert!(
-            vmm.configure_boot_source(String::from("dummy-path"), None)
-                .is_err()
-        );
+        assert!(vmm
+            .configure_boot_source(String::from("dummy-path"), None)
+            .is_err());
 
         // Test valid kernel path and invalid cmdline.
         let kernel_file = NamedTempFile::new().expect("Failed to create temporary kernel file.");
         let kernel_path = String::from(kernel_file.path().to_path_buf().to_str().unwrap());
         let invalid_cmdline =
             String::from_utf8(vec![b'X'; x86_64::layout::CMDLINE_MAX_SIZE + 1]).unwrap();
-        assert!(
-            vmm.configure_boot_source(kernel_path.clone(), Some(invalid_cmdline))
-                .is_err()
-        );
+        assert!(vmm
+            .configure_boot_source(kernel_path.clone(), Some(invalid_cmdline))
+            .is_err());
 
         // Test valid configuration.
         assert!(vmm.configure_boot_source(kernel_path.clone(), None).is_ok());
-        assert!(
-            vmm.configure_boot_source(kernel_path.clone(), Some(String::from("reboot=k")))
-                .is_ok()
-        );
+        assert!(vmm
+            .configure_boot_source(kernel_path.clone(), Some(String::from("reboot=k")))
+            .is_ok());
 
         // Test valid configuration after boot (should fail).
         vmm.set_instance_state(InstanceState::Running);
-        assert!(
-            vmm.configure_boot_source(kernel_path.clone(), None)
-                .is_err()
-        );
+        assert!(vmm
+            .configure_boot_source(kernel_path.clone(), None)
+            .is_err());
     }
 
     #[test]
@@ -2581,10 +2589,9 @@ mod tests {
         };
 
         assert!(vmm.insert_block_device(root_block_device.clone()).is_ok());
-        assert!(
-            vmm.insert_block_device(non_root_block_device.clone())
-                .is_ok()
-        );
+        assert!(vmm
+            .insert_block_device(non_root_block_device.clone())
+            .is_ok());
 
         assert!(vmm.init_guest_memory().is_ok());
         assert!(vmm.guest_memory.is_some());
@@ -2600,7 +2607,8 @@ mod tests {
                 dummy_box,
                 &mut kernel_cmdline::Cmdline::new(x86_64::layout::CMDLINE_MAX_SIZE),
                 Some(scratch_id.clone()),
-            ).unwrap();
+            )
+            .unwrap();
 
         vmm.mmio_device_manager = Some(device_manager);
         vmm.set_instance_state(InstanceState::Running);
@@ -2652,10 +2660,9 @@ mod tests {
 
         // Test rescan not allowed.
         let mut vmm = create_vmm_object(InstanceState::Uninitialized);
-        assert!(
-            vmm.insert_block_device(non_root_block_device.clone())
-                .is_ok()
-        );
+        assert!(vmm
+            .insert_block_device(non_root_block_device.clone())
+            .is_ok());
         match vmm.rescan_block_device(&scratch_id) {
             Err(VmmActionError::DriveConfig(
                 ErrorKind::User,

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -270,27 +270,21 @@ mod tests {
         };
 
         let mut block_devices_configs = BlockDeviceConfigs::new();
-        assert!(
-            block_devices_configs
-                .insert(dummy_block_device.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .insert(dummy_block_device.clone())
+            .is_ok());
 
         assert_eq!(block_devices_configs.has_root_block, false);
         assert_eq!(block_devices_configs.config_list.len(), 1);
 
         let dev_config = block_devices_configs.config_list.iter().next().unwrap();
         assert_eq!(dev_config, &dummy_block_device);
-        assert!(
-            block_devices_configs
-                .get_index_of_drive_path(&dummy_path)
-                .is_some()
-        );
-        assert!(
-            block_devices_configs
-                .get_index_of_drive_id(&dummy_id)
-                .is_some()
-        );
+        assert!(block_devices_configs
+            .get_index_of_drive_path(&dummy_path)
+            .is_some());
+        assert!(block_devices_configs
+            .get_index_of_drive_id(&dummy_id)
+            .is_some());
     }
 
     #[test]
@@ -308,11 +302,9 @@ mod tests {
         };
 
         let mut block_devices_configs = BlockDeviceConfigs::new();
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .create(dummy_block_device.clone())
+            .is_ok());
 
         assert_eq!(block_devices_configs.has_root_block, true);
         assert_eq!(block_devices_configs.config_list.len(), 1);
@@ -392,21 +384,15 @@ mod tests {
         };
 
         let mut block_devices_configs = BlockDeviceConfigs::new();
-        assert!(
-            block_devices_configs
-                .create(root_block_device.clone())
-                .is_ok()
-        );
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device_2.clone())
-                .is_ok()
-        );
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device_3.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .create(root_block_device.clone())
+            .is_ok());
+        assert!(block_devices_configs
+            .create(dummy_block_device_2.clone())
+            .is_ok());
+        assert!(block_devices_configs
+            .create(dummy_block_device_3.clone())
+            .is_ok());
 
         assert_eq!(block_devices_configs.has_root_block_device(), true);
         assert_eq!(block_devices_configs.has_partuuid_root(), false);
@@ -455,21 +441,15 @@ mod tests {
         };
 
         let mut block_devices_configs = BlockDeviceConfigs::new();
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device_2.clone())
-                .is_ok()
-        );
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device_3.clone())
-                .is_ok()
-        );
-        assert!(
-            block_devices_configs
-                .create(root_block_device.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .create(dummy_block_device_2.clone())
+            .is_ok());
+        assert!(block_devices_configs
+            .create(dummy_block_device_3.clone())
+            .is_ok());
+        assert!(block_devices_configs
+            .create(root_block_device.clone())
+            .is_ok());
 
         assert_eq!(block_devices_configs.has_root_block_device(), true);
         assert_eq!(block_devices_configs.has_partuuid_root(), false);
@@ -510,16 +490,12 @@ mod tests {
         let mut block_devices_configs = BlockDeviceConfigs::new();
 
         // Add 2 block devices.
-        assert!(
-            block_devices_configs
-                .create(root_block_device.clone())
-                .is_ok()
-        );
-        assert!(
-            block_devices_configs
-                .create(dummy_block_device_2.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .create(root_block_device.clone())
+            .is_ok());
+        assert!(block_devices_configs
+            .create(dummy_block_device_2.clone())
+            .is_ok());
 
         // Get index zero.
         assert_eq!(
@@ -530,26 +506,20 @@ mod tests {
         );
 
         // Get None.
-        assert!(
-            block_devices_configs
-                .get_index_of_drive_id(&String::from("foo"))
-                .is_none()
-        );
+        assert!(block_devices_configs
+            .get_index_of_drive_id(&String::from("foo"))
+            .is_none());
 
         // Test several update cases using dummy_block_device_2.
         // Validate `dummy_block_device_2` is already in the list
-        assert!(
-            block_devices_configs
-                .get_index_of_drive_id(&dummy_block_device_2.drive_id)
-                .is_some()
-        );
+        assert!(block_devices_configs
+            .get_index_of_drive_id(&dummy_block_device_2.drive_id)
+            .is_some());
         // Update OK.
         dummy_block_device_2.is_read_only = true;
-        assert!(
-            block_devices_configs
-                .insert(dummy_block_device_2.clone())
-                .is_ok()
-        );
+        assert!(block_devices_configs
+            .insert(dummy_block_device_2.clone())
+            .is_ok());
 
         let index = block_devices_configs
             .get_index_of_drive_id(&dummy_block_device_2.drive_id)
@@ -594,19 +564,15 @@ mod tests {
         let index1 = block_devices_configs
             .get_index_of_drive_id(&root_block_device_old.drive_id)
             .unwrap();
-        assert!(
-            &block_devices_configs
-                .update(index1, root_block_device_old)
-                .is_ok()
-        );
+        assert!(&block_devices_configs
+            .update(index1, root_block_device_old)
+            .is_ok());
         let index2 = block_devices_configs
             .get_index_of_drive_id(&root_block_device_new.drive_id)
             .unwrap();
-        assert!(
-            &block_devices_configs
-                .update(index2, root_block_device_new)
-                .is_ok()
-        );
+        assert!(&block_devices_configs
+            .update(index2, root_block_device_new)
+            .is_ok());
         assert!(block_devices_configs.has_partuuid_root);
     }
 }

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -212,9 +212,10 @@ impl NetworkInterfaceConfigs {
         new_config: &NetworkInterfaceConfig,
     ) -> result::Result<(), NetworkInterfaceError> {
         // Check that there is no other interface in the list that has the same mac.
-        if new_config.guest_mac.is_some() && self
-            .get_index_of_mac(&new_config.guest_mac.unwrap())
-            .is_some()
+        if new_config.guest_mac.is_some()
+            && self
+                .get_index_of_mac(&new_config.guest_mac.unwrap())
+                .is_some()
         {
             return Err(NetworkInterfaceError::GuestMacAddressInUse(
                 new_config.guest_mac.unwrap().to_string(),

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -193,7 +193,8 @@ impl Vcpu {
                 .ok_or(Error::VcpuCountNotInitialized)?,
             machine_config.ht_enabled.ok_or(Error::HTNotInitialized)?,
             &mut self.cpuid,
-        ).map_err(|e| Error::CpuId(e))?;
+        )
+        .map_err(|e| Error::CpuId(e))?;
         match machine_config.cpu_template {
             Some(template) => match template {
                 CpuFeaturesTemplate::T2 => {
@@ -220,7 +221,8 @@ impl Vcpu {
             kernel_start_addr.offset() as u64,
             x86_64::layout::BOOT_STACK_POINTER as u64,
             x86_64::layout::ZERO_PAGE_START as u64,
-        ).map_err(Error::REGSConfiguration)?;
+        )
+        .map_err(Error::REGSConfiguration)?;
         regs::setup_fpu(&self.fd).map_err(Error::FPUConfiguration)?;
         regs::setup_sregs(vm_memory, &self.fd).map_err(Error::SREGSConfiguration)?;
         interrupts::set_lint(&self.fd).map_err(Error::LocalIntConfiguration)?;

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -264,7 +264,8 @@ mod tests {
             e820_map[0].addr,
             e820_map[0].size,
             e820_map[0].type_,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             format!("{:?}", params.e820_map[0]),
             format!("{:?}", expected_params.e820_map[0])
@@ -274,13 +275,12 @@ mod tests {
         // Exercise the scenario where the field storing the length of the e820 entry table is
         // is bigger than the allocated memory.
         params.e820_entries = params.e820_map.len() as u8 + 1;
-        assert!(
-            add_e820_entry(
-                &mut params,
-                e820_map[0].addr,
-                e820_map[0].size,
-                e820_map[0].type_
-            ).is_err()
-        );
+        assert!(add_e820_entry(
+            &mut params,
+            e820_map[0].addr,
+            e820_map[0].size,
+            e820_map[0].type_
+        )
+        .is_err());
     }
 }

--- a/x86_64/src/mptable.rs
+++ b/x86_64/src/mptable.rs
@@ -135,11 +135,12 @@ pub fn setup_mptable(mem: &GuestMemory, num_cpus: u8) -> Result<()> {
             mpc_cpu.type_ = MP_PROCESSOR as u8;
             mpc_cpu.apicid = cpu_id;
             mpc_cpu.apicver = APIC_VERSION;
-            mpc_cpu.cpuflag = CPU_ENABLED as u8 | if cpu_id == 0 {
-                CPU_BOOTPROCESSOR as u8
-            } else {
-                0
-            };
+            mpc_cpu.cpuflag = CPU_ENABLED as u8
+                | if cpu_id == 0 {
+                    CPU_BOOTPROCESSOR as u8
+                } else {
+                    0
+                };
             mpc_cpu.cpufeature = CPU_STEPPING;
             mpc_cpu.featureflag = CPU_FEATURE_APIC | CPU_FEATURE_FPU;
             mem.write_obj_at_addr(mpc_cpu, base_mp)
@@ -260,7 +261,8 @@ mod tests {
         let mem = GuestMemory::new(&[(
             GuestAddress(layout::MPTABLE_START),
             compute_mp_size(num_cpus),
-        )]).unwrap();
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
     }
@@ -271,7 +273,8 @@ mod tests {
         let mem = GuestMemory::new(&[(
             GuestAddress(layout::MPTABLE_START),
             compute_mp_size(num_cpus) - 1,
-        )]).unwrap();
+        )])
+        .unwrap();
 
         assert!(setup_mptable(&mem, num_cpus).is_err());
     }
@@ -282,7 +285,8 @@ mod tests {
         let mem = GuestMemory::new(&[(
             GuestAddress(layout::MPTABLE_START),
             compute_mp_size(num_cpus),
-        )]).unwrap();
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
 
@@ -299,7 +303,8 @@ mod tests {
         let mem = GuestMemory::new(&[(
             GuestAddress(layout::MPTABLE_START),
             compute_mp_size(num_cpus),
-        )]).unwrap();
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
 
@@ -334,7 +339,8 @@ mod tests {
         let mem = GuestMemory::new(&[(
             GuestAddress(layout::MPTABLE_START),
             compute_mp_size(MAX_CPUS),
-        )]).unwrap();
+        )])
+        .unwrap();
 
         for i in 0..MAX_CPUS {
             setup_mptable(&mem, i).unwrap();

--- a/x86_64/src/regs.rs
+++ b/x86_64/src/regs.rs
@@ -210,7 +210,8 @@ fn setup_page_tables(mem: &GuestMemory, sregs: &mut kvm_sregs) -> Result<()> {
         mem.write_obj_at_addr(
             (i << 21) + 0x83u64,
             boot_pde_addr.unchecked_add((i * 8) as usize),
-        ).map_err(|_| Error::WritePDEAddress)?;
+        )
+        .map_err(|_| Error::WritePDEAddress)?;
     }
 
     sregs.cr3 = boot_pml4_addr.offset() as u64;
@@ -421,7 +422,8 @@ mod tests {
             expected_regs.rip,
             expected_regs.rsp,
             expected_regs.rsi,
-        ).unwrap();
+        )
+        .unwrap();
 
         let actual_regs: kvm_regs = vcpu.get_regs().unwrap();
         assert_eq!(actual_regs, expected_regs);


### PR DESCRIPTION
# Description of changes:
- Updated dev container toolchain to Rust 1.31.
- Updated the dev container version to v2.
- Added `rustfmt` to the dev container.
- Removed `rustfmt-preview` installation from `test_style.py`.
- Updated `devtool` to force the use of a specific version of the dev container. This is another step on our way to supporting reproducible builds.
- Removed the `devtool update` command - it doesn't make sense anymore, when using versioned containers.
- New `devtool` command: `fmt` (i.e. `devtool fmt`) - a wrapper around `cargo fmt --all`.
- Applied `rustfmt` to the whole code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
