### PR TITLE
Fix clippy warnings and errors in the codebase

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -363,7 +363,7 @@ fn parse_vsocks_req<'a>(path: &'a str, method: Method, body: &Chunk) -> Result<'
 
     match path_tokens[1..].len() {
         1 if method == Method::Put => Ok(serde_json::from_slice::<VsockDeviceConfig>(body)
-            .map_err(|e| Error::SerdeJson(e))?
+            .map_err(Error::SerdeJson)?
             .into_parsed_request(Some(id_from_path.to_string()), method)
             .map_err(|s| {
                 METRICS.put_api_requests.network_fails.inc();

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -688,7 +688,7 @@ mod tests {
                 acc.extend_from_slice(&*chunk);
                 Ok::<_, hyper::Error>(acc)
             })
-            .and_then(move |value| Ok(value));
+            .and_then(Ok);
 
         String::from_utf8_lossy(
             &ret.wait()
@@ -1365,7 +1365,7 @@ mod tests {
 
         // Test all valid requests
         // Each request type is unit tested separately
-        for path in vec![
+        for path in &[
             "/boot-source",
             "/drives",
             "/machine-config",

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -45,12 +45,12 @@ fn validate_payload(action_body: &ActionBody) -> Result<(), String> {
                     }
                     Ok(())
                 }
-                None => return Err("Payload is required for block device rescan.".to_string()),
+                None => Err("Payload is required for block device rescan.".to_string()),
             }
         }
         ActionType::FlushMetrics | ActionType::InstanceStart | ActionType::SendCtrlAltDel => {
             // Neither FlushMetrics nor InstanceStart should have a payload.
-            if !action_body.payload.is_none() {
+            if action_body.payload.is_some() {
                 return Err(format!(
                     "{:?} does not support a payload.",
                     action_body.action_type

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -257,8 +257,8 @@ mod tests {
             rate_limiter: None,
         };
         assert!(
-            &desc.into_parsed_request(Some(String::from("foo")), Method::Options)
-                == &Err(String::from("Invalid method."))
+            desc.into_parsed_request(Some(String::from("foo")), Method::Options)
+                == Err(String::from("Invalid method."))
         );
 
         // BlockDeviceConfig doesn't implement Clone so we have to define multiple identical vars.

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -86,7 +86,7 @@ impl IntoParsedRequest for PatchDrivePayload {
                 let drive_id: String = self.get_string_field_unchecked("drive_id");
                 let path_on_host: String = self.get_string_field_unchecked("path_on_host");
 
-                let id_from_path = id_from_path.unwrap_or(String::new());
+                let id_from_path = id_from_path.unwrap_or_default();
                 if id_from_path != drive_id {
                     return Err(String::from(
                         "The id from the path does not match the id from the body!",
@@ -110,7 +110,7 @@ impl IntoParsedRequest for BlockDeviceConfig {
         id_from_path: Option<String>,
         method: Method,
     ) -> result::Result<ParsedRequest, String> {
-        let id_from_path = id_from_path.unwrap_or(String::new());
+        let id_from_path = id_from_path.unwrap_or_default();
         if id_from_path != self.drive_id {
             return Err(String::from(
                 "The id from the path does not match the id from the body!",

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -19,6 +19,7 @@ use hyper::{Method, StatusCode};
 use http_service::{empty_response, json_fault_message, json_response};
 use vmm::{ErrorKind, OutcomeReceiver, VmmAction, VmmActionError, VmmData};
 
+#[allow(clippy::large_enum_variant)]
 pub enum ParsedRequest {
     GetInstanceInfo,
     GetMMDS,

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -37,7 +37,7 @@ impl IntoParsedRequest for NetworkInterfaceUpdateConfig {
         id_from_path: Option<String>,
         _: Method,
     ) -> result::Result<ParsedRequest, String> {
-        let id_from_path = id_from_path.unwrap_or(String::new());
+        let id_from_path = id_from_path.unwrap_or_default();
         if id_from_path != self.iface_id {
             return Err(String::from(
                 "The id from the path does not match the id from the body!",

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -16,7 +16,7 @@ impl IntoParsedRequest for NetworkInterfaceConfig {
         id_from_path: Option<String>,
         _: Method,
     ) -> result::Result<ParsedRequest, String> {
-        let id_from_path = id_from_path.unwrap_or(String::new());
+        let id_from_path = id_from_path.unwrap_or_default();
         if id_from_path != self.iface_id {
             return Err(String::from(
                 "The id from the path does not match the id from the body!",

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -16,7 +16,7 @@ impl IntoParsedRequest for VsockDeviceConfig {
         id_from_path: Option<String>,
         _: Method,
     ) -> result::Result<ParsedRequest, String> {
-        let id_from_path = id_from_path.unwrap_or(String::new());
+        let id_from_path = id_from_path.unwrap_or_default();
         if id_from_path != self.id.as_str() {
             return Err(String::from(
                 "The id from the path does not match the id from the body!",

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -24,7 +24,7 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 // 1MB.  We don't put anything above here except the kernel itself.
-pub const HIMEM_START: usize = 0x100000;
+pub const HIMEM_START: usize = 0x0010_0000;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;

--- a/arch/src/x86_64/gdt.rs
+++ b/arch/src/x86_64/gdt.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn field_parse() {
-        let gdt = gdt_entry(0xA09B, 0x100000, 0xfffff);
+        let gdt = gdt_entry(0xA09B, 0x10_0000, 0xfffff);
         let seg = kvm_segment_from_gdt(gdt, 0);
         // 0xA09B
         // 'A'
@@ -108,7 +108,7 @@ mod tests {
         // 'B'
         assert_eq!(0xB, seg.type_);
         // base and limit
-        assert_eq!(0x100000, seg.base);
+        assert_eq!(0x10_0000, seg.base);
         assert_eq!(0xfffff, seg.limit);
         assert_eq!(0x0, seg.unusable);
     }

--- a/arch/src/x86_64/gdt.rs
+++ b/arch/src/x86_64/gdt.rs
@@ -11,53 +11,53 @@ use kvm_bindings::kvm_segment;
 
 /// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
 pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {
-    ((((base as u64) & 0xff000000u64) << (56 - 24))
-        | (((flags as u64) & 0x0000f0ffu64) << 40)
-        | (((limit as u64) & 0x000f0000u64) << (48 - 16))
-        | (((base as u64) & 0x00ffffffu64) << 16)
-        | ((limit as u64) & 0x0000ffffu64))
+    (((u64::from(base) & 0xff00_0000u64) << (56 - 24))
+        | ((u64::from(flags) & 0x0000_f0ffu64) << 40)
+        | ((u64::from(limit) & 0x000f_0000u64) << (48 - 16))
+        | ((u64::from(base) & 0x00ff_ffffu64) << 16)
+        | (u64::from(limit) & 0x0000_ffffu64))
 }
 
 fn get_base(entry: u64) -> u64 {
-    ((((entry) & 0xFF00000000000000) >> 32)
-        | (((entry) & 0x000000FF00000000) >> 16)
-        | (((entry) & 0x00000000FFFF0000) >> 16))
+    ((((entry) & 0xFF00_0000_0000_0000) >> 32)
+        | (((entry) & 0x0000_00FF_0000_0000) >> 16)
+        | (((entry) & 0x0000_0000_FFFF_0000) >> 16))
 }
 
 fn get_limit(entry: u64) -> u32 {
-    ((((entry) & 0x000F000000000000) >> 32) | ((entry) & 0x000000000000FFFF)) as u32
+    ((((entry) & 0x000F_0000_0000_0000) >> 32) | ((entry) & 0x0000_0000_0000_FFFF)) as u32
 }
 
 fn get_g(entry: u64) -> u8 {
-    ((entry & 0x0080000000000000) >> 55) as u8
+    ((entry & 0x0080_0000_0000_0000) >> 55) as u8
 }
 
 fn get_db(entry: u64) -> u8 {
-    ((entry & 0x0040000000000000) >> 54) as u8
+    ((entry & 0x0040_0000_0000_0000) >> 54) as u8
 }
 
 fn get_l(entry: u64) -> u8 {
-    ((entry & 0x0020000000000000) >> 53) as u8
+    ((entry & 0x0020_0000_0000_0000) >> 53) as u8
 }
 
 fn get_avl(entry: u64) -> u8 {
-    ((entry & 0x0010000000000000) >> 52) as u8
+    ((entry & 0x0010_0000_0000_0000) >> 52) as u8
 }
 
 fn get_p(entry: u64) -> u8 {
-    ((entry & 0x0000800000000000) >> 47) as u8
+    ((entry & 0x0000_8000_0000_0000) >> 47) as u8
 }
 
 fn get_dpl(entry: u64) -> u8 {
-    ((entry & 0x0000600000000000) >> 45) as u8
+    ((entry & 0x0000_6000_0000_0000) >> 45) as u8
 }
 
 fn get_s(entry: u64) -> u8 {
-    ((entry & 0x0000100000000000) >> 44) as u8
+    ((entry & 0x0000_1000_0000_0000) >> 44) as u8
 }
 
 fn get_type(entry: u64) -> u8 {
-    ((entry & 0x00000F0000000000) >> 40) as u8
+    ((entry & 0x0000_0F00_0000_0000) >> 40) as u8
 }
 
 /// Automatically build the kvm struct for SET_SREGS from the kernel bit fields.
@@ -70,7 +70,7 @@ pub fn kvm_segment_from_gdt(entry: u64, table_index: u8) -> kvm_segment {
     kvm_segment {
         base: get_base(entry),
         limit: get_limit(entry),
-        selector: (table_index * 8) as u16,
+        selector: u16::from(table_index * 8),
         type_: get_type(entry),
         present: get_p(entry),
         dpl: get_dpl(entry),

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 use std::io::{self, Cursor};
-use std::mem;
 use std::result;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -32,7 +31,7 @@ fn get_klapic_reg(klapic: &kvm_lapic_state, reg_offset: usize) -> u32 {
     let sliceu8 = unsafe {
         // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
         // Cursors are only readable on arrays of u8, not i8(c_char).
-        mem::transmute::<&[i8], &[u8]>(&klapic.regs[reg_offset..])
+        &*(&klapic.regs[reg_offset..] as *const [i8] as *const [u8])
     };
     let mut reader = Cursor::new(sliceu8);
     // Following call can't fail if the offsets defined above are correct.
@@ -45,7 +44,7 @@ fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
     let sliceu8 = unsafe {
         // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
         // Cursors are only readable on arrays of u8, not i8(c_char).
-        mem::transmute::<&mut [i8], &mut [u8]>(&mut klapic.regs[reg_offset..])
+        &mut *(&mut klapic.regs[reg_offset..] as *mut [i8] as *mut [u8])
     };
     let mut writer = Cursor::new(sliceu8);
     // Following call can't fail if the offsets defined above are correct.

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -17,7 +17,7 @@ pub const CMDLINE_START: usize = 0x20000;
 pub const CMDLINE_MAX_SIZE: usize = 0x10000;
 
 /// Address for the TSS setup.
-pub const KVM_TSS_ADDRESS: usize = 0xfffbd000;
+pub const KVM_TSS_ADDRESS: usize = 0xfffb_d000;
 
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: usize = 0x7000;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm = GuestMemory::new(&vec![(GuestAddress(0), 0x10000)]).unwrap();
+        let gm = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
         let config_err = configure_system(&gm, GuestAddress(0), 0, 1);
         assert!(config_err.is_err());
         assert_eq!(

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -92,9 +92,9 @@ pub fn configure_system(
     num_cpus: u8,
 ) -> super::Result<()> {
     const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
-    const KERNEL_HDR_MAGIC: u32 = 0x53726448;
+    const KERNEL_HDR_MAGIC: u32 = 0x5372_6448;
     const KERNEL_LOADER_OTHER: u8 = 0xff;
-    const KERNEL_MIN_ALIGNMENT_BYTES: u32 = 0x1000000; // Must be non-zero.
+    const KERNEL_MIN_ALIGNMENT_BYTES: u32 = 0x0100_0000; // Must be non-zero.
     let first_addr_past_32bits = GuestAddress(FIRST_ADDR_PAST_32BITS);
     let end_32bit_gap_start = GuestAddress(get_32bit_gap_start());
 

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -92,8 +92,8 @@ const MPC_SPEC: i8 = 4;
 const MPC_OEM: [c_char; 8] = char_array!(c_char; 'F', 'C', ' ', ' ', ' ', ' ', ' ', ' ');
 const MPC_PRODUCT_ID: [c_char; 12] = ['0' as c_char; 12];
 const BUS_TYPE_ISA: [u8; 6] = char_array!(u8; 'I', 'S', 'A', ' ', ' ', ' ');
-const IO_APIC_DEFAULT_PHYS_BASE: u32 = 0xfec00000; // source: linux/arch/x86/include/asm/apicdef.h
-const APIC_DEFAULT_PHYS_BASE: u32 = 0xfee00000; // source: linux/arch/x86/include/asm/apicdef.h
+const IO_APIC_DEFAULT_PHYS_BASE: u32 = 0xfec0_0000; // source: linux/arch/x86/include/asm/apicdef.h
+const APIC_DEFAULT_PHYS_BASE: u32 = 0xfee0_0000; // source: linux/arch/x86/include/asm/apicdef.h
 const APIC_VERSION: u8 = 0x14;
 const CPU_STEPPING: u32 = 0x600;
 const CPU_FEATURE_APIC: u32 = 0x200;
@@ -126,7 +126,7 @@ fn compute_mp_size(num_cpus: u8) -> usize {
 
 /// Performs setup of the MP table for the given `num_cpus`.
 pub fn setup_mptable(mem: &GuestMemory, num_cpus: u8) -> Result<()> {
-    if num_cpus as u32 > MAX_SUPPORTED_CPUS {
+    if u32::from(num_cpus) > MAX_SUPPORTED_CPUS {
         return Err(Error::TooManyCpus);
     }
 

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -286,7 +286,7 @@ mod tests {
     use super::*;
 
     fn table_entry_size(type_: u8) -> usize {
-        match type_ as u32 {
+        match u32::from(type_) {
             mpspec::MP_PROCESSOR => mem::size_of::<MpcCpuWrapper>(),
             mpspec::MP_BUS => mem::size_of::<MpcBusWrapper>(),
             mpspec::MP_IOAPIC => mem::size_of::<MpcIoapicWrapper>(),
@@ -390,7 +390,7 @@ mod tests {
                     .checked_add(table_entry_size(entry_type))
                     .unwrap();
                 assert!(entry_offset <= mpc_end);
-                if entry_type as u32 == mpspec::MP_PROCESSOR {
+                if u32::from(entry_type) == mpspec::MP_PROCESSOR {
                     cpu_count += 1;
                 }
             }

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -69,6 +69,7 @@ pub fn setup_msrs(vcpu: &VcpuFd) -> Result<()> {
     let vec_size_bytes =
         mem::size_of::<kvm_msrs>() + (entry_vec.len() * mem::size_of::<kvm_msr_entry>());
     let vec: Vec<u8> = Vec::with_capacity(vec_size_bytes);
+    #[allow(clippy::cast_ptr_alignment)]
     let msrs: &mut kvm_msrs = unsafe {
         // Converting the vector's memory to a struct is unsafe.  Carefully using the read-only
         // vector to size and set the members ensures no out-of-bounds errors below.
@@ -97,7 +98,7 @@ pub fn setup_msrs(vcpu: &VcpuFd) -> Result<()> {
 /// * `boot_si` - Must point to zero page address per Linux ABI.
 pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64, boot_sp: u64, boot_si: u64) -> Result<()> {
     let regs: kvm_regs = kvm_regs {
-        rflags: 0x0000000000000002u64,
+        rflags: 0x0000_0000_0000_0002u64,
         rip: boot_ip,
         rsp: boot_sp,
         rbp: boot_sp,
@@ -132,7 +133,7 @@ const EFER_LMA: u64 = 0x400;
 const EFER_LME: u64 = 0x100;
 
 const X86_CR0_PE: u64 = 0x1;
-const X86_CR0_PG: u64 = 0x80000000;
+const X86_CR0_PG: u64 = 0x8000_0000;
 const X86_CR4_PAE: u64 = 0x20;
 
 fn write_gdt_table(table: &[u64], guest_mem: &GuestMemory) -> Result<()> {
@@ -272,7 +273,7 @@ fn create_msr_entries() -> Vec<kvm_msr_entry> {
     });
     entries.push(kvm_msr_entry {
         index: msr_index::MSR_IA32_MISC_ENABLE,
-        data: msr_index::MSR_IA32_MISC_ENABLE_FAST_STRING as u64,
+        data: u64::from(msr_index::MSR_IA32_MISC_ENABLE_FAST_STRING),
         ..Default::default()
     });
 

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -287,7 +287,7 @@ mod tests {
     use memory_model::{GuestAddress, GuestMemory};
 
     fn create_guest_mem() -> GuestMemory {
-        GuestMemory::new(&vec![(GuestAddress(0), 0x10000)]).unwrap()
+        GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap()
     }
 
     fn read_u64(gm: &GuestMemory, offset: usize) -> u64 {
@@ -302,9 +302,9 @@ mod tests {
         configure_segments_and_sregs(&gm, &mut sregs).unwrap();
 
         assert_eq!(0x0, read_u64(&gm, BOOT_GDT_OFFSET));
-        assert_eq!(0xaf9b000000ffff, read_u64(&gm, BOOT_GDT_OFFSET + 8));
-        assert_eq!(0xcf93000000ffff, read_u64(&gm, BOOT_GDT_OFFSET + 16));
-        assert_eq!(0x8f8b000000ffff, read_u64(&gm, BOOT_GDT_OFFSET + 24));
+        assert_eq!(0xaf_9b00_0000_ffff, read_u64(&gm, BOOT_GDT_OFFSET + 8));
+        assert_eq!(0xcf_9300_0000_ffff, read_u64(&gm, BOOT_GDT_OFFSET + 16));
+        assert_eq!(0x8f_8b00_0000_ffff, read_u64(&gm, BOOT_GDT_OFFSET + 24));
         assert_eq!(0x0, read_u64(&gm, BOOT_IDT_OFFSET));
 
         assert_eq!(0, sregs.cs.base);
@@ -363,6 +363,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_ptr_alignment)]
     fn test_setup_msrs() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -410,7 +411,7 @@ mod tests {
         let vcpu = vm.create_vcpu(0).unwrap();
 
         let expected_regs: kvm_regs = kvm_regs {
-            rflags: 0x0000000000000002u64,
+            rflags: 0x0000_0000_0000_0002u64,
             rip: 1,
             rsp: 2,
             rbp: 2,

--- a/arch_gen/src/lib.rs
+++ b/arch_gen/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate memory_model;
+
+#[allow(clippy::all)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod x86;

--- a/arch_gen/src/lib.rs
+++ b/arch_gen/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate memory_model;
-
 #[allow(clippy::all)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod x86;

--- a/cpuid/src/bit_helper.rs
+++ b/cpuid/src/bit_helper.rs
@@ -251,7 +251,7 @@ mod tests {
                 lsb_index: 2
             }
             .get_mask()
-                == 0b111100
+                == 0b11_1100
         );
         assert!(
             BitRange {
@@ -259,7 +259,7 @@ mod tests {
                 lsb_index: 2
             }
             .get_mask()
-                == 0b1111100
+                == 0b111_1100
         );
         assert!(
             BitRange {
@@ -267,7 +267,7 @@ mod tests {
                 lsb_index: 2
             }
             .get_mask()
-                == 0b11111100
+                == 0b1111_1100
         );
     }
 
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_read_bits() {
-        let val: u32 = 0b10000000000000000011010100010000;
+        let val: u32 = 0b1000_0000_0000_0000_0011_0101_0001_0000;
 
         // Test a couple of successive ranges
         assert!(
@@ -314,43 +314,43 @@ mod tests {
             val.read_bits_in_range(&BitRange {
                 msb_index: 7,
                 lsb_index: 2
-            }) == 0b000100
+            }) == 0b00_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 8,
                 lsb_index: 2
-            }) == 0b1000100
+            }) == 0b100_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 9,
                 lsb_index: 2
-            }) == 0b01000100
+            }) == 0b0100_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 10,
                 lsb_index: 2
-            }) == 0b101000100
+            }) == 0b1_0100_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 11,
                 lsb_index: 2
-            }) == 0b0101000100
+            }) == 0b01_0100_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 12,
                 lsb_index: 2
-            }) == 0b10101000100
+            }) == 0b101_0100_0100
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 13,
                 lsb_index: 2
-            }) == 0b110101000100
+            }) == 0b1101_0100_0100
         );
 
         // Test max left and max right
@@ -358,19 +358,19 @@ mod tests {
             val.read_bits_in_range(&BitRange {
                 msb_index: 31,
                 lsb_index: 15
-            }) == 0b10000000000000000
+            }) == 0b1_0000_0000_0000_0000
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 14,
                 lsb_index: 0
-            }) == 0b011010100010000
+            }) == 0b011_0101_0001_0000
         );
         assert!(
             val.read_bits_in_range(&BitRange {
                 msb_index: 31,
                 lsb_index: 0
-            }) == 0b10000000000000000011010100010000
+            }) == 0b1000_0000_0000_0000_0011_0101_0001_0000
         );
     }
 
@@ -432,7 +432,7 @@ mod tests {
                     lsb_index: 2
                 },
                 0b0100
-            ) == &0b010000
+            ) == &0b01_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -440,8 +440,8 @@ mod tests {
                     msb_index: 6,
                     lsb_index: 2
                 },
-                0b00100
-            ) == &0b0010000
+                0b0_0100
+            ) == &0b001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -449,8 +449,8 @@ mod tests {
                     msb_index: 7,
                     lsb_index: 2
                 },
-                0b000100
-            ) == &0b00010000
+                0b00_0100
+            ) == &0b0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -458,8 +458,8 @@ mod tests {
                     msb_index: 8,
                     lsb_index: 2
                 },
-                0b1000100
-            ) == &0b100010000
+                0b100_0100
+            ) == &0b1_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -467,8 +467,8 @@ mod tests {
                     msb_index: 9,
                     lsb_index: 2
                 },
-                0b01000100
-            ) == &0b0100010000
+                0b0100_0100
+            ) == &0b01_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -476,8 +476,8 @@ mod tests {
                     msb_index: 10,
                     lsb_index: 2
                 },
-                0b101000100
-            ) == &0b10100010000
+                0b1_0100_0100
+            ) == &0b101_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -485,8 +485,8 @@ mod tests {
                     msb_index: 11,
                     lsb_index: 2
                 },
-                0b0101000100
-            ) == &0b010100010000
+                0b01_0100_0100
+            ) == &0b0101_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -494,8 +494,8 @@ mod tests {
                     msb_index: 12,
                     lsb_index: 2
                 },
-                0b10101000100
-            ) == &0b1010100010000
+                0b101_0100_0100
+            ) == &0b1_0101_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -503,8 +503,8 @@ mod tests {
                     msb_index: 13,
                     lsb_index: 2
                 },
-                0b110101000100
-            ) == &0b11010100010000
+                0b1101_0100_0100
+            ) == &0b11_0101_0001_0000
         );
 
         // Test max left and max right
@@ -515,8 +515,8 @@ mod tests {
                     msb_index: 31,
                     lsb_index: 15
                 },
-                0b10000000000000000
-            ) == &0b10000000000000000000000000000000
+                0b1_0000_0000_0000_0000
+            ) == &0b1000_0000_0000_0000_0000_0000_0000_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -524,8 +524,8 @@ mod tests {
                     msb_index: 14,
                     lsb_index: 0
                 },
-                0b011010100010000
-            ) == &0b10000000000000000011010100010000
+                0b011_0101_0001_0000
+            ) == &0b1000_0000_0000_0000_0011_0101_0001_0000
         );
         assert!(
             val.write_bits_in_range(
@@ -533,8 +533,8 @@ mod tests {
                     msb_index: 31,
                     lsb_index: 0
                 },
-                0b10000000000000000011010100010000
-            ) == &0b10000000000000000011010100010000
+                0b1000_0000_0000_0000_0011_0101_0001_0000
+            ) == &0b1000_0000_0000_0000_0011_0101_0001_0000
         );
     }
 
@@ -572,6 +572,6 @@ mod tests {
             0b1011,
         );
 
-        assert!(val == 0b10110001010100000001100000010000);
+        assert!(val == 0b1011_0001_0101_0000_0001_1000_0001_0000);
     }
 }

--- a/cpuid/src/brand_string.rs
+++ b/cpuid/src/brand_string.rs
@@ -69,14 +69,14 @@ impl BrandString {
     /// of the host CPU.
     pub fn from_host_cpuid() -> Result<Self, Error> {
         let mut this = Self::new();
-        let mut cpuid_regs = unsafe { host_cpuid(0x80000000) };
+        let mut cpuid_regs = unsafe { host_cpuid(0x8000_0000) };
 
-        if cpuid_regs.eax < 0x80000004 {
+        if cpuid_regs.eax < 0x8000_0004 {
             // Brand string not supported by the host CPU
             return Err(Error::NotSupported);
         }
 
-        for leaf in 0x80000002..=0x80000004 {
+        for leaf in 0x8000_0002..=0x8000_0004 {
             cpuid_regs = unsafe { host_cpuid(leaf) };
             this.set_reg_for_leaf(leaf, Reg::EAX, cpuid_regs.eax);
             this.set_reg_for_leaf(leaf, Reg::EBX, cpuid_regs.ebx);
@@ -116,7 +116,7 @@ impl BrandString {
         // It's ok not to validate parameters here, leaf and reg should
         // both be compile-time constants. If there's something wrong with them,
         // that's a programming error and we should panic anyway.
-        self.reg_buf[(leaf - 0x80000002) as usize * 4 + reg as usize]
+        self.reg_buf[(leaf - 0x8000_0002) as usize * 4 + reg as usize]
     }
 
     /// Sets the value for the given leaf/register pair.
@@ -127,7 +127,7 @@ impl BrandString {
         // It's ok not to validate parameters here, leaf and reg should
         // both be compile-time constants. If there's something wrong with them,
         // that's a programming error and we should panic anyway.
-        self.reg_buf[(leaf - 0x80000002) as usize * 4 + reg as usize] = val;
+        self.reg_buf[(leaf - 0x8000_0002) as usize * 4 + reg as usize] = val;
     }
 
     /// Gets an immutable `u8` slice view into the brand string buffer.
@@ -149,7 +149,7 @@ impl BrandString {
 
     /// Asserts whether or not there is enough room to append `src` to the brand string.
     fn check_push(&mut self, src: &[u8]) -> bool {
-        !(src.len() > Self::MAX_LEN - self.len)
+        src.len() <= Self::MAX_LEN - self.len
     }
 
     /// Appends `src` to the brand string if there is enough room to append it.

--- a/cpuid/src/c3_template.rs
+++ b/cpuid/src/c3_template.rs
@@ -11,7 +11,7 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
             0x1 => {
                 // Set CPU Basic Information
                 // EAX[20:27] Extended Family ID = 0
-                entry.eax &= !(0b11111111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT);
+                entry.eax &= !(0b1111_1111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT);
 
                 // EAX[19:16] Extended Processor Model ID = 3 (Haswell)
                 entry.eax &= !(0b1111 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT);
@@ -76,7 +76,7 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
                     entry.ecx &= !(1 << leaf_0x7::index0::ecx::SGX_LC_SHIFT);
                 }
             }
-            0x80000001 => {
+            0x8000_0001 => {
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::PREFETCH_SHIFT);
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::LZCNT_SHIFT);
                 entry.edx &= !(1 << leaf_0x80000001::edx::PDPE1GB_SHIFT);

--- a/cpuid/src/c3_template.rs
+++ b/cpuid/src/c3_template.rs
@@ -94,6 +94,7 @@ mod tests {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[test]
+    #[allow(clippy::erasing_op)]
     fn test_c3_cpuid_template() {
         let mut kvm_cpuid = CpuId::new(5);
         {
@@ -117,7 +118,7 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[3].function = 0x80000001;
+            entries[3].function = 0x8000_0001;
             entries[3].ecx = 0b11;
             entries[3].edx = 0b111;
         }
@@ -134,7 +135,7 @@ mod tests {
             index: 0,
             flags: 0,
             eax: 0
-                & !(0b11111111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT)
+                & !(0b1111_1111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT)
                 & !(0b1111 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT)
                 | 3 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT
                     & !(0b11 << leaf_0x1::eax::PROCESSOR_TYPE_SHIFT)
@@ -217,7 +218,7 @@ mod tests {
             assert_eq!(entries[2], cpuid_f7_index_non0);
         }
         let cpuid_f801 = kvm_cpuid_entry2 {
-            function: 0x80000001,
+            function: 0x8000_0001,
             index: 0,
             flags: 0,
             eax: 0,

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -76,7 +76,7 @@ pub fn filter_cpuid(
     kvm_cpuid: &mut CpuId,
 ) -> Result<()> {
     let entries = kvm_cpuid.mut_entries_slice();
-    let max_addr_cpu = get_max_addressable_lprocessors(cpu_count)? as u32;
+    let max_addr_cpu = u32::from(get_max_addressable_lprocessors(cpu_count)?);
 
     let res = get_brand_string();
     let bstr = res.0;
@@ -215,7 +215,7 @@ pub fn filter_cpuid(
                     }
                 }
             }
-            0x80000002..=0x80000004 => {
+            0x8000_0002..=0x8000_0004 => {
                 entry.eax = bstr.get_reg_for_leaf(entry.function, BsReg::EAX);
                 entry.ebx = bstr.get_reg_for_leaf(entry.function, BsReg::EBX);
                 entry.ecx = bstr.get_reg_for_leaf(entry.function, BsReg::ECX);
@@ -247,8 +247,8 @@ const DEFAULT_BRAND_STRING: &[u8] = b"Intel(R) Xeon(R) Processor";
 /// The maximum number of addressable logical CPUs is computed as the closest power of 2
 /// higher or equal to the CPU count configured by the user.
 fn get_max_addressable_lprocessors(cpu_count: u8) -> Result<u8> {
-    let mut max_addressable_lcpu = (cpu_count as f64).log2().ceil();
-    max_addressable_lcpu = (2 as f64).powf(max_addressable_lcpu);
+    let mut max_addressable_lcpu = f64::from(cpu_count).log2().ceil();
+    max_addressable_lcpu = f64::from(2).powf(max_addressable_lcpu);
     // check that this number is still an u8
     if max_addressable_lcpu > u8::max_value().into() {
         return Err(Error::VcpuCountOverflow);
@@ -274,7 +274,7 @@ fn get_brand_string() -> PartialError<BrandString, brand_string::Error> {
         if host_bstr.starts_with(b"Intel") {
             if let Some(freq) = host_bstr.find_freq() {
                 let mut v3 = vec![];
-                v3.extend_from_slice(" @ ".as_bytes());
+                v3.extend_from_slice(b" @ ");
                 v3.extend_from_slice(freq);
                 if let Err(e) = bstr.push_bytes(&v3) {
                     return (bstr, Some(e));

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -94,7 +94,7 @@ pub fn filter_cpuid(
 
                 entry
                     .ebx
-                    .write_bits_in_range(&ebx::APICID_BITRANGE, cpu_id as u32)
+                    .write_bits_in_range(&ebx::APICID_BITRANGE, u32::from(cpu_id))
                     .write_bits_in_range(&ebx::CLFLUSH_SIZE_BITRANGE, EBX_CLFLUSH_CACHELINE)
                     .write_bits_in_range(&ebx::CPU_COUNT_BITRANGE, max_addr_cpu);
 
@@ -121,7 +121,7 @@ pub fn filter_cpuid(
                         // The L3 cache is shared among all the logical threads
                         entry.eax.write_bits_in_range(
                             &eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE,
-                            (cpu_count - 1) as u32,
+                            u32::from(cpu_count - 1),
                         );
                     }
                     _ => (),
@@ -130,7 +130,7 @@ pub fn filter_cpuid(
                 // Put all the cores in the same socket
                 entry.eax.write_bits_in_range(
                     &eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE,
-                    (cpu_count - 1) as u32,
+                    u32::from(cpu_count - 1),
                 );
             }
             0x6 => {
@@ -157,7 +157,7 @@ pub fn filter_cpuid(
                 entry.ecx = 0 as u32;
                 // EDX bits 31..0 contain x2APIC ID of current logical processor
                 // x2APIC increases the size of the APIC ID from 8 bits to 32 bits
-                entry.edx = cpu_id as u32;
+                entry.edx = u32::from(cpu_id);
                 match entry.index {
                     // Thread Level Topology; index = 0
                     0 => {
@@ -199,7 +199,7 @@ pub fn filter_cpuid(
                         } else {
                             entry.ebx.write_bits_in_range(
                                 &ebx::NUM_LOGICAL_PROCESSORS_BITRANGE,
-                                cpu_count as u32,
+                                u32::from(cpu_count),
                             );
                             entry
                                 .ecx

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -367,17 +367,17 @@ mod tests {
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[2].function = 0x4;
-            entries[2].eax = 0b100000;
+            entries[2].eax = 0b10_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[3].function = 0x4;
-            entries[3].eax = 0b1000000;
+            entries[3].eax = 0b100_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[4].function = 0x4;
-            entries[4].eax = 0b1100000;
+            entries[4].eax = 0b110_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
@@ -406,10 +406,10 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[10].function = 0x80000003;
+            entries[10].function = 0x8000_0003;
         }
         filter_cpuid(0, 1, false, &mut kvm_cpuid).unwrap();
-        let max_addr_cpu = get_max_addressable_lprocessors(1).unwrap() as u32;
+        let max_addr_cpu = u32::from(get_max_addressable_lprocessors(1).unwrap());
 
         let cpuid_f1 = kvm_cpuid_entry2 {
             function: 1,
@@ -432,7 +432,8 @@ mod tests {
             index: 0,
             flags: 0,
             eax: 0b10000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -446,8 +447,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b10_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -461,8 +463,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1000000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b100_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -476,8 +479,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b110_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -559,13 +563,13 @@ mod tests {
         }
         let bstr = get_brand_string().0;
         let cpuid_fother = kvm_cpuid_entry2 {
-            function: 0x80000003,
+            function: 0x8000_0003,
             index: 0,
             flags: 0,
-            eax: bstr.get_reg_for_leaf(0x80000003, BsReg::EAX),
-            ebx: bstr.get_reg_for_leaf(0x80000003, BsReg::EBX),
-            ecx: bstr.get_reg_for_leaf(0x80000003, BsReg::ECX),
-            edx: bstr.get_reg_for_leaf(0x80000003, BsReg::EDX),
+            eax: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EAX),
+            ebx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EBX),
+            ecx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::ECX),
+            edx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EDX),
             padding: [0, 0, 0],
         };
         {
@@ -590,17 +594,17 @@ mod tests {
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[2].function = 0x4;
-            entries[2].eax = 0b100000;
+            entries[2].eax = 0b10_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[3].function = 0x4;
-            entries[3].eax = 0b1000000;
+            entries[3].eax = 0b100_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[4].function = 0x4;
-            entries[4].eax = 0b1100000;
+            entries[4].eax = 0b110_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
@@ -629,11 +633,11 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[10].function = 0x80000003;
+            entries[10].function = 0x8000_0003;
         }
         let cpu_count = 3;
         filter_cpuid(0, cpu_count, false, &mut kvm_cpuid).unwrap();
-        let max_addr_cpu = get_max_addressable_lprocessors(cpu_count).unwrap() as u32;
+        let max_addr_cpu = u32::from(get_max_addressable_lprocessors(cpu_count).unwrap());
 
         let cpuid_f1 = kvm_cpuid_entry2 {
             function: 1,
@@ -655,8 +659,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b10000 & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b10000
+                & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -671,10 +676,11 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
-                & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b10_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+                & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -689,10 +695,11 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1000000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
-                & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b100_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+                & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -707,12 +714,13 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b110_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index
-                    & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+                    & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -770,7 +778,7 @@ mod tests {
             index: 1,
             flags: 0,
             eax: LEAFBH_INDEX1_APICID,
-            ebx: cpu_count as u32,
+            ebx: u32::from(cpu_count),
             ecx: 1 | leaf_0xb::LEVEL_TYPE_CORE << leaf_0xb::ecx::LEVEL_TYPE_BITRANGE.lsb_index,
             edx: 0,
             padding: [0, 0, 0],
@@ -795,13 +803,13 @@ mod tests {
         }
         let bstr = get_brand_string().0;
         let cpuid_fother = kvm_cpuid_entry2 {
-            function: 0x80000003,
+            function: 0x8000_0003,
             index: 0,
             flags: 0,
-            eax: bstr.get_reg_for_leaf(0x80000003, BsReg::EAX),
-            ebx: bstr.get_reg_for_leaf(0x80000003, BsReg::EBX),
-            ecx: bstr.get_reg_for_leaf(0x80000003, BsReg::ECX),
-            edx: bstr.get_reg_for_leaf(0x80000003, BsReg::EDX),
+            eax: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EAX),
+            ebx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EBX),
+            ecx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::ECX),
+            edx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EDX),
             padding: [0, 0, 0],
         };
         {
@@ -821,22 +829,22 @@ mod tests {
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[1].function = 0x4;
-            entries[1].eax = 0b10000;
+            entries[1].eax = 0b10_000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[2].function = 0x4;
-            entries[2].eax = 0b100000;
+            entries[2].eax = 0b10_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[3].function = 0x4;
-            entries[3].eax = 0b1000000;
+            entries[3].eax = 0b100_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[4].function = 0x4;
-            entries[4].eax = 0b1100000;
+            entries[4].eax = 0b110_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
@@ -865,10 +873,10 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[10].function = 0x80000003;
+            entries[10].function = 0x8000_0003;
         }
         filter_cpuid(0, 1, true, &mut kvm_cpuid).unwrap();
-        let max_addr_cpu = get_max_addressable_lprocessors(1).unwrap() as u32;
+        let max_addr_cpu = u32::from(get_max_addressable_lprocessors(1).unwrap());
 
         let cpuid_f1 = kvm_cpuid_entry2 {
             function: 1,
@@ -890,8 +898,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b10000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b1_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -905,8 +914,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b10_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -920,8 +930,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1000000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b100_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -935,8 +946,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
+            eax: 0b110_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index),
             ebx: 0,
             ecx: 0,
             edx: 0,
@@ -1018,13 +1030,13 @@ mod tests {
         }
         let bstr = get_brand_string().0;
         let cpuid_fother = kvm_cpuid_entry2 {
-            function: 0x80000003,
+            function: 0x8000_0003,
             index: 0,
             flags: 0,
-            eax: bstr.get_reg_for_leaf(0x80000003, BsReg::EAX),
-            ebx: bstr.get_reg_for_leaf(0x80000003, BsReg::EBX),
-            ecx: bstr.get_reg_for_leaf(0x80000003, BsReg::ECX),
-            edx: bstr.get_reg_for_leaf(0x80000003, BsReg::EDX),
+            eax: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EAX),
+            ebx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EBX),
+            ecx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::ECX),
+            edx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EDX),
             padding: [0, 0, 0],
         };
         {
@@ -1044,22 +1056,22 @@ mod tests {
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[1].function = 0x4;
-            entries[1].eax = 0b10000;
+            entries[1].eax = 0b1_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[2].function = 0x4;
-            entries[2].eax = 0b100000;
+            entries[2].eax = 0b10_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[3].function = 0x4;
-            entries[3].eax = 0b1000000;
+            entries[3].eax = 0b100_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
             entries[4].function = 0x4;
-            entries[4].eax = 0b1100000;
+            entries[4].eax = 0b110_0000;
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
@@ -1088,11 +1100,11 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[10].function = 0x80000003;
+            entries[10].function = 0x8000_0003;
         }
         let cpu_count = 3;
         filter_cpuid(0, cpu_count, true, &mut kvm_cpuid).unwrap();
-        let max_addr_cpu = get_max_addressable_lprocessors(cpu_count).unwrap() as u32;
+        let max_addr_cpu = u32::from(get_max_addressable_lprocessors(cpu_count).unwrap());
 
         let cpuid_f1 = kvm_cpuid_entry2 {
             function: 1,
@@ -1114,8 +1126,9 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b10000 & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b1_0000
+                & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -1130,11 +1143,12 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+            eax: 0b10_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
                 | 1 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index
-                    & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+                    & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -1149,11 +1163,12 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1000000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+            eax: 0b100_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
                 | 1 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index
-                    & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+                    & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -1168,12 +1183,13 @@ mod tests {
             function: 0x4,
             index: 0,
             flags: 0,
-            eax: 0b1100000
-                & !(0b111111111111 << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+            eax: 0b110_0000
+                & !(0b1111_1111_1111
+                    << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_SHARING_CACHE_BITRANGE.lsb_index
-                    & !(0b111111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
-                | ((cpu_count - 1) as u32)
+                    & !(0b11_1111 << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index)
+                | u32::from(cpu_count - 1)
                     << leaf_0x4::eax::MAX_ADDR_IDS_IN_PACKAGE_BITRANGE.lsb_index,
             ebx: 0,
             ecx: 0,
@@ -1231,7 +1247,7 @@ mod tests {
             index: 1,
             flags: 0,
             eax: LEAFBH_INDEX1_APICID,
-            ebx: cpu_count as u32,
+            ebx: u32::from(cpu_count),
             ecx: 1 | leaf_0xb::LEVEL_TYPE_CORE << leaf_0xb::ecx::LEVEL_TYPE_BITRANGE.lsb_index,
             edx: 0,
             padding: [0, 0, 0],
@@ -1256,13 +1272,13 @@ mod tests {
         }
         let bstr = get_brand_string().0;
         let cpuid_fother = kvm_cpuid_entry2 {
-            function: 0x80000003,
+            function: 0x8000_0003,
             index: 0,
             flags: 0,
-            eax: bstr.get_reg_for_leaf(0x80000003, BsReg::EAX),
-            ebx: bstr.get_reg_for_leaf(0x80000003, BsReg::EBX),
-            ecx: bstr.get_reg_for_leaf(0x80000003, BsReg::ECX),
-            edx: bstr.get_reg_for_leaf(0x80000003, BsReg::EDX),
+            eax: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EAX),
+            ebx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EBX),
+            ecx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::ECX),
+            edx: bstr.get_reg_for_leaf(0x8000_0003, BsReg::EDX),
             padding: [0, 0, 0],
         };
         {

--- a/cpuid/src/t2_template.rs
+++ b/cpuid/src/t2_template.rs
@@ -11,7 +11,7 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
             0x1 => {
                 // Set CPU Basic Information
                 // EAX[20:27] Extended Family ID = 0
-                entry.eax &= !(0b11111111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT);
+                entry.eax &= !(0b1111_1111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT);
 
                 // EAX[19:16] Extended Processor Model ID = 3 (Haswell)
                 entry.eax &= !(0b1111 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT);
@@ -69,7 +69,7 @@ pub fn set_cpuid_entries(entries: &mut [kvm_cpuid_entry2]) {
                     entry.ecx &= !(1 << leaf_0x7::index0::ecx::SGX_LC_SHIFT);
                 }
             }
-            0x80000001 => {
+            0x8000_0001 => {
                 entry.ecx &= !(1 << leaf_0x80000001::ecx::PREFETCH_SHIFT);
                 entry.edx &= !(1 << leaf_0x80000001::edx::PDPE1GB_SHIFT);
             }

--- a/cpuid/src/t2_template.rs
+++ b/cpuid/src/t2_template.rs
@@ -86,6 +86,7 @@ mod tests {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[test]
+    #[allow(clippy::erasing_op)]
     fn test_t2_cpuid_template() {
         let mut kvm_cpuid = CpuId::new(5);
         {
@@ -109,7 +110,7 @@ mod tests {
         }
         {
             let entries = kvm_cpuid.mut_entries_slice();
-            entries[3].function = 0x80000001;
+            entries[3].function = 0x8000_0001;
             entries[3].ecx = 0b11;
             entries[3].edx = 0b111;
         }
@@ -126,7 +127,7 @@ mod tests {
             index: 0,
             flags: 0,
             eax: 0
-                & !(0b11111111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT)
+                & !(0b1111_1111 << leaf_0x1::eax::EXTENDED_FAMILY_ID_SHIFT)
                 & !(0b1111 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT)
                 | 3 << leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_SHIFT
                     & !(0b11 << leaf_0x1::eax::PROCESSOR_TYPE_SHIFT)
@@ -202,7 +203,7 @@ mod tests {
             assert_eq!(entries[2], cpuid_f7_index_non0);
         }
         let cpuid_f801 = kvm_cpuid_entry2 {
-            function: 0x80000001,
+            function: 0x8000_0001,
             index: 0,
             flags: 0,
             eax: 0,

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -61,7 +61,7 @@ impl PartialOrd for BusRange {
 ///
 /// This doesn't have any restrictions on what kind of device or address space this applies to. The
 /// only restriction is that no two devices can overlap in this address space.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Bus {
     devices: BTreeMap<BusRange, Arc<Mutex<BusDevice>>>,
 }

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -210,9 +210,9 @@ mod tests {
         assert!(bus.read(0x16, &mut [0, 0, 0, 0]));
         assert!(bus.write(0x16, &[0, 0, 0, 0]));
         assert!(!bus.read(0x20, &mut [0, 0, 0, 0]));
-        assert!(!bus.write(0x20, &mut [0, 0, 0, 0]));
+        assert!(!bus.write(0x20, &[0, 0, 0, 0]));
         assert!(!bus.read(0x06, &mut [0, 0, 0, 0]));
-        assert!(!bus.write(0x06, &mut [0, 0, 0, 0]));
+        assert!(!bus.write(0x06, &[0, 0, 0, 0]));
     }
 
     #[test]
@@ -239,14 +239,14 @@ mod tests {
         assert!(BusRange(0x10, 2) < BusRange(0x12, 3));
 
         let bus_range = BusRange(0x10, 2);
-        assert_eq!(bus_range, bus_range.clone());
+        assert_eq!(bus_range, bus_range);
 
         let mut bus = Bus::new();
         let mut data = [1, 2, 3, 4];
         assert!(bus
             .insert(Arc::new(Mutex::new(DummyDevice)), 0x10, 0x10)
             .is_ok());
-        assert!(bus.write(0x10, &mut data));
+        assert!(bus.write(0x10, &data));
         let bus_clone = bus.clone();
         assert!(bus.read(0x10, &mut data));
         assert_eq!(data, [1, 2, 3, 4]);

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -349,7 +349,7 @@ mod tests {
         // counter doesn't change (for 0 it blocks).
         assert!(reset_evt.write(1).is_ok());
         let mut data = [CMD_RESET_CPU];
-        i8042.write(OFS_STATUS, &mut data);
+        i8042.write(OFS_STATUS, &data);
         assert_eq!(reset_evt.read().unwrap(), 2);
 
         // Check if reading with offset 1 doesn't have side effects.
@@ -359,13 +359,13 @@ mod tests {
         // Check invalid `write`s.
         let before = METRICS.i8042.missed_write_count.count();
         // offset != 0.
-        i8042.write(1, &mut data);
+        i8042.write(1, &data);
         // data != CMD_RESET_CPU
         data[0] = CMD_RESET_CPU + 1;
-        i8042.write(1, &mut data);
+        i8042.write(1, &data);
         // data.len() != 1
-        let mut data = [CMD_RESET_CPU; 2];
-        i8042.write(1, &mut data);
+        let data = [CMD_RESET_CPU; 2];
+        i8042.write(1, &data);
         assert_eq!(METRICS.i8042.missed_write_count.count(), before + 3);
     }
 

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -58,7 +58,7 @@ const CMD_WRITE_OUTP: u8 = 0xD1; // Write output port
 const CMD_RESET_CPU: u8 = 0xFE; // Reset CPU
 
 /// i8042 status register bits
-const SB_OUT_DATA_AVAIL: u8 = 1 << 0; // Data available at port 0x60
+const SB_OUT_DATA_AVAIL: u8 = 1; // Data available at port 0x60
 const SB_I8042_CMD_DATA: u8 = 1 << 3; // i8042 expecting command parameter at port 0x60
 const SB_KBD_ENABLED: u8 = 1 << 4; // 1 = kbd enabled, 0 = kbd locked
 

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -63,6 +63,7 @@ const SB_I8042_CMD_DATA: u8 = 1 << 3; // i8042 expecting command parameter at po
 const SB_KBD_ENABLED: u8 = 1 << 4; // 1 = kbd enabled, 0 = kbd locked
 
 /// i8042 control register bits
+#[allow(clippy::identity_op)]
 const CB_KBD_INT: u8 = 1 << 0; // kbd interrupt enabled
 const CB_POST_OK: u8 = 1 << 2; // POST ok (should always be 1)
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -274,13 +274,13 @@ mod tests {
 
         let mut serial = Serial::new_out(intr_evt, Box::new(serial_out.clone()));
 
-        serial.write(DATA as u64, &['x' as u8, 'y' as u8]);
-        serial.write(DATA as u64, &['a' as u8]);
-        serial.write(DATA as u64, &['b' as u8]);
-        serial.write(DATA as u64, &['c' as u8]);
+        serial.write(u64::from(DATA), &[b'x', b'y']);
+        serial.write(u64::from(DATA), &[b'a']);
+        serial.write(u64::from(DATA), &[b'b']);
+        serial.write(u64::from(DATA), &[b'c']);
         assert_eq!(
             serial_out.buf.lock().unwrap().as_slice(),
-            &['a' as u8, 'b' as u8, 'c' as u8]
+            &[b'a', b'b', b'c']
         );
     }
 
@@ -295,27 +295,25 @@ mod tests {
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
-        serial.write(IER as u64, &[IER_RECV_BIT]);
-        serial
-            .queue_input_bytes(&['a' as u8, 'b' as u8, 'c' as u8])
-            .unwrap();
+        serial.write(u64::from(IER), &[IER_RECV_BIT]);
+        serial.queue_input_bytes(&[b'a', b'b', b'c']).unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);
 
         // check if reading in a 2-length array doesn't have side effects
         let mut data = [0u8, 0u8];
-        serial.read(DATA as u64, &mut data[..]);
+        serial.read(u64::from(DATA), &mut data[..]);
         assert_eq!(data, [0u8, 0u8]);
 
         let mut data = [0u8];
-        serial.read(LSR as u64, &mut data[..]);
+        serial.read(u64::from(LSR), &mut data[..]);
         assert_ne!(data[0] & LSR_DATA_BIT, 0);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'a' as u8);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'b' as u8);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'c' as u8);
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'a');
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'b');
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'c');
 
         // check if reading from the largest u8 offset returns 0
         serial.read(0xff, &mut data[..]);
@@ -330,14 +328,14 @@ mod tests {
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
-        serial.write(IER as u64, &[IER_THR_BIT]);
-        serial.write(DATA as u64, &['a' as u8]);
+        serial.write(u64::from(IER), &[IER_THR_BIT]);
+        serial.write(u64::from(DATA), &[b'a']);
 
         assert_eq!(intr_evt.read().unwrap(), 2);
         let mut data = [0u8];
-        serial.read(IER as u64, &mut data[..]);
+        serial.read(u64::from(IER), &mut data[..]);
         assert_eq!(data[0] & IER_FIFO_BITS, IER_THR_BIT);
-        serial.read(IIR as u64, &mut data[..]);
+        serial.read(u64::from(IIR), &mut data[..]);
         assert_ne!(data[0] & IIR_THR_BIT, 0);
     }
 
@@ -345,16 +343,16 @@ mod tests {
     fn serial_dlab() {
         let mut serial = Serial::new_sink(EventFd::new().unwrap());
 
-        serial.write(LCR as u64, &[LCR_DLAB_BIT as u8]);
-        serial.write(DLAB_LOW as u64, &[0x12 as u8]);
-        serial.write(DLAB_HIGH as u64, &[0x34 as u8]);
+        serial.write(u64::from(LCR), &[LCR_DLAB_BIT as u8]);
+        serial.write(u64::from(DLAB_LOW), &[0x12 as u8]);
+        serial.write(u64::from(DLAB_HIGH), &[0x34 as u8]);
 
         let mut data = [0u8];
-        serial.read(LCR as u64, &mut data[..]);
+        serial.read(u64::from(LCR), &mut data[..]);
         assert_eq!(data[0], LCR_DLAB_BIT as u8);
-        serial.read(DLAB_LOW as u64, &mut data[..]);
+        serial.read(u64::from(DLAB_LOW), &mut data[..]);
         assert_eq!(data[0], 0x12);
-        serial.read(DLAB_HIGH as u64, &mut data[..]);
+        serial.read(u64::from(DLAB_HIGH), &mut data[..]);
         assert_eq!(data[0], 0x34);
     }
 
@@ -362,32 +360,32 @@ mod tests {
     fn serial_modem() {
         let mut serial = Serial::new_sink(EventFd::new().unwrap());
 
-        serial.write(MCR as u64, &[MCR_LOOP_BIT as u8]);
-        serial.write(DATA as u64, &['a' as u8]);
-        serial.write(DATA as u64, &['b' as u8]);
-        serial.write(DATA as u64, &['c' as u8]);
+        serial.write(u64::from(MCR), &[MCR_LOOP_BIT as u8]);
+        serial.write(u64::from(DATA), &[b'a']);
+        serial.write(u64::from(DATA), &[b'b']);
+        serial.write(u64::from(DATA), &[b'c']);
 
         let mut data = [0u8];
-        serial.read(MSR as u64, &mut data[..]);
+        serial.read(u64::from(MSR), &mut data[..]);
         assert_eq!(data[0], DEFAULT_MODEM_STATUS as u8);
-        serial.read(MCR as u64, &mut data[..]);
+        serial.read(u64::from(MCR), &mut data[..]);
         assert_eq!(data[0], MCR_LOOP_BIT as u8);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'a' as u8);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'b' as u8);
-        serial.read(DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'c' as u8);
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'a');
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'b');
+        serial.read(u64::from(DATA), &mut data[..]);
+        assert_eq!(data[0], b'c');
     }
 
     #[test]
     fn serial_scratch() {
         let mut serial = Serial::new_sink(EventFd::new().unwrap());
 
-        serial.write(SCR as u64, &[0x12 as u8]);
+        serial.write(u64::from(SCR), &[0x12 as u8]);
 
         let mut data = [0u8];
-        serial.read(SCR as u64, &mut data[..]);
+        serial.read(u64::from(SCR), &mut data[..]);
         assert_eq!(data[0], 0x12 as u8);
     }
 }

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -162,10 +162,10 @@ impl Serial {
     fn handle_write(&mut self, offset: u8, v: u8) -> Result<()> {
         match offset as u8 {
             DLAB_LOW if self.is_dlab_set() => {
-                self.baud_divisor = (self.baud_divisor & 0xff00) | v as u16
+                self.baud_divisor = (self.baud_divisor & 0xff00) | u16::from(v)
             }
             DLAB_HIGH if self.is_dlab_set() => {
-                self.baud_divisor = (self.baud_divisor & 0x00ff) | ((v as u16) << 8)
+                self.baud_divisor = (self.baud_divisor & 0x00ff) | (u16::from(v) << 8)
             }
             DATA => {
                 if self.is_loop() {

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -38,6 +38,7 @@ pub type DeviceEventT = u16;
 
 /// The payload is used to handle events where the internal state of the VirtIO device
 /// needs to be changed.
+#[allow(clippy::large_enum_variant)]
 pub enum EpollHandlerPayload {
     /// DrivePayload(disk_image)
     DrivePayload(File),

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -147,9 +147,7 @@ fn build_disk_image_id(disk_image: &File) -> Vec<u8> {
             // This will also zero out any leftover bytes.
             let disk_id = m.as_bytes();
             let bytes_to_copy = cmp::min(disk_id.len(), VIRTIO_BLK_ID_BYTES as usize);
-            for i in 0..bytes_to_copy {
-                default_disk_image_id[i] = disk_id[i];
-            }
+            default_disk_image_id[..bytes_to_copy].clone_from_slice(&disk_id[..bytes_to_copy])
         }
     }
     default_disk_image_id
@@ -224,6 +222,7 @@ impl Request {
         Ok(req)
     }
 
+    #[allow(clippy::ptr_arg)]
     fn execute<T: Seek + Read + Write>(
         &self,
         disk: &mut T,

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -1114,6 +1114,7 @@ mod tests {
         n.activate(mem.clone(), interrupt_evt, status, queues, queue_evts)
     }
 
+    #[allow(clippy::needless_lifetimes)]
     fn default_test_netepollhandler<'a>(
         mem: &'a GuestMemory,
         test_mutators: TestMutators,
@@ -1173,6 +1174,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_virtio_device() {
         let mac = MacAddr::parse_str("11:22:33:44:55:66").unwrap();
         let mut dummy = DummyNet::new(Some(&mac));

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -142,8 +142,8 @@ fn frame_bytes_from_buf_mut(buf: &mut [u8]) -> &mut [u8] {
 fn init_vnet_hdr(buf: &mut [u8]) {
     // The buffer should be larger than vnet_hdr_len.
     // TODO: any better way to set all these bytes to 0? Or is this optimized by the compiler?
-    for i in 0..vnet_hdr_len() {
-        buf[i] = 0;
+    for i in &mut buf[0..vnet_hdr_len()] {
+        *i = 0;
     }
 }
 
@@ -466,7 +466,7 @@ impl NetEpollHandler {
             if Self::write_to_mmds_or_tap(
                 self.mmds_ns.as_mut(),
                 &mut self.tx.rate_limiter,
-                &mut self.tx.frame_buf[..read_count],
+                &self.tx.frame_buf[..read_count],
                 &mut self.tap,
                 self.guest_mac,
             ) && !self.rx.deferred_frame

--- a/devices/src/virtio/queue.rs
+++ b/devices/src/virtio/queue.rs
@@ -548,7 +548,7 @@ pub(crate) mod tests {
         // We try to make sure things are aligned properly :-s
         pub fn new(start: GuestAddress, mem: &'a GuestMemory, qsize: u16) -> Self {
             // power of 2?
-            assert!(qsize > 0 && qsize & qsize - 1 == 0);
+            assert!(qsize > 0 && qsize & (qsize - 1) == 0);
 
             let mut dtable = Vec::with_capacity(qsize as usize);
 
@@ -627,10 +627,10 @@ pub(crate) mod tests {
         assert!(DescriptorChain::checked_new(m, vq.dtable_start(), 16, 16).is_none());
 
         // desc_table address is way off
-        assert!(DescriptorChain::checked_new(m, GuestAddress(0xffffffffff), 16, 0).is_none());
+        assert!(DescriptorChain::checked_new(m, GuestAddress(0x00ff_ffff_ffff), 16, 0).is_none());
 
         // the addr field of the descriptor is way off
-        vq.dtable[0].addr.set(0xfffffffffff);
+        vq.dtable[0].addr.set(0x0fff_ffff_ffff);
         assert!(DescriptorChain::checked_new(m, vq.dtable_start(), 16, 0).is_none());
 
         // let's create some invalid chains
@@ -639,7 +639,7 @@ pub(crate) mod tests {
             // the addr field of the desc is ok now
             vq.dtable[0].addr.set(0x1000);
             // ...but the length is too large
-            vq.dtable[0].len.set(0xffffffff);
+            vq.dtable[0].len.set(0xffff_ffff);
             assert!(DescriptorChain::checked_new(m, vq.dtable_start(), 16, 0).is_none());
         }
 
@@ -707,19 +707,19 @@ pub(crate) mod tests {
 
         // or if the various addresses are off
 
-        q.desc_table = GuestAddress(0xffffffff);
+        q.desc_table = GuestAddress(0xffff_ffff);
         assert!(!q.is_valid(m));
         q.desc_table = GuestAddress(0x1001);
         assert!(!q.is_valid(m));
         q.desc_table = vq.dtable_start();
 
-        q.avail_ring = GuestAddress(0xffffffff);
+        q.avail_ring = GuestAddress(0xffff_ffff);
         assert!(!q.is_valid(m));
         q.avail_ring = GuestAddress(0x1001);
         assert!(!q.is_valid(m));
         q.avail_ring = vq.avail_start();
 
-        q.used_ring = GuestAddress(0xffffffff);
+        q.used_ring = GuestAddress(0xffff_ffff);
         assert!(!q.is_valid(m));
         q.used_ring = GuestAddress(0x1001);
         assert!(!q.is_valid(m));

--- a/devices/src/virtio/vhost/handle.rs
+++ b/devices/src/virtio/vhost/handle.rs
@@ -61,15 +61,15 @@ impl<T: Vhost> VhostEpollHandler<T> {
             .fetch_or(INTERRUPT_STATUS_USED_RING as usize, Ordering::SeqCst);
         self.interrupt_evt
             .write(1)
-            .map_err(|e| DeviceError::FailedSignalingUsedQueue(e))
+            .map_err(DeviceError::FailedSignalingUsedQueue)
     }
 
     pub fn get_queue_evt(&self) -> RawFd {
-        return self.queue_evt.as_raw_fd();
+        self.queue_evt.as_raw_fd()
     }
 
     pub fn get_device(&self) -> &T {
-        return &self.vhost_dev;
+        &self.vhost_dev
     }
 }
 

--- a/devices/src/virtio/vhost/vsock.rs
+++ b/devices/src/virtio/vhost/vsock.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 const QUEUE_SIZE: u16 = 256;
 const NUM_QUEUES: usize = 3;
-const QUEUE_SIZES: &'static [u16] = &[QUEUE_SIZE; NUM_QUEUES];
+const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 
 impl std::convert::From<super::Error> for ActivateError {
     fn from(error: super::Error) -> Self {
@@ -84,8 +84,8 @@ impl VirtioDevice for Vsock {
 
     fn ack_features(&mut self, page: u32, value: u32) {
         let mut v = match page {
-            0 => value as u64,
-            1 => (value as u64) << 32,
+            0 => u64::from(value),
+            1 => u64::from(value) << 32,
             _ => {
                 warn!(
                     "vsock: virtio-vsock device cannot ack unknown feature page: {}",
@@ -109,9 +109,9 @@ impl VirtioDevice for Vsock {
     fn read_config(&self, offset: u64, data: &mut [u8]) {
         match offset {
             0 if data.len() == 8 => LittleEndian::write_u64(data, self.cid),
-            0 if data.len() == 4 => LittleEndian::write_u32(data, (self.cid & 0xffffffff) as u32),
+            0 if data.len() == 4 => LittleEndian::write_u32(data, (self.cid & 0xffff_ffff) as u32),
             4 if data.len() == 4 => {
-                LittleEndian::write_u32(data, ((self.cid >> 32) & 0xffffffff) as u32)
+                LittleEndian::write_u32(data, ((self.cid >> 32) & 0xffff_ffff) as u32)
             }
             _ => warn!(
                 "vsock: virtio-vsock received invalid read request of {} bytes at offset {}",

--- a/dumbo/src/lib.rs
+++ b/dumbo/src/lib.rs
@@ -25,6 +25,9 @@ pub trait ByteBuffer: Index<usize, Output = u8> {
     /// Returns the length of the buffer.
     fn len(&self) -> usize;
 
+    /// Checks if the buffer is empty.
+    fn is_empty(&self) -> bool;
+
     /// Reads `buf.len()` bytes from `buf` into the inner buffer, starting at `offset`.
     ///
     /// # Panics
@@ -37,6 +40,11 @@ impl ByteBuffer for [u8] {
     #[inline]
     fn len(&self) -> usize {
         self.len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     #[inline]

--- a/dumbo/src/lib.rs
+++ b/dumbo/src/lib.rs
@@ -62,6 +62,10 @@ mod tests {
         buf.len()
     }
 
+    fn bb_is_empty<T: ByteBuffer + ?Sized>(buf: &T) -> bool {
+        buf.len() == 0
+    }
+
     fn bb_read_from_1<T: ByteBuffer + ?Sized>(src: &T, dst: &mut [u8]) {
         src.read_to_slice(1, dst);
     }
@@ -71,6 +75,7 @@ mod tests {
         let a = [1u8, 2, 3];
         let mut b = [0u8; 2];
         assert_eq!(bb_len(a.as_ref()), a.len());
+        assert_eq!(bb_is_empty(a.as_ref()), false);
         bb_read_from_1(a.as_ref(), b.as_mut());
         assert_eq!(b, [2, 3]);
     }

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -120,7 +120,7 @@ impl MmdsNetworkStack {
         } else {
             METRICS.mmds.rx_bad_eth.inc();
         }
-        return false;
+        false
     }
 
     fn detour_arp(&mut self, eth: EthernetFrame<&[u8]>) -> bool {
@@ -251,9 +251,8 @@ impl MmdsNetworkStack {
             .tcp_handler
             .write_next_packet(eth_unsized.inner_mut().payload_mut())?;
 
-        match event {
-            WriteEvent::EndpointDone => METRICS.mmds.connections_destroyed.inc(),
-            _ => (),
+        if let WriteEvent::EndpointDone = event {
+            METRICS.mmds.connections_destroyed.inc()
         }
 
         if let Some(packet_len) = maybe_len {

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -347,13 +347,14 @@ mod tests {
         }
 
         fn next_frame_as_ipv4_packet<'a>(&mut self, buf: &'a mut [u8]) -> IPv4Packet<&'a [u8]> {
-            let len = self.write_next_frame(buf.as_mut()).unwrap().get();
+            let len = self.write_next_frame(buf).unwrap().get();
             let eth = EthernetFrame::from_bytes(&buf[..len]).unwrap();
             IPv4Packet::from_bytes(&buf[eth.payload_offset()..len], true).unwrap()
         }
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_ns() {
         let mut ns = MmdsNetworkStack::new_with_defaults();
         assert_eq!(ns.mac_addr, MacAddr::parse_str(DEFAULT_MAC_ADDR).unwrap());

--- a/dumbo/src/pdu/arp.rs
+++ b/dumbo/src/pdu/arp.rs
@@ -393,6 +393,7 @@ mod tests {
             assert_eq!(f.spa(), spa);
             assert_eq!(f.tha(), tha);
             assert_eq!(f.tpa(), tpa);
+            assert_eq!(f.is_empty(), false);
         }
 
         // Now let's try to parse a request.

--- a/dumbo/src/pdu/arp.rs
+++ b/dumbo/src/pdu/arp.rs
@@ -179,9 +179,16 @@ impl<'a, T: NetworkBytes> EthIPv4ArpFrame<'a, T> {
         // length in request_from_bytes(). For some reason it seems nicer leaving it as is.
         self.bytes.len()
     }
+
+    /// Check if the frame is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.len() == 0
+    }
 }
 
 impl<'a, T: NetworkBytesMut> EthIPv4ArpFrame<'a, T> {
+    #[allow(clippy::too_many_arguments)]
     fn write_raw(
         buf: T,
         htype: u16,

--- a/dumbo/src/pdu/ethernet.rs
+++ b/dumbo/src/pdu/ethernet.rs
@@ -230,6 +230,7 @@ mod tests {
             assert_eq!(f2.ethertype(), ethertype);
             assert_eq!(f2.payload()[1], 132);
             assert_eq!(f2.len(), f2.bytes.len());
+            assert_eq!(f2.is_empty(), f2.bytes.len() == 0);
         }
 
         {

--- a/dumbo/src/pdu/ethernet.rs
+++ b/dumbo/src/pdu/ethernet.rs
@@ -95,6 +95,12 @@ impl<'a, T: NetworkBytes> EthernetFrame<'a, T> {
     pub fn len(&self) -> usize {
         self.bytes.len()
     }
+
+    /// Checks if the frame is empty or not.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.len() == 0
+    }
 }
 
 impl<'a, T: NetworkBytesMut> EthernetFrame<'a, T> {

--- a/dumbo/src/pdu/ipv4.rs
+++ b/dumbo/src/pdu/ipv4.rs
@@ -556,6 +556,7 @@ mod tests {
             assert_eq!(p.version_and_header_len(), (IPV4_VERSION, header_len));
             assert_eq!(p.dscp_and_ecn(), (0, 0));
             assert_eq!(p.total_len() as usize, buf_len);
+            assert_eq!(p.is_empty(), false);
             assert_eq!(p.identification(), 0);
             assert_eq!(p.flags_and_fragment_offset(), (0, 0));
             assert_eq!(p.ttl(), DEFAULT_TTL);

--- a/dumbo/src/pdu/ipv4.rs
+++ b/dumbo/src/pdu/ipv4.rs
@@ -212,6 +212,12 @@ impl<'a, T: NetworkBytes> IPv4Packet<'a, T> {
         self.bytes.len()
     }
 
+    /// Checks if the inner byte sequence is empty or not
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.len() == 0
+    }
+
     /// Computes and returns the packet header checksum using the provided header length.
     ///
     /// A nice description of how this works can be found [here]. May panic for invalid values of
@@ -225,7 +231,7 @@ impl<'a, T: NetworkBytes> IPv4Packet<'a, T> {
     pub fn compute_checksum_unchecked(&self, header_len: usize) -> u16 {
         let mut sum = 0u32;
         for i in 0..header_len / 2 {
-            sum += self.bytes.ntohs_unchecked(i * 2) as u32;
+            sum += u32::from(self.bytes.ntohs_unchecked(i * 2));
         }
 
         while sum >> 16 != 0 {
@@ -307,7 +313,7 @@ impl<'a, T: NetworkBytesMut> IPv4Packet<'a, T> {
     /// Sets the values of the `flags` and `fragment offset` header fields.
     #[inline]
     pub fn set_flags_and_fragment_offset(&mut self, flags: u8, fragment_offset: u16) -> &mut Self {
-        let value = ((flags as u16) << 13) | fragment_offset;
+        let value = (u16::from(flags) << 13) | fragment_offset;
         self.bytes
             .htons_unchecked(FLAGS_AND_FRAGMENTOFF_OFFSET, value);
         self

--- a/dumbo/src/pdu/tcp.rs
+++ b/dumbo/src/pdu/tcp.rs
@@ -629,12 +629,12 @@ mod tests {
         assert_eq!(p.destination_port(), 322);
 
         assert_eq!(p.sequence_number(), 0);
-        p.set_sequence_number(1234567);
-        assert_eq!(p.sequence_number(), 1234567);
+        p.set_sequence_number(1_234_567);
+        assert_eq!(p.sequence_number(), 1_234_567);
 
         assert_eq!(p.ack_number(), 0);
-        p.set_ack_number(345234);
-        assert_eq!(p.ack_number(), 345234);
+        p.set_ack_number(345_234);
+        assert_eq!(p.ack_number(), 345_234);
 
         assert_eq!(p.header_len_rsvd_ns(), (0, 0, false));
         assert_eq!(p.header_len(), 0);
@@ -662,6 +662,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::len_zero)]
     fn test_constructors() {
         let mut a = [1u8; 1460];
         let b = [2u8; 1000];
@@ -671,8 +672,8 @@ mod tests {
         let dst_addr = Ipv4Addr::new(192, 168, 44, 77);
         let src_port = 1234;
         let dst_port = 5678;
-        let seq_number = 11111222;
-        let ack_number = 34566543;
+        let seq_number = 11_111_222;
+        let ack_number = 34_566_543;
         let flags_after_ns = Flags::SYN | Flags::RST;
         let window_size = 19999;
         let mss_left = 1460;

--- a/dumbo/src/pdu/tcp.rs
+++ b/dumbo/src/pdu/tcp.rs
@@ -725,6 +725,7 @@ mod tests {
 
             // Payload was smaller than mss_left after options.
             assert_eq!(p.len(), header_len + b.len());
+            assert_eq!(p.is_empty(), p.len() == 0);
 
             p.len()
             // Mutable borrow of a goes out of scope.

--- a/dumbo/src/tcp/endpoint.rs
+++ b/dumbo/src/tcp/endpoint.rs
@@ -243,7 +243,7 @@ impl Endpoint {
             None
         };
 
-        return match self.connection.write_next_segment(
+        match self.connection.write_next_segment(
             buf,
             mss_reserved,
             tcp_payload_src,
@@ -254,7 +254,7 @@ impl Endpoint {
                 METRICS.mmds.tx_errors.inc();
                 None
             }
-        };
+        }
     }
 
     #[inline]

--- a/dumbo/src/tcp/endpoint.rs
+++ b/dumbo/src/tcp/endpoint.rs
@@ -305,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_endpoint() {
         let mut buf1 = [0u8; 500];
         let mut buf2 = [0u8; 500];

--- a/dumbo/src/tcp/handler.rs
+++ b/dumbo/src/tcp/handler.rs
@@ -492,6 +492,7 @@ mod tests {
         TcpSegment::from_bytes(p.payload_mut(), None).unwrap()
     }
 
+    #[allow(clippy::type_complexity)]
     fn write_next<'a>(
         h: &mut TcpIPv4Handler,
         buf: &'a mut [u8],
@@ -546,6 +547,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_handler() {
         let mut buf = [0u8; 100];
         let mut buf2 = [0u8; 2000];
@@ -695,13 +697,7 @@ mod tests {
 
         // Let's ACK the SYNACK.
         {
-            let seq = h
-                .connections
-                .get(&remote_tuple)
-                .unwrap()
-                .connection()
-                .first_not_sent()
-                .0;
+            let seq = h.connections[&remote_tuple].connection().first_not_sent().0;
             inner_tcp_mut(&mut p)
                 .set_flags_after_ns(TcpFlags::ACK)
                 .set_ack_number(seq);

--- a/dumbo/src/tcp/handler.rs
+++ b/dumbo/src/tcp/handler.rs
@@ -235,7 +235,6 @@ impl TcpIPv4Handler {
 
                 if self.connections.len() >= self.max_connections {
                     if let Some(evict_tuple) = self.find_evictable_connection() {
-                        // The unwrap() is safe because evict_tuple must be present as a key.
                         let rst_config = self.connections[&evict_tuple]
                             .connection()
                             .make_rst_config();

--- a/dumbo/src/tcp/mod.rs
+++ b/dumbo/src/tcp/mod.rs
@@ -59,8 +59,8 @@ impl RstConfig {
 
     /// Returns the sequence number, acknowledgement number, and TCP flags (not counting `NS`) that
     /// must be set on the outgoing `RST` segment.
-    pub fn seq_ack_tcp_flags(&self) -> (u32, u32, TcpFlags) {
-        match *self {
+    pub fn seq_ack_tcp_flags(self) -> (u32, u32, TcpFlags) {
+        match self {
             RstConfig::Seq(seq) => (seq, 0, TcpFlags::RST),
             RstConfig::Ack(ack) => (0, ack, TcpFlags::RST | TcpFlags::ACK),
         }

--- a/jailer/src/cgroup.rs
+++ b/jailer/src/cgroup.rs
@@ -21,7 +21,7 @@ const CPUSET_MEMS: &str = "cpuset.mems";
 const CONTROLLER_PIDS: &str = "pids";
 
 // The list of cgroup controllers we're interested in.
-const CONTROLLERS: [&'static str; 3] = [CONTROLLER_CPU, CONTROLLER_CPUSET, CONTROLLER_PIDS];
+const CONTROLLERS: [&str; 3] = [CONTROLLER_CPU, CONTROLLER_CPUSET, CONTROLLER_PIDS];
 const PROC_MOUNTS: &str = "/proc/mounts";
 const NODE_TO_CPULIST: &str = "/sys/devices/system/node/node";
 
@@ -143,16 +143,16 @@ impl Cgroup {
                 // We could do the search in a more efficient manner but eh.
                 let v: Vec<&str> = capture["options"].split(',').collect();
 
-                for controller in CONTROLLERS.into_iter() {
-                    if v.contains(controller) {
-                        if let Some(_) =
-                            found_controllers.insert(controller, PathBuf::from(&capture["dir"]))
-                        {
-                            return Err(Error::CgroupLineNotUnique(
-                                PROC_MOUNTS.to_string(),
-                                controller.to_string(),
-                            ));
-                        }
+                for controller in CONTROLLERS.iter() {
+                    if v.contains(controller)
+                        && found_controllers
+                            .insert(controller, PathBuf::from(&capture["dir"]))
+                            .is_some()
+                    {
+                        return Err(Error::CgroupLineNotUnique(
+                            PROC_MOUNTS.to_string(),
+                            controller.to_string(),
+                        ));
                     }
                 }
             }
@@ -162,7 +162,7 @@ impl Cgroup {
 
         if keys_len < CONTROLLERS.len() {
             // We return an error about the first one we didn't find.
-            for controller in CONTROLLERS.into_iter() {
+            for controller in CONTROLLERS.iter() {
                 if !found_controllers.contains_key(controller) {
                     return Err(Error::CgroupLineNotFound(
                         PROC_MOUNTS.to_string(),

--- a/jailer/src/cgroup.rs
+++ b/jailer/src/cgroup.rs
@@ -253,7 +253,7 @@ mod tests {
         let dir = tempdir().expect("Cannot create temporary directory.");
         // This is /A/B/C .
         let dir2 = tempdir_in(dir.path()).expect("Cannot create temporary directory.");
-        let path2 = PathBuf::from(dir2.path());
+        let mut path2 = PathBuf::from(dir2.path());
         let result = inherit_from_parent(&mut PathBuf::from(&path2), "inexistent");
         assert!(result.is_err());
         assert!(format!("{:?}", result).contains("ReadToString"));
@@ -262,7 +262,7 @@ mod tests {
         // the grandparent file does not exist.
         let mut named_file = NamedTempFile::new_in(dir.path()).expect("Cannot create named file.");
         let result = inherit_from_parent(
-            &mut PathBuf::from(path2.clone()),
+            &mut path2.clone(),
             named_file.path().file_name().unwrap().to_str().unwrap(),
         );
         assert!(result.is_err());
@@ -277,7 +277,7 @@ mod tests {
         let some_line = "Parent line";
         writeln!(named_file, "{}", some_line).expect("Cannot write to file.");
         let result = inherit_from_parent(
-            &mut PathBuf::from(path2),
+            &mut path2,
             named_file.path().file_name().unwrap().to_str().unwrap(),
         );
         assert!(result.is_ok());

--- a/jailer/src/env.rs
+++ b/jailer/src/env.rs
@@ -329,6 +329,7 @@ mod tests {
 
     use clap_app;
 
+    #[allow(clippy::too_many_arguments)]
     fn make_args<'a>(
         node: &str,
         id: &str,

--- a/jailer/src/env.rs
+++ b/jailer/src/env.rs
@@ -63,7 +63,7 @@ impl Env {
         // should not fail.
         let id = get_value(&args, "id")?;
 
-        validators::validate_instance_id(id).map_err(|e| Error::InvalidInstanceId(e))?;
+        validators::validate_instance_id(id).map_err(Error::InvalidInstanceId)?;
 
         let numa_node_str = get_value(&args, "numa_node")?;
         let numa_node = numa_node_str
@@ -113,7 +113,7 @@ impl Env {
         // they are all unsigned integers.
         let seccomp_level = get_value(&args, "seccomp-level")?
             .parse::<u32>()
-            .map_err(|err| Error::SeccompLevel(err))?;
+            .map_err(Error::SeccompLevel)?;
 
         Ok(Env {
             id: id.to_string(),

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -378,6 +378,7 @@ mod tests {
         assert!(fs::remove_dir_all(tmp_dir_path).is_ok());
     }
 
+    #[allow(clippy::cyclomatic_complexity)]
     #[test]
     fn test_error_display() {
         let path = PathBuf::from("/foo");
@@ -420,19 +421,19 @@ mod tests {
             "Found more than one cgroups configuration line in /proc/mounts for sysfs",
         );
         assert_eq!(
-            format!("{}", Error::ChangeFileOwner(err42.clone(), "/dev/net/tun")),
+            format!("{}", Error::ChangeFileOwner(err42, "/dev/net/tun")),
             "Failed to change owner for /dev/net/tun: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::ChdirNewRoot(err42.clone())),
+            format!("{}", Error::ChdirNewRoot(err42)),
             "Failed to chdir into chroot directory: Errno 42"
         );
         assert_eq!(
-            format!("{}", Error::CloseNetNsFd(err42.clone())),
+            format!("{}", Error::CloseNetNsFd(err42)),
             "Failed to close netns fd: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::CloseDevNullFd(err42.clone())),
+            format!("{}", Error::CloseDevNullFd(err42)),
             "Failed to close /dev/null fd: Errno 42",
         );
         assert_eq!(
@@ -461,7 +462,7 @@ mod tests {
             "Encountered interior \\0 while parsing a string",
         );
         assert_eq!(
-            format!("{}", Error::Dup2(err42.clone())),
+            format!("{}", Error::Dup2(err42)),
             "Failed to duplicate fd: Errno 42",
         );
         assert_eq!(
@@ -484,7 +485,7 @@ mod tests {
             "Failed to decode string from byte array: [47, 0]",
         );
         assert_eq!(
-            format!("{}", Error::GetOldFdFlags(err42.clone())),
+            format!("{}", Error::GetOldFdFlags(err42)),
             "Failed to get flags from fd: Errno 42",
         );
         assert_eq!(
@@ -507,19 +508,19 @@ mod tests {
             "File /foo/bar doesn't have a parent",
         );
         assert_eq!(
-            format!("{}", Error::MkdirOldRoot(err42.clone())),
+            format!("{}", Error::MkdirOldRoot(err42)),
             "Failed to create the jail root directory before pivoting root: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::MknodDev(err42.clone(), "/dev/net/tun")),
+            format!("{}", Error::MknodDev(err42, "/dev/net/tun")),
             "Failed to create /dev/net/tun via mknod inside the jail: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::MountBind(err42.clone())),
+            format!("{}", Error::MountBind(err42)),
             "Failed to bind mount the jail root directory: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::MountPropagationPrivate(err42.clone())),
+            format!("{}", Error::MountPropagationPrivate(err42)),
             "Failed to change the propagation type to private: Errno 42",
         );
         assert_eq!(
@@ -531,7 +532,7 @@ mod tests {
             "Invalid numa node: foobar",
         );
         assert_eq!(
-            format!("{}", Error::OpenDevNull(err42.clone())),
+            format!("{}", Error::OpenDevNull(err42)),
             "Failed to open /dev/null: Errno 42",
         );
         assert_eq!(
@@ -542,7 +543,7 @@ mod tests {
             "Failed to parse path /foo/bar into an OsString",
         );
         assert_eq!(
-            format!("{}", Error::PivotRoot(err42.clone())),
+            format!("{}", Error::PivotRoot(err42)),
             "Failed to pivot root: Errno 42",
         );
         assert_eq!(
@@ -564,7 +565,7 @@ mod tests {
             format!("Regex failed: {:?}", err_regex),
         );
         assert_eq!(
-            format!("{}", Error::RmOldRootDir(err42.clone())),
+            format!("{}", Error::RmOldRootDir(err42)),
             "Failed to remove old jail root directory: Errno 42",
         );
         assert_eq!(
@@ -576,11 +577,11 @@ mod tests {
             format!("Failed to change current directory: {}", err2_str),
         );
         assert_eq!(
-            format!("{}", Error::SetNetNs(err42.clone())),
+            format!("{}", Error::SetNetNs(err42)),
             "Failed to join network namespace: netns: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::SetSid(err42.clone())),
+            format!("{}", Error::SetSid(err42)),
             "Failed to daemonize: setsid: Errno 42",
         );
         assert_eq!(
@@ -588,7 +589,7 @@ mod tests {
             "Invalid uid: foobar",
         );
         assert_eq!(
-            format!("{}", Error::UmountOldRoot(err42.clone())),
+            format!("{}", Error::UmountOldRoot(err42)),
             "Failed to unmount the old jail root: Errno 42",
         );
         assert_eq!(
@@ -596,11 +597,11 @@ mod tests {
             "Unexpected value for the socket listener fd: 42",
         );
         assert_eq!(
-            format!("{}", Error::UnshareNewNs(err42.clone())),
+            format!("{}", Error::UnshareNewNs(err42)),
             "Failed to unshare into new mount namespace: Errno 42",
         );
         assert_eq!(
-            format!("{}", Error::UnsetCloexec(err42.clone())),
+            format!("{}", Error::UnsetCloexec(err42)),
             "Failed to unset the O_CLOEXEC flag on the socket fd: Errno 42",
         );
         assert_eq!(

--- a/kernel/src/cmdline/mod.rs
+++ b/kernel/src/cmdline/mod.rs
@@ -83,7 +83,7 @@ impl Cmdline {
         assert_ne!(capacity, 0);
         Cmdline {
             line: String::with_capacity(capacity),
-            capacity: capacity,
+            capacity,
         }
     }
 

--- a/kernel/src/loader/elf.rs
+++ b/kernel/src/loader/elf.rs
@@ -90,6 +90,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::zero_ptr)]
     fn bindgen_test_layout_elf64_phdr() {
         assert_eq!(
             ::std::mem::size_of::<elf64_phdr>(),
@@ -184,6 +185,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::zero_ptr)]
     fn bindgen_test_layout_elf64_hdr() {
         assert_eq!(
             ::std::mem::size_of::<elf64_hdr>(),

--- a/kernel/src/loader/mod.rs
+++ b/kernel/src/loader/mod.rs
@@ -152,10 +152,10 @@ mod tests {
     use memory_model::{GuestAddress, GuestMemory};
     use std::io::Cursor;
 
-    const MEM_SIZE: usize = 0x180000;
+    const MEM_SIZE: usize = 0x18_0000;
 
     fn create_guest_mem() -> GuestMemory {
-        GuestMemory::new(&vec![(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+        GuestMemory::new(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
     }
 
     #[test]
@@ -185,19 +185,19 @@ mod tests {
             )
         );
         let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, '1' as u8);
+        assert_eq!(val, b'1');
         cmdline_address = cmdline_address.unchecked_add(1);
         let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, '2' as u8);
+        assert_eq!(val, b'2');
         cmdline_address = cmdline_address.unchecked_add(1);
         let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, '3' as u8);
+        assert_eq!(val, b'3');
         cmdline_address = cmdline_address.unchecked_add(1);
         let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, '4' as u8);
+        assert_eq!(val, b'4');
         cmdline_address = cmdline_address.unchecked_add(1);
         let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, '\0' as u8);
+        assert_eq!(val, b'\0');
     }
 
     // Elf64 image that prints hello world on x86_64.
@@ -212,7 +212,7 @@ mod tests {
         let gm = create_guest_mem();
         let image = make_elf_bin();
         assert_eq!(
-            Ok(GuestAddress(0x100000)),
+            Ok(GuestAddress(0x10_0000)),
             load_kernel(&gm, &mut Cursor::new(&image), 0)
         );
     }

--- a/kvm/src/ioctl_defs.rs
+++ b/kvm/src/ioctl_defs.rs
@@ -84,7 +84,7 @@ mod tests {
     use super::*;
     use sys_util::{ioctl, ioctl_with_val};
 
-    const KVM_PATH: &'static str = "/dev/kvm\0";
+    const KVM_PATH: &str = "/dev/kvm\0";
 
     #[test]
     fn get_version() {

--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -37,17 +37,17 @@ pub enum LoggerError {
 impl fmt::Display for LoggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
-            LoggerError::NeverInitialized(ref e) => format!("{}", e),
-            LoggerError::IsPreinitializing => format!(
-                "{}",
+            LoggerError::NeverInitialized(ref e) => e.to_string(),
+            LoggerError::IsPreinitializing => {
                 "The logger is preinitializing. Can't perform the requested action right now."
-            ),
-            LoggerError::IsInitializing => format!(
-                "{}",
+                    .to_string()
+            }
+            LoggerError::IsInitializing => {
                 "The logger is initializing. Can't perform the requested action right now."
-            ),
+                    .to_string()
+            }
             LoggerError::AlreadyInitialized => {
-                format!("{}", "Reinitialization of logger not allowed.")
+                "Reinitialization of logger not allowed.".to_string()
             }
             LoggerError::InvalidLogOption(ref s) => format!("Invalid log option: {}", s),
             LoggerError::OpenFIFO(ref e) => {
@@ -59,9 +59,9 @@ impl fmt::Display for LoggerError {
             LoggerError::LogFlush(ref e) => {
                 format!("Failed to flush logs. Error: {}", e.description())
             }
-            LoggerError::MutexLockFailure(ref e) => format!("{}", e),
-            LoggerError::LogMetricFailure(ref e) => format!("{}", e),
-            LoggerError::LogMetricRateLimit => format!("{}", "Metric will not yet be logged."),
+            LoggerError::MutexLockFailure(ref e) => e.to_string(),
+            LoggerError::LogMetricFailure(ref e) => e.to_string(),
+            LoggerError::LogMetricRateLimit => "Metric will not yet be logged.".to_string(),
         };
         write!(f, "{}", printable)
     }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -515,7 +515,7 @@ impl Logger {
         }
     }
 
-    fn set_flags(options: &Vec<Value>) -> Result<()> {
+    fn set_flags(options: &[Value]) -> Result<()> {
         let mut flags = 0;
         for option in options.iter() {
             if let Value::String(s_opt) = option {
@@ -634,7 +634,7 @@ impl Logger {
         instance_id: &str,
         log_pipe: String,
         metrics_pipe: String,
-        options: &Vec<Value>,
+        options: &[Value],
     ) -> Result<()> {
         self.try_lock(INITIALIZING)?;
 

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -847,6 +847,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_init() {
         let app_info = AppInfo::new(TEST_APP_NAME, TEST_APP_VERSION);
 
@@ -876,7 +877,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
-                l.init(&app_info, TEST_INSTANCE_ID, log_file.clone(), metrics_file.clone(), &vec![Value::Bool(true)])
+                l.init(&app_info, TEST_INSTANCE_ID, log_file.clone(), metrics_file.clone(), &[Value::Bool(true)])
                     .err()
             ),
             "Some(NeverInitialized(\"Could not set option flags: Invalid log option: Bool(true)\"))"
@@ -889,7 +890,7 @@ mod tests {
                     TEST_INSTANCE_ID,
                     log_file.clone(),
                     metrics_file.clone(),
-                    &vec![Value::String("foobar".to_string())]
+                    &[Value::String("foobar".to_string())]
                 )
                 .err()
             ),
@@ -915,7 +916,7 @@ mod tests {
                 TEST_INSTANCE_ID,
                 log_file.clone(),
                 metrics_file.clone(),
-                &vec![Value::String("LogDirtyPages".to_string())]
+                &[Value::String("LogDirtyPages".to_string())]
             )
             .is_ok());
 
@@ -928,7 +929,7 @@ mod tests {
                 TEST_INSTANCE_ID,
                 log_file.clone(),
                 metrics_file.clone(),
-                &vec![]
+                &[]
             )
             .is_err());
 
@@ -966,7 +967,7 @@ mod tests {
                 TEST_INSTANCE_ID,
                 String::from(""),
                 metrics_file.clone(),
-                &vec![]
+                &[]
             )
             .is_err());
 
@@ -975,7 +976,7 @@ mod tests {
             TEST_INSTANCE_ID,
             log_file.clone(),
             String::from(""),
-            &vec![],
+            &[],
         );
         assert!(res.is_err());
 
@@ -1010,7 +1011,7 @@ mod tests {
                     TEST_INSTANCE_ID,
                     log_file.clone(),
                     metrics_file.clone(),
-                    &vec![]
+                    &[]
                 )
                 .err()
             ),

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -59,7 +59,7 @@ pub struct SimpleMetric(AtomicUsize);
 
 impl Metric for SimpleMetric {
     fn add(&self, value: usize) {
-        let ref count = self.0;
+        let count = &self.0;
         count.store(count.load(Ordering::Relaxed) + value, Ordering::Relaxed);
     }
 

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -455,7 +455,7 @@ mod tests {
         // but it something fails, then we definitely have a problem :-s
 
         const NUM_THREADS_TO_SPAWN: usize = 4;
-        const NUM_INCREMENTS_PER_THREAD: usize = 100000;
+        const NUM_INCREMENTS_PER_THREAD: usize = 10_0000;
         const M2_INITIAL_COUNT: usize = 123;
 
         m2.add(M2_INITIAL_COUNT);

--- a/logger/src/writers.rs
+++ b/logger/src/writers.rs
@@ -22,7 +22,7 @@ pub struct PipeLogWriter {
 }
 
 impl PipeLogWriter {
-    pub fn new(fifo_path: &String) -> Result<PipeLogWriter> {
+    pub fn new(fifo_path: &str) -> Result<PipeLogWriter> {
         let fifo = PathBuf::from(fifo_path);
         match OpenOptions::new()
             .custom_flags(O_NONBLOCK)
@@ -33,15 +33,15 @@ impl PipeLogWriter {
             Ok(t) => Ok(PipeLogWriter {
                 line_writer: Mutex::new(LineWriter::new(t)),
             }),
-            Err(e) => return Err(LoggerError::OpenFIFO(e)),
+            Err(e) => Err(LoggerError::OpenFIFO(e)),
         }
     }
 
-    pub fn write(&self, msg: &String) -> Result<()> {
+    pub fn write(&self, msg: &str) -> Result<()> {
         let mut line_writer = self.get_line_writer()?;
         line_writer
             .write_all(msg.as_bytes())
-            .map_err(|e| LoggerError::LogWrite(e))
+            .map_err(LoggerError::LogWrite)
     }
 
     fn get_line_writer(&self) -> Result<(MutexGuard<LineWriter<File>>)> {

--- a/memory_model/src/guest_address.rs
+++ b/memory_model/src/guest_address.rs
@@ -25,34 +25,34 @@ impl GuestAddress {
     ///   let addr = GuestAddress(0x150);
     ///   assert_eq!(addr.offset_from(base), 0x50usize);
     /// ```
-    pub fn offset_from(&self, base: GuestAddress) -> usize {
+    pub fn offset_from(self, base: GuestAddress) -> usize {
         self.0 - base.0
     }
 
     /// Returns the address as a usize offset from 0x0.
     /// Use this when a raw number is needed to pass to the kernel.
-    pub fn offset(&self) -> usize {
+    pub fn offset(self) -> usize {
         self.0
     }
 
     /// Returns the result of the add or None if there is overflow.
-    pub fn checked_add(&self, other: usize) -> Option<GuestAddress> {
+    pub fn checked_add(self, other: usize) -> Option<GuestAddress> {
         self.0.checked_add(other).map(GuestAddress)
     }
 
     /// Returns the result of the base address + the size.
     /// Only use this when `offset` is guaranteed not to overflow.
-    pub fn unchecked_add(&self, offset: usize) -> GuestAddress {
+    pub fn unchecked_add(self, offset: usize) -> GuestAddress {
         GuestAddress(self.0 + offset)
     }
 
     /// Returns the result of the subtraction of None if there is underflow.
-    pub fn checked_sub(&self, other: usize) -> Option<GuestAddress> {
+    pub fn checked_sub(self, other: usize) -> Option<GuestAddress> {
         self.0.checked_sub(other).map(GuestAddress)
     }
 
     /// Returns the bitwise and of the address with the given mask.
-    pub fn mask(&self, mask: u64) -> GuestAddress {
+    pub fn mask(self, mask: u64) -> GuestAddress {
         GuestAddress(self.0 & mask as usize)
     }
 }

--- a/memory_model/src/guest_address.rs
+++ b/memory_model/src/guest_address.rs
@@ -109,6 +109,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::eq_op)]
     fn cmp() {
         let a = GuestAddress(0x300);
         let b = GuestAddress(0x301);
@@ -135,8 +136,8 @@ mod tests {
 
     #[test]
     fn checked_add_overflow() {
-        let a = GuestAddress(0xffffffffffffff55);
-        assert_eq!(Some(GuestAddress(0xffffffffffffff57)), a.checked_add(2));
+        let a = GuestAddress(0xffff_ffff_ffff_ff55);
+        assert_eq!(Some(GuestAddress(0xffff_ffff_ffff_ff57)), a.checked_add(2));
         assert!(a.checked_add(0xf0).is_none());
     }
 

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -390,7 +390,7 @@ impl GuestMemory {
         self.do_in_region(guest_addr, 1, |mapping, offset| {
             // This is safe; `do_in_region` already checks that offset is in
             // bounds.
-            Ok(unsafe { mapping.as_ptr().offset(offset as isize) } as *const u8)
+            Ok(unsafe { mapping.as_ptr().add(offset) } as *const u8)
         })
     }
 

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -475,14 +475,13 @@ mod tests {
     fn test_regions() {
         // No regions provided should return error.
         assert_eq!(
-            format!("{:?}", GuestMemory::new(&vec![]).err().unwrap()),
+            format!("{:?}", GuestMemory::new(&[]).err().unwrap()),
             format!("{:?}", Error::NoMemoryRegions)
         );
 
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x800);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
         assert_eq!(guest_mem.num_regions(), 2);
         assert!(guest_mem.address_in_range(GuestAddress(0x200)));
         assert!(!guest_mem.address_in_range(GuestAddress(0x600)));
@@ -499,7 +498,7 @@ mod tests {
     fn overlap_memory() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let res = GuestMemory::new(&vec![(start_addr1, 0x2000), (start_addr2, 0x2000)]);
+        let res = GuestMemory::new(&[(start_addr1, 0x2000), (start_addr2, 0x2000)]);
         assert_eq!(
             format!("{:?}", res.err().unwrap()),
             format!("{:?}", Error::MemoryRegionOverlap)
@@ -513,10 +512,10 @@ mod tests {
         let bad_addr = GuestAddress(0x2001);
         let bad_addr2 = GuestAddress(0x1ffc);
 
-        let gm = GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let gm = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
 
-        let val1: u64 = 0xaa55aa55aa55aa55;
-        let val2: u64 = 0x55aa55aa55aa55aa;
+        let val1: u64 = 0xaa55_aa55_aa55_aa55;
+        let val2: u64 = 0x55aa_55aa_55aa_55aa;
         assert_eq!(
             format!("{:?}", gm.write_obj_at_addr(val1, bad_addr).err().unwrap()),
             format!(
@@ -546,7 +545,7 @@ mod tests {
     #[test]
     fn write_and_read_slice() {
         let mut start_addr = GuestAddress(0x1000);
-        let gm = GuestMemory::new(&vec![(start_addr, 0x400)]).unwrap();
+        let gm = GuestMemory::new(&[(start_addr, 0x400)]).unwrap();
         let sample_buf = &[1, 2, 3, 4, 5];
 
         assert_eq!(gm.write_slice_at_addr(sample_buf, start_addr).unwrap(), 5);
@@ -563,7 +562,7 @@ mod tests {
 
     #[test]
     fn read_to_and_write_from_mem() {
-        let gm = GuestMemory::new(&vec![(GuestAddress(0x1000), 0x400)]).unwrap();
+        let gm = GuestMemory::new(&[(GuestAddress(0x1000), 0x400)]).unwrap();
         let addr = GuestAddress(0x1010);
         gm.write_obj_at_addr(!0u32, addr).unwrap();
         gm.read_to_memory(
@@ -616,7 +615,7 @@ mod tests {
     fn guest_to_host() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x100);
-        let mem = GuestMemory::new(&vec![(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
+        let mem = GuestMemory::new(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
 
         // Verify the host addresses match what we expect from the mappings.
         let addr1_base = get_mapping(&mem, start_addr1).unwrap();
@@ -627,7 +626,7 @@ mod tests {
         assert_eq!(host_addr2, addr2_base);
 
         // Check that a bad address returns an error.
-        let bad_addr = GuestAddress(0x123456);
+        let bad_addr = GuestAddress(0x12_3456);
         assert!(mem.get_host_address(bad_addr).is_err());
     }
 
@@ -635,7 +634,7 @@ mod tests {
     fn test_map_fold() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x400);
-        let mem = GuestMemory::new(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+        let mem = GuestMemory::new(&[(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
 
         assert_eq!(
             mem.map_and_fold(

--- a/memory_model/src/mmap.rs
+++ b/memory_model/src/mmap.rs
@@ -313,6 +313,7 @@ impl MemoryMapping {
         std::slice::from_raw_parts(self.addr, self.size)
     }
 
+    #[allow(clippy::mut_from_ref)]
     unsafe fn as_mut_slice(&self) -> &mut [u8] {
         // This is safe because we mapped the area at addr ourselves, so this slice will not
         // overflow. However, it is possible to alias.

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -92,21 +92,15 @@ mod tests {
 
         assert!(headers.headers.contains_key(&Header::ContentType));
         assert_eq!(
-            headers.headers.get(&Header::ContentType).unwrap(),
+            &headers.headers[&Header::ContentType],
             &"text/plain".to_string()
         );
         assert!(headers.headers.contains_key(&Header::ContentLength));
-        assert_eq!(
-            headers.headers.get(&Header::ContentLength).unwrap(),
-            &"120".to_string()
-        );
+        assert_eq!(&headers.headers[&Header::ContentLength], &"120".to_string());
 
         // Test that adding a Header with the same key, updates the value.
         headers.add(Header::ContentLength, "130".to_string());
-        assert_eq!(
-            headers.headers.get(&Header::ContentLength).unwrap(),
-            &"130".to_string()
-        );
+        assert_eq!(&headers.headers[&Header::ContentLength], &"130".to_string());
     }
 
     #[test]

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -33,9 +33,9 @@ pub struct Headers {
 impl Headers {
     /// By default Requests are created with no headers.
     pub fn default() -> Headers {
-        return Headers {
+        Headers {
             headers: HashMap::new(),
-        };
+        }
     }
 
     /// Adds a new header to the list.

--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -46,12 +46,17 @@ impl Body {
 
     /// Returns the body as an `u8 slice`.
     pub fn raw(&self) -> &[u8] {
-        return self.body.as_slice();
+        self.body.as_slice()
     }
 
     /// Returns the length of the `Body`.
     pub fn len(&self) -> usize {
-        return self.body.len();
+        self.body.len()
+    }
+
+    /// Checks if the body is empty, ie with zero length
+    pub fn is_empty(&self) -> bool {
+        self.body.len() == 0
     }
 }
 
@@ -107,7 +112,7 @@ pub enum Version {
 
 impl Version {
     /// HTTP Version as an `u8 slice`.
-    pub fn raw(&self) -> &'static [u8] {
+    pub fn raw(self) -> &'static [u8] {
         match self {
             Version::Http10 => b"HTTP/1.0",
             Version::Http11 => b"HTTP/1.1",

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -187,7 +187,7 @@ mod tests {
     impl<'a> PartialEq for Request<'a> {
         fn eq(&self, other: &Request) -> bool {
             // Ignore the other fields of Request for now because they are not used.
-            return self.request_line == other.request_line;
+            self.request_line == other.request_line
         }
     }
 

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -32,7 +32,7 @@ impl<'a> Uri<'a> {
     }
 
     fn try_from(bytes: &'a [u8]) -> Result<Self, RequestError> {
-        if bytes.len() == 0 {
+        if bytes.is_empty() {
             return Err(RequestError::InvalidUri("Empty URI not allowed."));
         }
         let utf8_slice =
@@ -57,7 +57,7 @@ impl<'a> Uri<'a> {
 
         if self.slice.starts_with(HTTP_SCHEME_PREFIX) {
             let without_scheme = &self.slice[HTTP_SCHEME_PREFIX.len()..];
-            if without_scheme.len() == 0 {
+            if without_scheme.is_empty() {
                 return "";
             }
             // The host in this case includes the port and contains the bytes after http:// up to
@@ -67,7 +67,7 @@ impl<'a> Uri<'a> {
                 None => "",
             }
         } else {
-            if self.slice.starts_with("/") {
+            if self.slice.starts_with('/') {
                 return &self.slice;
             }
 

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -27,7 +27,7 @@ pub enum StatusCode {
 }
 
 impl StatusCode {
-    fn raw(&self) -> &'static [u8; 3] {
+    fn raw(self) -> &'static [u8; 3] {
         match self {
             StatusCode::OK => b"200",
             StatusCode::BadRequest => b"400",
@@ -45,10 +45,10 @@ struct StatusLine {
 
 impl StatusLine {
     fn new(http_version: Version, status_code: StatusCode) -> Self {
-        return StatusLine {
+        StatusLine {
             http_version,
             status_code,
-        };
+        }
     }
 
     fn write_all<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
@@ -74,11 +74,11 @@ pub struct Response {
 impl Response {
     /// Creates a new HTTP `Response` with an empty body.
     pub fn new(http_version: Version, status_code: StatusCode) -> Response {
-        return Response {
+        Response {
             status_line: StatusLine::new(http_version, status_code),
             headers: Headers::default(),
             body: None,
-        };
+        }
     }
 
     /// Updates the body of the `Response`.
@@ -128,7 +128,7 @@ impl Response {
 
     /// Returns the HTTP Version of the response.
     pub fn http_version(&self) -> Version {
-        self.status_line.http_version.clone()
+        self.status_line.http_version
     }
 }
 

--- a/mmds/src/data_store.rs
+++ b/mmds/src/data_store.rs
@@ -32,7 +32,7 @@ impl Mmds {
     /// code should be 404 (Not Found) otherwise the returned status code should be
     /// 204 (No Content).
     pub fn is_initialized(&self) -> bool {
-        return self.is_initialized;
+        self.is_initialized
     }
 
     pub fn put_data(&mut self, data: Value) {
@@ -50,7 +50,7 @@ impl Mmds {
         if self.data_store.is_null() {
             return String::from("{}");
         }
-        return self.data_store.to_string();
+        self.data_store.to_string()
     }
 
     /// This function replicates the behavior of the Instance Metadata Service
@@ -64,9 +64,10 @@ impl Mmds {
     pub fn get_value(&self, path: String) -> Result<Vec<String>, Error> {
         // The pointer function splits the input by "/". With a trailing "/", pointer does not
         // know how to get the object.
-        let value = match path.ends_with('/') {
-            true => self.data_store.pointer(&path.as_str()[..(path.len() - 1)]),
-            false => self.data_store.pointer(path.as_str()),
+        let value = if path.ends_with('/') {
+            self.data_store.pointer(&path.as_str()[..(path.len() - 1)])
+        } else {
+            self.data_store.pointer(path.as_str())
         };
 
         match value {
@@ -88,7 +89,7 @@ impl Mmds {
 
                             ret.push(key);
                         }
-                        return Ok(ret);
+                        Ok(ret)
                     }
                     None => {
                         // When the object is not a map, return the value.
@@ -96,14 +97,14 @@ impl Mmds {
                         match val.as_str() {
                             Some(str_val) => {
                                 ret.push(str_val.to_string());
-                                return Ok(ret);
+                                Ok(ret)
                             }
-                            None => return Err(Error::UnsupportedValueType),
-                        };
+                            None => Err(Error::UnsupportedValueType),
+                        }
                     }
-                };
+                }
             }
-            None => return Err(Error::NotFound),
+            None => Err(Error::NotFound),
         }
     }
 }

--- a/mmds/src/lib.rs
+++ b/mmds/src/lib.rs
@@ -208,7 +208,7 @@ mod tests {
 
         let request = b"GET http://169.254.169.254/age HTTP/1.0\r\n";
         let mut expected_response = Response::new(Version::Http10, StatusCode::InternalServerError);
-        let body = format!("The resource /age has an invalid format.");
+        let body = "The resource /age has an invalid format.".to_string();
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
         assert!(expected_response.status() == actual_response.status());

--- a/mmds/src/lib.rs
+++ b/mmds/src/lib.rs
@@ -33,7 +33,7 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
     match request {
         Ok(request) => {
             let uri = request.uri().get_abs_path();
-            if uri.len() == 0 {
+            if uri.is_empty() {
                 return build_response(
                     request.http_version(),
                     StatusCode::BadRequest,
@@ -61,21 +61,21 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
                         MmdsError::NotFound => {
                             // NotFound
                             let error_msg = format!("Resource not found: {}.", uri);
-                            return build_response(
+                            build_response(
                                 request.http_version(),
                                 StatusCode::NotFound,
                                 Body::new(error_msg),
-                            );
+                            )
                         }
                         MmdsError::UnsupportedValueType => {
                             // InternalServerError
                             let error_msg =
                                 format!("The resource {} has an invalid format.", uri.to_string());
-                            return build_response(
+                            build_response(
                                 request.http_version(),
                                 StatusCode::InternalServerError,
                                 Body::new(error_msg),
-                            );
+                            )
                         }
                     }
                 }

--- a/net_gen/src/lib.rs
+++ b/net_gen/src/lib.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -46,7 +46,7 @@ impl MacAddr {
         // TODO: using something like std::mem::uninitialized could avoid the extra initialization,
         // if this ever becomes a performance bottleneck.
         let mut bytes = [0u8; MAC_ADDR_LEN];
-        &bytes[..].copy_from_slice(&src[..]);
+        bytes[..].copy_from_slice(&src[..]);
 
         MacAddr { bytes }
     }
@@ -65,7 +65,7 @@ impl MacAddr {
         &self.bytes
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_string(self) -> String {
         let b = &self.bytes;
         format!(
             "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -401,11 +401,7 @@ mod tests {
 
         // Find the network interface with the provided name.
         let interfaces = datalink::interfaces();
-        let interface = interfaces
-            .into_iter()
-            .filter(interface_name_matches)
-            .next()
-            .unwrap();
+        let interface = interfaces.into_iter().find(interface_name_matches).unwrap();
 
         if let Ok(Ethernet(tx, rx)) = datalink::channel(&interface, Default::default()) {
             (interface.mac_address(), tx, rx)

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -45,7 +45,7 @@ pub struct Tap {
 
 impl PartialEq for Tap {
     fn eq(&self, other: &Tap) -> bool {
-        return self.if_name == other.if_name;
+        self.if_name == other.if_name
     }
 }
 
@@ -111,7 +111,7 @@ impl Tap {
         // Safe since only the name is accessed, and it's cloned out.
         Ok(Tap {
             tap_file: tuntap,
-            if_name: unsafe { ifreq.ifr_ifrn.ifrn_name.as_ref().clone() },
+            if_name: unsafe { *ifreq.ifr_ifrn.ifrn_name.as_ref() },
         })
     }
 
@@ -134,6 +134,7 @@ impl Tap {
         }
 
         // ioctl is safe. Called with a valid sock fd, and we check the return.
+        #[allow(clippy::cast_lossless)]
         let ret =
             unsafe { ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFADDR as c_ulong, &ifreq) };
         if ret < 0 {
@@ -157,6 +158,7 @@ impl Tap {
         }
 
         // ioctl is safe. Called with a valid sock fd, and we check the return.
+        #[allow(clippy::cast_lossless)]
         let ret =
             unsafe { ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFNETMASK as c_ulong, &ifreq) };
         if ret < 0 {
@@ -169,6 +171,7 @@ impl Tap {
     /// Set the offload flags for the tap interface.
     pub fn set_offload(&self, flags: c_uint) -> Result<()> {
         // ioctl is safe. Called with a valid tap fd, and we check the return.
+        #[allow(clippy::cast_lossless)]
         let ret =
             unsafe { ioctl_with_val(&self.tap_file, net_gen::TUNSETOFFLOAD(), flags as c_ulong) };
         if ret < 0 {
@@ -192,6 +195,7 @@ impl Tap {
         }
 
         // ioctl is safe. Called with a valid sock fd, and we check the return.
+        #[allow(clippy::cast_lossless)]
         let ret =
             unsafe { ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFFLAGS as c_ulong, &ifreq) };
         if ret < 0 {
@@ -338,7 +342,7 @@ mod tests {
                     str::from_utf8(udp.payload()).unwrap()
                 );
             }
-            println!("");
+            println!();
         }
     }
 

--- a/seccomp/src/lib.rs
+++ b/seccomp/src/lib.rs
@@ -288,19 +288,19 @@ const BPF_K: u16 = 0x00;
 
 // Return codes for BPF programs.
 // See /usr/include/linux/seccomp.h .
-const SECCOMP_RET_ALLOW: u32 = 0x7fff0000;
-const SECCOMP_RET_ERRNO: u32 = 0x00050000;
-const SECCOMP_RET_KILL: u32 = 0x00000000;
-const SECCOMP_RET_LOG: u32 = 0x7ffc0000;
-const SECCOMP_RET_TRACE: u32 = 0x7ff00000;
-const SECCOMP_RET_TRAP: u32 = 0x00030000;
-const SECCOMP_RET_MASK: u32 = 0x0000ffff;
+const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+const SECCOMP_RET_KILL: u32 = 0x0000_0000;
+const SECCOMP_RET_LOG: u32 = 0x7ffc_0000;
+const SECCOMP_RET_TRACE: u32 = 0x7ff0_0000;
+const SECCOMP_RET_TRAP: u32 = 0x0003_0000;
+const SECCOMP_RET_MASK: u32 = 0x0000_ffff;
 
 // x86_64 architecture identifier.
 // See /usr/include/linux/audit.h .
 // Defined as:
 // `#define AUDIT_ARCH_X86_64	(EM_X86_64|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)`
-const AUDIT_ARCH_X86_64: u32 = 62 | 0x80000000 | 0x40000000;
+const AUDIT_ARCH_X86_64: u32 = 62 | 0x8000_0000 | 0x4000_0000;
 
 // The maximum number of a syscall argument.
 // A syscall can have at most 6 arguments.
@@ -508,9 +508,9 @@ impl SeccompCondition {
     fn into_eq_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, offset + 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, lsb, 0, offset),
         ]
     }
@@ -524,10 +524,10 @@ impl SeccompCondition {
     fn into_ge_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, msb, 3, 0),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, offset + 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, lsb, 0, offset),
         ]
     }
@@ -541,10 +541,10 @@ impl SeccompCondition {
     fn into_gt_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, msb, 3, 0),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, offset + 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, lsb, 0, offset),
         ]
     }
@@ -558,10 +558,10 @@ impl SeccompCondition {
     fn into_le_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, msb, offset + 3, 0),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, lsb, offset, 0),
         ]
     }
@@ -575,10 +575,10 @@ impl SeccompCondition {
     fn into_lt_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, msb, offset + 3, 0),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, lsb, offset, 0),
         ]
     }
@@ -599,10 +599,10 @@ impl SeccompCondition {
         let (mask_msb, mask_lsb) = ((mask >> 32) as u32, mask as u32);
 
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_STMT(BPF_ALU + BPF_AND + BPF_K, mask_msb),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, offset + 3),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_STMT(BPF_ALU + BPF_AND + BPF_K, mask_lsb),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, lsb, 0, offset),
         ]
@@ -617,9 +617,9 @@ impl SeccompCondition {
     fn into_ne_bpf(self, offset: u8) -> Vec<sock_filter> {
         let (msb, lsb, msb_offset, lsb_offset) = self.value_segments();
         vec![
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, msb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(msb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, msb, 0, 2),
-            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, lsb_offset as u32),
+            BPF_STMT(BPF_LD + BPF_W + BPF_ABS, u32::from(lsb_offset)),
             BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, lsb, offset, 0),
         ]
     }
@@ -714,7 +714,7 @@ impl SeccompRule {
         // The two initial jump statements are prepended to the rule.
         let rule_jumps = vec![
             BPF_STMT(BPF_JMP + BPF_JA, 1),
-            BPF_STMT(BPF_JMP + BPF_JA, offset as u32 + 1),
+            BPF_STMT(BPF_JMP + BPF_JA, u32::from(offset) + 1),
         ];
         rule_len += rule_jumps.len();
         accumulator.push(rule_jumps);
@@ -748,7 +748,7 @@ impl SeccompRule {
     ) {
         // Tries to detect whether prepending the current condition will produce an unjumpable
         // offset (since BPF jumps are a maximum of 255 instructions).
-        if *offset as u16 + CONDITION_MAX_LEN + 1 > ::std::u8::MAX as u16 {
+        if u16::from(*offset) + CONDITION_MAX_LEN + 1 > u16::from(::std::u8::MAX) {
             // If that is the case, three additional helper jumps are prepended and the offset
             // is reset to 1.
             //
@@ -761,8 +761,8 @@ impl SeccompRule {
             // case of the last rule chain.
             let helper_jumps = vec![
                 BPF_STMT(BPF_JMP + BPF_JA, 2),
-                BPF_STMT(BPF_JMP + BPF_JA, *offset as u32 + 1),
-                BPF_STMT(BPF_JMP + BPF_JA, *offset as u32 + 1),
+                BPF_STMT(BPF_JMP + BPF_JA, u32::from(*offset) + 1),
+                BPF_STMT(BPF_JMP + BPF_JA, u32::from(*offset) + 1),
             ];
             *rule_len += helper_jumps.len();
             accumulator.push(helper_jumps);
@@ -790,7 +790,7 @@ impl SeccompFilterContext {
     ) -> Result<Self> {
         // All inserted syscalls must have at least one rule, otherwise BPF code will break.
         for (_, value) in rules.iter() {
-            if value.1.len() == 0 {
+            if value.1.is_empty() {
                 return Err(Error::EmptyRulesVector);
             }
         }
@@ -819,7 +819,7 @@ impl SeccompFilterContext {
         mut rules: Vec<SeccompRule>,
     ) -> Result<()> {
         // All inserted syscalls must have at least one rule, otherwise BPF code will break.
-        if rules.len() == 0 {
+        if rules.is_empty() {
             return Err(Error::EmptyRulesVector);
         }
 
@@ -840,7 +840,7 @@ impl SeccompFilterContext {
         let mut context_len = 1;
         accumulator.push(vec![BPF_STMT(
             BPF_LD + BPF_W + BPF_ABS,
-            SECCOMP_DATA_NR_OFFSET as u32,
+            u32::from(SECCOMP_DATA_NR_OFFSET),
         )]);
 
         // Orders syscalls by priority, the highest number represents the highest priority.
@@ -902,7 +902,7 @@ impl SeccompFilterContext {
     ) -> Result<()> {
         // The rules of the chain are translated into BPF statements.
         let chain: Vec<_> = chain.into_iter().map(|rule| rule.into_bpf()).collect();
-        let chain_len = chain.iter().map(|rule| rule.len()).fold(0, |a, b| a + b);
+        let chain_len: usize = chain.iter().map(|rule| rule.len()).sum();
 
         // The chain starts with a comparison checking the loaded syscall number against the
         // syscall number of the chain.

--- a/seccomp/src/lib.rs
+++ b/seccomp/src/lib.rs
@@ -1101,7 +1101,7 @@ mod tests {
             BPF_JUMP(0x15, 0, 0, 3),
             BPF_STMT(0x20, 16 + lsb_offset),
             BPF_JUMP(0x15, 1, 0, 1),
-            BPF_STMT(0x06, 0x7fff0000),
+            BPF_STMT(0x06, 0x7fff_0000),
         ];
 
         // Compares translated rule with hardcoded BPF instructions.
@@ -1156,7 +1156,7 @@ mod tests {
                 BPF_JUMP(0x15, 0, 0, offset),
             ]);
         }
-        instructions.push(BPF_STMT(0x06, 0x7fff0000));
+        instructions.push(BPF_STMT(0x06, 0x7fff_0000));
 
         // Compares translated rule with hardcoded BPF instructions.
         assert_eq!(rule.into_bpf(), instructions);
@@ -1220,7 +1220,7 @@ mod tests {
             BPF_JUMP(0x15, 0, 0, 2),
             BPF_STMT(0x20, 32),
             BPF_JUMP(0x25, 14, 1, 0),
-            BPF_STMT(0x06, 0x7fff0000),
+            BPF_STMT(0x06, 0x7fff_0000),
             BPF_STMT(0x05, 1),
             BPF_STMT(0x05, 12),
             BPF_STMT(0x20, 36),
@@ -1233,8 +1233,8 @@ mod tests {
             BPF_JUMP(0x15, 0, 0, 3),
             BPF_STMT(0x20, 32),
             BPF_JUMP(0x25, 20, 0, 1),
-            BPF_STMT(0x06, 0x7fff0000),
-            BPF_STMT(0x06, 0x00030000),
+            BPF_STMT(0x06, 0x7fff_0000),
+            BPF_STMT(0x06, 0x0003_0000),
             BPF_JUMP(0x15, 9, 0, 1),
             BPF_STMT(0x05, 1),
             BPF_STMT(0x05, 8),
@@ -1244,9 +1244,9 @@ mod tests {
             BPF_STMT(0x20, 24),
             BPF_STMT(0x54, 0b100),
             BPF_JUMP(0x15, 36 & 0b100, 0, 1),
-            BPF_STMT(0x06, 0x7fff0000),
-            BPF_STMT(0x06, 0x00030000),
-            BPF_STMT(0x06, 0x00030000),
+            BPF_STMT(0x06, 0x7fff_0000),
+            BPF_STMT(0x06, 0x0003_0000),
+            BPF_STMT(0x06, 0x0003_0000),
         ];
 
         assert_eq!(context.into_bpf().unwrap(), instructions);
@@ -1291,7 +1291,7 @@ mod tests {
                     code: 21,
                     jt: 1,
                     jf: 0,
-                    k: 0xC000003E,
+                    k: 0xC000_003E,
                 },
                 sock_filter {
                     code: 6,
@@ -1327,7 +1327,7 @@ mod tests {
                     code: 6,
                     jt: 0,
                     jf: 0,
-                    k: 0x7FFF0000,
+                    k: 0x7FFF_0000,
                 },
             ];
             assert_eq!(ret, instructions);

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ mod tests {
                 "TEST-ID",
                 log_file_temp.path().to_str().unwrap().to_string(),
                 metrics_file_temp.path().to_str().unwrap().to_string(),
-                &vec![],
+                &[],
             )
             .expect("Could not initialize logger.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
 
     if let Err(e) = vmm::setup_sigsys_handler() {
         error!("Failed to register signal handler: {}", e);
-        process::exit(vmm::FC_EXIT_CODE_GENERIC_ERROR as i32);
+        process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
     }
 
     // Start firecracker by setting up a panic hook, which will be called before
@@ -118,7 +118,7 @@ fn main() {
 
     let bind_path = cmd_arguments
         .value_of("api_sock")
-        .map(|s| PathBuf::from(s))
+        .map(PathBuf::from)
         .expect("Missing argument: api_sock");
 
     // It's safe to unwrap here because clap's been provided with a default value

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,10 +222,11 @@ mod tests {
             }
             return true;
         }
-        return false;
+        false
     }
 
     #[test]
+    #[allow(clippy::unit_cmp)]
     fn test_main() {
         const FIRECRACKER_INIT_TIMEOUT_MILLIS: u64 = 100;
 

--- a/sys_util/src/errno.rs
+++ b/sys_util/src/errno.rs
@@ -36,7 +36,7 @@ impl Error {
 
     /// Gets the `errno` for this error.
     ///
-    pub fn errno(&self) -> i32 {
+    pub fn errno(self) -> i32 {
         self.0
     }
 }

--- a/sys_util/src/ioctl.rs
+++ b/sys_util/src/ioctl.rs
@@ -15,6 +15,7 @@ use std::os::unix::io::AsRawFd;
 macro_rules! ioctl_ioc_nr {
     ($name:ident, $dir:expr, $ty:expr, $nr:expr, $size:expr) => {
         #[allow(non_snake_case)]
+        #[allow(clippy::cast_lossless)]
         pub fn $name() -> ::std::os::raw::c_ulong {
             (($dir << $crate::ioctl::_IOC_DIRSHIFT)
                 | ($ty << $crate::ioctl::_IOC_TYPESHIFT)
@@ -152,9 +153,9 @@ mod tests {
 
     #[test]
     fn ioctl_macros() {
-        assert_eq!(0x0000AE01, KVM_CREATE_VM());
-        assert_eq!(0x800454CF, TUNGETFEATURES());
-        assert_eq!(0x400454D9, TUNSETQUEUE());
-        assert_eq!(0xC004AE02, KVM_GET_MSR_INDEX_LIST());
+        assert_eq!(0x0000_AE01, KVM_CREATE_VM());
+        assert_eq!(0x8004_54CF, TUNGETFEATURES());
+        assert_eq!(0x4004_54D9, TUNSETQUEUE());
+        assert_eq!(0xC004_AE02, KVM_GET_MSR_INDEX_LIST());
     }
 }

--- a/sys_util/src/ioctl.rs
+++ b/sys_util/src/ioctl.rs
@@ -89,10 +89,10 @@ pub const _IOC_DIRSHIFT: c_uint = 30;
 pub const _IOC_NONE: c_uint = 0;
 pub const _IOC_WRITE: c_uint = 1;
 pub const _IOC_READ: c_uint = 2;
-pub const IOC_IN: c_uint = 1073741824;
-pub const IOC_OUT: c_uint = 2147483648;
-pub const IOC_INOUT: c_uint = 3221225472;
-pub const IOCSIZE_MASK: c_uint = 1073676288;
+pub const IOC_IN: c_uint = 1_073_741_824;
+pub const IOC_OUT: c_uint = 2_147_483_648;
+pub const IOC_INOUT: c_uint = 3_221_225_472;
+pub const IOCSIZE_MASK: c_uint = 1_073_676_288;
 pub const IOCSIZE_SHIFT: c_uint = 16;
 
 // The type of the `req` parameter is different for the `musl` library. This will enable

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -161,6 +161,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::empty_loop)]
     fn test_killing_thread() {
         let killable = thread::spawn(|| thread::current().id());
         let killable_id = killable.join().unwrap();

--- a/sys_util/src/struct_util.rs
+++ b/sys_util/src/struct_util.rs
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn struct_basic_read() {
         let orig = TestRead {
-            a: 0x7766554433221100,
+            a: 0x7766_5544_3322_1100,
             b: 0x88,
             c: 0x99,
             d: 0xaa,
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn struct_read_past_end() {
         let orig = TestRead {
-            a: 0x7766554433221100,
+            a: 0x7766_5544_3322_1100,
             b: 0x88,
             c: 0x99,
             d: 0xaa,
@@ -118,21 +118,21 @@ mod tests {
     fn struct_slice_read() {
         let orig = vec![
             TestRead {
-                a: 0x7766554433221100,
+                a: 0x7766_5544_3322_1100,
                 b: 0x88,
                 c: 0x99,
                 d: 0xaa,
                 e: 0xbb,
             },
             TestRead {
-                a: 0x7867564534231201,
+                a: 0x7867_5645_3423_1201,
                 b: 0x02,
                 c: 0x13,
                 d: 0x24,
                 e: 0x35,
             },
             TestRead {
-                a: 0x7a69584736251403,
+                a: 0x7a69_5847_3625_1403,
                 b: 0x04,
                 c: 0x15,
                 d: 0x26,

--- a/sys_util/src/struct_util.rs
+++ b/sys_util/src/struct_util.rs
@@ -38,6 +38,9 @@ pub unsafe fn read_struct<T: Copy, F: Read>(f: &mut F, out: &mut T) -> Result<()
 ///
 /// * `f` - The input to read from.  Often this is a file.
 /// * `len` - The number of structs to fill with data read from `f`.
+// This lint check is now deprecated - https://github.com/rust-lang/rust-clippy/pull/3478/files
+// we can safely allow this.
+#[allow(clippy::unsafe_vector_initialization)]
 pub unsafe fn read_struct_slice<T: Copy, F: Read>(f: &mut F, len: usize) -> Result<Vec<T>> {
     let mut out: Vec<T> = Vec::with_capacity(len);
     out.set_len(len);

--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -79,7 +79,7 @@ def test_python_style():
 def test_rust_clippy():
     """Fails if clippy generates any error, warnings are ignored."""
     run(
-        'cargo clippy --all-targets --all-features',
+        'cargo clippy --all-targets --all-features -- -D warnings',
         shell=True,
         check=True,
         stdout=PIPE

--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -76,6 +76,16 @@ def test_python_style():
     )
 
 
+def test_rust_clippy():
+    """Fails if clippy generates any error, warnings are ignored."""
+    run(
+        'cargo clippy --all-targets --all-features',
+        shell=True,
+        check=True,
+        stdout=PIPE
+    )
+
+
 def test_yaml_style():
     """Fail if our swagger specification is malformed."""
     yaml_spec = os.path.normpath(

--- a/vhost_backend/src/vsock.rs
+++ b/vhost_backend/src/vsock.rs
@@ -12,7 +12,7 @@ use memory_model::GuestMemory;
 use sys_util::ioctl_with_ref;
 use vhost_gen::*;
 
-const VHOST_PATH: &'static str = "/dev/vhost-vsock";
+const VHOST_PATH: &str = "/dev/vhost-vsock";
 
 /// Handle for running VHOST_VSOCK ioctls.
 pub struct Vsock {

--- a/vhost_gen/src/lib.rs
+++ b/vhost_gen/src/lib.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/virtio_gen/src/lib.rs
+++ b/virtio_gen/src/lib.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_basic_seccomp() {
         let mut rules = ALLOWED_SYSCALLS.to_vec();
-        rules.extend(vec![
+        rules.extend(&[
             libc::SYS_clone,
             libc::SYS_mprotect,
             libc::SYS_rt_sigprocmask,
@@ -733,7 +733,7 @@ mod tests {
     fn test_advanced_seccomp() {
         // Sets up context with additional rules required by the test.
         let mut context = default_context().unwrap();
-        for rule in vec![
+        for rule in &[
             libc::SYS_clone,
             libc::SYS_mprotect,
             libc::SYS_rt_sigprocmask,
@@ -742,7 +742,7 @@ mod tests {
         ] {
             assert!(context
                 .add_rules(
-                    rule,
+                    *rule,
                     None,
                     vec![seccomp::SeccompRule::new(
                         vec![],

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -45,10 +45,10 @@ const EPOLL_CTL_DEL: u64 = 2;
 // See include/uapi/asm-generic/fcntl.h in the kernel code.
 const FCNTL_FD_CLOEXEC: u64 = 1;
 const FCNTL_F_SETFD: u64 = 2;
-const O_CLOEXEC: u64 = 0x02000000;
-const O_NONBLOCK: u64 = 0x00004000;
-const O_RDONLY: u64 = 0x00000000;
-const O_RDWR: u64 = 0x00000002;
+const O_CLOEXEC: u64 = 0x0200_0000;
+const O_NONBLOCK: u64 = 0x0000_4000;
+const O_RDONLY: u64 = 0x0000_0000;
+const O_RDWR: u64 = 0x0000_0002;
 
 // See include/uapi/linux/futex.h in the kernel code.
 const FUTEX_WAIT: u64 = 0;
@@ -72,28 +72,28 @@ const KVM_CREATE_VM: u64 = 0xae01;
 const KVM_CHECK_EXTENSION: u64 = 0xae03;
 const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
 const KVM_CREATE_VCPU: u64 = 0xae41;
-const KVM_GET_DIRTY_LOG: u64 = 0x4010ae42;
+const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
 const KVM_SET_TSS_ADDR: u64 = 0xae47;
 const KVM_CREATE_IRQCHIP: u64 = 0xae60;
 const KVM_RUN: u64 = 0xae80;
-const KVM_SET_MSRS: u64 = 0x4008ae89;
-const KVM_SET_CPUID2: u64 = 0x4008ae90;
-const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020ae46;
-const KVM_IRQFD: u64 = 0x4020ae76;
-const KVM_CREATE_PIT2: u64 = 0x4040ae77;
-const KVM_IOEVENTFD: u64 = 0x4040ae79;
-const KVM_SET_REGS: u64 = 0x4090ae82;
-const KVM_SET_SREGS: u64 = 0x4138ae84;
-const KVM_SET_FPU: u64 = 0x41a0ae8d;
-const KVM_SET_LAPIC: u64 = 0x4400ae8f;
-const KVM_GET_SREGS: u64 = 0x8138ae83;
-const KVM_GET_LAPIC: u64 = 0x8400ae8e;
-const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008ae05;
+const KVM_SET_MSRS: u64 = 0x4008_ae89;
+const KVM_SET_CPUID2: u64 = 0x4008_ae90;
+const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
+const KVM_IRQFD: u64 = 0x4020_ae76;
+const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
+const KVM_IOEVENTFD: u64 = 0x4040_ae79;
+const KVM_SET_REGS: u64 = 0x4090_ae82;
+const KVM_SET_SREGS: u64 = 0x4138_ae84;
+const KVM_SET_FPU: u64 = 0x41a0_ae8d;
+const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
+const KVM_GET_SREGS: u64 = 0x8138_ae83;
+const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
+const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
-const TUNSETIFF: u64 = 0x400454ca;
-const TUNSETOFFLOAD: u64 = 0x400454d0;
-const TUNSETVNETHDRSZ: u64 = 0x400454d8;
+const TUNSETIFF: u64 = 0x4004_54ca;
+const TUNSETOFFLOAD: u64 = 0x4004_54d0;
+const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
 
 // See include/uapi/asm-generic/mman-common.h in the kernel code.
 const PROT_NONE: u64 = 0x0;

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -108,18 +108,18 @@ const MAP_NORESERVE: u64 = 0x4000;
 
 #[cfg(feature = "vsock")]
 mod vsock_ioctls {
-    pub const VHOST_GET_FEATURES: u64 = 0x8008af00;
-    pub const VHOST_SET_FEATURES: u64 = 0x4008af00;
-    pub const VHOST_SET_OWNER: u64 = 0x0000af01;
-    pub const VHOST_SET_MEM_TABLE: u64 = 0x4008af03;
-    pub const VHOST_SET_VRING_NUM: u64 = 0x4008af10;
-    pub const VHOST_SET_VRING_ADDR: u64 = 0x4028af11;
-    pub const VHOST_SET_VRING_BASE: u64 = 0x4008af12;
-    pub const VHOST_GET_VRING_BASE: u64 = 0xc008af12;
-    pub const VHOST_SET_VRING_KICK: u64 = 0x4008af20;
-    pub const VHOST_SET_VRING_CALL: u64 = 0x4008af21;
-    pub const VHOST_VSOCK_SET_GUEST_CID: u64 = 0x4008af60;
-    pub const VHOST_VSOCK_SET_RUNNING: u64 = 0x4004af61;
+    pub const VHOST_GET_FEATURES: u64 = 0x8008_af00;
+    pub const VHOST_SET_FEATURES: u64 = 0x4008_af00;
+    pub const VHOST_SET_OWNER: u64 = 0x0000_af01;
+    pub const VHOST_SET_MEM_TABLE: u64 = 0x4008_af03;
+    pub const VHOST_SET_VRING_NUM: u64 = 0x4008_af10;
+    pub const VHOST_SET_VRING_ADDR: u64 = 0x4028_af11;
+    pub const VHOST_SET_VRING_BASE: u64 = 0x4008_af12;
+    pub const VHOST_GET_VRING_BASE: u64 = 0xc008_af12;
+    pub const VHOST_SET_VRING_KICK: u64 = 0x4008_af20;
+    pub const VHOST_SET_VRING_CALL: u64 = 0x4008_af21;
+    pub const VHOST_VSOCK_SET_GUEST_CID: u64 = 0x4008_af60;
+    pub const VHOST_VSOCK_SET_RUNNING: u64 = 0x4004_af61;
 }
 
 /// Applies the configured level of seccomp filtering to the current thread.
@@ -702,7 +702,7 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
     {
         let mut rule = create_common_ioctl_seccomp_rule()?;
         rule.append(&mut create_vsock_ioctl_seccomp_rule()?);
-        return Ok(rule);
+        Ok(rule)
     }
     #[cfg(not(feature = "vsock"))]
     Ok(create_common_ioctl_seccomp_rule()?)

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -72,7 +72,7 @@ impl LegacyDeviceManager {
     pub fn register_devices(&mut self) -> Result<()> {
         self.io_bus
             .insert(self.stdio_serial.clone(), 0x3f8, 0x8)
-            .map_err(|err| Error::BusError(err))?;
+            .map_err(Error::BusError)?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -81,7 +81,7 @@ impl LegacyDeviceManager {
                 0x2f8,
                 0x8,
             )
-            .map_err(|err| Error::BusError(err))?;
+            .map_err(Error::BusError)?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -90,7 +90,7 @@ impl LegacyDeviceManager {
                 0x3e8,
                 0x8,
             )
-            .map_err(|err| Error::BusError(err))?;
+            .map_err(Error::BusError)?;
         self.io_bus
             .insert(
                 Arc::new(Mutex::new(devices::legacy::Serial::new_sink(
@@ -99,14 +99,14 @@ impl LegacyDeviceManager {
                 0x2e8,
                 0x8,
             )
-            .map_err(|err| Error::BusError(err))?;
+            .map_err(Error::BusError)?;
         self.stdin_handle
             .lock()
             .set_raw_mode()
-            .map_err(|e| Error::StdinHandle(e))?;
+            .map_err(Error::StdinHandle)?;
         self.io_bus
             .insert(self.i8042.clone(), 0x060, 0x5)
-            .map_err(|err| Error::BusError(err))?;
+            .map_err(Error::BusError)?;
         Ok(())
     }
 }

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -105,8 +105,9 @@ impl MMIODeviceManager {
         let mmio_device = devices::virtio::MmioDevice::new(self.guest_mem.clone(), device)
             .map_err(Error::CreateMmioDevice)?;
         for (i, queue_evt) in mmio_device.queue_evts().iter().enumerate() {
-            let io_addr =
-                IoeventAddress::Mmio(self.mmio_base + u64::from(devices::virtio::NOTIFY_REG_OFFSET));
+            let io_addr = IoeventAddress::Mmio(
+                self.mmio_base + u64::from(devices::virtio::NOTIFY_REG_OFFSET),
+            );
             self.vm_requests.push(VmRequest::RegisterIoevent(
                 queue_evt.try_clone().map_err(Error::CloneIoEventFd)?,
                 io_addr,

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -172,7 +172,7 @@ impl MMIODeviceManager {
     /// drive. The purpose of this method is to test error scenarios and should otherwise
     /// not be used.
     #[cfg(test)]
-    pub fn remove_address(&mut self, id: &String) {
+    pub fn remove_address(&mut self, id: &str) {
         self.id_to_addr_map.remove(id).unwrap();
     }
 }
@@ -185,7 +185,7 @@ mod tests {
     use memory_model::{GuestAddress, GuestMemory};
     use std::sync::atomic::AtomicUsize;
     use sys_util::EventFd;
-    const QUEUE_SIZES: &'static [u16] = &[64];
+    const QUEUE_SIZES: &[u16] = &[64];
 
     #[allow(dead_code)]
     #[derive(Clone)]
@@ -235,9 +235,8 @@ mod tests {
     fn register_device() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd0000000);
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd000_0000);
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
@@ -251,13 +250,12 @@ mod tests {
     fn register_too_many_devices() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd0000000);
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd000_0000);
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
-        for _i in IRQ_BASE..(MAX_IRQ + 1) {
+        for _i in IRQ_BASE..=MAX_IRQ {
             device_manager
                 .register_device(dummy_box.clone(), &mut cmdline, None)
                 .unwrap();
@@ -292,9 +290,8 @@ mod tests {
     fn test_error_messages() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let device_manager = MMIODeviceManager::new(guest_mem, 0xd0000000);
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let device_manager = MMIODeviceManager::new(guest_mem, 0xd000_0000);
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let e = Error::Cmdline(
             cmdline
@@ -334,27 +331,25 @@ mod tests {
     fn test_update_drive() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd0000000);
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd000_0000);
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
 
         if let Ok(addr) =
             device_manager.register_device(dummy_box, &mut cmdline, Some(String::from("foo")))
         {
-            assert!(device_manager.update_drive(addr, 1048576).is_ok());
+            assert!(device_manager.update_drive(addr, 1_048_576).is_ok());
         }
-        assert!(device_manager.update_drive(0xbeef, 1048576).is_err());
+        assert!(device_manager.update_drive(0xbeef, 1_048_576).is_err());
     }
 
     #[test]
     fn test_get_address() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemory::new(&vec![(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd0000000);
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager = MMIODeviceManager::new(guest_mem, 0xd000_0000);
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -261,6 +261,7 @@ impl Display for VmmActionError {
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.), together with an OutcomeSender, which is always present.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum VmmAction {
     /// Configure the boot source of the microVM using as input the `ConfigureBootSource`. This
     /// action can only be called before the microVM has booted. The response is sent using the
@@ -1334,6 +1335,7 @@ impl Vmm {
         }
     }
 
+    #[allow(clippy::unused_label)]
     fn run_control(&mut self) -> Result<()> {
         const EPOLL_EVENTS_LEN: usize = 100;
 
@@ -1345,8 +1347,8 @@ impl Vmm {
         'poll: loop {
             let num_events = epoll::wait(epoll_raw_fd, -1, &mut events[..]).map_err(Error::Poll)?;
 
-            for i in 0..num_events {
-                let dispatch_idx = events[i].data as usize;
+            for event in events.iter().take(num_events) {
+                let dispatch_idx = event.data as usize;
 
                 if let Some(dispatch_type) = self.epoll_context.dispatch_table[dispatch_idx] {
                     match dispatch_type {
@@ -1391,7 +1393,7 @@ impl Vmm {
                                 Ok(handler) => {
                                     match handler.handle_event(
                                         device_token,
-                                        events[i].events,
+                                        event.events,
                                         EpollHandlerPayload::Empty,
                                     ) {
                                         Err(devices::Error::PayloadExpected) => panic!(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -850,7 +850,7 @@ impl Vmm {
             let epoll_config = self.epoll_context.allocate_virtio_vsock_tokens();
 
             let vsock_box = Box::new(
-                devices::virtio::Vsock::new(cfg.guest_cid as u64, guest_mem, epoll_config)
+                devices::virtio::Vsock::new(u64::from(cfg.guest_cid), guest_mem, epoll_config)
                     .map_err(StartMicrovmError::CreateVsockDevice)?,
             );
             device_manager

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2033,7 +2033,7 @@ mod tests {
             }
         }
 
-        fn remove_addr(&mut self, id: &String) {
+        fn remove_addr(&mut self, id: &str) {
             self.mmio_device_manager
                 .as_mut()
                 .unwrap()
@@ -2151,14 +2151,13 @@ mod tests {
         }));
 
         let (_to_vmm, from_api) = channel();
-        let vmm = Vmm::new(
+        Vmm::new(
             shared_info,
             EventFd::new().expect("cannot create eventFD"),
             from_api,
             seccomp::SECCOMP_LEVEL_ADVANCED,
         )
-        .expect("Cannot Create VMM");
-        return vmm;
+        .expect("Cannot Create VMM")
     }
 
     #[test]
@@ -2281,7 +2280,7 @@ mod tests {
         let network_interface = NetworkInterfaceConfig {
             iface_id: String::from("netif"),
             host_dev_name: String::from("hostname2"),
-            guest_mac: Some(mac.clone()),
+            guest_mac: Some(mac),
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
@@ -2408,6 +2407,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_machine_configuration() {
         let mut vmm = create_vmm_object(InstanceState::Uninitialized);
 
@@ -2869,7 +2869,6 @@ mod tests {
         // Test rescan_block_device with invalid ID.
         match vmm.rescan_block_device(&"foo".to_string()) {
             Err(VmmActionError::DriveConfig(ErrorKind::User, DriveError::InvalidBlockDeviceID)) => {
-                ()
             }
             _ => assert!(false),
         }
@@ -2886,7 +2885,6 @@ mod tests {
         vmm.remove_addr(&scratch_id);
         match vmm.rescan_block_device(&scratch_id) {
             Err(VmmActionError::DriveConfig(ErrorKind::User, DriveError::InvalidBlockDeviceID)) => {
-                ()
             }
             _ => assert!(false),
         }

--- a/vmm/src/sigsys_handler.rs
+++ b/vmm/src/sigsys_handler.rs
@@ -59,7 +59,7 @@ extern "C" fn sigsys_handler(
     // Sanity check. The condition should never be true.
     if num != si_signo || num != libc::SIGSYS || si_code != SYS_SECCOMP_CODE as i32 {
         // Safe because we're terminating the process anyway.
-        unsafe { libc::_exit(super::FC_EXIT_CODE_UNEXPECTED_ERROR as i32) };
+        unsafe { libc::_exit(i32::from(super::FC_EXIT_CODE_UNEXPECTED_ERROR)) };
     }
 
     // Other signals which might do async unsafe things incompatible with the rest of this
@@ -80,7 +80,7 @@ extern "C" fn sigsys_handler(
     // running unit tests.
     #[cfg(not(test))]
     unsafe {
-        libc::_exit(super::FC_EXIT_CODE_BAD_SYSCALL as i32)
+        libc::_exit(i32::from(super::FC_EXIT_CODE_BAD_SYSCALL))
     };
 }
 

--- a/vmm/src/sigsys_handler.rs
+++ b/vmm/src/sigsys_handler.rs
@@ -113,7 +113,7 @@ mod tests {
         let mut num = 0;
         for i in 0..libc::CPU_SETSIZE as usize {
             if unsafe { libc::CPU_ISSET(i, &cpuset) } {
-                num = num + 1;
+                num += 1;
             }
         }
         num

--- a/vmm/src/vm_control.rs
+++ b/vmm/src/vm_control.rs
@@ -41,16 +41,16 @@ impl VmRequest {
     /// `VmResponse` with the intended purpose of sending the response back over the  socket that
     /// received this `VmRequest`.
     pub fn execute(&self, vm: &VmFd) -> VmResponse {
-        match self {
-            &VmRequest::RegisterIoevent(ref evt, ref addr, datamatch) => {
+        match *self {
+            VmRequest::RegisterIoevent(ref evt, ref addr, datamatch) => {
                 match vm.register_ioevent(evt, addr, datamatch) {
                     Ok(_) => VmResponse::Ok,
                     Err(e) => VmResponse::Err(e),
                 }
             }
-            &VmRequest::RegisterIrqfd(ref evt, irq) => match vm.register_irqfd(evt, irq) {
+            VmRequest::RegisterIrqfd(ref evt, irq) => match vm.register_irqfd(evt, irq) {
                 Ok(_) => VmResponse::Ok,
-                Err(e) => return VmResponse::Err(e),
+                Err(e) => VmResponse::Err(e),
             },
         }
     }

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -95,6 +95,7 @@ impl BlockDeviceConfig {
 }
 
 /// Wrapper for the collection that holds all the Block Devices Configs
+#[derive(Default)]
 pub struct BlockDeviceConfigs {
     /// A list of `BlockDeviceConfig` objects.
     pub config_list: VecDeque<BlockDeviceConfig>,
@@ -131,15 +132,13 @@ impl BlockDeviceConfigs {
 
     /// Gets the index of the device with the specified `drive_id` if it exists in the list.
     pub fn get_index_of_drive_id(&self, drive_id: &str) -> Option<usize> {
-        self
-            .config_list
+        self.config_list
             .iter()
             .position(|cfg| cfg.drive_id.eq(drive_id))
     }
 
     fn get_index_of_drive_path(&self, drive_path: &PathBuf) -> Option<usize> {
-        self
-            .config_list
+        self.config_list
             .iter()
             .position(|cfg| cfg.path_on_host.eq(drive_path))
     }

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -116,7 +116,7 @@ impl BlockDeviceConfigs {
 
     /// Checks whether any of the added BlockDevice is the root.
     pub fn has_root_block_device(&self) -> bool {
-        return self.has_root_block;
+        self.has_root_block
     }
 
     /// Checks whether the root device has read-only permisssions.
@@ -130,18 +130,18 @@ impl BlockDeviceConfigs {
     }
 
     /// Gets the index of the device with the specified `drive_id` if it exists in the list.
-    pub fn get_index_of_drive_id(&self, drive_id: &String) -> Option<usize> {
-        return self
+    pub fn get_index_of_drive_id(&self, drive_id: &str) -> Option<usize> {
+        self
             .config_list
             .iter()
-            .position(|cfg| cfg.drive_id.eq(drive_id));
+            .position(|cfg| cfg.drive_id.eq(drive_id))
     }
 
     fn get_index_of_drive_path(&self, drive_path: &PathBuf) -> Option<usize> {
-        return self
+        self
             .config_list
             .iter()
-            .position(|cfg| cfg.path_on_host.eq(drive_path));
+            .position(|cfg| cfg.path_on_host.eq(drive_path))
     }
 
     /// Inserts `block_device_config` in the block device configuration list.

--- a/vmm/src/vmm_config/machine_config.rs
+++ b/vmm/src/vmm_config/machine_config.rs
@@ -79,7 +79,7 @@ where
     if let Some(ref value) = val {
         if *value > MAX_SUPPORTED_VCPUS {
             return Err(de::Error::invalid_value(
-                de::Unexpected::Unsigned(*value as u64),
+                de::Unexpected::Unsigned(u64::from(*value)),
                 &"number of vCPUs exceeds the maximum limitation",
             ));
         }

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -309,10 +309,10 @@ mod tests {
             NetworkInterfaceConfig {
                 iface_id: self.iface_id.clone(),
                 host_dev_name: self.host_dev_name.clone(),
-                guest_mac: self.guest_mac.clone(),
+                guest_mac: self.guest_mac,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
-                allow_mmds_requests: self.allow_mmds_requests.clone(),
+                allow_mmds_requests: self.allow_mmds_requests,
                 tap: None,
             }
         }

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -177,17 +177,17 @@ impl NetworkInterfaceConfigs {
     }
 
     fn get_index_of_mac(&self, mac: &MacAddr) -> Option<usize> {
-        return self
+        self
             .if_list
             .iter()
-            .position(|netif| netif.guest_mac == Some(*mac));
+            .position(|netif| netif.guest_mac == Some(*mac))
     }
 
-    fn get_index_of_dev_name(&self, host_dev_name: &String) -> Option<usize> {
-        return self
+    fn get_index_of_dev_name(&self, host_dev_name: &str) -> Option<usize> {
+        self
             .if_list
             .iter()
-            .position(|netif| &netif.host_dev_name == host_dev_name);
+            .position(|netif| &netif.host_dev_name == host_dev_name)
     }
 
     fn validate_update(

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -142,6 +142,7 @@ impl Display for NetworkInterfaceError {
 }
 
 /// A wrapper over the list of the `NetworkInterfaceConfig` that the microvm has configured.
+#[derive(Default)]
 pub struct NetworkInterfaceConfigs {
     if_list: Vec<NetworkInterfaceConfig>,
 }
@@ -176,18 +177,16 @@ impl NetworkInterfaceConfigs {
         }
     }
 
-    fn get_index_of_mac(&self, mac: &MacAddr) -> Option<usize> {
-        self
-            .if_list
+    fn get_index_of_mac(&self, mac: MacAddr) -> Option<usize> {
+        self.if_list
             .iter()
-            .position(|netif| netif.guest_mac == Some(*mac))
+            .position(|netif| netif.guest_mac == Some(mac))
     }
 
     fn get_index_of_dev_name(&self, host_dev_name: &str) -> Option<usize> {
-        self
-            .if_list
+        self.if_list
             .iter()
-            .position(|netif| &netif.host_dev_name == host_dev_name)
+            .position(|netif| netif.host_dev_name == host_dev_name)
     }
 
     fn validate_update(
@@ -199,7 +198,7 @@ impl NetworkInterfaceConfigs {
         // network interface that has the same mac address as the one specified in new_config.
         // If the same mac is used in another network interface config, return error.
         if new_config.guest_mac.is_some() {
-            let mac_index = self.get_index_of_mac(&new_config.guest_mac.unwrap());
+            let mac_index = self.get_index_of_mac(new_config.guest_mac.unwrap());
             if mac_index.is_some() && mac_index.unwrap() != index {
                 return Err(NetworkInterfaceError::GuestMacAddressInUse(
                     new_config.guest_mac.unwrap().to_string(),
@@ -248,7 +247,7 @@ impl NetworkInterfaceConfigs {
         // Check that there is no other interface in the list that has the same mac.
         if new_config.guest_mac.is_some()
             && self
-                .get_index_of_mac(&new_config.guest_mac.unwrap())
+                .get_index_of_mac(new_config.guest_mac.unwrap())
                 .is_some()
         {
             return Err(NetworkInterfaceError::GuestMacAddressInUse(

--- a/vmm/src/vmm_config/vsock.rs
+++ b/vmm/src/vmm_config/vsock.rs
@@ -39,6 +39,7 @@ impl Display for VsockError {
 }
 
 /// A list with all the vsock devices.
+#[derive(Default)]
 pub struct VsockDeviceConfigs {
     configs: Vec<VsockDeviceConfig>,
 }

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -242,16 +242,15 @@ impl Vcpu {
                 self.id, e
             );
         }
-        match machine_config.cpu_template {
-            Some(template) => match template {
+        if let Some(template) = machine_config.cpu_template {
+            match template {
                 CpuFeaturesTemplate::T2 => {
                     t2_template::set_cpuid_entries(self.cpuid.mut_entries_slice())
                 }
                 CpuFeaturesTemplate::C3 => {
                     c3_template::set_cpuid_entries(self.cpuid.mut_entries_slice())
                 }
-            },
-            None => (),
+            }
         }
 
         self.fd


### PR DESCRIPTION
Issue #890

Description of changes:

This PR fixes warnings and errors generated by rust-clippy. It ignores checking autogenerated packages which include
* arch_gen
* net_gen
* vhost_gen
* virtio_gen

This Pull Request fixes all the warnings produced by rust-clippy on the codebase. It ignores some clippy lint errors, which may require some discussion before working on. Those issues can be worked out separately later on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Reviewers
@andreeaflorescu @acipu-aws @raduweiss 