### PR TITLE
mmds: return dictionary keys

### DIFF
--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -152,7 +152,12 @@ def test_mmds(test_microvm_with_ssh, network_config):
     # Test reading a non-leaf node WITHOUT a trailing slash.
     cmd = pre + 'latest/meta-data'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, '')
+    _assert_out_multiple(
+        stdout,
+        stderr,
+        ['ami-id', 'reservation-id', 'local-hostname', 'public-hostname',
+         'network/']
+    )
 
     # Test reading a non-leaf node with a trailing slash.
     cmd = pre + 'latest/meta-data/'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
 Return dictionary keys when path doesn't end with '/'. This change is necessary for the MMDS to be backwards compatible with the IMDS implementation on C5.

Same commit as in PR #562.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
