### PR TITLE
seccomp: allow madvise(*, *, MADV_DONTNEED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
 
+### Fixed
+
+- A `madvise` call issued by the `musl` allocator was added to the seccomp
+  whitelist to prevent Firecracker from terminating abruptly when allocating
+  memory in certain conditions.
+
 ### Removed
 
 - Removed the `seccomp.bad_syscalls` metric.

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -23,6 +23,8 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_futex,
     libc::SYS_ioctl,
     libc::SYS_lseek,
+    #[cfg(musl)]
+    libc::SYS_madvise,
     libc::SYS_mmap,
     libc::SYS_munmap,
     libc::SYS_open,
@@ -240,6 +242,21 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
             (
                 libc::SYS_lseek,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            #[cfg(musl)]
+            (
+                libc::SYS_madvise,
+                (
+                    0,
+                    vec![SeccompRule::new(
+                        vec![SeccompCondition::new(
+                            2,
+                            SeccompCmpOp::Eq,
+                            libc::MADV_DONTNEED as u64,
+                        )?],
+                        SeccompAction::Allow,
+                    )],
+                ),
             ),
             (
                 libc::SYS_mmap,


### PR DESCRIPTION
Issue #, if available: #982

Description of changes: Allow `madvise(MADV_DONTNEED)`, which [can be called by the musl allocator](https://elixir.bootlin.com/musl/v1.1.20/source/src/malloc/malloc.c#L501).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
