### PR TITLE
swagger: remove InstanceHalt from actions

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -367,7 +367,6 @@ definitions:
         enum:
         - BlockDeviceRescan
         - InstanceStart
-        - InstanceHalt
       payload:
         type: string
 


### PR DESCRIPTION
Issue #, if available:
Related to https://github.com/firecracker-microvm/firecracker/issues/673

Description of changes:
Removed InstanceHalt action type from swagger as we don't support it yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
