### PR TITLE
Added URL Decoding to API server (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Updated the swagger definition of the `Logger` to specify the required fields
   and provide default values for optional fields.
 - Default `seccomp-level` is `2` (was previously 0).
+- API Resource IDs can only contain alphanumeric characters and underscores.
 
 ### Fixed
 


### PR DESCRIPTION
Added URL decoding to `id` from HTTP request path.

Issue #, if available: #794 
Description of changes:
Used `percent_decode` from the `url` crate to decode `id` extracted from HTTP request path.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
