### PR TITLE
Drop usage of `sys_util::Error` in `EventFd`

### DIFF
--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -6,7 +6,8 @@
 // found in the THIRD-PARTY file.
 
 use logger::{Metric, METRICS};
-use sys_util::{EventFd, Result};
+use std::{io, result};
+use sys_util::EventFd;
 
 use BusDevice;
 
@@ -24,8 +25,8 @@ impl I8042Device {
     }
 
     /// Returns a clone of the EventFd
-    pub fn get_eventfd_clone(&self) -> Result<EventFd> {
-        return self.reset_evt.try_clone();
+    pub fn get_eventfd_clone(&self) -> result::Result<EventFd, io::Error> {
+        self.reset_evt.try_clone()
     }
 }
 
@@ -74,7 +75,7 @@ mod tests {
         assert!(reset_evt.write(1).is_ok());
         let mut data = [RESET_CMD];
         i8042.write(0, &mut data);
-        assert_eq!(reset_evt.read(), Ok(2));
+        assert_eq!(reset_evt.read().unwrap(), 2);
 
         // Check if reading with offset 1 doesn't have side effects.
         i8042.read(1, &mut data);

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -6,7 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::collections::VecDeque;
-use std::io;
+use std::{io, result};
 
 use logger::{Metric, METRICS};
 use sys_util::{EventFd, Result};
@@ -151,7 +151,7 @@ impl Serial {
         Ok(())
     }
 
-    fn trigger_interrupt(&mut self) -> Result<()> {
+    fn trigger_interrupt(&mut self) -> result::Result<(), io::Error> {
         self.interrupt_evt.write(1)
     }
 
@@ -300,7 +300,7 @@ mod tests {
             .queue_input_bytes(&['a' as u8, 'b' as u8, 'c' as u8])
             .unwrap();
 
-        assert_eq!(intr_evt.read(), Ok(2));
+        assert_eq!(intr_evt.read().unwrap(), 2);
 
         // check if reading in a 2-length array doesn't have side effects
         let mut data = [0u8, 0u8];
@@ -333,7 +333,7 @@ mod tests {
         serial.write(IER as u64, &[IER_THR_BIT]);
         serial.write(DATA as u64, &['a' as u8]);
 
-        assert_eq!(intr_evt.read(), Ok(2));
+        assert_eq!(intr_evt.read().unwrap(), 2);
         let mut data = [0u8];
         serial.read(IER as u64, &mut data[..]);
         assert_eq!(data[0] & IER_FIFO_BITS, IER_THR_BIT);

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -26,7 +26,7 @@ extern crate virtio_gen;
 
 use rate_limiter::Error as RateLimiterError;
 use std::fs::File;
-use sys_util::Error as Errno;
+use std::io;
 
 mod bus;
 pub mod legacy;
@@ -60,10 +60,10 @@ pub trait EpollHandler: Send {
 pub enum Error {
     FailedReadingQueue {
         event_type: &'static str,
-        underlying: Errno,
+        underlying: io::Error,
     },
     FailedReadTap,
-    FailedSignalingUsedQueue(Errno),
+    FailedSignalingUsedQueue(io::Error),
     RateLimited(RateLimiterError),
     PayloadExpected,
     UnknownEvent {

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -762,7 +762,7 @@ mod tests {
         h.handle_event(QUEUE_AVAIL_EVENT, 0, EpollHandlerPayload::Empty)
             .unwrap();
         // validate the queue operation finished successfully
-        assert_eq!(h.interrupt_evt.read(), Ok(2));
+        assert_eq!(h.interrupt_evt.read().unwrap(), 2);
     }
 
     #[test]
@@ -1325,7 +1325,7 @@ mod tests {
                 // assert that limiter is blocked
                 assert!(h.get_rate_limiter().is_blocked());
                 // assert that no operation actually completed (limiter blocked it)
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1343,7 +1343,7 @@ mod tests {
                 // validate the rate_limiter is no longer blocked
                 assert!(!h.get_rate_limiter().is_blocked());
                 // make sure the virtio queue operation completed this time
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
 
                 // make sure the data queue advanced
                 assert_eq!(vq.used.idx.get(), 1);
@@ -1386,7 +1386,7 @@ mod tests {
                 // assert that limiter is blocked
                 assert!(h.get_rate_limiter().is_blocked());
                 // assert that no operation actually completed (limiter blocked it)
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1403,7 +1403,7 @@ mod tests {
                 // assert that limiter is blocked
                 assert!(h.get_rate_limiter().is_blocked());
                 // assert that no operation actually completed (limiter blocked it)
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(vq.used.idx.get(), 0);
             }
@@ -1421,7 +1421,7 @@ mod tests {
                 // validate the rate_limiter is no longer blocked
                 assert!(!h.get_rate_limiter().is_blocked());
                 // make sure the virtio queue operation completed this time
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
 
                 // make sure the data queue advanced
                 assert_eq!(vq.used.idx.get(), 1);

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -1487,7 +1487,7 @@ mod tests {
                 h.rx.queue = rxq.create_queue();
                 h.interrupt_evt.write(1).unwrap();
                 // The prev rx_single_frame_no_irq_coalescing() call should have written one more.
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
             }
 
             {
@@ -1504,7 +1504,7 @@ mod tests {
                 rxq.used.idx.set(0);
                 h.rx.queue = rxq.create_queue();
                 h.interrupt_evt.write(1).unwrap();
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
             }
 
             // set rx_count back to 0
@@ -1540,7 +1540,7 @@ mod tests {
             h.handle_event(RX_TAP_EVENT, 0, EpollHandlerPayload::Empty)
                 .unwrap();
             assert!(h.rx.deferred_frame);
-            assert_eq!(h.interrupt_evt.read(), Ok(2));
+            assert_eq!(h.interrupt_evt.read().unwrap(), 2);
             // The #cfg(test) enabled version of read_tap always returns 1234 bytes (or the len of
             // the buffer, whichever is smaller).
             assert_eq!(rxq.used.ring[0].get().len, 1234);
@@ -1557,7 +1557,7 @@ mod tests {
             h.handle_event(RX_TAP_EVENT, 0, EpollHandlerPayload::Empty)
                 .unwrap();
             assert!(h.rx.deferred_frame);
-            assert_eq!(h.interrupt_evt.read(), Ok(2));
+            assert_eq!(h.interrupt_evt.read().unwrap(), 2);
 
             // ... but the following shouldn't, because we emulate receiving much more data than
             // we can fit inside a single descriptor
@@ -1573,7 +1573,7 @@ mod tests {
                 h.handle_event(RX_TAP_EVENT, 0, EpollHandlerPayload::Empty)
             );
             assert!(h.rx.deferred_frame);
-            assert_eq!(h.interrupt_evt.read(), Ok(2));
+            assert_eq!(h.interrupt_evt.read().unwrap(), 2);
 
             // A mismatch shows the reception was unsuccessful.
             assert_ne!(rxq.used.ring[0].get().len as usize, h.rx.bytes_read);
@@ -1592,7 +1592,7 @@ mod tests {
             h.interrupt_evt.write(1).unwrap();
             h.handle_event(RX_QUEUE_EVENT, 0, EpollHandlerPayload::Empty)
                 .unwrap();
-            assert_eq!(h.interrupt_evt.read(), Ok(2));
+            assert_eq!(h.interrupt_evt.read().unwrap(), 2);
         }
 
         {
@@ -1685,7 +1685,7 @@ mod tests {
                 assert!(h.get_rx_rate_limiter().is_blocked());
                 assert!(h.rx.deferred_frame);
                 // assert that no operation actually completed (limiter blocked it)
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(rxq.used.idx.get(), 0);
             }
@@ -1703,7 +1703,7 @@ mod tests {
                 // validate the rate_limiter is no longer blocked
                 assert!(!h.get_rx_rate_limiter().is_blocked());
                 // make sure the virtio queue operation completed this time
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
                 // make sure the data queue advanced
                 assert_eq!(rxq.used.idx.get(), 1);
                 // The #cfg(test) enabled version of read_tap always returns 1234 bytes
@@ -1792,7 +1792,7 @@ mod tests {
                 assert!(h.get_rx_rate_limiter().is_blocked());
                 assert!(h.rx.deferred_frame);
                 // assert that no operation actually completed (limiter blocked it)
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(rxq.used.idx.get(), 0);
 
@@ -1802,7 +1802,7 @@ mod tests {
                 h.handle_event(RX_TAP_EVENT, 0, EpollHandlerPayload::Empty)
                     .unwrap();
                 // assert that no operation actually completed, that the limiter blocked it
-                assert_eq!(h.interrupt_evt.read(), Ok(1));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
                 assert_eq!(rxq.used.idx.get(), 0);
             }
@@ -1818,7 +1818,7 @@ mod tests {
                 h.handle_event(RX_RATE_LIMITER_EVENT, 0, EpollHandlerPayload::Empty)
                     .unwrap();
                 // make sure the virtio queue operation completed this time
-                assert_eq!(h.interrupt_evt.read(), Ok(2));
+                assert_eq!(h.interrupt_evt.read().unwrap(), 2);
                 // make sure the data queue advanced
                 assert_eq!(rxq.used.idx.get(), 1);
                 // The #cfg(test) enabled version of read_tap always returns 1234 bytes

--- a/devices/src/virtio/vhost/mod.rs
+++ b/devices/src/virtio/vhost/mod.rs
@@ -8,7 +8,7 @@
 //! Implements vhost-based virtio devices.
 
 use std;
-use sys_util::Error as SysError;
+use std::io;
 
 pub mod handle;
 pub mod vsock;
@@ -16,11 +16,11 @@ pub mod vsock;
 #[derive(Debug)]
 pub enum Error {
     /// Creating kill eventfd failed.
-    CreateKillEventFd(SysError),
+    CreateKillEventFd(io::Error),
     /// Cloning kill eventfd failed.
-    CloneKillEventFd(SysError),
+    CloneKillEventFd(io::Error),
     /// Error while polling for events.
-    PollError(SysError),
+    PollError(io::Error),
     /// Failed to open vhost device.
     VhostOpen(vhost_backend::Error),
     /// Set owner failed.
@@ -48,9 +48,9 @@ pub enum Error {
     /// Failed to start vhost-vsock driver.
     VhostVsockStart(vhost_backend::Error),
     /// Failed to create vhost eventfd.
-    VhostIrqCreate(SysError),
+    VhostIrqCreate(io::Error),
     /// Failed to read vhost eventfd.
-    VhostIrqRead(SysError),
+    VhostIrqRead(io::Error),
 }
 type Result<T> = std::result::Result<T, Error>;
 const INTERRUPT_STATUS_USED_RING: u32 = 0x1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,19 +147,15 @@ fn main() {
     ) {
         Ok(_) => (),
         Err(Error::Io(inner)) => match inner.kind() {
-            ErrorKind::AddrInUse => panic!(
-                "Failed to open the API socket: IO Error: {:?}",
-                Error::Io(inner)
-            ),
+            ErrorKind::AddrInUse => panic!("Failed to open the API socket: {:?}", Error::Io(inner)),
             _ => panic!(
-                "Failed to communicate with the API socket: IO Error: {:?}",
+                "Failed to communicate with the API socket: {:?}",
                 Error::Io(inner)
             ),
         },
-        Err(Error::Eventfd(inner)) => panic!(
-            "Failed to open the API socket: EventFd Error: {:?}",
-            Error::Eventfd(inner)
-        ),
+        Err(eventfd_err @ Error::Eventfd(_)) => {
+            panic!("Failed to open the API socket: {:?}", eventfd_err)
+        }
     }
 }
 

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -17,7 +17,7 @@ pub enum Error {
     /// Cannot add legacy device to Bus.
     BusError(devices::BusError),
     /// Cannot create EventFd.
-    EventFd(sys_util::Error),
+    EventFd(io::Error),
     /// Cannot set mode for terminal.
     StdinHandle(sys_util::Error),
 }
@@ -122,8 +122,8 @@ mod tests {
     #[test]
     fn test_debug_error() {
         assert_eq!(
-            format!("{:?}", Error::EventFd(sys_util::Error::new(0))),
-            "EventFd(Error(0))"
+            format!("{:?}", Error::EventFd(io::Error::from_raw_os_error(0))),
+            format!("EventFd({:?})", io::Error::from_raw_os_error(0))
         );
         assert_eq!(
             format!("{:?}", Error::StdinHandle(sys_util::Error::new(1))),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -118,7 +118,7 @@ enum Error {
     /// An operation on the epoll instance failed due to resource exhaustion or bad configuration.
     EpollFd(io::Error),
     /// Cannot read from an Event file descriptor.
-    EventFd(sys_util::Error),
+    EventFd(std::io::Error),
     /// Describes a logical problem.
     GeneralFailure, // TODO: there are some cases in which this error should be replaced.
     /// Cannot open /dev/kvm. Either the host does not have KVM or Firecracker does not have


### PR DESCRIPTION
Description of changes:

- Removes the usage of `sys_util::Error` in `EventFd`, in the spirit of #858 . Originally part of #863, but split off to expedite merging and to keep work in scope, as recommended in https://github.com/firecracker-microvm/firecracker/pull/863#pullrequestreview-195704361
- Added Debug and Display implementations for api_server errors
- Fixed error output/panics in main as well