### PR TITLE
[RFC] Adaptive coverage threshold based on assisted dilligence

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,8 +19,8 @@ import pytest
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 
-COVERAGE_TARGET_PCT = 81.0
-# TODO: Put the coverage in s3 and update it automatically.
+COVERAGE_TARGET_PCT = 82.0
+COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')
 
@@ -73,4 +73,19 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
     with open(coverage_file) as cov_output:
         coverage = float(re.findall(KCOV_COVERAGE_REGEX, cov_output.read())[0])
     print("Coverage is: " + str(coverage))
-    assert coverage >= COVERAGE_TARGET_PCT
+
+    coverage_low_msg = (
+        'Current code coverage is below the target of {}%'
+        .format(COVERAGE_TARGET_PCT)
+    )
+
+    assert coverage >= COVERAGE_TARGET_PCT, coverage_low_msg
+
+    coverage_high_msg = (
+        'Please update the value of COVERAGE_TARGET_PCT '
+        'in test_coverage.py such that current_coverage - '
+        'COVERAGE_TARGET_PCT <= {}'.format(COVERAGE_MAX_DELTA)
+    )
+
+    assert coverage - COVERAGE_TARGET_PCT <= COVERAGE_MAX_DELTA,\
+        coverage_high_msg


### PR DESCRIPTION
This PR resolves #829 by more or less forcing future PR authors to both avoid decreasing overall code coverage, and to update `COVERAGE_TARGET_PCT` in `test_coverage.py` so the target percentage closely follows the currently achieved percentage.

Using this approach, we get the adaptive coverage threshold behavior with each PR by default, without having to build more tooling.

The downside is that submitting successful PRs becomes a bit more awkward, but hopefully this won't be such a big issue once people become accustomed to it (and the test failure message is pretty clear about what needs to be done) :D

Thoughts?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
