### PR TITLE
jailer: Handle cgroups v2 mounts

### DIFF
--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 clap = ">=2.27.1"
+lazy_static = ">=1.2.0"
 libc = ">=0.2.39"
 regex = ">=1.0.0"
 serde = ">=1.0.27"

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -3,6 +3,8 @@
 
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate regex;
 extern crate serde;
@@ -50,6 +52,7 @@ pub enum Error {
     Canonicalize(PathBuf, io::Error),
     CgroupInheritFromParent(PathBuf, String),
     CgroupLineNotFound(String, String),
+    CgroupLineNotMatched(String, String),
     CgroupLineNotUnique(String, String),
     ChangeDevNetTunOwner(sys_util::Error),
     ChdirNewRoot(sys_util::Error),
@@ -119,6 +122,11 @@ impl fmt::Display for Error {
                 f,
                 "{} configurations not found in {}",
                 controller, proc_mounts
+            ),
+            CgroupLineNotMatched(ref line, ref controller) => write!(
+                f,
+                "{} configurations did not match line '{}'",
+                controller, line
             ),
             CgroupLineNotUnique(ref proc_mounts, ref controller) => write!(
                 f,
@@ -445,6 +453,13 @@ mod tests {
                 Error::CgroupLineNotFound(proc_mounts.to_string(), controller.to_string())
             ),
             "sysfs configurations not found in /proc/mounts",
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Error::CgroupLineNotMatched(proc_mounts.to_string(), controller.to_string())
+            ),
+            "sysfs configurations did not match line '/proc/mounts'",
         );
         assert_eq!(
             format!(


### PR DESCRIPTION
Issue #, if available: #841 

Description of changes: The previous version of the jailer only handled cgroups v1. The current
implementation also handles v2, but still gives priority to v1 (e.g. if
a cgroups v1 mount point that matches a controller is found, that one is
used)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Andrei Cipu <acipu@amazon.com>