### PR TITLE
Add Firecracker memory error on FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -191,3 +191,12 @@ Possible mitigations are:
   kernel so as to use `vmalloc` instead of `kmalloc` for them.
 - Reduce memory pressure on the host.
 
+### Error appears when starting Firecracker.
+
+```
+Cannot create VMM.: Vm(VmFd(Error(12)))
+```
+
+If the above error appears when trying to start
+Firecracker, then there is not enough free memory on your system for
+Firecracker to run.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,16 +25,50 @@ The generic requirements are explained below:
 
 - **Linux 4.14+**
 
-  Firecracker currently supports physical Linux x86_64 hosts, running kernel
-  version 4.14 or later.
+Firecracker currently supports physical Linux x86_64 hosts, running kernel
+version 4.14 or later. Please check first if your Linux host supports
+vitualization running as root the following command:
+
+```
+egrep '(vmx|svm)' --color=always /proc/cpuinfo
+```
+
+you should see the following answer (number of flags depends of the number
+of cores on the CPU):
+
+```
+flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe$
+flags: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe$
+```
+
+if no answer appears, then virtualization is not supported by your CPU.
 
 - **KVM**
 
-  Please make sure that:
-  1. you have KVM enabled in your Linux kernel, and
-  2. you have read/write access to `/dev/kvm`.
-     If you need help setting up access to `/dev/kvm`, you should check out
-     [Appendix A](#appendix-a-setting-up-kvm-access).
+Please make sure that you have KVM enabled in your Linux kernel, to do so
+you can run:
+
+```
+lsmod | grep '^kvm'
+```
+
+you should see an answer like the following:
+
+```
+kvm_intel             172032  0
+kvm                   544768  1 kvm_intel
+```
+
+or
+
+```
+kvm_amd                86016  0
+kvm                   598016  1 kvm_amd
+```
+
+You also need to have read/write access to `/dev/kvm`. If you need help
+setting up access to `/dev/kvm`, you should check out
+[Appendix A](#appendix-a-setting-up-kvm-access).
 
 <details>
 


### PR DESCRIPTION
Error may appears when there isn't enough memory for Firecracker to run.

Issue #835 

Signed-off-by: Javier Romero <xavinux@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.