### PR TITLE
tests: cargo doc integration test

### DIFF
--- a/tests/integration_tests/build/test_doc.py
+++ b/tests/integration_tests/build/test_doc.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that check if building the documentation works."""
+
+import os
+
+
+from subprocess import run
+
+import host_tools.cargo_build as host  # pylint: disable=import-error
+
+CARGO_DOC_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'doc')
+
+
+def test_doc(test_session_root_path):
+    """Test successful documentation build."""
+    cmd = (
+        'cargo doc --target-dir {}'
+    ).format(
+        os.path.join(test_session_root_path, CARGO_DOC_REL_PATH)
+    )
+    run(cmd, shell=True, check=True)


### PR DESCRIPTION
Issue #, if available: Fixes #559 

Description of changes: Added an integration test that does `cargo doc` and checks that it is succesful.
Disclaimer: have not found a documentation related error that `cargo build` does not also surface by itself. However, I think it is useful to have this test for 2 reasons:
* (Unlikely) There might be some errors that cargo build does not know about.
* For when we decide to upload our generated doc in the repo in the form of a pdf, html etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
