### PR TITLE
Jailer: Allow 'none' device for cgroups

### DIFF
--- a/jailer/src/cgroup.rs
+++ b/jailer/src/cgroup.rs
@@ -135,7 +135,7 @@ impl Cgroup {
 
         // Regex courtesy of Filippo.
         let re = Regex::new(
-            r"^cgroup[[:space:]](?P<dir>.*)[[:space:]]cgroup[[:space:]](?P<options>.*)[[:space:]]0[[:space:]]0$",
+            r"^(cgroup|none)[[:space:]](?P<dir>.*)[[:space:]]cgroup[[:space:]](?P<options>.*)[[:space:]]0[[:space:]]0$",
         ).map_err(Error::RegEx)?;
         for l in BufReader::new(f).lines() {
             let l = l.map_err(|e| Error::ReadLine(PathBuf::from(PROC_MOUNTS), e))?;


### PR DESCRIPTION
Issue #, if available: #842 

Description of changes: According to the cgroups man page, the device used in the mount point
can be 'none'. Modify the regex used in the jailer to also match that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
