### PR TITLE
Remove file descriptor inheritance from Jailer to Firecracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,6 @@ version = "0.15.0"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
- "kvm 0.1.0",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,6 @@ dependencies = [
  "logger 0.1.0",
  "mmds 0.1.0",
  "seccomp 0.1.0",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm 0.1.0",
 ]
@@ -340,9 +339,6 @@ dependencies = [
  "kvm 0.1.0",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 [dependencies]
 chrono = ">=0.4"
 clap = "=2.27.1"
-serde_json = ">=1.0.9"
 
 api_server = { path = "api_server" }
 fc_util = { path = "fc_util" }

--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -9,7 +9,6 @@ libc = ">=0.2.39"
 regex = ">=1.0.0"
 
 fc_util = { path = "../fc_util" }
-kvm = { path = "../kvm" }
 sys_util = { path = "../sys_util" }
 
 [dev-dependencies]

--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -7,9 +7,6 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 clap = ">=2.27.1"
 libc = ">=0.2.39"
 regex = ">=1.0.0"
-serde = ">=1.0.27"
-serde_derive = "=1.0.27"
-serde_json = ">=1.0.9"
 
 fc_util = { path = "../fc_util" }
 kvm = { path = "../kvm" }

--- a/jailer/src/env.rs
+++ b/jailer/src/env.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate serde_json;
-
 use std::ffi::CStr;
 use std::fs::{self, canonicalize, File};
 use std::os::unix::io::IntoRawFd;
@@ -17,7 +15,7 @@ use cgroup::Cgroup;
 use chroot::chroot;
 use fc_util::validators;
 use sys_util;
-use {Error, FirecrackerContext, Result};
+use {Error, Result};
 
 const STDIN_FILENO: libc::c_int = 0;
 const STDOUT_FILENO: libc::c_int = 1;
@@ -299,20 +297,13 @@ impl Env {
             }
         }
 
-        let context = FirecrackerContext {
-            id: self.id.clone(),
-            jailed: true,
-            seccomp_level: self.seccomp_level,
-            start_time_us: self.start_time_us,
-            start_time_cpu_us: self.start_time_cpu_us,
-        };
-
         Err(Error::Exec(
             Command::new(chroot_exec_file)
-                .arg(format!(
-                    "--context={}",
-                    serde_json::to_string(&context).expect("Failed to serialize context")
-                ))
+                .arg(format!("--id={}", self.id))
+                .arg("--jailed")
+                .arg(format!("--seccomp-level={}", self.seccomp_level))
+                .arg(format!("--start-time-us={}", self.start_time_us))
+                .arg(format!("--start-time-cpu-us={}", self.start_time_cpu_us))
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())

--- a/jailer/src/lib.rs
+++ b/jailer/src/lib.rs
@@ -5,9 +5,6 @@
 extern crate clap;
 extern crate libc;
 extern crate regex;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 
 extern crate fc_util;
 extern crate kvm;
@@ -36,16 +33,6 @@ pub const KVM_FD: i32 = 3;
 pub const LISTENER_FD: i32 = 4;
 
 const SOCKET_FILE_NAME: &str = "api.socket";
-
-#[derive(Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FirecrackerContext {
-    pub id: String,
-    pub jailed: bool,
-    pub seccomp_level: u32,
-    pub start_time_us: u64,
-    pub start_time_cpu_us: u64,
-}
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,14 +179,8 @@ fn main() {
         .get_event_fd_clone()
         .expect("Cannot clone API eventFD.");
 
-    let kvm_fd = if is_jailed {
-        Some(jailer::KVM_FD)
-    } else {
-        None
-    };
-
     let _vmm_thread_handle =
-        vmm::start_vmm_thread(shared_info, api_event_fd, from_api, seccomp_level, kvm_fd);
+        vmm::start_vmm_thread(shared_info, api_event_fd, from_api, seccomp_level);
 
     let uds_path_or_fd = if is_jailed {
         UnixDomainSocket::Fd(jailer::LISTENER_FD)

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -107,7 +107,7 @@ class JailerContext:
 
     def api_socket_path(self):
         """Return the MicroVM API socket path."""
-        return os.path.join(self.chroot_base_with_id(), API_USOCKET_NAME)
+        return os.path.join(self.chroot_path(), API_USOCKET_NAME)
 
     def chroot_path(self):
         """Return the MicroVM chroot path."""

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -323,13 +323,14 @@ class Microvm:
                                          .format(screen_pid)
                                          ).read().strip()
 
-        # Wait for the jailer to create resources needed.
+        # Wait for the jailer to create resources needed, and Firecracker to
+        # create its API socket.
         # We expect the jailer to start within 80 ms. However, we wait for
-        # 1 sec since we are rechecking the existence of the socket 500 times
-        # and leave 0.002 delay between them.
+        # 1 sec since we are rechecking the existence of the socket 5 times
+        # and leave 0.2 delay between them.
         self._wait_create()
 
-    @retry(delay=0.100, tries=10)
+    @retry(delay=0.2, tries=5)
     def _wait_create(self):
         """Wait until the API socket and chroot folder are available."""
         os.stat(self._jailer.api_socket_path())

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 
-COVERAGE_TARGET_PCT = 82.2
+COVERAGE_TARGET_PCT = 82.4
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -290,7 +290,6 @@ mod tests {
 
     use super::*;
     use net_util::MacAddr;
-    use VmmActionError::NetworkConfig;
 
     fn create_netif(id: &str, name: &str, mac: &str) -> NetworkInterfaceConfig {
         NetworkInterfaceConfig {

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -289,23 +289,19 @@ impl Vcpu {
 mod tests {
     use super::*;
 
-    use std::os::unix::io::AsRawFd;
-
     #[test]
     fn create_vm() {
-        let kvm_fd = Kvm::new().unwrap();
-        let kvm = KvmContext::new(Some(kvm_fd.as_raw_fd())).unwrap();
+        let kvm = KvmContext::new().unwrap();
         let gm = GuestMemory::new(&vec![(GuestAddress(0), 0x10000)]).unwrap();
-        let mut vm = Vm::new(&kvm_fd).expect("new vm failed");
+        let mut vm = Vm::new(kvm.fd()).expect("new vm failed");
         assert!(vm.memory_init(gm, &kvm).is_ok());
     }
 
     #[test]
     fn get_memory() {
-        let kvm_fd = Kvm::new().unwrap();
-        let kvm = KvmContext::new(Some(kvm_fd.as_raw_fd())).unwrap();
+        let kvm = KvmContext::new().unwrap();
         let gm = GuestMemory::new(&vec![(GuestAddress(0), 0x1000)]).unwrap();
-        let mut vm = Vm::new(&kvm_fd).expect("new vm failed");
+        let mut vm = Vm::new(kvm.fd()).expect("new vm failed");
         assert!(vm.memory_init(gm, &kvm).is_ok());
         let obj_addr = GuestAddress(0xf0);
         vm.get_memory()
@@ -323,10 +319,9 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_configure_vcpu() {
-        let kvm_fd = Kvm::new().unwrap();
-        let kvm = KvmContext::new(Some(kvm_fd.as_raw_fd())).unwrap();
+        let kvm = KvmContext::new().unwrap();
         let gm = GuestMemory::new(&vec![(GuestAddress(0), 0x10000)]).unwrap();
-        let mut vm = Vm::new(&kvm_fd).expect("new vm failed");
+        let mut vm = Vm::new(kvm.fd()).expect("new vm failed");
         assert!(vm.memory_init(gm, &kvm).is_ok());
         let dummy_eventfd_1 = EventFd::new().unwrap();
         let dummy_eventfd_2 = EventFd::new().unwrap();
@@ -385,9 +380,8 @@ mod tests {
         let load_addr = GuestAddress(0x1000);
         let mem = GuestMemory::new(&vec![(load_addr, mem_size)]).unwrap();
 
-        let kvm_fd = Kvm::new().expect("new kvm failed");
-        let kvm = KvmContext::new(Some(kvm_fd.as_raw_fd())).unwrap();
-        let mut vm = Vm::new(&kvm_fd).expect("new vm failed");
+        let kvm = KvmContext::new().unwrap();
+        let mut vm = Vm::new(kvm.fd()).expect("new vm failed");
         assert!(vm.memory_init(mem, &kvm).is_ok());
         vm.get_memory()
             .unwrap()


### PR DESCRIPTION
This is leftover logic from when `seccomp()` was done in jailer and Firecracker was not allowed to `open()` anything.

Now, Firecracker does `seccomp()` itself just before booting the guest, which means it can also set up its own resources beforehand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
