### PR TITLE
vhost-vsock: fix build after epoll crate update

### DIFF
--- a/devices/src/virtio/vhost/vsock.rs
+++ b/devices/src/virtio/vhost/vsock.rs
@@ -227,9 +227,12 @@ impl VirtioDevice for Vsock {
 
                 epoll::ctl(
                     self.epoll_config.get_raw_epoll_fd(),
-                    epoll::EPOLL_CTL_ADD,
+                    epoll::ControlOptions::EPOLL_CTL_ADD,
                     queue_evt_raw_fd,
-                    epoll::Event::new(epoll::EPOLLIN, self.epoll_config.get_queue_evt_token()),
+                    epoll::Event::new(
+                        epoll::Events::EPOLLIN,
+                        self.epoll_config.get_queue_evt_token(),
+                    ),
                 )
                 .map_err(ActivateError::EpollCtl)?;
 


### PR DESCRIPTION
Description of changes:
Commit d6861f91ac forgot to update the vhost vsock part and build fails when vsock is enabled.
