### PR TITLE
arm64: added memory layout representation

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -1,6 +1,59 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//      ==== Address map in use in ARM development systems today ====
+//
+//              - 32-bit -              - 36-bit -          - 40-bit -
+//1024GB    +                   +                      +-------------------+     <- 40-bit
+//          |                                           | DRAM              |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//          |                                           |                   |
+//          |                                           |                   |
+//          |                                           |                   |
+//544GB     +                   +                       +-------------------+
+//          |                                           | Hole or DRAM      |
+//          |                                           |                   |
+//512GB     +                   +                       +-------------------+
+//          |                                           |       Mapped      |
+//          |                                           |       I/O         |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//256GB     +                   +                       +-------------------+
+//          |                                           |       Reserved    |
+//          ~                   ~                       ~                   ~
+//          |                                           |                   |
+//64GB      +                   +-----------------------+-------------------+   <- 36-bit
+//          |                   |                   DRAM                    |
+//          ~                   ~                   ~                       ~
+//          |                   |                                           |
+//          |                   |                                           |
+//34GB      +                   +-----------------------+-------------------+
+//          |                   |                  Hole or DRAM             |
+//32GB      +                   +-----------------------+-------------------+
+//          |                   |                   Mapped I/O              |
+//          ~                   ~                       ~                   ~
+//          |                   |                                           |
+//16GB      +                   +-----------------------+-------------------+
+//          |                   |                   Reserved                |
+//          ~                   ~                       ~                   ~
+//4GB       +-------------------+-----------------------+-------------------+   <- 32-bit
+//          |           2GB of DRAM                                         |
+//          |                                                               |
+//2GB       +-------------------+-----------------------+-------------------+
+//          |                           Mapped I/O                          |
+//1GB       +-------------------+-----------------------+-------------------+
+//          |                          ROM & RAM & I/O                      |
+//0GB       +-------------------+-----------------------+-------------------+   0
+//              - 32-bit -              - 36-bit -              - 40-bit -
+//
+// Taken from (http://infocenter.arm.com/help/topic/com.arm.doc.den0001c/DEN0001C_principles_of_arm_memory_maps.pdf).
+
+/// Start of RAM on 64 bit ARM.
+pub const DRAM_MEM_START: usize = 0x8000_0000; // 2 GB.
+/// The maximum addressable RAM address.
+pub const DRAM_MEM_END: usize = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
+
 /// Kernel command line start address.
 pub const CMDLINE_START: usize = 0x0;
 /// Kernel command line start address maximum size.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -3,11 +3,15 @@
 
 pub mod layout;
 
+use std::cmp::min;
+
 use memory_model::{GuestAddress, GuestMemory};
 
-/// Stub function that needs to be implemented when aarch64 functionality is added.
+/// Returns a Vec of the valid memory addresses for aarch64.
+/// See [`layout`](layout) module for a drawing of the specific memory model for this platform.
 pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
-    vec![(GuestAddress(0), size)]
+    let dram_size = min(size, layout::DRAM_MEM_END);
+    vec![(GuestAddress(layout::DRAM_MEM_START), dram_size)]
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
@@ -23,4 +27,25 @@ pub fn configure_system(
 /// Stub function that needs to be implemented when aarch64 functionality is added.
 pub fn get_reserved_mem_addr() -> usize {
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regions_lt_1024gb() {
+        let regions = arch_memory_regions(1usize << 29);
+        assert_eq!(1, regions.len());
+        assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
+        assert_eq!(1usize << 29, regions[0].1);
+    }
+
+    #[test]
+    fn regions_gt_1024gb() {
+        let regions = arch_memory_regions(1usize << 41);
+        assert_eq!(1, regions.len());
+        assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
+        assert_eq!(super::layout::DRAM_MEM_END, regions[0].1);
+    }
 }


### PR DESCRIPTION
The code follows the memory address mapping of a 64-bit guest.
Link to documentation can be found in the following diff.

Issue #, if available: #757 

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
