### PR TITLE
tests: increase api timeouts from 100 to 200ms

### DIFF
--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -11,7 +11,7 @@ JAILER_BINARY_NAME = 'jailer'
 """Jailer's binary name."""
 JAILER_DEFAULT_CHROOT = '/srv/jailer'
 """The default location for the chroot."""
-MAX_API_CALL_DURATION_MS = 100
+MAX_API_CALL_DURATION_MS = 300
 """Maximum accepted duration of an API call, in milliseconds."""
 MICROVM_KERNEL_RELPATH = 'kernel/'
 """Relative path to the location of the kernel file."""


### PR DESCRIPTION
Issue #976 

Description of changes: Bumps the API Timeout from 100 to 200ms for all API calls during testing to avoid unnecessary vsock errors. This does increase the timeout for _all_ API calls, not just vsock, which should be noted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
