### PR TITLE
Apply seccomp filters to all firecracker threads

### DIFF
--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -4,11 +4,14 @@
 extern crate libc;
 
 use seccomp::{
-    Error, SeccompAction, SeccompCmpOp, SeccompCondition, SeccompFilterContext, SeccompRule,
+    setup_seccomp, Error, SeccompAction, SeccompCmpOp, SeccompCondition, SeccompFilterContext,
+    SeccompLevel, SeccompRule, SECCOMP_LEVEL_ADVANCED, SECCOMP_LEVEL_BASIC, SECCOMP_LEVEL_NONE,
 };
 
 /// List of allowed syscalls, necessary for Firecracker to function correctly.
 pub const ALLOWED_SYSCALLS: &[i64] = &[
+    libc::SYS_accept,
+    libc::SYS_clock_gettime,
     libc::SYS_close,
     libc::SYS_dup,
     libc::SYS_epoll_ctl,
@@ -28,6 +31,7 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_rt_sigreturn,
     libc::SYS_stat,
     libc::SYS_timerfd_settime,
+    libc::SYS_tkill,
     libc::SYS_write,
     libc::SYS_writev,
 ];
@@ -95,11 +99,31 @@ const MAP_PRIVATE: u64 = 0x02;
 const MAP_ANONYMOUS: u64 = 0x20;
 const MAP_NORESERVE: u64 = 0x4000;
 
+/// Applies the configured level of seccomp filtering to the current thread.
+pub fn set_seccomp_level(seccomp_level: u32) -> Result<(), Error> {
+    // Load seccomp filters before executing guest code.
+    // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
+    // altogether is the desired behaviour.
+    match seccomp_level {
+        SECCOMP_LEVEL_ADVANCED => setup_seccomp(SeccompLevel::Advanced(default_context()?)),
+        SECCOMP_LEVEL_BASIC => setup_seccomp(seccomp::SeccompLevel::Basic(ALLOWED_SYSCALLS)),
+        SECCOMP_LEVEL_NONE | _ => Ok(()),
+    }
+}
+
 /// The default context containing the white listed syscall rules required by `Firecracker` to
 /// function.
 pub fn default_context() -> Result<SeccompFilterContext, Error> {
     Ok(SeccompFilterContext::new(
         vec![
+            (
+                libc::SYS_accept,
+                (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            (
+                libc::SYS_clock_gettime,
+                (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
             (
                 libc::SYS_close,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
@@ -484,6 +508,10 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
             ),
             (
                 libc::SYS_stat,
+                (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            (
+                libc::SYS_tkill,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
             ),
             (

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -34,7 +34,8 @@ extern crate seccomp;
 extern crate sys_util;
 extern crate x86_64;
 
-mod default_syscalls;
+/// Syscalls allowed through the seccomp filter.
+pub mod default_syscalls;
 mod device_manager;
 /// Signal handling utilities for seccomp violations.
 mod sigsys_handler;
@@ -70,9 +71,6 @@ use kernel::loader as kernel_loader;
 use kvm::*;
 use logger::{Level, LogOption, Metric, LOGGER, METRICS};
 use memory_model::{GuestAddress, GuestMemory};
-use seccomp::{
-    setup_seccomp, SeccompLevel, SECCOMP_LEVEL_ADVANCED, SECCOMP_LEVEL_BASIC, SECCOMP_LEVEL_NONE,
-};
 use serde_json::Value;
 pub use sigsys_handler::setup_sigsys_handler;
 use sys_util::{register_signal_handler, EventFd, Killable, Terminal};
@@ -899,7 +897,7 @@ impl Vmm {
                 .map_err(|_| StartMicrovmError::EventFd)?;
 
             let mut vcpu = Vcpu::new(cpu_id, &self.vm).map_err(StartMicrovmError::Vcpu)?;
-
+            let seccomp_level = self.seccomp_level;
             // It is safe to unwrap the ht_enabled flag because the machine configure
             // has default values for all fields.
             vcpu.configure(&self.vm_config, entry_addr, &self.vm)
@@ -918,6 +916,17 @@ impl Vmm {
                                 true,
                             )
                             .expect("Failed to register vcpu signal handler");
+                        }
+
+                        // Load seccomp filters for this vCPU thread.
+                        // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
+                        // altogether is the desired behaviour.
+                        match default_syscalls::set_seccomp_level(seccomp_level) {
+                            Ok(_) => (),
+                            Err(e) => panic!(
+                                "Failed to set the requested seccomp filters: Error: {:?}",
+                                e
+                            ),
                         }
 
                         vcpu_thread_barrier.wait();
@@ -1017,25 +1026,11 @@ impl Vmm {
             );
         }
 
-        // Load seccomp filters before executing guest code.
+        // Load seccomp filters for the VMM thread.
         // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
         // altogether is the desired behaviour.
-        match self.seccomp_level {
-            SECCOMP_LEVEL_ADVANCED => {
-                setup_seccomp(SeccompLevel::Advanced(
-                    default_syscalls::default_context()
-                        .map_err(|e| StartMicrovmError::SeccompFilters(e))?,
-                ))
-                .map_err(|e| StartMicrovmError::SeccompFilters(e))?;
-            }
-            SECCOMP_LEVEL_BASIC => {
-                setup_seccomp(seccomp::SeccompLevel::Basic(
-                    default_syscalls::ALLOWED_SYSCALLS,
-                ))
-                .map_err(|e| StartMicrovmError::SeccompFilters(e))?;
-            }
-            SECCOMP_LEVEL_NONE | _ => {}
-        }
+        default_syscalls::set_seccomp_level(self.seccomp_level)
+            .map_err(|e| StartMicrovmError::SeccompFilters(e))?;
 
         vcpu_thread_barrier.wait();
 


### PR DESCRIPTION
Refactor and move the seccomp setup to before creating the vCPUs,
that way the vCPU threads inherit the filters from the VMM thread.

Also pass a closure that sets up the seccomp filters to the API
thread to be called after the API thread bind()s and listen()s
on the API socket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
