### PR TITLE
devtool: fix building on SELinux

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -299,11 +299,12 @@ run_devctr() {
     done
 
     # Finally, run the dev container
-    #
+    # Use 'z' on the --volume parameter for docker to automatically relabel the
+    # content and allow sharing between containers.
     docker run "${docker_args[@]}" \
         --init \
         --rm \
-        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR" \
+        --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR:z" \
         --env OPT_LOCAL_IMAGES_PATH="$(dirname "$CTR_MICROVM_IMAGES_DIR")" \
         --env PYTHONDONTWRITEBYTECODE=1 \
         "$DEVCTR_IMAGE" "${ctr_args[@]}"


### PR DESCRIPTION
When using SELinux for controlling processes within a container,
you need to make sure any content that gets volume mounted into
the container is readable, and potentially writable.

Use 'z' on the --volumes parameter for docker to automatically
relabel the content and allow sharing between containers.

Fixes #682 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
