### PR TITLE
Remove logger dependency from the `cpuid` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,6 @@ version = "0.1.0"
 dependencies = [
  "kvm 0.1.0",
  "kvm_gen 0.1.0",
- "logger 0.1.0",
 ]
 
 [[package]]

--- a/cpuid/Cargo.toml
+++ b/cpuid/Cargo.toml
@@ -6,4 +6,3 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 [dependencies]
 kvm = { path = "../kvm" }
 kvm_gen = { path = "../kvm_gen" }
-logger = { path = "../logger" }

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -353,6 +353,8 @@ pub struct VcpuMetrics {
     pub exit_mmio_write: SharedMetric,
     /// Number of errors during this VCPU's run.
     pub failures: SharedMetric,
+    /// Failures in configuring the CPUID.
+    pub fitler_cpuid: SharedMetric,
 }
 
 /// Metrics specific to the machine manager as a whole.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 
-COVERAGE_TARGET_PCT = 78.0
+COVERAGE_TARGET_PCT = 81.0
 # TODO: Put the coverage in s3 and update it automatically.
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')
@@ -35,8 +35,8 @@ KCOV_COVERAGE_REGEX = r'"covered":"(\d+\.\d)"'
 def test_coverage(test_session_root_path, test_session_tmp_path):
     """Test line coverage with kcov.
 
-    The result is extracted from the index.json created by kcov after a
-    coverage run.
+    The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
+    after a coverage run.
     """
     exclude_pattern = (
         '${CARGO_HOME:-$HOME/.cargo/},'


### PR DESCRIPTION
Issue #, if available:

Description of changes: A new type for propagating an error that can be optionally handled is implemented.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
