### PR TITLE
Platform dependent irq assignment for the mmio device manager

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -5,3 +5,15 @@
 pub const CMDLINE_START: usize = 0x0;
 /// Kernel command line start address maximum size.
 pub const CMDLINE_MAX_SIZE: usize = 0x0;
+
+// As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
+// the number of interrupts our GIC will support to be:
+// * bigger than 32
+// * less than 1023 and
+// * a multiple of 32.
+// We are setting up our interrupt controller to support a maximum of 128 interrupts.
+/// First usable interrupt on aarch64.
+pub const IRQ_BASE: u32 = 32;
+
+/// Last usable interrupt on aarch64.
+pub const IRQ_MAX: u32 = 159;

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -37,5 +37,5 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     arch_memory_regions, configure_system, get_32bit_gap_start as get_reserved_mem_addr,
-    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
+    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, layout::IRQ_BASE, layout::IRQ_MAX,
 };

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -28,7 +28,7 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, configure_system, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START,
+    layout::CMDLINE_START, layout::IRQ_BASE, layout::IRQ_MAX,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -16,6 +16,12 @@ pub const CMDLINE_START: usize = 0x20000;
 /// Kernel command line start address maximum size.
 pub const CMDLINE_MAX_SIZE: usize = 0x10000;
 
+// Typically, on x86 systems 16 IRQs are used (0-15).
+/// First usable IRQ ID for virtio device interrupts on x86_64.
+pub const IRQ_BASE: u32 = 5;
+/// Last usable IRQ ID for virtio device interrupts on x86_64.
+pub const IRQ_MAX: u32 = 15;
+
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: usize = 0xfffb_d000;
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -927,8 +927,11 @@ impl Vmm {
 
         // Instantiate the MMIO device manager.
         // 'mmio_base' address has to be an address which is protected by the kernel.
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
 
         self.attach_block_devices(&mut device_manager)?;
         self.attach_net_devices(&mut device_manager)?;
@@ -2372,8 +2375,11 @@ mod tests {
         vmm.init_guest_memory().unwrap();
         vmm.default_kernel_config();
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
         vmm.attach_net_devices(&mut device_manager).unwrap();
         vmm.set_instance_state(InstanceState::Running);
 
@@ -2648,8 +2654,11 @@ mod tests {
         vmm.default_kernel_config();
 
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
         assert!(vmm.attach_block_devices(&mut device_manager).is_ok());
         assert!(vmm.get_kernel_cmdline_str().contains("root=/dev/vda"));
 
@@ -2672,8 +2681,11 @@ mod tests {
         vmm.default_kernel_config();
 
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
         assert!(vmm.attach_block_devices(&mut device_manager).is_ok());
         assert!(vmm
             .get_kernel_cmdline_str()
@@ -2700,8 +2712,11 @@ mod tests {
         vmm.default_kernel_config();
 
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
         assert!(vmm.attach_block_devices(&mut device_manager).is_ok());
         // Test that kernel commandline does not contain either /dev/vda or PARTUUID.
         assert!(!vmm.get_kernel_cmdline_str().contains("root=PARTUUID="));
@@ -2734,8 +2749,11 @@ mod tests {
         vmm.default_kernel_config();
 
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
 
         // test create network interface
         let network_interface = NetworkInterfaceConfig {
@@ -2830,8 +2848,11 @@ mod tests {
         assert!(vmm.guest_memory.is_some());
 
         let guest_mem = vmm.guest_memory.clone().unwrap();
-        let mut device_manager =
-            MMIODeviceManager::new(guest_mem.clone(), arch::get_reserved_mem_addr() as u64);
+        let mut device_manager = MMIODeviceManager::new(
+            guest_mem.clone(),
+            arch::get_reserved_mem_addr() as u64,
+            (arch::IRQ_BASE, arch::IRQ_MAX),
+        );
 
         let dummy_box = Box::new(DummyDevice { dummy: 0 });
         // Use a dummy command line as it is not used in this test.


### PR DESCRIPTION
Issue #, if available: #757 

Description of changes: The interrupts assignment (irq base, maximum irq) is platform dependent but up until now we would be hard coding those for x86_64 inside the mmio device manager. Refactored the code accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
