### PR TITLE
Test that vsock feature builds

### DIFF
--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -18,7 +18,7 @@ RELEASE_BINARIES_REL_PATH = 'x86_64-unknown-linux-musl/release/'
 
 
 def cargo_build(path, flags='', extra_args=''):
-    """Use to ensure a single binary build and release path for all tests."""
+    """Trigger build depending on flags provided."""
     cmd = 'CARGO_TARGET_DIR={} cargo build {} {}'.format(
         path,
         flags,

--- a/tests/integration_tests/build/test_build.py
+++ b/tests/integration_tests/build/test_build.py
@@ -4,15 +4,20 @@
 
 import os
 
-import pytest
-
 import host_tools.cargo_build as host  # pylint:disable=import-error
 
 
 CARGO_DEBUG_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'debug')
+CARGO_DEBUG_REL_PATH_FEATURES = os.path.join(
+    host.CARGO_BUILD_REL_PATH,
+    'debug-features'
+)
+CARGO_RELEASE_REL_PATH_FEATURES = os.path.join(
+    host.CARGO_BUILD_REL_PATH,
+    'release-features'
+)
 
 
-@pytest.mark.timeout(240)
 def test_build_debug(test_session_root_path):
     """Test if a debug-mode build works."""
     build_path = os.path.join(
@@ -22,6 +27,18 @@ def test_build_debug(test_session_root_path):
     host.cargo_build(build_path)
 
 
+def test_build_debug_with_features(test_session_root_path):
+    """Test if a debug-mode build works for supported features."""
+    build_path = os.path.join(
+        test_session_root_path,
+        CARGO_DEBUG_REL_PATH_FEATURES
+    )
+    # Building with multiple features is as simple as:
+    # cargo build --features "feature1 feature2". We are currently
+    # supporting only one features: vsock.
+    host.cargo_build(build_path, '--features "{}"'.format('vsock'))
+
+
 def test_build_release(test_session_root_path):
     """Test if a release-mode build works."""
     build_path = os.path.join(
@@ -29,3 +46,16 @@ def test_build_release(test_session_root_path):
         host.CARGO_RELEASE_REL_PATH
     )
     host.cargo_build(build_path, '--release')
+
+
+def test_build_release_with_features(test_session_root_path):
+    """Test if a release-mode build works for supported features."""
+    build_path = os.path.join(
+        test_session_root_path,
+        CARGO_RELEASE_REL_PATH_FEATURES
+    )
+    host.cargo_build(
+        build_path,
+        '--features "{}"'.format('vsock'),
+        '--release'
+    )


### PR DESCRIPTION
Issue #, if available:

Description of changes: Added two integration tests, one that checks that features vsock builds in both debug and release mode.
This will help us avoid situations like this one: #804.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
