### PR TITLE
Update getting-started.md with error on Firecracker

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -37,12 +37,18 @@ to integrate with container ecosystems.
 The Firecracker VMM is built to be processor agnostic. Today, it can run on
 Intel processors. AMD and ARM processors will be supported in the near future.
 
-### Can Firecracker be used with Kubernetes, Docker, or Kata containers today?
+### Can Firecracker be used with Kata containers, Kubernetes or Docker today?
 
-Not yet. We are making Firecracker open source because it provides a
-meaningfully different approach to security for running containers. We hope that
-others in the communities that build open source container technology find it
-useful. We are working to make Firecracker integrate naturally with the
+Since release
+[1.5.0](https://github.com/kata-containers/runtime/releases/tag/1.5.0)
+of Kata Containers, support for the Firecracker VMM has been included.
+Docker CLI and Kubernetes can be used with Firecracker when configured
+with Kata containers, but there are limitations with Kubernetes use cases.
+There is also a work in progress on
+[Firecracker-containerd](https://github.com/firecracker-microvm/firecracker-containerd)
+to enable containerd to manage containers as Firecracker microVMs. We hope
+that others in the communities that build open source container technology find
+it useful. We are working to make Firecracker integrate naturally with the
 container ecosystem, with the goal to provide seamless integration in the future
 to provide more choices in how container workloads are isolated.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,16 +25,49 @@ The generic requirements are explained below:
 
 - **Linux 4.14+**
 
-  Firecracker currently supports physical Linux x86_64 hosts, running kernel
-  version 4.14 or later.
+Firecracker currently supports physical Linux x86_64 hosts, running kernel
+version 4.14 or later. Please check first if your Linux host supports
+vitualization running as root the following command:
+  
+```
+egrep '(vmx|svm)' --color=always /proc/cpuinfo
+```
+
+you should see the following answer (number of flags depends of the number of cores on the CPU):
+  
+```
+flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm 3dnowext 3dnow constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid pni monitor cx16 popcnt lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt nodeid_msr hw_pstate vmmcall npt lbrv svm_lock nrip_save
+flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm 3dnowext 3dnow constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid pni monitor cx16 popcnt lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt nodeid_msr hw_pstate vmmcall npt lbrv svm_lock nrip_save
+```
+
+if no answer appears, then virtualization is not supported by your CPU.  
 
 - **KVM**
 
-  Please make sure that:
-  1. you have KVM enabled in your Linux kernel, and
-  2. you have read/write access to `/dev/kvm`.
-     If you need help setting up access to `/dev/kvm`, you should check out
-     [Appendix A](#appendix-a-setting-up-kvm-access).
+Please make sure that you have KVM enabled in your Linux kernel, to do so
+you can run:
+  
+```
+lsmod | grep '^kvm'
+```
+
+you should see an answer like the following:
+  
+```
+kvm_intel             172032  0 
+kvm                   544768  1 kvm_intel
+```
+   
+or
+  
+```
+kvm_amd                86016  0
+kvm                   598016  1 kvm_amd
+```
+
+You also need to have read/write access to `/dev/kvm`. If you need help
+setting up access to `/dev/kvm`, you should check out
+[Appendix A](#appendix-a-setting-up-kvm-access).
 
 <details>
 
@@ -126,6 +159,13 @@ rm -f /tmp/firecracker.socket
 
 ```bash
 ./firecracker --api-sock /tmp/firecracker.socket
+```
+Note that if the following error appears when trying to start
+Firecracker, then there is not eonugh free memory on your system for
+Firecracker to run:
+
+```
+Cannot create VMM.: Vm(VmFd(Error(12)))
 ```
 
 In your **second shell** prompt:


### PR DESCRIPTION
Error that appears when there isn't enough memory for Firecracker to run.

Issue #835

Signed-off-by: Javier Romero <xavinux@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
