### PR TITLE
Let MMDS accept only String values on PUT and PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   in favor of individual classic command-line parameters.
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
+- `PUT` and `PATCH` requests on `/mmds` with data containing any value type other
+  than `String`, `Array`, `Object` will return status code 400.
 
 ### Removed
 

--- a/fc_util/src/validators.rs
+++ b/fc_util/src/validators.rs
@@ -51,10 +51,14 @@ mod tests {
     #[test]
     fn test_validate_instance_id() {
         assert_eq!(
-            validate_instance_id("").unwrap_err(),
-            Error::InvalidLen(0, MIN_INSTANCE_ID_LEN, MAX_INSTANCE_ID_LEN)
+            format!("{}", validate_instance_id("").unwrap_err()),
+            "invalid len (0);  the length must be between 1 and 64"
         );
         assert!(validate_instance_id("12-3aa").is_ok());
+        assert_eq!(
+            format!("{}", validate_instance_id("12_3aa").unwrap_err()),
+            "invalid char (_) at position 2"
+        );
         assert_eq!(
             validate_instance_id("12:3aa").unwrap_err(),
             Error::InvalidChar(':', 2)

--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -177,4 +177,16 @@ mod tests {
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
         );
     }
+
+    #[test]
+    fn test_body() {
+        let body = Body::new("".to_string());
+        // Test for is_empty
+        assert!(body.is_empty());
+        let body = Body::new("This is a body.".to_string());
+        // Test for len
+        assert_eq!(body.len(), 15);
+        // Test for raw
+        assert_eq!(body.raw(), b"This is a body.");
+    }
 }

--- a/mmds/src/lib.rs
+++ b/mmds/src/lib.rs
@@ -126,7 +126,8 @@ mod tests {
         }"#;
         MMDS.lock()
             .unwrap()
-            .put_data(serde_json::from_str(data).unwrap());
+            .put_data(serde_json::from_str(data).unwrap())
+            .unwrap();
 
         // Test invalid request.
         let request = b"HTTP/1.1";
@@ -194,7 +195,6 @@ mod tests {
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
         assert!(expected_response.http_version() == actual_response.http_version());
 
-        // Test Internal Server Error.
         let data = r#"{
             "name": {
                 "first": "John",
@@ -202,17 +202,11 @@ mod tests {
             },
             "age": 43
         }"#;
-        MMDS.lock()
-            .unwrap()
-            .put_data(serde_json::from_str(data).unwrap());
-
-        let request = b"GET http://169.254.169.254/age HTTP/1.0\r\n";
-        let mut expected_response = Response::new(Version::Http10, StatusCode::InternalServerError);
-        let body = "The resource /age has an invalid format.".to_string();
-        expected_response.set_body(Body::new(body));
-        let actual_response = parse_request(request);
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
+        assert_eq!(
+            MMDS.lock()
+                .unwrap()
+                .put_data(serde_json::from_str(data).unwrap()),
+            Err(MmdsError::UnsupportedValueType)
+        );
     }
 }

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -771,4 +771,17 @@ mod tests {
         assert_eq!(x.bandwidth, Some(new_bw));
         assert_eq!(x.ops, Some(new_ops));
     }
+
+    #[test]
+    fn test_rate_limiter_debug() {
+        let l = RateLimiter::new(1, Some(2), 3, 4, Some(5), 6).unwrap();
+        assert_eq!(
+            format!("{:?}", l),
+            format!(
+                "RateLimiter {{ bandwidth: {:?}, ops: {:?} }}",
+                l.bandwidth(),
+                l.ops()
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Signed-off-by: ylyu <lyuyuan92@gmail.com>

Issue #, if available:
#529

Description of changes:
1. Add data validator method Mmds::is_data_valid().
2. Call is_data_valid in put and patch to valid the payload first.
3. Add BadRequest response in http_service if put/patch data is invalid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
