### PR TITLE
move 'floating' vCPU code to the `vcpu` struct

### DIFF
--- a/cpuid/src/common.rs
+++ b/cpuid/src/common.rs
@@ -73,7 +73,6 @@ pub fn get_vendor_id() -> Result<[u8; 12], Error> {
 #[cfg(test)]
 pub mod tests {
     use common::*;
-    use cpu_leaf::*;
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_topoext_fn() -> u32 {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,7 +18,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.3
+COVERAGE_TARGET_PCT = 83.6
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -125,7 +125,7 @@ def _configure_vm(microvm, network_info=None):
     response = microvm.logger.put(
         log_fifo=microvm.create_jailed_resource(log_fifo.path),
         metrics_fifo=microvm.create_jailed_resource(metrics_fifo.path),
-        level='Warning',
+        level='Info',
         show_level=False,
         show_log_origin=False
     )

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -175,15 +175,6 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             // can return. Otherwise we get stuck in a fault loop.
             allow_syscall(libc::SYS_rt_sigreturn),
             allow_syscall(libc::SYS_stat),
-            allow_syscall_if(
-                libc::SYS_tkill,
-                or![and![Cond::new(
-                    1,
-                    Eq,
-                    sys_util::validate_signal_num(super::super::VCPU_RTSIG_OFFSET, true)
-                        .map_err(|_| Error::InvalidArgumentNumber)? as u64,
-                )?]],
-            ),
             allow_syscall(libc::SYS_timerfd_create),
             allow_syscall(libc::SYS_timerfd_settime),
             allow_syscall(libc::SYS_write),

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -230,7 +230,7 @@ impl Display for StartMicrovmError {
                 let mut err_msg = format!("{:?}", err);
                 err_msg = err_msg.replace("\"", "");
 
-                write!(f, "Cannot create a new vCPU file descriptor. {}", err_msg)
+                write!(f, "Cannot create a new vCPU. {}", err_msg)
             }
             VcpuConfigure(ref err) => {
                 let mut err_msg = format!("{:?}", err);


### PR DESCRIPTION
Move the main loop being run by vCPU threads from the generic `vmm/src/lib.rs` inside the implementation of the existing `vcpu` struct defined in `vmm/src/vstate.rs`.

Fixes https://github.com/firecracker-microvm/firecracker/issues/1002.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
