### PR TITLE
Expose vCPU thread IDs to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [the docs](docs/api_requests/actions.md#sendctrlaltdel) for details.
 - New metric counting the number of egress packets with a spoofed MAC:
   `net.tx_spoofed_mac_count`.
+- New struct member - `InstanceInfo::vcpus` - the list of running vCPUs
+  and their host thread IDs.
 
 ### Changed
 

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -385,6 +385,7 @@ definitions:
       - id
       - state
       - vmm_version
+      - vcpus
     properties:
       id:
         description: MicroVM / instance ID.
@@ -406,6 +407,11 @@ definitions:
         description: MicroVM hypervisor build version.
         type: string
         readOnly: true
+      vcpus:
+        description: The list of running vCPUs.
+        type: array
+        items:
+            $ref: "#definitions/VcpuInfo"
 
   Logger:
     type: object
@@ -513,6 +519,24 @@ definitions:
       ops:
         $ref: "#/definitions/TokenBucket"
         description: Token bucket with operations as tokens
+
+  VcpuInfo:
+    type: object
+    description: Describes a running vCPU thread.
+    required:
+      - id
+      - thread_id
+    properties:
+      id:
+        type: integer
+        description: vCPU ID (index).
+        minimum: 0
+      thread_id:
+        type: integer
+        description:
+          The ID of the host thread used to run this vCPU.
+        format: i64
+        minimum: 0
 
   TokenBucket:
     type: object

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ fn main() {
         state: InstanceState::Uninitialized,
         id: instance_id,
         vmm_version: crate_version!().to_string(),
+        vcpus: Vec::new(),
     }));
     let mmds_info = MMDS.clone();
     let (to_vmm, from_api) = channel();

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -30,6 +30,15 @@ pub enum InstanceState {
     Halted,
 }
 
+#[derive(Copy, Clone, Debug, Serialize)]
+/// vCPU info
+pub struct VcpuInfo {
+    /// vCPU ID/index (guest CPU #).
+    pub id: u8,
+    /// Host thread ID.
+    pub thread_id: usize,
+}
+
 /// The strongly typed that contains general information about the microVM.
 #[derive(Debug, Serialize)]
 pub struct InstanceInfo {
@@ -39,6 +48,8 @@ pub struct InstanceInfo {
     pub state: InstanceState,
     /// The version of the VMM that runs the microVM.
     pub vmm_version: String,
+    /// The list of running vCPUs.
+    pub vcpus: Vec<VcpuInfo>,
 }
 
 /// Errors associated with starting the instance.


### PR DESCRIPTION
Issue #, if available: #718 

**Description of changes**:
Added the list of running vCPUs to the `InstanceInfo` struct, to be exposed to the user via `GET /`. Currently, the only supported vCPU property is its associated host thread ID.

Closes #718 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
