### PR TITLE
fix error message when writing commandline to memory

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -306,11 +306,6 @@ mod tests {
             )),
         );
         check_error_response(vmm_resp, StatusCode::InternalServerError);
-        let vmm_resp = VmmActionError::StartMicrovm(
-            ErrorKind::User,
-            StartMicrovmError::Loader(kernel::loader::Error::BigEndianElfOnLittle),
-        );
-        check_error_response(vmm_resp, StatusCode::BadRequest);
         let vmm_resp =
             VmmActionError::StartMicrovm(ErrorKind::Internal, StartMicrovmError::EventFd);
         check_error_response(vmm_resp, StatusCode::InternalServerError);
@@ -327,5 +322,75 @@ mod tests {
             StartMicrovmError::VcpuSpawn(std::io::Error::from_raw_os_error(11)),
         );
         check_error_response(vmm_resp, StatusCode::InternalServerError);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::BigEndianElfOnLittle),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineCopy),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineOverflow),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::InvalidElfMagicNumber),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::InvalidEntryAddress),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::InvalidProgramHeaderSize),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::InvalidProgramHeaderOffset),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::InvalidProgramHeaderAddress),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::ReadElfHeader),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::ReadKernelImage),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::ReadProgramHeader),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::SeekKernelStart),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::SeekElfStart),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::User,
+            StartMicrovmError::KernelLoader(kernel::loader::Error::SeekProgramHeader),
+        );
+        check_error_response(vmm_resp, StatusCode::BadRequest);
     }
 }

--- a/kernel/src/loader/mod.rs
+++ b/kernel/src/loader/mod.rs
@@ -7,6 +7,7 @@
 
 use std;
 use std::ffi::CStr;
+use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
 
@@ -33,6 +34,34 @@ pub enum Error {
     SeekElfStart,
     SeekProgramHeader,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                Error::BigEndianElfOnLittle => "Unsupported ELF File byte order",
+                Error::CommandLineCopy => "Failed to copy the command line string to guest memory",
+                Error::CommandLineOverflow => "Command line string overflows guest memory",
+                Error::InvalidElfMagicNumber => "Invalid ELF magic number",
+                Error::InvalidEntryAddress => "Invalid entry address found in ELF header",
+                Error::InvalidProgramHeaderSize => "Invalid ELF program header size",
+                Error::InvalidProgramHeaderOffset => "Invalid ELF program header offset",
+                Error::InvalidProgramHeaderAddress => "Invalid ELF program header address",
+                Error::ReadElfHeader => "Failed to read ELF header",
+                Error::ReadKernelImage => "Failed to write kernel image to guest memory",
+                Error::ReadProgramHeader => "Failed to read ELF program header",
+                Error::SeekKernelStart => {
+                    "Failed to seek to file offset as pointed by the ELF program header"
+                }
+                Error::SeekElfStart => "Failed to seek to start of kernel image",
+                Error::SeekProgramHeader => "Failed to seek to ELF program header",
+            }
+        )
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Loads a kernel from a vmlinux elf image to a slice

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1206,9 +1206,9 @@ impl Vmm {
             &mut kernel_config.kernel_file,
             arch::HIMEM_START,
         )
-        .map_err(StartMicrovmError::Loader)?;
+        .map_err(StartMicrovmError::KernelLoader)?;
         kernel_loader::load_cmdline(vm_memory, kernel_config.cmdline_addr, &cmdline_cstring)
-            .map_err(StartMicrovmError::Loader)?;
+            .map_err(StartMicrovmError::LoadCommandline)?;
 
         // The vcpu_count has a default value. We shouldn't have gotten to this point without
         // having set the vcpu count.

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -71,10 +71,12 @@ pub enum StartMicrovmError {
     GuestMemory(GuestMemoryError),
     /// The kernel command line is invalid.
     KernelCmdline(String),
+    /// Cannot load kernel due to invalid memory configuration or invalid kernel image.
+    KernelLoader(kernel_loader::Error),
     /// Cannot add devices to the Legacy I/O Bus.
     LegacyIOBus(device_manager::legacy::Error),
-    /// Cannot load kernel due to invalid memory configuration or invalid kernel image.
-    Loader(kernel_loader::Error),
+    /// Cannot load command line string.
+    LoadCommandline(kernel_loader::Error),
     /// The start command was issued more than once.
     MicroVMAlreadyRunning,
     /// Cannot start the VM because the kernel was not configured.
@@ -155,22 +157,26 @@ impl Display for StartMicrovmError {
                 write!(f, "Invalid Memory Configuration: {}", err_msg)
             }
             KernelCmdline(ref err) => write!(f, "Invalid kernel command line: {}", err),
-            LegacyIOBus(ref err) => {
-                let mut err_msg = format!("{:?}", err);
+            KernelLoader(ref err) => {
+                let mut err_msg = format!("{}", err);
                 err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot add devices to the legacy I/O Bus. {}", err_msg)
-            }
-            Loader(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
                 write!(
                     f,
                     "Cannot load kernel due to invalid memory configuration or invalid kernel \
                      image. {}",
                     err_msg
                 )
+            }
+            LegacyIOBus(ref err) => {
+                let mut err_msg = format!("{:?}", err);
+                err_msg = err_msg.replace("\"", "");
+
+                write!(f, "Cannot add devices to the legacy I/O Bus. {}", err_msg)
+            }
+            LoadCommandline(ref err) => {
+                let mut err_msg = format!("{}", err);
+                err_msg = err_msg.replace("\"", "");
+                write!(f, "Cannot load command line string. {}", err_msg)
             }
             MicroVMAlreadyRunning => write!(f, "Microvm already running."),
             MissingKernelConfig => write!(f, "Cannot start microvm without kernel configuration."),


### PR DESCRIPTION
Issue #855  
Transform the `map_err()` into an   ##`expect()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
