### PR TITLE
API Requests Usage Docs & LoggerConfig Refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Documentation for Logger API Requests in `docs/api_requests/logger.md`.
+
+### Changed
+- Updated the swagger definition of the `Logger` to specify the required fields
+  and provide default values for optional fields.
+
 ## [0.12.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Firecracker's overall architecture is described in
 
 Firecracker consists of a single micro Virtual Machine Manager process that
 exposes an API endpoint to the host once started. The API is
-[specified in OpenAPI format](api_server/swagger/firecracker.yaml).
+[specified in OpenAPI format](api_server/swagger/firecracker.yaml). Read more
+about it in the [API docs](docs/api_requests).
 
 The **API endpoint** can be used to:
 

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -631,6 +631,7 @@ mod tests {
     use futures::sync::oneshot;
     use hyper::header::{ContentType, Headers};
     use hyper::Body;
+    use vmm::vmm_config::logger::LoggerLevel;
     use vmm::vmm_config::machine_config::CpuFeaturesTemplate;
     use vmm::VmmAction;
 
@@ -1028,6 +1029,19 @@ mod tests {
     #[test]
     fn test_parse_logger_source_req() {
         let logger_path = "/logger";
+
+        // PUT with default values for optional fields.
+        let default_json = r#"{
+            "log_fifo": "tmp1",
+            "metrics_fifo": "tmp2"
+        }"#;
+        let logger_body: Chunk = Chunk::from(default_json);
+        let logger_config =
+            serde_json::from_slice::<LoggerConfig>(&logger_body).expect("deserialization failed");
+        assert_eq!(logger_config.level, LoggerLevel::Warning);
+        assert_eq!(logger_config.show_log_origin, false);
+        assert_eq!(logger_config.show_level, false);
+
         let json = "{
                 \"log_fifo\": \"tmp1\",
                 \"metrics_fifo\": \"tmp2\",

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -29,15 +29,16 @@ mod tests {
     use super::*;
 
     use serde_json::Value;
+    use vmm::vmm_config::logger::LoggerLevel;
 
     #[test]
     fn test_into_parsed_request() {
         let desc = LoggerConfig {
             log_fifo: String::from("log"),
             metrics_fifo: String::from("metrics"),
-            level: None,
-            show_level: None,
-            show_log_origin: None,
+            level: LoggerLevel::Warning,
+            show_level: false,
+            show_log_origin: false,
             options: Value::Array(vec![]),
         };
         format!("{:?}", desc);

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -391,28 +391,35 @@ definitions:
     type: object
     description:
       Describes the configuration option for the logging capability.
+    required:
+      - log_fifo
+      - metrics_fifo
     properties:
       log_fifo:
         type: string
         description: The named pipe for the human readable log output.
       metrics_fifo:
-              type: string
-              description: The named pipe where the JSON-formatted metrics will be flushed.
+        type: string
+        description: The named pipe where the JSON-formatted metrics will be flushed.
       level:
         type: string
         description: Set the level.
         enum: [Error, Warning, Info, Debug]
+        default: Warning
       show_level:
         type: boolean
         description: Whether or not to output the level in the logs.
+        default: false
       show_log_origin:
         type: boolean
         description: Whether or not to include the file path and line number of the log's origin.
+        default: false
       options:
         type: array
         items:
           type: string
         description: Additional logging options. Only "LogDirtyPages" is supported.
+        default: []
 
   MachineConfiguration:
     type: object

--- a/docs/api_requests/logger.md
+++ b/docs/api_requests/logger.md
@@ -1,0 +1,45 @@
+# Logger API Request
+The Logger can be configured by sending a `PUT` API Request to the `/logger`
+path.
+
+Details about the required fields can be found in the
+[swagger definition](../../api_server/swagger/firecracker.yaml).
+
+## LogDirtyPages Option
+When the `LogDirtyPages` option is specified in the `options` field, every 60
+seconds a metric with the guest dirty pages count is emitted.
+The `dirty_pages` number represents the number of pages in the guest memory
+that have been dirtied since the last call to `KVM_GET_DIRTY_LOG`.
+See the
+[KVM documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
+for details.
+
+### Logger Configuration Example with LogDirtyPages
+
+```bash
+# Create the required named pipes.
+mkfifo logs.fifo
+mkfifo metrics.fifo
+
+# Configure the Logger.
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT "http://localhost/logger" \
+    -H "accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "{
+            \"log_fifo\": \"logs.fifo\",
+            \"metrics_fifo\": \"metrics.fifo\",
+            \"options\": [\"LogDirtyPages\"]
+    }"
+```
+
+Every 60 seconds the metric `dirty_pages` is going to be updated.
+To check the count of dirty pages in the guest, grep after `dirty_pages` in the
+`metrics.fifo` named pipe.
+
+```bash
+$ grep -Eo "\"dirty_pages\":[[:digit:]]+" metrics.fifo
+"dirty_pages":0
+"dirty_pages":49319
+"dirty_pages":1126
+```

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1620,22 +1620,14 @@ impl Vmm {
         }
 
         match api_logger.level {
-            Some(val) => match val {
-                LoggerLevel::Error => LOGGER.set_level(Level::Error),
-                LoggerLevel::Warning => LOGGER.set_level(Level::Warn),
-                LoggerLevel::Info => LOGGER.set_level(Level::Info),
-                LoggerLevel::Debug => LOGGER.set_level(Level::Debug),
-            },
-            None => (),
+            LoggerLevel::Error => LOGGER.set_level(Level::Error),
+            LoggerLevel::Warning => LOGGER.set_level(Level::Warn),
+            LoggerLevel::Info => LOGGER.set_level(Level::Info),
+            LoggerLevel::Debug => LOGGER.set_level(Level::Debug),
         }
 
-        if let Some(val) = api_logger.show_log_origin {
-            LOGGER.set_include_origin(val, val);
-        }
-
-        if let Some(val) = api_logger.show_level {
-            LOGGER.set_include_level(val);
-        }
+        LOGGER.set_include_origin(api_logger.show_log_origin, api_logger.show_log_origin);
+        LOGGER.set_include_level(api_logger.show_level);
 
         let options = match api_logger.options {
             Value::Array(options) => options,
@@ -2680,9 +2672,9 @@ mod tests {
         let desc = LoggerConfig {
             log_fifo: log_file.path().to_str().unwrap().to_string(),
             metrics_fifo: metrics_file.path().to_str().unwrap().to_string(),
-            level: Some(LoggerLevel::Warning),
-            show_level: Some(true),
-            show_log_origin: Some(true),
+            level: LoggerLevel::Warning,
+            show_level: true,
+            show_log_origin: true,
             options: Value::Array(vec![]),
         };
 
@@ -2696,9 +2688,9 @@ mod tests {
         let desc = LoggerConfig {
             log_fifo: String::from("not_found_file_log"),
             metrics_fifo: String::from("not_found_file_metrics"),
-            level: None,
-            show_level: None,
-            show_log_origin: None,
+            level: LoggerLevel::Warning,
+            show_level: false,
+            show_log_origin: false,
             options: Value::Array(vec![]),
         };
         assert!(vmm.init_logger(desc).is_err());
@@ -2707,9 +2699,9 @@ mod tests {
         let desc = LoggerConfig {
             log_fifo: String::from("not_found_file_log"),
             metrics_fifo: String::from("not_found_file_metrics"),
-            level: None,
-            show_level: None,
-            show_log_origin: None,
+            level: LoggerLevel::Warning,
+            show_level: false,
+            show_log_origin: false,
             options: Value::Array(vec![Value::String("foobar".to_string())]),
         };
         assert!(vmm.init_logger(desc).is_err());
@@ -2720,9 +2712,9 @@ mod tests {
         let desc = LoggerConfig {
             log_fifo: log_file.path().to_str().unwrap().to_string(),
             metrics_fifo: metrics_file.path().to_str().unwrap().to_string(),
-            level: Some(LoggerLevel::Warning),
-            show_level: Some(true),
-            show_log_origin: Some(true),
+            level: LoggerLevel::Warning,
+            show_level: true,
+            show_log_origin: true,
             options: Value::Array(vec![Value::String("LogDirtyPages".to_string())]),
         };
         assert!(vmm.init_logger(desc).is_ok());

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -32,17 +32,21 @@ pub struct LoggerConfig {
     /// Named pipe used as output for metrics.
     pub metrics_fifo: String,
     /// The level of the Logger.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub level: Option<LoggerLevel>,
+    #[serde(default = "default_level")]
+    pub level: LoggerLevel,
     /// When enabled, the logger will append to the output the severity of the log entry.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub show_level: Option<bool>,
+    #[serde(default)]
+    pub show_level: bool,
     /// When enabled, the logger will append the origin of the log entry.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub show_log_origin: Option<bool>,
+    #[serde(default)]
+    pub show_log_origin: bool,
     /// Additional logging options.
     #[serde(default = "default_log_options")]
     pub options: Value,
+}
+
+fn default_level() -> LoggerLevel {
+    LoggerLevel::Warning
 }
 
 fn default_log_options() -> Value {


### PR DESCRIPTION
Issue #, if available:
Related to https://github.com/firecracker-microvm/firecracker/issues/785.

Description of changes:
#### Documentation
Added a directory in docs called `api_requests`. This directory should contain examples and details about API requests that are too technical to be included in the swagger definition.
The first document added is detailing the Logger option 

#### Swagger Fix
Added default values for the optional fields in the Logger object and specified the required fields.

#### Refactoring
Refactored the LoggerConfig structure. Insteaad of using optional values in the strongly typed serde structure, use defaults.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
