### PR TITLE
fixed the test for the kvm_run loop

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,7 +18,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.7
+COVERAGE_TARGET_PCT = 82.8
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
We weren't checking the MMIO Read & MMIO Write because we were actually
performing read & write to an address that was part of the guest memory.

Issue #, if available: #999 

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
