### PR TITLE
Fix dirty page logging functionality and corresponding integration test

### DIFF
--- a/vmm/src/default_syscalls.rs
+++ b/vmm/src/default_syscalls.rs
@@ -70,6 +70,7 @@ const KVM_CREATE_VM: u64 = 0xae01;
 const KVM_CHECK_EXTENSION: u64 = 0xae03;
 const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
 const KVM_CREATE_VCPU: u64 = 0xae41;
+const KVM_GET_DIRTY_LOG: u64 = 0x4010ae42;
 const KVM_SET_TSS_ADDR: u64 = 0xae47;
 const KVM_CREATE_IRQCHIP: u64 = 0xae60;
 const KVM_RUN: u64 = 0xae80;
@@ -265,6 +266,14 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
                         ),
                         SeccompRule::new(
                             vec![SeccompCondition::new(1, SeccompCmpOp::Eq, KVM_CREATE_VCPU)?],
+                            SeccompAction::Allow,
+                        ),
+                        SeccompRule::new(
+                            vec![SeccompCondition::new(
+                                1,
+                                SeccompCmpOp::Eq,
+                                KVM_GET_DIRTY_LOG,
+                            )?],
                             SeccompAction::Allow,
                         ),
                         SeccompRule::new(


### PR DESCRIPTION
Issue #, if available: #845, #847

Description of changes:
* whitelisted the `KVM_GET_DIRTY_LOG` ioctl in the seccomp filters. It was not getting through with the advanced filters, causing a SIGSYS and a failure to get the actual dirtied page count, which stayed 0.
* verified in the corresponding integration test that the metric is correctly emitted (i.e. after the microVM has been up for some time, it has dirtied a positive number of pages).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
