### PR TITLE
V0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.15.1]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- A `madvise` call issued by the `musl` allocator was added to the seccomp
+  whitelist to prevent Firecracker from terminating abruptly when allocating
+  memory in certain conditions.
+
 ## [0.15.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
- "jailer 0.14.0",
+ "jailer 0.15.0",
  "logger 0.1.0",
  "mmds 0.1.0",
  "seccomp 0.1.0",
@@ -333,7 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
- "jailer 0.15.0",
+ "jailer 0.15.1",
  "logger 0.1.0",
  "mmds 0.1.0",
  "seccomp 0.1.0",
@@ -333,7 +333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Amazon firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -4,7 +4,7 @@ info:
   description: RESTful public-facing API.
                The API is accessible through HTTP calls on specific URLs carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.15.0
+  version: 0.15.1
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/vmm/src/default_syscalls/x86_64.rs
+++ b/vmm/src/default_syscalls/x86_64.rs
@@ -23,6 +23,8 @@ pub const ALLOWED_SYSCALLS: &[i64] = &[
     libc::SYS_futex,
     libc::SYS_ioctl,
     libc::SYS_lseek,
+    #[cfg(musl)]
+    libc::SYS_madvise,
     libc::SYS_mmap,
     libc::SYS_munmap,
     libc::SYS_open,
@@ -240,6 +242,21 @@ pub fn default_context() -> Result<SeccompFilterContext, Error> {
             (
                 libc::SYS_lseek,
                 (0, vec![SeccompRule::new(vec![], SeccompAction::Allow)]),
+            ),
+            #[cfg(musl)]
+            (
+                libc::SYS_madvise,
+                (
+                    0,
+                    vec![SeccompRule::new(
+                        vec![SeccompCondition::new(
+                            2,
+                            SeccompCmpOp::Eq,
+                            libc::MADV_DONTNEED as u64,
+                        )?],
+                        SeccompAction::Allow,
+                    )],
+                ),
             ),
             (
                 libc::SYS_mmap,


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Trying out patch releases with branches corresponding to tags.

### Process for patch releases

```
git checkout v0.15.0
git checkout -b v0.15.1
git cherry-pick de34b8100a2fe13298c47cb041dbe2ac42c0de06 # This is the commit that fixes the sycalls bug
# Manually fix the conflicts
git cherry-pick --continue
# Add a commit for v0.15.1 release
```