### PR TITLE
virtio-blk flush and bound checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added missing `vmm_version` field to the InstanceInfo API swagger
   definition, and marked several other mandatory fields as such.
 
+### Fixed
+- virtio-blk: VIRTIO_BLK_T_FLUSH now working as expected.
+
 ## [0.14.0]
 
 ### Added

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -70,4 +70,5 @@ pub enum Error {
         device: &'static str,
         event: DeviceEventT,
     },
+    IoError(io::Error),
 }


### PR DESCRIPTION
Issue #, if available: #857 and (partly) #865.

Description of changes:
- Fixed virtio-blk flush request handling: now, our device advertises flush functionality and handles flush requests correctly (i.e. the requests may or may not contain a data buffer).
- Fixed a couple of possible bound check problems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
