### PR TITLE
Clarify getting started section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ To read more about Firecracker, check out
 
 ## Getting Started
 
+To get started with Firecracker, download the latest
+[release](https://github.com/firecracker-microvm/firecracker/releases) binaries or build it from source.
+
 You can build Firecracker on any system that has Docker running (we use a
-development container). The simple steps to get & build Firecracker are:
+development container) as follows:
 
 ```bash
 git clone https://github.com/firecracker-microvm/firecracker


### PR DESCRIPTION
**Summary**

* There seems to be a common misconception in the Firecracker Slack
channel that you have to start off by building Firecracker when there
are binaries ready for download that don't require the whole docker
setup. Bit me and I've seen some other people in the Slack do the same
thing
* Hopefully this gives a useful pointer to where to look if you just
want to run Firecracker
