### PR TITLE
improve jailer startup time

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 
-COVERAGE_TARGET_PCT = 82.0
+COVERAGE_TARGET_PCT = 82.1
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Issue #, if available: #873 

Description of changes:

improve jailer startup time by changing the strategy used to sanitize
the process. Close all the file descriptors listed in /proc/self/fd
instead of trying to close all the file descriptors from 3 until
libc::_SC_OPEN_MAX

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
