### PR TITLE
Metrics: remove `bad_syscalls`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
 
+### Removed
+
+- Removed the `seccomp.bad_syscalls` metric.
+
 ## [0.15.0]
 
 ### Added

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -29,8 +29,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use chrono;
 use serde::{Serialize, Serializer};
 
-const SYSCALL_MAX: usize = 350;
-
 /// Used for defining new types of metrics that can be either incremented with an unit
 /// or an arbitrary amount of units.
 // This trait helps with writing less code. It has to be in scope (via an use directive) in order
@@ -308,25 +306,10 @@ pub struct NetDeviceMetrics {
 }
 
 /// Metrics for the seccomp filtering.
-#[derive(Serialize)]
+#[derive(Default, Serialize)]
 pub struct SeccompMetrics {
-    /// Number of black listed syscalls.
-    pub bad_syscalls: Vec<SharedMetric>,
     /// Number of errors inside the seccomp filtering.
     pub num_faults: SharedMetric,
-}
-
-impl Default for SeccompMetrics {
-    fn default() -> SeccompMetrics {
-        let mut def_syscalls = vec![];
-        for _syscall in 0..SYSCALL_MAX {
-            def_syscalls.push(SharedMetric::default());
-        }
-        SeccompMetrics {
-            num_faults: SharedMetric::default(),
-            bad_syscalls: def_syscalls,
-        }
-    }
 }
 
 /// Metrics specific to the UART device.


### PR DESCRIPTION
Issue #, if available: #869

Description of changes: Removed the `bad_syscalls` array metric. In case of seccomp fault, the offending syscall is already logged and the exit code is already appropriately set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
