### PR TITLE
Apply seccomp filters to all firecracker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,23 @@
 ## Unreleased
 
 ### Added
+
 - Documentation for Logger API Requests in `docs/api_requests/logger.md`.
 
 ### Changed
+
 - Updated the swagger definition of the `Logger` to specify the required fields
   and provide default values for optional fields.
+- Default `seccomp-level` is `2` (was previously 0).
+
+### Fixed
+
+- Seccomp filters are now applied to all Firecracker threads.
 
 ## [0.12.0]
 
 ### Added
+
 - The `/logger` API has a new field called `options`. This is an array of
   strings that specify additional logging configurations. The only supported
   value is `LogDirtyPages`.
@@ -31,6 +39,7 @@
 - Log messages use `anonymous-instance` as instance id if none is specified.
 
 ### Fixed
+
 - Fixed crash upon instance start on hosts without 1GB huge page support.
 - Fixed "fault_message" inconsistency between Open API specification and code base.
 - Ensure MMDS compatibility with C5's IMDS implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "jailer 0.12.0",
  "logger 0.1.0",
  "mmds 0.1.0",
+ "seccomp 0.1.0",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ clap = "=2.27.1"
 serde_json = ">=1.0.9"
 
 api_server = { path = "api_server" }
-jailer = { path = "jailer" }
-logger = { path = "logger"}
-mmds = { path = "mmds" }
-vmm = { path = "vmm" }
 fc_util = { path = "fc_util" }
+jailer = { path = "jailer" }
+logger = { path = "logger" }
+mmds = { path = "mmds" }
+seccomp = { path = "seccomp" }
+vmm = { path = "vmm" }
 
 [dev-dependencies]
 tempfile = ">=3.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate jailer;
 #[macro_use]
 extern crate logger;
 extern crate mmds;
+extern crate seccomp;
 extern crate vmm;
 
 use backtrace::Backtrace;
@@ -83,7 +84,7 @@ fn main() {
         .expect("Missing argument: api_sock");
 
     let mut instance_id = String::from(DEFAULT_INSTANCE_ID);
-    let mut seccomp_level = 0;
+    let mut seccomp_level = seccomp::SECCOMP_LEVEL_ADVANCED;
     let mut start_time_us = None;
     let mut start_time_cpu_us = None;
     let mut is_jailed = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,12 @@ fn main() {
         UnixDomainSocket::Path(bind_path)
     };
 
-    match server.bind_and_run(uds_path_or_fd, start_time_us, start_time_cpu_us) {
+    match server.bind_and_run(
+        uds_path_or_fd,
+        start_time_us,
+        start_time_cpu_us,
+        seccomp_level,
+    ) {
         Ok(_) => (),
         Err(Error::Io(inner)) => match inner.kind() {
             ErrorKind::AddrInUse => panic!(

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -55,7 +55,7 @@ fn SIGRTMAX() -> c_int {
 /// Verifies that a signal number is valid: for VCPU signals, it needs to be enclosed within the OS
 /// limits for realtime signals, and the remaining ones need to be between the minimum (SIGHUP) and
 /// maximum (SIGSYS) values.
-fn validate_signal_num(num: c_int, for_vcpu: bool) -> Result<c_int> {
+pub fn validate_signal_num(num: c_int, for_vcpu: bool) -> Result<c_int> {
     if for_vcpu {
         let actual_num = num + SIGRTMIN();
         if actual_num <= SIGRTMAX() {

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -65,7 +65,7 @@ class Microvm:
             jailer_id=self._microvm_id,
             exec_file=self._fc_binary_path
         )
-        self._jailer_clone_pid = None
+        self.jailer_clone_pid = None
 
         # Now deal with the things specific to the api session used to
         # communicate with this machine.
@@ -106,8 +106,8 @@ class Microvm:
     def kill(self):
         """All clean up associated with this microVM should go here."""
         if self._jailer.daemonize:
-            if self._jailer_clone_pid:
-                run('kill -9 {}'.format(self._jailer_clone_pid), shell=True)
+            if self.jailer_clone_pid:
+                run('kill -9 {}'.format(self.jailer_clone_pid), shell=True)
         else:
             run(
                 'screen -XS {} kill'.format(self._session_name),
@@ -255,7 +255,7 @@ class Microvm:
                     stdout=PIPE,
                     check=True
                 )
-                self._jailer_clone_pid = int(_p.stdout.decode().rstrip())
+                self.jailer_clone_pid = int(_p.stdout.decode().rstrip())
             else:
                 # This code path is not used at the moment, but I just feel
                 # it's nice to have a fallback mechanism in place, in case
@@ -266,7 +266,7 @@ class Microvm:
                         self._jailer_binary_path,
                         [self._jailer_binary_path] + jailer_param_list
                     )
-                self._jailer_clone_pid = _pid
+                self.jailer_clone_pid = _pid
         else:
             start_cmd = 'screen -dmS {session} {binary} {params}'
             start_cmd = start_cmd.format(
@@ -281,9 +281,9 @@ class Microvm:
                 .stdout.decode('utf-8')
             screen_pid = re.search(r'([0-9]+)\.{}'.format(self._session_name),
                                    out).group(1)
-            self._jailer_clone_pid = open('/proc/{0}/task/{0}/children'
-                                          .format(screen_pid)
-                                          ).read().strip()
+            self.jailer_clone_pid = open('/proc/{0}/task/{0}/children'
+                                         .format(screen_pid)
+                                         ).read().strip()
 
         # Wait for the jailer to create resources needed.
         # We expect the jailer to start within 80 ms. However, we wait for
@@ -324,7 +324,7 @@ class Microvm:
         if self.monitor_memory:
             mem_tools.threaded_memory_monitor(
                 mem_size_mib,
-                self._jailer_clone_pid
+                self.jailer_clone_pid
             )
 
         # Add a kernel to start booting from.

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -27,11 +27,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
     test_microvm.start()
 
     # Get Firecracker PID so we can count the number of threads.
-    cmd = 'lsof -U | grep {} | awk \'{{print $2}}\''.format(
-        test_microvm.api_socket
-    )
-    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
-    firecracker_pid = int(process.stdout.decode('utf-8').rstrip())
+    firecracker_pid = test_microvm.jailer_clone_pid
 
     # Get number of threads in Firecracker
     cmd = 'ps -o nlwp {} | tail -1 | awk \'{{print $1}}\''.format(

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -184,7 +184,7 @@ def test_seccomp_applies_to_all_threads(test_microvm_with_api):
     test_microvm.start()
 
     # Get Firecracker PID so we can count the number of threads.
-    firecracker_pid = test_microvm._jailer_clone_pid
+    firecracker_pid = test_microvm.jailer_clone_pid
 
     # Get number of threads in Firecracker
     cmd = 'ps -T --no-headers -p {} | awk \'{{print $2}}\''.format(

--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -552,6 +552,7 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
 }
 
 #[cfg(test)]
+#[cfg(target_env = "musl")]
 mod tests {
     extern crate libc;
     extern crate seccomp;
@@ -559,7 +560,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(target_env = "musl")]
     fn test_basic_seccomp() {
         let mut rules = ALLOWED_SYSCALLS.to_vec();
         rules.extend(vec![
@@ -573,7 +573,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_env = "musl")]
     fn test_advanced_seccomp() {
         // Sets up context with additional rules required by the test.
         let mut context = default_context().unwrap();

--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate libc;
+extern crate sys_util;
 
 use seccomp::{
     setup_seccomp, Error, SeccompAction, SeccompCmpOp, SeccompCondition, SeccompFilterContext,
@@ -513,7 +514,19 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
             ),
             (
                 libc::SYS_tkill,
-                (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+                (
+                    0,
+                    vec![SeccompRule::new(
+                        vec![SeccompCondition::new(
+                            1,
+                            SeccompCmpOp::Eq,
+                            sys_util::validate_signal_num(super::VCPU_RTSIG_OFFSET, true)
+                                .map_err(|_| Error::InvalidArgumentNumber)?
+                                as u64,
+                        )?],
+                        SeccompAction::Allow,
+                    )],
+                ),
             ),
             (
                 libc::SYS_timerfd_create,


### PR DESCRIPTION
Apply seccomp filters to all firecracker threads

Refactor and apply the seccomp filters to all Firecracker threads.
New syscalls had to be whitelisted as they are necessary (previously API and vCPUs threads had no filters installed).

Firecracker default SECCOMP level is now 2 - SECCOMP_ADVANCED meaning filtering both on the syscall number and the syscall parameters.

Added integration test to validate all Firecracker threads have seccomp applied.

Fixes #800.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
