### PR TITLE
Add Swagger operationId of /machine-config get

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -177,6 +177,7 @@ paths:
         Gets the machine configuration of the VM. When called before the PUT operation, it
         will return the default values for the vCPU count (=1), memory size (=128 MiB).
         By default Hyperthreading is disabled and there is no CPU Template.
+      operationId: getMachineConfiguration
       responses:
         200:
           description: OK


### PR DESCRIPTION
Swagger operationId is often used by code generators.
But the current `/machine-config get` does not have it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
