### PR TITLE
ARM: corectly place x86_64 specific error

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -301,9 +301,12 @@ mod tests {
             StartMicrovmError::DeviceVmRequest(io::Error::from_raw_os_error(22)),
         );
         check_error_response(vmm_resp, StatusCode::InternalServerError);
+        #[cfg(target_arch = "x86_64")]
         let vmm_resp = VmmActionError::StartMicrovm(
             ErrorKind::Internal,
-            StartMicrovmError::ConfigureSystem(arch::Error::ZeroPagePastRamEnd),
+            StartMicrovmError::ConfigureSystem(arch::Error::X86_64Setup(
+                arch::x86_64::Error::ZeroPagePastRamEnd,
+            )),
         );
         check_error_response(vmm_resp, StatusCode::InternalServerError);
         let vmm_resp = VmmActionError::StartMicrovm(

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -16,10 +16,6 @@ pub enum Error {
     #[cfg(target_arch = "x86_64")]
     /// X86_64 specific error triggered during system configuration.
     X86_64Setup(x86_64::Error),
-    /// The zero page extends past the end of guest_mem.
-    ZeroPagePastRamEnd,
-    /// Error writing the zero page of guest memory.
-    ZeroPageSetup,
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -33,6 +33,10 @@ pub enum Error {
     E820Configuration,
     /// Error writing MP table to memory.
     MpTableSetup(mptable::Error),
+    /// The zero page extends past the end of guest_mem.
+    ZeroPagePastRamEnd,
+    /// Error writing the zero page of guest memory.
+    ZeroPageSetup,
 }
 
 impl From<Error> for super::Error {
@@ -142,10 +146,10 @@ pub fn configure_system(
     let zero_page_addr = GuestAddress(layout::ZERO_PAGE_START);
     guest_mem
         .checked_offset(zero_page_addr, mem::size_of::<boot_params>())
-        .ok_or(super::Error::ZeroPagePastRamEnd)?;
+        .ok_or(Error::ZeroPagePastRamEnd)?;
     guest_mem
         .write_obj_at_addr(params, zero_page_addr)
-        .map_err(|_| super::Error::ZeroPageSetup)?;
+        .map_err(|_| Error::ZeroPageSetup)?;
 
     Ok(())
 }

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -5,7 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-extern crate arch;
 extern crate devices;
 extern crate logger;
 extern crate sys_util;
@@ -16,6 +15,7 @@ use std::result;
 use kvm_bindings::{kvm_pit_config, KVM_PIT_SPEAKER_DUMMY};
 
 use super::KvmContext;
+use arch;
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3_template, filter_cpuid, t2_template};
 use kvm::*;


### PR DESCRIPTION
Since there is no Zero Page concept under aarch64,
move the related errors under specific x86_64 code.

Signed-off-by: Diana Popa <dpopa@amazon.com>

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
