### PR TITLE
Correct specification of the "options" property of the Logger object

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -411,7 +411,8 @@ definitions:
         description: Whether or not to include the file path and line number of the log's origin.
       options:
         type: array
-        items: string
+        items:
+          type: string
         description: Additional logging options. Only "LogDirtyPages" is supported.
 
   MachineConfiguration:


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

Addresses #774 

Description of changes: This change corrects the OpenAPI specification of the "options" array property of the Logger object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
