### PR TITLE
pretty print panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## Unreleased
 
 ### Added
+
 - Documentation for development environment setup on AWS.
 
 ### Changed
+
+- Pretty print panic information.
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
         // We're currently using the closure parameter, which is a &PanicInfo, for printing the
         // origin of the panic, including the payload passed to panic! and the source code location
         // from which the panic originated.
-        error!("Panic occurred: {:?}", info);
+        error!("Firecracker {}", info);
         METRICS.vmm.panic_count.inc();
         let bt = Backtrace::new();
         error!("{:?}", bt);
@@ -240,7 +240,7 @@ mod tests {
                 log_file.as_str(),
                 &[
                     // Lines containing these words should have appeared in the log, in this order
-                    ("ERROR", "main.rs", "Panic occurred"),
+                    ("ERROR", "main.rs", "Firecracker panicked at"),
                     ("ERROR", "main.rs", "stack backtrace:"),
                     ("0:", "0x", "firecracker::main::"),
                 ],


### PR DESCRIPTION
Issue #, if available: #837 

Description of changes:
Instead of printing the PanicInfo using debug, we can use display
as this generates a human readable panic.

Before:
Panic occurred: PanicInfo { payload: Any, message: Some(Failed to
open the API socket: IO Error: Io(Os ...

After:
Firecracker panicked at 'Failed to open the API socket: IO Error:
...

This is the first step in having human readable panics. Next we
should implement Display for errors that can generate panics.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
