### PR TITLE
Update to Rust 1.32

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v2"
+DEVCTR_IMAGE="fcuvm/dev:v3"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -10,6 +10,7 @@ use seccomp::{
 /// Taken from the musl repo (i.e arch/x86_64/bits/syscall.h).
 pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_accept,
+    libc::SYS_brk,
     libc::SYS_clock_gettime,
     libc::SYS_close,
     libc::SYS_dup,
@@ -124,6 +125,10 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
         vec![
             (
                 libc::SYS_accept,
+                (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            (
+                libc::SYS_brk,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
             ),
             (

--- a/vmm/src/sigsys_handler.rs
+++ b/vmm/src/sigsys_handler.rs
@@ -125,6 +125,7 @@ mod tests {
 
         // Syscalls that have to be allowed in order for the test to work.
         const REQUIRED_SYSCALLS: &[i64] = &[
+            libc::SYS_brk,
             libc::SYS_exit,
             libc::SYS_futex,
             libc::SYS_munmap,


### PR DESCRIPTION
Description of changes:
- Updated dev container to Rust 1.32
- Added brk() to the seccomp whitelist (needed to support Rust 1.32)

Closes #870 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
