### PR TITLE
devtool: add command to create release tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   `net.tx_spoofed_mac_count`.
 - New API call: `PATCH /network-interfaces/`, used to update the rate limiters
   on a network interface, after the start of a microVM.
+- New `devtool` command: `prepare_release`. This updates the Firecracker
+  version, crate dependencies and credits in preparation for a new release.
+- New `devtool` command: `tag`. This creates a new git tag for the specified
+  release number, based on the changelog contents.
 
 ### Changed
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -275,8 +275,40 @@ validate_version() {
     if [ -z "$version" ]; then
         die "Version cannot be empty."
     elif [[ ! "$version" =~ $version_regex ]]; then
-        die "Invalid version number: $version (expected: \$Major.\$Minor.\$Build).".
+        die "Invalid version number: $version (expected: \$Major.\$Minor.\$Build)."
     fi
+
+}
+
+# Compose the text for a new release tag using the information in the changelog,
+# between the two specified releases.
+# The following transformations are applied:
+# * `-` is replaced with `*` for unnumbered lists.
+# * section headers (`###`) are removed.
+#
+# Args:
+#   $1  previous version.
+#   $2  new version.
+#
+compose_tag_text() {
+    declare prev_ver="$1"
+    declare curr_ver="$2"
+    declare changelog="$FC_ROOT_DIR/CHANGELOG.md"
+
+    validate_version "$prev_ver"
+    validate_version "$curr_ver"
+
+    # Patterns for the sections in the changelog corresponding to the versions.
+    pat_prev="^##\s\[$prev_ver\]"
+    pat_curr="^##\s\[$curr_ver\]"
+
+    # Extract the section enclosed between the 2 headers and strip off the first
+    # 2 and last 2 lines (one is blank and one contains the header `## [A.B.C]`).
+    # Then, replace `-` with `*` and remove section headers.
+    sed "/$pat_curr/,/$pat_prev/!d" "$changelog" \
+      | sed '1,2d;$d' \
+      | sed "s/^-/*/g" \
+      | sed "s/^###\s//g"
 }
 
 # Helper function to run the dev container.
@@ -359,6 +391,11 @@ cmd_help() {
     echo "        -p, --privileged    Run the container as root, in privileged mode."
     echo "                            Running Firecracker via the jailer requires elevated"
     echo "                            privileges, though the build phase does not."
+    echo ""
+    echo "    tag <version>"
+    echo "        Create a git tag for the specified version. The tag message will contain "
+    echo "        the contents of CHANGELOG.md enclosed between the header corresponding to "
+    echo "        the specified version and the one corresponding to the previous version."
     echo ""
     echo "    test [-- [<pytest args>]]"
     echo "        Run the Firecracker integration tests."
@@ -629,6 +666,70 @@ cmd_prepare_release() {
     rm -f "$FC_ROOT_DIR/CHANGELOG.md="
 }
 
+# Create a tag for the specified release.
+# The tag text will be composed from the changelog contents enclosed between the
+# specified release number and the previous one.
+# Args:
+#   $1  release number.
+# Example: `devtool tag 0.42.0`
+#
+cmd_tag() {
+
+    # Parse any command line args.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "-h"|"--help")      { cmd_help; exit 1;    } ;;
+            *)                  { version="$1"; break; } ;;
+        esac
+        shift
+    done
+
+    validate_version "$version"
+
+    declare pat_release="^## \[([0-9]+\.){2}[0-9]+\]"
+    declare changelog="$FC_ROOT_DIR/CHANGELOG.md"
+
+    grep -q "\[$version\]" "$changelog"
+    ok_or_die "No changelog entry for release $version can be found."
+
+    # We work with the assumption that the changelog has already been updated
+    # and contains a header (and a corresponding section) for the new release.
+
+    # Step 1: Get all release numbers.
+    all_releases=($(grep -E "$pat_release" "$changelog"))
+
+    # Step 2: Trim out headers (`##`).
+    all_releases=(${all_releases[@]//##*})
+
+    # Step 3: Walk the array until we come across the desired release number,
+    # then pick up the next one. Since the latest releases are at the top of the
+    # changelog, the next one in line will be the previous one chronologically.
+    # The array now contains all the release numbers in the changelog, enclosed
+    # in square brackets.
+    found=
+    for release in "${all_releases[@]}"; do
+        if [ ! -z "$found" ]; then
+            # Trim out square brackets.
+            prev_version=$(echo "$release" | awk -F"[][]" "{print \$2}")
+            break
+        elif [ "$release" == "[$version]" ]; then
+            found=1
+        fi
+    done
+
+    # Create tag.
+    tag_text=$(compose_tag_text "$prev_version" "$version")
+    say "Preparing to create tag..."
+    say "Tag: v$version"
+    say "Tag text:"
+    echo "$tag_text"
+    say "Continue with tag creation?"
+    get_user_confirmation || die "Tag not created."
+
+    git tag -a "v$version" -m "$tag_text"
+    ok_or_die "Tag v$version not created."
+    say "Tag v$version created."
+}
 
 main() {
 


### PR DESCRIPTION
Issue #, if available: #901 

Description of changes: Added a `devtool tag $release` command that takes the text from `CHANGELOG.md` between the specified version and the previous one, removes header markers (`#`) and replaces `-` with `*` and uses it as the tag message for a new release tag.

Testing done:

```bash
tools/devtool tag asdf
[Firecracker devtool] Invalid version number: asdf (expected: $Major.$Minor.$Build).
tools/devtool tag 1.2.3
[Firecracker devtool] No changelog entry for release 1.2.3 can be found.
tools/devtool tag 0.14.0
[Firecracker devtool] Preparing to create tag...
[Firecracker devtool] Tag: v0.14.0
[Firecracker devtool] Tag text:
Added

* Documentation for development environment setup on AWS in
  `dev-machine-setup.md`.
* Documentation for microVM networking setup in `docs/network-setup.md`.
* Limit the maximum supported vCPUs to 32.

Changed

* Log the app version when the `Logger` is initialized.
* Pretty print panic information.
* Firecracker terminates with exit code 148 when a non-whitelisted syscall
  is intercepted.

Fixed

* Fixed build with the `vsock` feature.
[Firecracker devtool] Continue with tag creation?
[Firecracker devtool] Continue? (y/n) y
fatal: tag 'v0.14.0' already exists
[Firecracker devtool] Tag v0.14.0 not created.
```

```bash
sed -i 's/Unreleased/0.14.1/' CHANGELOG.md 

tools/devtool tag 0.14.1
[Firecracker devtool] Preparing to create tag...
[Firecracker devtool] Tag: v0.14.1
[Firecracker devtool] Tag text:
Changed

* Added missing `vmm_version` field to the InstanceInfo API swagger
  definition, and marked several other mandatory fields as such.
[Firecracker devtool] Continue with tag creation?
[Firecracker devtool] Continue? (y/n) y
[Firecracker devtool] Tag v0.14.1 created.
git show v0.14.1
tag v0.14.1
Tagger: Alexandra Iordache <aghecen@amazon.com>
Date:   Wed Jan 30 14:58:53 2019 +0200

Changed

* Added missing `vmm_version` field to the InstanceInfo API swagger
  definition, and marked several other mandatory fields as such.

commit 7fb867b14e912a67aab599cec067707ebcb7141c
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
