### PR TITLE
Release automation with devtool

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,6 @@
+Alexandra Iordache <aghecen@amazon.com> Alexandra Ghecenco <aghecen@amazon.com>
 Alexandru Branciog <branciog@amazon.com> <31914537+alexbranciog@users.noreply.github.com>
 Bogdan Ionita <bci@amazon.com> <bci@u249973545f4b59.ant.amazon.com>
+Marc Brooker <mbrooker@amazon.com> <marcbrooker@users.noreply.github.com>
 Radu Weiss <raduweis@amazon.com> <31901393+raduweiss@users.noreply.github.com>
 Rolf Neugebauer <neugebar@amazon.com> <rn@rneugeba.io>

--- a/tools/devtool
+++ b/tools/devtool
@@ -265,6 +265,20 @@ get_user_confirmation() {
     return 1
 }
 
+# Validate the user supplied version number.
+# It must be composed of 3 groups of integers separated by dot.
+#
+validate_version() {
+    declare version_regex="^([0-9]+.){2}[0-9]+$"
+    version="$1"
+
+    if [ -z "$version" ]; then
+        die "Version cannot be empty."
+    elif [[ ! "$version" =~ $version_regex ]]; then
+        die "Invalid version number: $version (expected: \$Major.\$Minor.\$Build).".
+    fi
+}
+
 # Helper function to run the dev container.
 # Usage: run_devctr <docker args> -- <container args>
 # Example: run_devctr --privileged -- bash -c "echo 'hello world'"
@@ -335,6 +349,10 @@ cmd_help() {
     echo ""
     echo "    help"
     echo "        Display this help message."
+    echo ""
+    echo "    prepare_release <version>"
+    echo "        Prepare a new Firecracker release by updating the version number, crate "
+    echo "        dependencies and credits."
     echo ""
     echo "    shell [--privileged]"
     echo "        Launch the development container and open an interactive BASH shell."
@@ -547,6 +565,57 @@ cmd_fmt() {
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
         cargo fmt --all
+}
+
+
+# Prepare a Firecracker release by updating the version, crate dependencies
+# and credits.
+# Example: `devtool release 0.42.0`
+#
+cmd_prepare_release() {
+
+    # Parse any command line args.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "-h"|"--help")      { cmd_help; exit 1;    } ;;
+            *)                  { version="$1"; break; } ;;
+        esac
+        shift
+    done
+
+    validate_version "$version"
+
+    # Get current version from the swagger spec.
+    swagger="$FC_ROOT_DIR/api_server/swagger/firecracker.yaml"
+    curr_ver=$(grep "version: " "$swagger" | awk -F : '{print $2}' | tr -d ' ')
+
+    say "Updating from $curr_ver to $version ..."
+    get_user_confirmation || die "Aborted."
+
+    # Update version in files.
+    files_to_change=("$swagger"                         \
+                     "$FC_ROOT_DIR/Cargo.toml"          \
+                     "$FC_ROOT_DIR/jailer/Cargo.toml")
+    for file in "${files_to_change[@]}"; do
+        sed -i "s/$curr_ver/$version/g" "$file"
+    done
+    say "Updated version number in source files."
+
+    # Update crate dependencies.
+    run_devctr \
+        --user "$(id -u):$(id -g)" \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        -- \
+        cargo update
+    say "Updated crate dependencies."
+
+    # Update credits.
+    . "$FC_TOOLS_DIR/update-credits.sh"
+    say "Updated credits."
+
+    # Update changelog.
+    sed -i "s/\[Unreleased\]/\[$version\]/g" "$FC_ROOT_DIR/CHANGELOG.md"
+    say "Updated changelog."
 }
 
 


### PR DESCRIPTION
Issue #, if available: #821 

Description of changes: added a `devtool` command that changes the version number, updates cargo dependencies,  the list of contributors and the changelog. Added 2 more name/email deduplications for the credits list.

Testing done:

```bash
tools/devtool release 0.14.1
[Firecracker devtool] Updating from 0.14.0 to 0.14.1 ...
[Firecracker devtool] Continue? (y/n) y
[Firecracker devtool] Updated version number in source files.
    Updating crates.io index
...
```

```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 4e719bf..4f4de06 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.14.1]
 
 ### Changed
 
diff --git a/CREDITS.md b/CREDITS.md
index eadb113..e981e65 100644
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -42,11 +42,14 @@ Contributors to the Firecracker repository:
 * german gomez <germangb42@gmail.com>
 * Greg Dunn <gregdunn@amazon.com>
 * Henri Yandell <hyandell@users.noreply.github.com>
+* Iggy Jackson <iggy@theiggy.com>
 * James Turnbull <james@lovedthanlost.net>
 * Josh Abraham <sinisterpatrician@gmail.com>
+* Julian Stecklina <jsteckli@amazon.de>
 * Liu Jiang <gerry@linux.alibaba.com>
 * Liu Jiang <liu.jiang@alibaba-inc.com>
 * Lloyd <lloydmeta@gmail.com>
+* lloydmeta <lloydmeta@gmail.com>
 * maciejhirsz <maciej.hirsz@gmail.com>
 * Marc Brooker <mbrooker@amazon.com>
 * Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
@@ -58,6 +61,7 @@ Contributors to the Firecracker repository:
 * Radu Matei Lăcraru <ral@amazon.com>
 * Radu Weiss <raduweis@amazon.com>
 * Ram Sripracha <ramsri@amazon.com>
+* Rob Devereux <robdevereux92@gmail.com>
 * Robert Grimes <rmzgrimes@gmail.com>
 * Rolf Neugebauer <neugebar@amazon.com>
 * Sam Jackson <sam@clique.app>
diff --git a/Cargo.lock b/Cargo.lock
index 7f6fb2a..ced0d5b 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,10 +44,10 @@ dependencies = [
  "arch_gen 0.1.0",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm 0.1.0",
- "kvm-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
...
diff --git a/Cargo.toml b/Cargo.toml
index cfbe4f5..cf4fd64 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
diff --git a/api_server/swagger/firecracker.yaml b/api_server/swagger/firecracker.yaml
index b8dcda9..e265870 100644
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -4,7 +4,7 @@ info:
   description: RESTful public-facing API.
                The API is accessible through HTTP calls on specific URLs carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.14.0
+  version: 0.14.1
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"
diff --git a/jailer/Cargo.toml b/jailer/Cargo.toml
index 27aa49b..b8c7277 100644
--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
