### PR TITLE
Added guest MAC spoofing detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - New API action: SendCtrlAltDel, used to initiate a graceful shutdown,
   if the guest has driver support for i8042 and AT Keyboard. See
   [the docs](docs/api_requests/actions.md#sendctrlaltdel) for details.
+- New metric counting the number of egress packets with a spoofed MAC:
+  `net.tx_spoofed_mac_count`.
 
 ### Changed
 

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -299,6 +299,8 @@ pub struct NetDeviceMetrics {
     pub tx_queue_event_count: SharedMetric,
     /// Number of events associated with the rate limiter installed on the transmitting path.
     pub tx_rate_limiter_event_count: SharedMetric,
+    /// Number of packets with a spoofed mac, sent by the guest.
+    pub tx_spoofed_mac_count: SharedMetric,
 }
 
 /// Metrics for the seccomp filtering.


### PR DESCRIPTION
Issue #, if available: #762

**Description of changes**:
Added a new metric (`net.tx_spoofed_mac_count`), to count the number of egress packets, having a spoofed MAC (i.e. different from the one set via `PUT /network-interfaces`, if one was provided).

Closes #762 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
