### PR TITLE
RFC: Add VM address space abstraction to memory_model

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -3,15 +3,15 @@
 
 pub mod layout;
 
-use memory_model::{AddressRegion, AddressRegionType, GuestAddress, GuestMemory};
+use memory_model::{AddressSpace, GuestAddress, GuestMemory};
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn arch_memory_regions(size: usize) -> Vec<AddressRegion> {
-    vec![AddressRegion::new(
-        AddressRegionType::DefaultMemory,
-        GuestAddress(0),
-        size,
-    )]
+pub fn create_address_space(size: usize) -> Result<AddressSpace, super::Error> {
+    let address_space = AddressSpace::with_capacity(1);
+    address_space
+        .add_default_memory(GuestAddress(0), size)
+        .map_err(|_| super::Error::ZeroPagePastRamEnd)?;
+    Ok(address_space)
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -3,11 +3,15 @@
 
 pub mod layout;
 
-use memory_model::{GuestAddress, GuestMemory};
+use memory_model::{AddressRegion, AddressRegionType, GuestAddress, GuestMemory};
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
-    vec![(GuestAddress(0), size)]
+pub fn arch_memory_regions(size: usize) -> Vec<AddressRegion> {
+    vec![AddressRegion::new(
+        AddressRegionType::DefaultMemory,
+        GuestAddress(0),
+        size,
+    )]
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -31,7 +31,7 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    arch_memory_regions, configure_system, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE,
+    configure_system, create_address_space, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE,
     layout::CMDLINE_START,
 };
 
@@ -40,6 +40,6 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, get_32bit_gap_start as get_reserved_mem_addr,
+    configure_system, create_address_space, get_32bit_gap_start as get_reserved_mem_addr,
     layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
 };

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -97,6 +97,11 @@ pub fn create_address_space(size: usize) -> Result<AddressSpace, Error> {
         )?;
     }
 
+    // Add address region for MMIO
+    address_space
+        .add_device_memory(memory_gap_start, memory_gap_end.offset_from(memory_gap_start))
+        .map_err(|_| Error::AddressSpaceSetup)?;
+
     Ok(address_space)
 }
 
@@ -192,7 +197,7 @@ mod tests {
     #[test]
     fn regions_lt_4gb() {
         let space = create_address_space(1usize << 29).unwrap();
-        assert_eq!(3, space.len());
+        assert_eq!(4, space.len());
 
         let region = space.get_region(0).unwrap();
         assert_eq!(GuestAddress(0), region.get_base());
@@ -206,7 +211,7 @@ mod tests {
     #[test]
     fn regions_gt_4gb() {
         let space = create_address_space((1usize << 32) + 0x8000).unwrap();
-        assert_eq!(4, space.len());
+        assert_eq!(5, space.len());
 
         let region = space.get_region(0).unwrap();
         assert_eq!(GuestAddress(0), region.get_base());

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -13,8 +13,9 @@ pub mod regs;
 
 use std::mem;
 
+use super::HIMEM_START;
 use arch_gen::x86::bootparam::{boot_params, E820_RAM};
-use memory_model::{AddressSpace, GuestAddress, GuestMemory};
+use memory_model::{AddressRegionType, AddressSpace, GuestAddress, GuestMemory};
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -33,7 +34,7 @@ impl From<Error> for super::Error {
 }
 
 // Where BIOS/VGA magic would live on a real PC.
-const EBDA_START: u64 = 0x9fc00;
+const EBDA_START: usize = 0x9fc00;
 const FIRST_ADDR_PAST_32BITS: usize = (1 << 32);
 const MEM_32BIT_GAP_SIZE: usize = (768 << 20);
 
@@ -45,25 +46,55 @@ pub fn create_address_space(size: usize) -> Result<AddressSpace, Error> {
     let memory_gap_start = GuestAddress(FIRST_ADDR_PAST_32BITS - MEM_32BIT_GAP_SIZE);
     let memory_gap_end = GuestAddress(FIRST_ADDR_PAST_32BITS);
     let requested_memory_size = GuestAddress(size);
-    let mut address_space = AddressSpace::with_capacity(1);
+    let mut address_space = AddressSpace::with_capacity(10);
+
+    fn add_memory(
+        address_space: &mut AddressSpace,
+        base: GuestAddress,
+        size: usize,
+    ) -> Result<usize, Error> {
+        address_space
+            .add_default_memory(base, size)
+            .map_err(|_| Error::AddressSpaceSetup)
+    };
+
+    // Guest memory is too small even no space for guest kernel
+    if requested_memory_size <= GuestAddress(HIMEM_START) {
+        return Err(Error::AddressSpaceSetup);
+    }
+
+    // Map memory below guest kernel, normal for boot info and BIOS
+    add_memory(&mut address_space, GuestAddress(0), EBDA_START)?;
+    address_space
+        .add_region(
+            AddressRegionType::BiosMemory,
+            GuestAddress(EBDA_START),
+            HIMEM_START - EBDA_START,
+            None,
+            0,
+        )
+        .map_err(|_| Error::AddressSpaceSetup)?;
 
     // case1: guest memory fits before the gap
     if requested_memory_size <= memory_gap_start {
-        address_space
-            .add_default_memory(GuestAddress(0), size)
-            .map_err(|_| Error::AddressSpaceSetup)?;
+        add_memory(
+            &mut address_space,
+            GuestAddress(HIMEM_START),
+            size - HIMEM_START,
+        )?;
     // case2: guest memory extends beyond the gap
     } else {
         // push memory before the gap
-        address_space
-            .add_default_memory(GuestAddress(0), memory_gap_start.offset())
-            .map_err(|_| Error::AddressSpaceSetup)?;
-        address_space
-            .add_default_memory(
-                memory_gap_end,
-                requested_memory_size.offset_from(memory_gap_start),
-            )
-            .map_err(|_| Error::AddressSpaceSetup)?;
+        add_memory(
+            &mut address_space,
+            GuestAddress(HIMEM_START),
+            memory_gap_start.offset() - HIMEM_START,
+        )?;
+        add_memory(
+            &mut address_space,
+            memory_gap_end,
+            requested_memory_size.offset_from(memory_gap_start),
+        )?;
     }
 
     Ok(address_space)
@@ -78,12 +109,13 @@ pub fn get_32bit_gap_start() -> usize {
 ///
 /// # Arguments
 ///
-/// * `guest_mem` - The memory to be used by the guest.
+/// * `boot_mem` - The memory used to boot the guest.
 /// * `cmdline_addr` - Address in `guest_mem` where the kernel command line was loaded.
 /// * `cmdline_size` - Size of the kernel command line in bytes including the null terminator.
 /// * `num_cpus` - Number of virtual CPUs the guest will have.
 pub fn configure_system(
-    guest_mem: &GuestMemory,
+    address_space: &AddressSpace,
+    boot_mem: &GuestMemory,
     cmdline_addr: GuestAddress,
     cmdline_size: usize,
     num_cpus: u8,
@@ -92,13 +124,9 @@ pub fn configure_system(
     const KERNEL_HDR_MAGIC: u32 = 0x53726448;
     const KERNEL_LOADER_OTHER: u8 = 0xff;
     const KERNEL_MIN_ALIGNMENT_BYTES: u32 = 0x1000000; // Must be non-zero.
-    let first_addr_past_32bits = GuestAddress(FIRST_ADDR_PAST_32BITS);
-    let end_32bit_gap_start = GuestAddress(get_32bit_gap_start());
-
-    let himem_start = GuestAddress(super::HIMEM_START);
 
     // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
+    mptable::setup_mptable(boot_mem, num_cpus).map_err(Error::MpTableSetup)?;
 
     let mut params: boot_params = Default::default();
 
@@ -109,38 +137,26 @@ pub fn configure_system(
     params.hdr.cmdline_size = cmdline_size as u32;
     params.hdr.kernel_alignment = KERNEL_MIN_ALIGNMENT_BYTES;
 
-    add_e820_entry(&mut params, 0, EBDA_START, E820_RAM)?;
-
-    let mem_end = guest_mem.end_addr();
-    if mem_end < end_32bit_gap_start {
-        add_e820_entry(
-            &mut params,
-            himem_start.offset() as u64,
-            mem_end.offset_from(himem_start) as u64,
-            E820_RAM,
-        )?;
-    } else {
-        add_e820_entry(
-            &mut params,
-            himem_start.offset() as u64,
-            end_32bit_gap_start.offset_from(himem_start) as u64,
-            E820_RAM,
-        )?;
-        if mem_end > first_addr_past_32bits {
-            add_e820_entry(
-                &mut params,
-                first_addr_past_32bits.offset() as u64,
-                mem_end.offset_from(first_addr_past_32bits) as u64,
-                E820_RAM,
-            )?;
-        }
-    }
+    address_space
+        .with_regions(|region| {
+            let ty = region.get_type();
+            if ty == AddressRegionType::DefaultMemory {
+                add_e820_entry(
+                    &mut params,
+                    region.get_base().offset() as u64,
+                    region.get_size() as u64,
+                    E820_RAM,
+                )?;
+            }
+            Ok(())
+        })
+        .map_err(|e: Error| e)?;
 
     let zero_page_addr = GuestAddress(layout::ZERO_PAGE_START);
-    guest_mem
+    boot_mem
         .checked_offset(zero_page_addr, mem::size_of::<boot_params>())
         .ok_or(super::Error::ZeroPagePastRamEnd)?;
-    guest_mem
+    boot_mem
         .write_obj_at_addr(params, zero_page_addr)
         .map_err(|_| super::Error::ZeroPageSetup)?;
 
@@ -176,21 +192,25 @@ mod tests {
     #[test]
     fn regions_lt_4gb() {
         let space = create_address_space(1usize << 29).unwrap();
-        assert_eq!(1, space.len());
+        assert_eq!(3, space.len());
 
         let region = space.get_region(0).unwrap();
         assert_eq!(GuestAddress(0), region.get_base());
-        assert_eq!(1usize << 29, region.get_size());
+        assert_eq!(EBDA_START, region.get_size());
+
+        let region = space.get_region(2).unwrap();
+        assert_eq!(GuestAddress(HIMEM_START), region.get_base());
+        assert_eq!((1usize << 29) - HIMEM_START, region.get_size());
     }
 
     #[test]
     fn regions_gt_4gb() {
         let space = create_address_space((1usize << 32) + 0x8000).unwrap();
-        assert_eq!(2, space.len());
+        assert_eq!(4, space.len());
 
         let region = space.get_region(0).unwrap();
         assert_eq!(GuestAddress(0), region.get_base());
-        let region = space.get_region(1).unwrap();
+        let region = space.get_region(3).unwrap();
         assert_eq!(GuestAddress(1usize << 32), region.get_base());
     }
 
@@ -205,8 +225,25 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm = GuestMemory::new(&vec![(GuestAddress(0), 0x10000)]).unwrap();
-        let config_err = configure_system(&gm, GuestAddress(0), 0, 1);
+        let mem_types = [
+            AddressRegionType::DefaultMemory,
+            AddressRegionType::BiosMemory,
+        ];
+
+        // Too less memory
+        let mem_size = HIMEM_START;
+        match create_address_space(mem_size) {
+            Err(Error::AddressSpaceSetup) => {}
+            _ => panic!("should fail!"),
+        }
+
+        // Missing the BIOS memory area
+        let mem_size = 128 << 20;
+        let space = create_address_space(mem_size).unwrap();
+        let gm = space
+            .map_guest_memory(&[AddressRegionType::DefaultMemory])
+            .unwrap();
+        let config_err = configure_system(&space, &gm, GuestAddress(0), 0, 1);
         assert!(config_err.is_err());
         assert_eq!(
             config_err.unwrap_err(),
@@ -215,29 +252,36 @@ mod tests {
             ))
         );
 
-        // Now assigning some memory that falls before the 32bit memory hole.
+        // Only the BIOS memory area
         let mem_size = 128 << 20;
         let space = create_address_space(mem_size).unwrap();
         let gm = space
-            .map_guest_memory(&[AddressRegionType::DefaultMemory])
+            .map_guest_memory(&[AddressRegionType::BiosMemory])
             .unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
+        let config_err = configure_system(&space, &gm, GuestAddress(0), 0, 1);
+        assert!(config_err.is_err());
+        assert_eq!(
+            config_err.unwrap_err(),
+            super::super::Error::ZeroPagePastRamEnd
+        );
+
+        // Now assigning some memory that falls before the 32bit memory hole.
+        let mem_size = 128 << 20;
+        let space = create_address_space(mem_size).unwrap();
+        let gm = space.map_guest_memory(&mem_types).unwrap();
+        configure_system(&space, &gm, GuestAddress(0), 0, no_vcpus).unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let space = create_address_space(mem_size).unwrap();
-        let gm = space
-            .map_guest_memory(&[AddressRegionType::DefaultMemory])
-            .unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
+        let gm = space.map_guest_memory(&mem_types).unwrap();
+        configure_system(&space, &gm, GuestAddress(0), 0, no_vcpus).unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let space = create_address_space(mem_size).unwrap();
-        let gm = space
-            .map_guest_memory(&[AddressRegionType::DefaultMemory])
-            .unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
+        let gm = space.map_guest_memory(&mem_types).unwrap();
+        configure_system(&space, &gm, GuestAddress(0), 0, no_vcpus).unwrap();
     }
 
     #[test]

--- a/memory_model/src/address_space.rs
+++ b/memory_model/src/address_space.rs
@@ -1,0 +1,499 @@
+// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Represent the physical address space of a virtual machine, which is composed
+//! by address ranges for memory and memory-mapped IO areas.
+
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::{Arc, Mutex};
+
+use guest_address::GuestAddress;
+use guest_memory::{Error, GuestMemory, MemoryRegion};
+use mmap::MemoryMapping;
+
+/// Type of address regions.
+/// On physical machines, physical memory may have different properties, such as
+/// volatile vs non-volatile, read-only vs read-write, non-executable vs
+/// executable etc. On virtual machines, the concept of memory property may be
+/// extended to support better cooperation between the hypervisor and the guest
+/// kernel. Here type means what the memory will be used for by the guest, and
+/// different permissions and policies may be applied to different region types.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum AddressRegionType {
+    /// Normal memory accessible by CPUs and IO devices
+    DefaultMemory,
+    /// Memory accessible by CPUs only
+    HighMemory,
+    /// Memory for IO/DMA buffers
+    IoBufferMemory,
+    /// Device MMIO address
+    DeviceMemory,
+    /// Memory for guest boot info, requiring system permission
+    BootInfo,
+    /// Memory for guest kernel code, requiring system permission
+    KernelText,
+    /// Memory for guest kernel read only data, requiring system permission
+    KernelRoData,
+    /// Memory for guest kernel data, requiring system permission
+    KernelData,
+}
+
+/// Represent a guest address region.
+pub struct AddressRegion {
+    ty: AddressRegionType,
+    base: GuestAddress,
+    size: usize,
+    fd: Option<Arc<AsRawFd>>,
+    offset: usize,
+}
+
+impl AddressRegion {
+    /// Create a memory region backed up by anonymous memory.
+    pub fn new(ty: AddressRegionType, base: GuestAddress, size: usize) -> Self {
+        AddressRegion {
+            ty,
+            base,
+            size,
+            fd: None,
+            offset: 0,
+        }
+    }
+
+    /// Create a memory region mapping content from a file descriptor.
+    pub fn from_fd(
+        ty: AddressRegionType,
+        base: GuestAddress,
+        size: usize,
+        fd: Arc<AsRawFd>,
+        offset: usize,
+    ) -> Self {
+        AddressRegion {
+            ty,
+            base,
+            size,
+            fd: Some(fd),
+            offset,
+        }
+    }
+
+    /// Get type of memory region.
+    pub fn get_type(&self) -> AddressRegionType {
+        self.ty
+    }
+
+    /// Get memory region base.
+    pub fn get_base(&self) -> GuestAddress {
+        self.base
+    }
+
+    /// Get memory region size.
+    pub fn get_size(&self) -> usize {
+        self.size
+    }
+
+    /// Get optional file descriptor backing the memory region.
+    pub fn get_fd(&self) -> Option<Arc<AsRawFd>> {
+        match self.fd {
+            Some(ref fd) => Some(fd.clone()),
+            None => None,
+        }
+    }
+
+    /// Get file offset to mmap().
+    pub fn get_offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Check whether memory region has associated file descriptor
+    pub fn has_fd(&self) -> bool {
+        self.fd.is_some()
+    }
+
+    /// Check whether memory region is valid.
+    pub fn is_valid(&self) -> bool {
+        !(self.base.checked_add(self.size).is_none() || (self.fd.is_none() && self.offset != 0))
+    }
+
+    /// Check whether intersects with another address region.
+    pub fn intersect_with(&self, other: &AddressRegion) -> bool {
+        // Treat invalid address region as intersecting always
+        let end1 = match self.base.checked_add(self.size) {
+            Some(addr) => addr,
+            None => return true,
+        };
+        let end2 = match other.base.checked_add(other.size) {
+            Some(addr) => addr,
+            None => return true,
+        };
+
+        if self.base >= other.base && self.base < end2 {
+            return true;
+        } else if end1 > other.base && end1 <= end2 {
+            return true;
+        } else if other.base >= self.base && other.base < end1 {
+            return true;
+        } else if end2 > self.base && end2 <= end1 {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl AsRawFd for AddressRegion {
+    fn as_raw_fd(&self) -> RawFd {
+        match self.fd {
+            Some(ref fd) => fd.as_raw_fd(),
+            None => panic!("memory region has no associated file descriptor!"),
+        }
+    }
+}
+
+/// Maintain address space information for a virtual machine.
+pub struct AddressSpace {
+    regions: Mutex<Vec<Arc<AddressRegion>>>,
+}
+
+impl AddressSpace {
+    /// Create an address space.
+    pub fn new(vec: Vec<Arc<AddressRegion>>) -> Self {
+        AddressSpace {
+            regions: Mutex::new(vec),
+        }
+    }
+
+    /// Create an empty address space.
+    pub fn with_capacity(size: usize) -> Self {
+        // with a default capacity enough for most cases
+        let cap = match size {
+            0 => 10,
+            _ => size,
+        };
+
+        AddressSpace {
+            regions: Mutex::new(Vec::with_capacity(cap)),
+        }
+    }
+
+    /// Create an address region mapping content from a file descriptor.
+    ///
+    /// # Arguments
+    /// * `ty` - Type of the address region
+    /// * `base` - Base address in VM to map content
+    /// * `size` - Length of content to map
+    /// * `fd` - File descriptor to map content from
+    /// * `offset` - The offset into file to start mapping
+    pub fn add_region(
+        &mut self,
+        ty: AddressRegionType,
+        base: GuestAddress,
+        size: usize,
+        fd: Option<Arc<AsRawFd>>,
+        offset: usize,
+    ) -> Result<usize, Error> {
+        let region = match fd {
+            Some(fd1) => Arc::new(AddressRegion::from_fd(ty, base, size, fd1, offset)),
+            None => Arc::new(AddressRegion::new(ty, base, size)),
+        };
+        self.insert_region(region)
+    }
+
+    /// Create an address region mapping anonymous memory.
+    ///
+    /// # Arguments
+    /// * `base` - Base address in VM to map content
+    /// * `size` - Length of content to map
+    pub fn add_default_memory(&mut self, base: GuestAddress, size: usize) -> Result<usize, Error> {
+        self.add_region(AddressRegionType::DefaultMemory, base, size, None, 0)
+    }
+
+    /// Create an address region for device MMIO.
+    ///
+    /// # Arguments
+    /// * `base` - Base address in VM to map content
+    /// * `size` - Length of content to map
+    pub fn add_device_memory(&mut self, base: GuestAddress, size: usize) -> Result<usize, Error> {
+        let region = Arc::new(AddressRegion::new(
+            AddressRegionType::DeviceMemory,
+            base,
+            size,
+        ));
+        self.insert_region(region)
+    }
+
+    /// Get number of memory regions.
+    pub fn len(&self) -> usize {
+        // Assuming the lock is healthy otherwise we are already in trouble
+        self.regions.lock().unwrap().len()
+    }
+
+    /// Get specific space region by index
+    pub fn get_region(&self, index: usize) -> Option<Arc<AddressRegion>> {
+        // Assuming the lock is healthy otherwise we are already in trouble
+        let regions = self.regions.lock().unwrap();
+        if index < regions.len() {
+            Some(regions[index].clone())
+        } else {
+            None
+        }
+    }
+
+    /// Get regions of specific type
+    pub fn get_regions_by_type(&self, ty: AddressRegionType) -> Vec<Arc<AddressRegion>> {
+        let mut vec = Vec::new();
+        let regions = self.regions.lock().unwrap();
+        for region in regions.iter() {
+            if region.get_type() == ty {
+                vec.push(region.clone());
+            }
+        }
+        vec
+    }
+
+    /// Map memory regions of specific type into current process.
+    pub fn map_guest_memory(&self, types: &[AddressRegionType]) -> Result<GuestMemory, Error> {
+        // Can't map regions of device MMIO into current process
+        if types.contains(&AddressRegionType::DeviceMemory) {
+            return Err(Error::InvalidASOperation);
+        }
+        let mut regions = Vec::<MemoryRegion>::new();
+        self.map_regions_by_types(types, &mut regions)?;
+        Ok(GuestMemory::from_regions(regions))
+    }
+
+    /// Perform the specified action on each address region.
+    pub fn with_regions<F, E>(&self, mut cb: F) -> Result<(), E>
+    where
+        F: FnMut(&AddressRegion) -> Result<(), E>,
+    {
+        // Assuming the lock is healthy otherwise we are already in trouble
+        let regions = self.regions.lock().unwrap();
+        for region in regions.iter() {
+            cb(region)?;
+        }
+        Ok(())
+    }
+
+    fn map_regions_by_types(
+        &self,
+        types: &[AddressRegionType],
+        regions: &mut Vec<MemoryRegion>,
+    ) -> Result<(), Error> {
+        // Assuming the lock is healthy otherwise we are already in trouble
+        let regs = self.regions.lock().unwrap();
+        for region in regs.iter() {
+            if types.contains(&region.ty) {
+                let mapping = match region.fd {
+                    Some(ref fd) => {
+                        MemoryMapping::from_fd_offset(&**fd, region.size, region.offset)
+                            .map_err(Error::MemoryMappingFailed)?
+                    }
+                    None => MemoryMapping::new(region.size).map_err(Error::MemoryMappingFailed)?,
+                };
+                regions.push(MemoryRegion::new(mapping, region.base));
+            }
+        }
+        Ok(())
+    }
+
+    fn insert_region(&mut self, region: Arc<AddressRegion>) -> Result<usize, Error> {
+        if !region.is_valid() {
+            return Err(Error::InvalidGuestAddressRange(
+                region.get_base(),
+                region.get_size(),
+            ));
+        }
+
+        // Assuming the lock is healthy otherwise we are already in trouble
+        let mut regions = self.regions.lock().unwrap();
+        for reg in regions.iter() {
+            if region.intersect_with(reg) {
+                return Err(Error::InvalidGuestAddressRange(
+                    region.get_base(),
+                    region.get_size(),
+                ));
+            }
+        }
+
+        regions.push(region);
+        Ok(regions.len() - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate tempfile;
+
+    use self::tempfile::tempfile;
+    use super::*;
+    use guest_address::GuestAddress;
+    use std::io::Write;
+
+    #[test]
+    fn test_memory_region_valid() {
+        let reg1 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0xFFFFFFFFFFFFF000),
+            0x2000,
+        );
+        assert!(!reg1.is_valid());
+        let reg1 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0xFFFFFFFFFFFFF000),
+            0x1000,
+        );
+        assert!(!reg1.is_valid());
+        let reg1 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0xFFFFFFFFFFFFE000),
+            0x1000,
+        );
+        assert!(reg1.is_valid());
+
+        let mut f = Arc::new(tempfile().unwrap());
+        let sample_buf = &[1, 2, 3, 4, 5];
+        assert!(Arc::get_mut(&mut f).unwrap().write_all(sample_buf).is_ok());
+        let reg2 = AddressRegion::from_fd(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x1000),
+            0x1000,
+            f.clone(),
+            0x0,
+        );
+        assert!(reg2.is_valid());
+    }
+
+    #[test]
+    fn test_memory_region_intersect() {
+        let reg1 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x1000),
+            0x1000,
+        );
+        let reg2 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x2000),
+            0x1000,
+        );
+        let reg3 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x1000),
+            0x1001,
+        );
+        let reg4 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x1100),
+            0x100,
+        );
+        let reg5 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0xFFFFFFFFFFFFF000),
+            0x2000,
+        );
+
+        assert!(!reg1.intersect_with(&reg2));
+        assert!(!reg2.intersect_with(&reg1));
+
+        // intersect with self
+        assert!(reg1.intersect_with(&reg1));
+
+        // intersect with others
+        assert!(reg3.intersect_with(&reg2));
+        assert!(reg2.intersect_with(&reg3));
+        assert!(reg1.intersect_with(&reg4));
+        assert!(reg4.intersect_with(&reg1));
+        assert!(reg1.intersect_with(&reg5));
+        assert!(reg5.intersect_with(&reg1));
+    }
+
+    #[test]
+    fn create_address_space() {
+        let mut f = Arc::new(tempfile().unwrap());
+        let sample_buf = &[1, 2, 3, 4, 5];
+        assert!(Arc::get_mut(&mut f).unwrap().write_all(sample_buf).is_ok());
+
+        let mut space = AddressSpace::with_capacity(0);
+        space
+            .add_region(
+                AddressRegionType::KernelText,
+                GuestAddress(0x100000),
+                0x1000,
+                Some(f.clone()),
+                0x0,
+            )
+            .unwrap();
+        let region = space.get_region(0).unwrap();
+        assert_eq!(region.get_fd().unwrap().as_raw_fd(), f.as_raw_fd());
+        assert_eq!(region.get_offset(), 0);
+        assert!(region.has_fd());
+
+        let regions = space.get_regions_by_type(AddressRegionType::DefaultMemory);
+        assert_eq!(regions.len(), 0);
+        let regions = space.get_regions_by_type(AddressRegionType::KernelText);
+        assert_eq!(regions.len(), 1);
+
+        space.add_default_memory(GuestAddress(0), 0x100000).unwrap();
+        assert_eq!(space.len(), 2);
+        assert!(space.get_region(2).is_none());
+        space
+            .with_regions(|region| {
+                if region.get_size() == 0x100000 {
+                    return Err(Error::InvalidASOperation);
+                }
+                Ok(())
+            })
+            .unwrap_err();
+
+        let region = space.get_region(1).unwrap();
+        assert_eq!(region.get_base().offset(), 0x0);
+        assert_eq!(region.get_size(), 0x100000);
+        assert_eq!(region.get_offset(), 0);
+        assert!(region.get_fd().is_none());
+        assert!(!region.has_fd());
+
+        let m = space.map_guest_memory(&[AddressRegionType::DeviceMemory]);
+        assert!(m.is_err());
+
+        let m = space
+            .map_guest_memory(&[
+                AddressRegionType::KernelData,
+                AddressRegionType::KernelRoData,
+            ])
+            .unwrap();
+        assert_eq!(m.num_regions(), 0);
+
+        let m = space
+            .map_guest_memory(&[AddressRegionType::KernelText])
+            .unwrap();
+        assert_eq!(m.num_regions(), 1);
+        let mut val: u8 = m.read_obj_from_addr(GuestAddress(0x100001)).unwrap();
+        assert_eq!(val, 2);
+
+        val = 0xa5;
+        m.write_obj_at_addr(val, GuestAddress(0x100001)).unwrap();
+        val = m.read_obj_from_addr(GuestAddress(0x100001)).unwrap();
+        assert_eq!(val, 0xa5);
+
+        // Update middle of mapped memory region
+        val = m.read_obj_from_addr(GuestAddress(0x100000)).unwrap();
+        assert_eq!(val, 1);
+        val = m.read_obj_from_addr(GuestAddress(0x100002)).unwrap();
+        assert_eq!(val, 3);
+        val = m.read_obj_from_addr(GuestAddress(0x100005)).unwrap();
+        assert_eq!(val, 0);
+
+        // Read ahead of mapped memory region
+        assert!(m.read_obj_from_addr::<u8>(GuestAddress(0x101000)).is_err());
+    }
+
+    #[test]
+    #[should_panic]
+    fn region_as_rawfd() {
+        let reg1 = AddressRegion::new(
+            AddressRegionType::DefaultMemory,
+            GuestAddress(0x1000),
+            0x1000,
+        );
+        let _ = reg1.as_raw_fd();
+    }
+}

--- a/memory_model/src/address_space.rs
+++ b/memory_model/src/address_space.rs
@@ -22,6 +22,8 @@ use mmap::MemoryMapping;
 pub enum AddressRegionType {
     /// Normal memory accessible by CPUs and IO devices
     DefaultMemory,
+    /// Memory reserved for BIOS/VGA
+    BiosMemory,
     /// Memory accessible by CPUs only
     HighMemory,
     /// Memory for IO/DMA buffers

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -32,6 +32,10 @@ pub enum Error {
     MemoryRegionOverlap,
     /// No memory regions were provided for initializing the guest memory.
     NoMemoryRegions,
+    /// Invalid address space region type
+    InvalidASRegionType,
+    /// Invalid operation for address space
+    InvalidASOperation,
 }
 type Result<T> = result::Result<T, Error>;
 
@@ -43,6 +47,13 @@ pub struct MemoryRegion {
 }
 
 impl MemoryRegion {
+    pub fn new(mapping: MemoryMapping, guest_base: GuestAddress) -> Self {
+        MemoryRegion {
+            mapping,
+            guest_base,
+        }
+    }
+
     pub fn size(&self) -> usize {
         self.mapping.size()
     }
@@ -89,6 +100,13 @@ impl GuestMemory {
         Ok(GuestMemory {
             regions: Arc::new(regions),
         })
+    }
+
+    /// Creates a container for guest memory regions.
+    pub fn from_regions(regions: Vec<MemoryRegion>) -> Self {
+        GuestMemory {
+            regions: Arc::new(regions),
+        }
     }
 
     /// Returns the end address of memory.

--- a/memory_model/src/lib.rs
+++ b/memory_model/src/lib.rs
@@ -51,10 +51,12 @@ data_init_type!(i32);
 data_init_type!(i64);
 data_init_type!(isize);
 
+mod address_space;
 mod guest_address;
 mod guest_memory;
 mod mmap;
 
+pub use address_space::{AddressRegion, AddressRegionType, AddressSpace};
 pub use guest_address::GuestAddress;
 pub use guest_memory::Error as GuestMemoryError;
 pub use guest_memory::GuestMemory;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -73,7 +73,7 @@ use kernel::loader as kernel_loader;
 use kvm::*;
 use logger::error::LoggerError;
 use logger::{AppInfo, Level, LogOption, Metric, LOGGER, METRICS};
-use memory_model::{GuestAddress, GuestMemory};
+use memory_model::{AddressRegionType, AddressSpace, GuestAddress, GuestMemory};
 use serde_json::Value;
 pub use sigsys_handler::setup_sigsys_handler;
 use sys_util::{register_signal_handler, EventFd, Terminal};
@@ -533,6 +533,7 @@ struct Vmm {
     shared_info: Arc<RwLock<InstanceInfo>>,
 
     // Guest VM core resources.
+    address_space: Option<AddressSpace>,
     guest_memory: Option<GuestMemory>,
     kernel_config: Option<KernelConfig>,
     vcpu_handles: Option<Vec<thread::JoinHandle<()>>>,
@@ -595,6 +596,7 @@ impl Vmm {
             kvm,
             vm_config: VmConfig::default(),
             shared_info: api_shared_info,
+            address_space: None,
             guest_memory: None,
             kernel_config: None,
             vcpu_handles: None,
@@ -828,9 +830,16 @@ impl Vmm {
                 memory_model::GuestMemoryError::MemoryNotInitialized,
             ))?
             << 20;
-        let arch_mem_regions = arch::arch_memory_regions(mem_size);
-        self.guest_memory =
-            Some(GuestMemory::new(&arch_mem_regions).map_err(StartMicrovmError::GuestMemory)?);
+
+        let address_space = arch::create_address_space(mem_size).map_err(|_| {
+            StartMicrovmError::GuestMemory(memory_model::GuestMemoryError::InvalidASOperation)
+        })?;
+        self.guest_memory = Some(
+            address_space
+                .map_guest_memory(&[AddressRegionType::DefaultMemory])
+                .map_err(|e| StartMicrovmError::GuestMemory(e))?,
+        );
+        self.address_space = Some(address_space);
         Ok(())
     }
 


### PR DESCRIPTION
Issue #, if available: #913 

Description of changes:
This is an RFC patchset to introduce an abstraction for VM address space into memory_model crate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
