### PR TITLE
x86_64: limit maximum number of supported CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Documentation for development environment setup on AWS.
+- Limit the maximum supported vCPUs to 32.
 
 ### Changed
 - Log the app version when the `Logger` is initialized.

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -1101,7 +1101,7 @@ mod tests {
     fn test_parse_machine_config_req() {
         let path = "/machine-config";
         let json = "{
-                \"vcpu_count\": 42,
+                \"vcpu_count\": 32,
                 \"mem_size_mib\": 1025,
                 \"ht_enabled\": true,
                 \"cpu_template\": \"T2\"
@@ -1118,7 +1118,7 @@ mod tests {
 
         // PUT
         let vm_config = VmConfig {
-            vcpu_count: Some(42),
+            vcpu_count: Some(32),
             mem_size_mib: Some(1025),
             ht_enabled: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
@@ -1145,6 +1145,20 @@ mod tests {
             String::from("Empty request."),
         ));
         assert!(parse_machine_config_req(path, Method::Put, &Chunk::from("{}")) == expected_err);
+
+        // Error Case: cpu count exceeds limitation
+        let json = "{
+                \"vcpu_count\": 33,
+                \"mem_size_mib\": 1025,
+                \"ht_enabled\": true,
+                \"cpu_template\": \"T2\"
+              }";
+        let body: Chunk = Chunk::from(json);
+        if let Err(Error::SerdeJson(e)) = parse_machine_config_req(path, Method::Put, &body) {
+            assert!(e.is_data());
+        } else {
+            assert!(false);
+        }
     }
 
     #[test]

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -430,6 +430,8 @@ definitions:
     properties:
       vcpu_count:
         type: integer
+        minimum: 1
+        maximum: 32
         description: Number of vCPUs (either 1 or an even number)
       mem_size_mib:
         type: integer


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fix a panicking when creating a VM with 255 vCPUs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
