### PR TITLE
kernel: remove x86_64 crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,6 @@ version = "0.1.0"
 dependencies = [
  "memory_model 0.1.0",
  "sys_util 0.1.0",
- "x86_64 0.1.0",
 ]
 
 [[package]]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -5,4 +5,3 @@ version = "0.1.0"
 [dependencies]
 sys_util = { path = "../sys_util" }
 memory_model = { path = "../memory_model" }
-x86_64 = { path = "../x86_64" }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -10,4 +10,3 @@ pub mod loader;
 
 extern crate memory_model;
 extern crate sys_util;
-extern crate x86_64;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1089,8 +1089,12 @@ impl Vmm {
         let vm_memory = self.vm.get_memory().ok_or(StartMicrovmError::GuestMemory(
             memory_model::GuestMemoryError::MemoryNotInitialized,
         ))?;
-        let entry_addr = kernel_loader::load_kernel(vm_memory, &mut kernel_config.kernel_file)
-            .map_err(|e| StartMicrovmError::Loader(e))?;
+        let entry_addr = kernel_loader::load_kernel(
+            vm_memory,
+            &mut kernel_config.kernel_file,
+            x86_64::layout::HIMEM_START,
+        )
+        .map_err(|e| StartMicrovmError::Loader(e))?;
         kernel_loader::load_cmdline(vm_memory, kernel_config.cmdline_addr, &cmdline_cstring)
             .map_err(|e| StartMicrovmError::Loader(e))?;
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The `load_kernel` function follows the boot documentation from
https://www.kernel.org/doc/Documentation/x86/boot.txt. Consequently,
labeled it as such and removed harcoded `HIMEM_START` value which should
be a parameter to the `load_kernel` function specifying where inferior
offset limit for placing the kernel.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
