### PR TITLE
api: tighten swagger definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Added missing `vmm_version` field to the InstanceInfo API swagger
+  definition, and marked several other mandatory fields as such.
+
 ## [0.14.0]
 
 ### Added
@@ -10,12 +17,14 @@
 - Limit the maximum supported vCPUs to 32.
 
 ### Changed
+
 - Log the app version when the `Logger` is initialized.
 - Pretty print panic information.
 - Firecracker terminates with exit code 148 when a non-whitelisted syscall
   is intercepted.
 
 ### Fixed
+
 - Fixed build with the `vsock` feature.
 
 ## [0.13.0]

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -351,19 +351,24 @@ definitions:
         $ref: "#/definitions/RateLimiter"
 
   Error:
+    type: object
     properties:
       fault_message:
         type: string
         description: A description of the error condition
+        readOnly: true
 
   InstanceActionInfo:
     type: object
     description:
       Variant wrapper containing the real action.
+    required:
+      - action_type
     properties:
       action_type:
         description: Enumeration indicating what type of action is contained in the payload
         type: string
+        readOnly: true
         enum:
         - BlockDeviceRescan
         - FlushMetrics
@@ -372,21 +377,34 @@ definitions:
         type: string
 
   InstanceInfo:
+    type: object
+    description:
+      Describes MicroVM instance information.
+    required:
+      - id
+      - state
+      - vmm_version
     properties:
       id:
         description: MicroVM / instance ID.
         type: string
+        readOnly: true
       state:
         description:
           The current detailed state of the Firecracker instance.
           This value is read-only for the control-plane.
         type: string
+        readOnly: true
         enum:
           - Uninitialized
           - Starting
           - Running
           - Halting
           - Halted
+      vmm_version:
+        description: MicroVM hypervisor build version.
+        type: string
+        readOnly: true
 
   Logger:
     type: object
@@ -448,6 +466,7 @@ definitions:
       Defines a network interface.
     required:
       - iface_id
+      - host_dev_name
     properties:
       iface_id:
         type: string
@@ -505,6 +524,9 @@ definitions:
       Consumption from the token bucket is unbounded in speed which allows for bursts
       bound in size by the amount of tokens available.
       Once the token bucket is empty, consumption speed is bound by the refill_rate.
+    required:
+      - size
+      - refill_time
     properties:
       size:
         type: integer


### PR DESCRIPTION
Tighten the API definition to better match the implementation:
- explicitly specify required fields
- explicitly specify read-only fields
- add missing `vmm_version` field in the API definition

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
