### PR TITLE
Add Firecracker error on getting-started.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -191,3 +191,15 @@ Possible mitigations are:
   kernel so as to use `vmalloc` instead of `kmalloc` for them.
 - Reduce memory pressure on the host.
 
+### Error appears when starting Firecracker.
+
+```
+Cannot create VMM.: Vm(VmFd(Error(12)))
+```
+
+If the above error appears when trying to start
+Firecracker, then there is not enough free memory on your system for
+Firecracker to run.
+
+
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,6 +128,14 @@ rm -f /tmp/firecracker.socket
 ./firecracker --api-sock /tmp/firecracker.socket
 ```
 
+Note that if the following error appears when trying to start
+Firecracker, then there is not eonugh free memory on your
+system for Firecracker to run:
+
+```
+Cannot create VMM.: Vm(VmFd(Error(12)))
+```
+
 In your **second shell** prompt:
 
 - get the kernel and rootfs, if you don't have any available:


### PR DESCRIPTION
Error that may appear when there isn't enough memory for Firecracker to run.

Issue #835

Signed-off-by: Javier Romero <xavinux@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.