### PR TITLE
vmm: move logic for creating vcpus

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -319,7 +319,12 @@ mod tests {
         check_error_response(vmm_resp, StatusCode::InternalServerError);
         let vmm_resp = VmmActionError::StartMicrovm(
             ErrorKind::Internal,
-            StartMicrovmError::VcpuSpawn(io::Error::from_raw_os_error(11)),
+            StartMicrovmError::VcpusNotConfigured,
+        );
+        check_error_response(vmm_resp, StatusCode::InternalServerError);
+        let vmm_resp = VmmActionError::StartMicrovm(
+            ErrorKind::Internal,
+            StartMicrovmError::VcpuSpawn(std::io::Error::from_raw_os_error(11)),
         );
         check_error_response(vmm_resp, StatusCode::InternalServerError);
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,7 +18,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.8
+COVERAGE_TARGET_PCT = 83.2
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
On aarch64 KVM_CREATE_VCPU needs to be called before setting up the
IRQCHIP, while on x86 it needs to be called after setting up the
IRQCHIP. Consequently the configuration of the vcpus was moved to a
different function.
Also, architecture specific labeling was added.

Signed-off-by: Diana Popa <dpopa@amazon.com>

Issue #, if available: #757 

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
