### PR TITLE
replace kvm_wrapper with kvm-bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "arch_gen 0.1.0",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm 0.1.0",
- "kvm_wrapper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_model 0.1.0",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,7 +180,7 @@ name = "cpuid"
 version = "0.1.0"
 dependencies = [
  "kvm 0.1.0",
- "kvm_wrapper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -382,15 +382,15 @@ name = "kvm"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm_wrapper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_model 0.1.0",
  "sys_util 0.1.0",
 ]
 
 [[package]]
-name = "kvm_wrapper"
-version = "0.1.1"
+name = "kvm-bindings"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1329,7 +1329,7 @@ dependencies = [
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum json-patch 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d3d2367729ae7dbae9780aa98a65514b982227a8d3761b7bd47553eef6577ca"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvm_wrapper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7929bb1d03a07b15ef29201307ecd9c689ea6bf8ce4fdd78c3e8841f92fc3e"
+"checksum kvm-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c2f311f4f41b07f02be446dc82e140053fe9f8410a1685589de34757aa07a3c"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 byteorder = "=1.2.1"
-kvm_wrapper = ">=0.1.0"
+kvm-bindings = "0.1"
 libc = ">=0.2.39"
 
 arch_gen = { path = "../arch_gen" }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate byteorder;
-extern crate kvm_wrapper;
+extern crate kvm_bindings;
 extern crate libc;
 
 extern crate arch_gen;

--- a/arch/src/x86_64/gdt.rs
+++ b/arch/src/x86_64/gdt.rs
@@ -7,7 +7,7 @@
 
 // For GDT details see arch/x86/include/asm/segment.h
 
-use kvm_wrapper::kvm_segment;
+use kvm_bindings::kvm_segment;
 
 /// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
 pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -12,7 +12,7 @@ use std::result;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use kvm;
-use kvm_wrapper::kvm_lapic_state;
+use kvm_bindings::kvm_lapic_state;
 use sys_util;
 
 #[derive(Debug)]

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -10,7 +10,7 @@ use std::{mem, result};
 use super::gdt::{gdt_entry, kvm_segment_from_gdt};
 use arch_gen::x86::msr_index;
 use kvm::VcpuFd;
-use kvm_wrapper::{kvm_fpu, kvm_msr_entry, kvm_msrs, kvm_regs, kvm_sregs};
+use kvm_bindings::{kvm_fpu, kvm_msr_entry, kvm_msrs, kvm_regs, kvm_sregs};
 use memory_model::{GuestAddress, GuestMemory};
 use sys_util;
 

--- a/cpuid/Cargo.toml
+++ b/cpuid/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-kvm_wrapper = ">=0.1.0"
+kvm-bindings = "0.1"
 
 kvm = { path = "../kvm" }

--- a/cpuid/src/c3_template.rs
+++ b/cpuid/src/c3_template.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cpu_leaf::*;
-use kvm_wrapper::kvm_cpuid_entry2;
+use kvm_bindings::kvm_cpuid_entry2;
 
 /// Sets up the cpuid entries for a given VCPU following a C3 template.
 pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -9,7 +9,7 @@
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 extern crate kvm;
-extern crate kvm_wrapper;
+extern crate kvm_bindings;
 
 use std::result;
 
@@ -288,7 +288,7 @@ fn get_brand_string() -> PartialError<BrandString, brand_string::Error> {
 mod tests {
     use super::*;
     use kvm::{Kvm, MAX_KVM_CPUID_ENTRIES};
-    use kvm_wrapper::kvm_cpuid_entry2;
+    use kvm_bindings::kvm_cpuid_entry2;
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[test]

--- a/cpuid/src/t2_template.rs
+++ b/cpuid/src/t2_template.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cpu_leaf::*;
-use kvm_wrapper::kvm_cpuid_entry2;
+use kvm_bindings::kvm_cpuid_entry2;
 
 /// Sets up the cpuid entries for a given VCPU following a T2 template.
 pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {

--- a/kvm/Cargo.toml
+++ b/kvm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-kvm_wrapper = ">=0.1.0"
+kvm-bindings = "0.1"
 libc = ">=0.2.39"
 
 memory_model = { path = "../memory_model" }

--- a/kvm/src/cap.rs
+++ b/kvm/src/cap.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use kvm_wrapper::*;
+use kvm_bindings::*;
 
 /// A capability the kernel's KVM interface can possibly expose.
 #[derive(Clone, Copy, Debug)]

--- a/kvm/src/ioctl_defs.rs
+++ b/kvm/src/ioctl_defs.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use kvm_wrapper::*;
+use kvm_bindings::*;
 
 // Declares necessary ioctls specific to their platform.
 

--- a/kvm/src/lib.rs
+++ b/kvm/src/lib.rs
@@ -11,7 +11,7 @@
 
 extern crate libc;
 
-extern crate kvm_wrapper;
+extern crate kvm_bindings;
 extern crate memory_model;
 #[macro_use]
 extern crate sys_util;
@@ -25,7 +25,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use libc::{open, EINVAL, ENOSPC, O_RDWR};
 
-use kvm_wrapper::*;
+use kvm_bindings::*;
 use memory_model::MemoryMapping;
 use sys_util::{errno_result, Error, EventFd, Result};
 use sys_util::{
@@ -34,7 +34,7 @@ use sys_util::{
 
 pub use cap::*;
 use ioctl_defs::*;
-pub use kvm_wrapper::KVM_API_VERSION;
+pub use kvm_bindings::KVM_API_VERSION;
 
 /// Taken from Linux Kernel v4.14.13 (arch/x86/include/asm/kvm_host.h)
 pub const MAX_KVM_CPUID_ENTRIES: usize = 80;


### PR DESCRIPTION

Description of changes:
The kvm_wrapper crate was deprecated in favor of kvm-bindings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
