### PR TITLE
Log with DEFAULT_INSTANCE_ID in the absence of instance id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `PUT` operations on `/network-interfaces` API resources no longer accept 
   the previously required `state` parameter.
 - The jailer starts with `--seccomp-level=2` (was previously 0) by default.
+- Log messages use `anonymous-instance` as instance-id if no instance-id is set.
 
 ## [0.11.0]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 
 fn main() {
     LOGGER
-        .init(&"", None, None, vec![])
+        .init(DEFAULT_INSTANCE_ID, None, None, vec![])
         .expect("Failed to register logger");
 
     // If the signal handler can't be set, it's OK to panic.


### PR DESCRIPTION
Issue #, if available: #763 

Description of changes: This patch adds the DEFAULT_INSTANCE_ID to log messages when no
instance id is specified.

Previous behavior:

`[:ERROR:src/main.rs:49] `

After: 

`[anonymous-instance:ERROR:src/main.rs:49] `

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
