### PR TITLE
Add support for building with system Rust toolchain (glibc)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -251,6 +251,25 @@ arguments is available via:
 tools/devtool --help
 ```
 
+### Alternative: Building Firecracker using glibc
+
+The toolchain that Firecracker is tested against and that is recommended for
+building production releases is the one that is automatically used by building
+using `devtool`. In this configuration, Firecracker is currently built as a
+static binary linked against the [musl](https://www.musl-libc.org/) libc
+implementation.
+
+Firecracker also builds using [glibc](https://www.gnu.org/software/libc/)
+toolchains, such as the default Rust toolchains provided in certain Linux
+distributions:
+
+```bash
+cargo build --target x86_64-unknown-linux-gnu
+```
+
+That being said, Firecracker binaries built without `devtool` are always
+considered experimental and should not be used in production.
+
 ## Running the Integration Test Suite
 
 You can also use our development tool to run the integration test suite:

--- a/tests/integration_tests/build/test_build.py
+++ b/tests/integration_tests/build/test_build.py
@@ -10,21 +10,21 @@ import host_tools.cargo_build as host  # pylint:disable=import-error
 
 FEATURES = ["", "vsock"]
 BUILD_TYPES = ["debug", "release"]
+TARGETS = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 
 
 @pytest.mark.parametrize(
-    "features, build_type",
-    itertools.product(FEATURES, BUILD_TYPES)
+    "features, build_type, target",
+    itertools.product(FEATURES, BUILD_TYPES, TARGETS)
 )
-def test_build(test_session_root_path, features, build_type):
+def test_build(test_session_root_path, features, build_type, target):
     """
     Test different builds.
 
-    Test builds using a cartesian product of possible features and build
-    types.
+    This will generate build tests using the cartesian product of all
+    features, build types (release/debug) and build targets (musl/gnu).
     """
-    extra_args = ""
-
+    extra_args = "--target {} ".format(target)
     if build_type == "release":
         extra_args += "--release "
 

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -9,13 +9,19 @@ use seccomp::{
 /// List of allowed syscalls necessary for correct functioning on x86_64 architectures.
 /// Taken from the musl repo (i.e arch/x86_64/bits/syscall.h).
 pub const ALLOWED_SYSCALLS: &[i64] = &[
+    #[cfg(target_env = "musl")]
     libc::SYS_accept,
+    #[cfg(target_env = "gnu")]
+    libc::SYS_accept4,
     libc::SYS_brk,
     libc::SYS_clock_gettime,
     libc::SYS_close,
     libc::SYS_dup,
     libc::SYS_epoll_ctl,
+    #[cfg(target_env = "musl")]
     libc::SYS_epoll_pwait,
+    #[cfg(target_env = "gnu")]
+    libc::SYS_epoll_wait,
     libc::SYS_exit,
     libc::SYS_exit_group,
     libc::SYS_fcntl,
@@ -27,7 +33,10 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_madvise,
     libc::SYS_mmap,
     libc::SYS_munmap,
+    #[cfg(target_env = "musl")]
     libc::SYS_open,
+    #[cfg(target_env = "gnu")]
+    libc::SYS_openat,
     libc::SYS_pipe,
     libc::SYS_read,
     libc::SYS_readv,


### PR DESCRIPTION
This pull request adds support for building Firecracker with the default Rust toolchain and without the docker container. This is nice, because building Firecracker on Ubuntu 18.04 is now as simple as:

```
sudo apt install rustc cargo
cargo build --target x86_64-unknown-linux-gnu
```

No Docker is required and building uses familiar Rust tools directly.

#647 tried to achieve the same. I'll let the Firecracker experts decide whether any of the changes in that PR are still necessary.

@andreeaflorescu was so nice to add integration testing (and went slightly overboard with refactoring :+1:  ).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
