### PR TITLE
vmm: fix vCPU-thread mapping

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1023,7 +1023,8 @@ impl Vmm {
 
         let vcpu_thread_barrier = Arc::new(Barrier::new((vcpu_count + 1) as usize));
 
-        for cpu_id in 0..vcpu_count {
+        // We're going in reverse so we can `.pop()` on the vec and still maintain order.
+        for cpu_id in (0..vcpu_count).rev() {
             let io_bus = self.legacy_device_manager.io_bus.clone();
             // mmio_device_manager is instantiated in init_devices, which is called before
             // start_vcpus.


### PR DESCRIPTION
Vcpus have an `id` which is a 0-based index, and this `id` matches the guest vCPU index. We also add this `id` in the name of each Firecracker vCPU thread so that guest vCPU index can be matched to a host thread.

This PR fixes this mapping since `.pop()` effectively reverses the order in which vcpus are consumed from a vec, by also reversing the order in which we iterate over the `id` numbers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
