### PR TITLE
Vsock tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,14 +142,15 @@ def test_images_s3_bucket():
 MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(test_images_s3_bucket())
 
 
-def init_microvm(root_path, cloner_path):
+def init_microvm(root_path, cloner_path, features=''):
     """Auxiliary function for instantiating a microvm and setting it up."""
     microvm_id = str(uuid.uuid4())
-    fc_binary, jailer_binary = build_tools.get_firecracker_binaries(root_path)
+    fc_binary, jailer_binary = build_tools.get_firecracker_binaries(root_path, features)
     vm = Microvm(
         resource_path=root_path,
         fc_binary_path=fc_binary,
         jailer_binary_path=jailer_binary,
+        build_feature=features,
         microvm_id=microvm_id,
         newpid_cloner_path=cloner_path
     )
@@ -211,15 +212,15 @@ def newpid_cloner_path(test_session_root_path):
     yield bin_path
 
 
-@pytest.fixture
-def microvm(test_session_root_path, newpid_cloner_path):
+@pytest.fixture(params=['', 'vsock'])
+def microvm(request, test_session_root_path, newpid_cloner_path):
     """Instantiate a microvm."""
     # pylint: disable=redefined-outer-name
     # The fixture pattern causes a pylint false positive for that rule.
 
     # Make sure the necessary binaries are there before instantiating the
     # microvm.
-    vm = init_microvm(test_session_root_path, newpid_cloner_path)
+    vm = init_microvm(test_session_root_path, newpid_cloner_path, features=request.param)
     yield vm
     vm.kill()
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -43,12 +43,17 @@ class Microvm:
         fc_binary_path,
         jailer_binary_path,
         microvm_id,
+        build_feature='',
         monitor_memory=True,
         newpid_cloner_path=None
     ):
         """Set up microVM attributes, paths, and data structures."""
         # Unique identifier for this machine.
         self._microvm_id = microvm_id
+
+        # This is used in tests to identify if the microvm was started
+        # using a vsock build or a default build.
+        self.build_feature = build_feature
 
         # Compose the paths to the resources specific to this microvm.
         self._path = os.path.join(resource_path, microvm_id)

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -17,11 +17,10 @@ CARGO_RELEASE_REL_PATH = os.path.join(CARGO_BUILD_REL_PATH, 'release')
 RELEASE_BINARIES_REL_PATH = 'x86_64-unknown-linux-musl/release/'
 
 
-def cargo_build(path, flags='', extra_args=''):
+def cargo_build(path, extra_args=''):
     """Trigger build depending on flags provided."""
-    cmd = 'CARGO_TARGET_DIR={} cargo build {} {}'.format(
+    cmd = 'CARGO_TARGET_DIR={} cargo build {}'.format(
         path,
-        flags,
         extra_args
     )
     run(cmd, shell=True, check=True)
@@ -54,7 +53,6 @@ def get_firecracker_binaries(root_path):
         )
         cargo_build(
             build_path,
-            flags='--release',
-            extra_args='>/dev/null 2>&1'
+            extra_args='--release >/dev/null 2>&1'
         )
     return fc_binary_path, jailer_binary_path

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -11,11 +11,26 @@ from framework.defs import FC_BINARY_NAME, JAILER_BINARY_NAME
 CARGO_BUILD_REL_PATH = 'firecracker_binaries'
 """Keep a single build path across all build tests."""
 
-CARGO_RELEASE_REL_PATH = os.path.join(CARGO_BUILD_REL_PATH, 'release')
+CARGO_RELEASE_REL_PATH = os.path.join(
+    CARGO_BUILD_REL_PATH, 'release'
+)
 """Keep a single Firecracker release binary path across all test types."""
+
+CARGO_RELEASE_VSOCK_REL_PATH = os.path.join(
+    CARGO_BUILD_REL_PATH, 'release-vsock'
+)
+"""Vsock release binaries relative path."""
 
 RELEASE_BINARIES_REL_PATH = 'x86_64-unknown-linux-musl/release/'
 
+
+class UnknownFeatureException(Exception):
+    """Exception Class for invalid build feature."""
+    def __init__(self):
+        Exception.__init__(
+            self,
+            "Trying to get build binaries for unknown feature!"
+        )
 
 def cargo_build(path, extra_args=''):
     """Trigger build depending on flags provided."""
@@ -26,16 +41,24 @@ def cargo_build(path, extra_args=''):
     run(cmd, shell=True, check=True)
 
 
-def get_firecracker_binaries(root_path):
+def get_firecracker_binaries(root_path, features=''):
     """Build the Firecracker and Jailer binaries if they don't exist.
 
     Returns the location of the firecracker related binaries eventually after
     building them in case they do not exist at the specified root_path.
     """
+
+    if features == '':
+        cargo_binaries_rel_path = CARGO_RELEASE_REL_PATH
+    elif features == 'vsock':
+        cargo_binaries_rel_path = CARGO_RELEASE_VSOCK_REL_PATH
+    else:
+        raise UnknownFeatureException
+
     path_to_binaries = os.path.join(
         root_path,
         os.path.join(
-            CARGO_RELEASE_REL_PATH,
+            cargo_binaries_rel_path,
             RELEASE_BINARIES_REL_PATH
         )
     )

--- a/tests/integration_tests/build/test_build.py
+++ b/tests/integration_tests/build/test_build.py
@@ -2,60 +2,47 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests that check if both the debug and the release builds pass."""
 
+import itertools
 import os
+import pytest
 
 import host_tools.cargo_build as host  # pylint:disable=import-error
 
+FEATURES = ["", "vsock"]
+BUILD_TYPES = ["debug", "release"]
 
-CARGO_DEBUG_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'debug')
-CARGO_DEBUG_REL_PATH_FEATURES = os.path.join(
-    host.CARGO_BUILD_REL_PATH,
-    'debug-features'
+
+@pytest.mark.parametrize(
+    "features, build_type",
+    itertools.product(FEATURES, BUILD_TYPES)
 )
-CARGO_RELEASE_REL_PATH_FEATURES = os.path.join(
-    host.CARGO_BUILD_REL_PATH,
-    'release-features'
-)
+def test_build(test_session_root_path, features, build_type):
+    """
+    Test build using a cartesian product of possible features and build
+    types.
+    """
+    extra_args = ""
 
+    if build_type == "release":
+        extra_args += "--release "
 
-def test_build_debug(test_session_root_path):
-    """Test if a debug-mode build works."""
+    # The relative path of the binaries is computed using the build_type
+    # (either release or debug) and if any features are provided also using
+    # the features names.
+    # For example, a default release build with no features will end up in
+    # the relative directory "release", but for a vsock release build the
+    # relative directory will be "release-vsock".
+    rel_path = os.path.join(
+        host.CARGO_BUILD_REL_PATH,
+        build_type
+    )
+    if features:
+        rel_path += "-{}".format(features)
+        extra_args = "--features {} ".format(features)
+
     build_path = os.path.join(
         test_session_root_path,
-        CARGO_DEBUG_REL_PATH
+        rel_path
     )
-    host.cargo_build(build_path)
 
-
-def test_build_debug_with_features(test_session_root_path):
-    """Test if a debug-mode build works for supported features."""
-    build_path = os.path.join(
-        test_session_root_path,
-        CARGO_DEBUG_REL_PATH_FEATURES
-    )
-    # Building with multiple features is as simple as:
-    # cargo build --features "feature1 feature2". We are currently
-    # supporting only one features: vsock.
-    host.cargo_build(build_path, '--features "{}"'.format('vsock'))
-
-
-def test_build_release(test_session_root_path):
-    """Test if a release-mode build works."""
-    build_path = os.path.join(
-        test_session_root_path,
-        host.CARGO_RELEASE_REL_PATH
-    )
-    host.cargo_build(build_path, '--release')
-
-
-def test_build_release_with_features(test_session_root_path):
-    """Test if a release-mode build works for supported features."""
-    build_path = os.path.join(
-        test_session_root_path,
-        CARGO_RELEASE_REL_PATH_FEATURES
-    )
-    host.cargo_build(
-        build_path,
-        '--features "{}"'.format('vsock'),
-        '--release'
-    )
+    host.cargo_build(build_path, extra_args=extra_args)

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -3,11 +3,30 @@
 """Tests that ensure the correctness of the Firecracker API."""
 
 import os
+import pytest
 
 import host_tools.drive as drive_tools
 import host_tools.logging as log_tools
 import host_tools.network as net_tools
 
+def test_dummy_test(test_microvm_with_api):
+    """Dummy test in which we check the build feature."""
+    if test_microvm_with_api.build_feature == 'vsock':
+        print("This is a microvm built with the vsock feature enabled.")
+
+def test_dummy_only_for_vsock_build(test_microvm_with_api):
+    """Dummy test that is executed only for vsock builds."""
+    if test_microvm_with_api.build_feature != 'vsock':
+        pytest.skip("This test is meant only for vsock builds")
+
+    assert test_microvm_with_api.build_feature == 'vsock'
+
+def test_dummy_only_default_build(test_microvm_with_api):
+    """Dummy test that is executed only for default builds."""
+    if test_microvm_with_api.build_feature != '':
+        pytest.skip("This test is meant only for default builds")
+
+    assert test_microvm_with_api.build_feature == ''
 
 def test_api_happy_start(test_microvm_with_api):
     """Test a regular microvm API start sequence."""


### PR DESCRIPTION
Partially addresses https://github.com/firecracker-microvm/firecracker/issues/912, but in this PR no special tests for vsock are added.

Description of changes:
CI: run integration tests with vsock binaries as well.
