### PR TITLE
[RFC-do not merge] boot-time: specify clock source as boot parameter

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -87,7 +87,8 @@ use vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceConfigs, NetworkIn
 use vmm_config::vsock::{VsockDeviceConfig, VsockDeviceConfigs, VsockError};
 use vstate::{Vcpu, Vm};
 
-const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0";
+const DEFAULT_KERNEL_CMDLINE: &str =
+    "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0 clocksource=kvm-clock";
 const MAGIC_IOPORT_SIGNAL_GUEST_BOOT_COMPLETE: u16 = 0x03f0;
 const MAGIC_VALUE_SIGNAL_GUEST_BOOT_COMPLETE: u8 = 123;
 const VCPU_RTSIG_OFFSET: i32 = 0;


### PR DESCRIPTION
*** DO NOT MERGE PLS *** If this is actually decreasing the boot time, the integration tests need to be adjusted.

Issue #, if available:

Description of changes:
For kernel older than 4.19 we noticed that 30ms are spent in TSC
calibration. Specify the the default clock-source as kvm-clock to
mitigate this problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
