### PR TITLE
Add a vmm action for flushing the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Documentation for Logger API Requests in `docs/api_requests/logger.md`.
 - Documentation for Actions API Requests in `docs/api_requests/actions.md`.
 - Documentation for MMDS in `docs/mmds.md`.
+- Flush metrics on request via a PUT `/actions` with the `action_type`
+  field set to `FlushMetrics`.
 
 ### Changed
 
@@ -37,7 +39,7 @@
 ### Changed
 
 - `PUT` requests on `/mmds` always return 204 on success.
-- `PUT` operations on `/network-interfaces` API resources no longer accept 
+- `PUT` operations on `/network-interfaces` API resources no longer accept
   the previously required `state` parameter.
 - The jailer starts with `--seccomp-level=2` (was previously 0) by default.
 - Log messages use `anonymous-instance` as instance id if none is specified.
@@ -48,7 +50,6 @@
 - Fixed "fault_message" inconsistency between Open API specification and code base.
 - Ensure MMDS compatibility with C5's IMDS implementation.
 - Corrected the swagger specification to ensure `OpenAPI 2.0` compatibility.
-
 
 ## [0.11.0]
 
@@ -74,6 +75,7 @@
   now featured in subject-specific docs.
 
 ### Fixed
+
 - Fixed bug in the MMDS network stack, that caused some RST packets to be sent
   without a destination.
 - Fixed bug in `PATCH /drives`, whereby the ID in the path was not checked

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -16,6 +16,7 @@ use vmm::VmmAction;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 enum ActionType {
     BlockDeviceRescan,
+    FlushMetrics,
     InstanceStart,
 }
 
@@ -46,10 +47,13 @@ fn validate_payload(action_body: &ActionBody) -> Result<(), String> {
                 None => return Err("Payload is required for block device rescan.".to_string()),
             }
         }
-        ActionType::InstanceStart => {
-            // InstanceStart does not have a payload
+        ActionType::FlushMetrics | ActionType::InstanceStart => {
+            // Neither FlushMetrics nor InstanceStart should have a payload.
             if !action_body.payload.is_none() {
-                return Err("InstanceStart does not support a payload.".to_string());
+                return Err(format!(
+                    "{:?} does not support a payload.",
+                    action_body.action_type
+                ));
             }
             Ok(())
         }
@@ -70,6 +74,13 @@ impl IntoParsedRequest for ActionBody {
                 let (sync_sender, sync_receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
                     VmmAction::RescanBlockDevice(block_device_id, sync_sender),
+                    sync_receiver,
+                ))
+            }
+            ActionType::FlushMetrics => {
+                let (sync_sender, sync_receiver) = oneshot::channel();
+                Ok(ParsedRequest::Sync(
+                    VmmAction::FlushMetrics(sync_sender),
                     sync_receiver,
                 ))
             }

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -366,6 +366,7 @@ definitions:
         type: string
         enum:
         - BlockDeviceRescan
+        - FlushMetrics
         - InstanceStart
       payload:
         type: string

--- a/docs/api_requests/actions.md
+++ b/docs/api_requests/actions.md
@@ -69,3 +69,19 @@ curl --unix-socket ${socket} -i \
             \"action_type\": \"InstanceStart\"
          }"
 ```
+
+## FlushMetrics
+
+The `FlushMetrics` action flushes the metrics on user demand.
+
+### FlushMetrics Example
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT "http://localhost/actions" \
+    -H  "accept: application/json" \
+    -H  "Content-Type: application/json" \
+    -d "{
+             \"action_type\": \"FlushMetrics\"
+    }"
+```

--- a/docs/api_requests/logger.md
+++ b/docs/api_requests/logger.md
@@ -1,18 +1,42 @@
 # Logger API Request
+
 The Logger can be configured by sending a `PUT` API Request to the `/logger`
 path.
+A minimal logger configuration example is the following:
 
-Details about the required fields can be found in the
+```bash
+# Create the required named pipes.
+mkfifo logs.fifo
+mkfifo metrics.fifo
+
+# Configure the Logger.
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT "http://localhost/logger" \
+    -H "accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "{
+             \"log_fifo\": \"logs.fifo\",
+             \"metrics_fifo\": \"metrics.fifo\"
+    }"
+```
+
+Details about the required and optional fields can be found in the
 [swagger definition](../../api_server/swagger/firecracker.yaml).
 
+The `logs.fifo` file stores the human readable logs (i.e errors,
+warnings etc) while the `metrics.fifo` file stores the metrics
+in JSON format. The metrics get flushed in two ways:
+
+* without user intervention every 60 seconds
+* upon user demand by issuing a [FlushMetrics][1] request.
+
 ## LogDirtyPages Option
+
 When the `LogDirtyPages` option is specified in the `options` field, every 60
 seconds a metric with the guest dirty pages count is emitted.
 The `dirty_pages` number represents the number of pages in the guest memory
 that have been dirtied since the last call to `KVM_GET_DIRTY_LOG`.
-See the
-[KVM documentation](https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt)
-for details.
+See the [KVM documentation][2] for details.
 
 ### Logger Configuration Example with LogDirtyPages
 
@@ -27,13 +51,14 @@ curl --unix-socket /tmp/firecracker.socket -i \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d "{
-            \"log_fifo\": \"logs.fifo\",
-            \"metrics_fifo\": \"metrics.fifo\",
-            \"options\": [\"LogDirtyPages\"]
+             \"log_fifo\": \"logs.fifo\",
+             \"metrics_fifo\": \"metrics.fifo\",
+             \"options\": [\"LogDirtyPages\"]
     }"
 ```
 
-Every 60 seconds the metric `dirty_pages` is going to be updated.
+With each flush of the metrics (either automatically each 60 seconds or
+by user demand), the `dirty_pages` metric is going to be updated.
 To check the count of dirty pages in the guest, grep after `dirty_pages` in the
 `metrics.fifo` named pipe.
 
@@ -43,3 +68,6 @@ $ grep -Eo "\"dirty_pages\":[[:digit:]]+" metrics.fifo
 "dirty_pages":49319
 "dirty_pages":1126
 ```
+
+[1]: https://github.com/firecracker-microvm/firecracker/blob/master/docs/api_requests/actions.md
+[2]: https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -237,6 +237,37 @@ def test_api_requests_logs(test_microvm_with_api):
     assert log_file_contains_strings(log_fifo, expected_log_strings)
 
 
+def test_flush_metrics(test_microvm_with_api):
+    """Check the `FlushMetrics` vmm action."""
+    microvm = test_microvm_with_api
+    microvm.spawn()
+    microvm.basic_config()
+
+    # Configure logging.
+    log_fifo_path = os.path.join(microvm.path, 'log_fifo')
+    metrics_fifo_path = os.path.join(microvm.path, 'metrics_fifo')
+    log_fifo = log_tools.Fifo(log_fifo_path)
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+
+    response = microvm.logger.put(
+        log_fifo=microvm.create_jailed_resource(log_fifo.path),
+        metrics_fifo=microvm.create_jailed_resource(metrics_fifo.path)
+    )
+    assert response.status_code == 204
+
+    microvm.start()
+
+    # Empty fifo before triggering `FlushMetrics` so that we get accurate data.
+    _ = metrics_fifo.sequential_reader(100)
+
+    how_many_flushes = 3
+    for _ in range(how_many_flushes):
+        response = microvm.actions.put(action_type='FlushMetrics')
+        assert response.status_code == 204
+    lines = metrics_fifo.sequential_reader(how_many_flushes)
+    assert len(lines) == how_many_flushes
+
+
 # pylint: disable=W0102
 def _test_log_config(
         microvm,

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -58,13 +58,16 @@ fn default_log_options() -> Value {
 pub enum LoggerConfigError {
     /// Cannot initialize the logger due to bad user input.
     InitializationFailure(String),
+    /// Cannot flush the metrics.
+    FlushMetrics(String),
 }
 
 impl Display for LoggerConfigError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use self::LoggerConfigError::*;
         match *self {
-            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg),
+            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
+            FlushMetrics(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
         }
     }
 }


### PR DESCRIPTION
At any time, the user can call the `FlushMetrics` api command for
getting the values of the metrics at that moment. The action can only be
called after the logger has been initialized (i.e a FIFO has been
provided as the destination for the metrics).

```
curl --unix-socket /tmp/firecracker.socket -i      
-X PUT "http://localhost/actions"      
-H  "accept: application/json"      
-H  "Content-Type: application/json"      
-d "{  
     \"action_type\": \"FlushMetrics\"
}"
```
You will get an error saying `  "fault_message": "Failed to log metrics. Logger was not initialized."
` if the logger has not been initialized beforehand. Othewise, you should see the json related metrics on the screen.
## Obs
* Unified behavior when receiving error on logging the metrics
* Wrote unit tests
* Wrote integration test
* Updated YAML, Changelog
* Partially fixes #573.
* Replaces #642  (old fork).
