### PR TITLE
Add Firecracker error on getting-started.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -191,3 +191,12 @@ Possible mitigations are:
   kernel so as to use `vmalloc` instead of `kmalloc` for them.
 - Reduce memory pressure on the host.
 
+### Error appears when starting Firecracker.
+
+```
+Cannot create VMM.: Vm(VmFd(Error(12)))
+```
+
+If the above error appears when trying to start
+Firecracker, then there is not enough free memory on your system for
+Firecracker to run.


### PR DESCRIPTION
Error may appears when there isn't enough memory for Firecracker to run.

Signed-off-by: xavinux <xavinux@gmail.com>

Issue #835

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.