### PR TITLE
remove memory dependency for arch_gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,6 @@ dependencies = [
 [[package]]
 name = "arch_gen"
 version = "0.1.0"
-dependencies = [
- "memory_model 0.1.0",
-]
 
 [[package]]
 name = "atty"

--- a/arch_gen/Cargo.toml
+++ b/arch_gen/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-memory_model = { path = "../memory_model" }
+

--- a/arch_gen/src/lib.rs
+++ b/arch_gen/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate memory_model;
-
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod x86;

--- a/arch_gen/src/x86/mod.rs
+++ b/arch_gen/src/x86/mod.rs
@@ -14,14 +14,3 @@ pub mod bootparam;
 pub mod mpspec;
 #[allow(non_upper_case_globals)]
 pub mod msr_index;
-
-// `boot_params` is just a series of ints, it is safe to initialize it.
-unsafe impl memory_model::DataInit for bootparam::boot_params {}
-// These `mpspec` types are only data, reading them from data is a safe initialization.
-unsafe impl memory_model::DataInit for mpspec::mpc_bus {}
-unsafe impl memory_model::DataInit for mpspec::mpc_cpu {}
-unsafe impl memory_model::DataInit for mpspec::mpc_intsrc {}
-unsafe impl memory_model::DataInit for mpspec::mpc_ioapic {}
-unsafe impl memory_model::DataInit for mpspec::mpc_table {}
-unsafe impl memory_model::DataInit for mpspec::mpc_lintsrc {}
-unsafe impl memory_model::DataInit for mpspec::mpf_intel {}


### PR DESCRIPTION
Issue #, if available: Fixes #871 

Description of changes:
Since rust prohibits that a foreign trait is implemented by a foreign type, we defined a wrapper over the foreign type as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
