### PR TITLE
manually update the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- New `devtool` command: `prepare_release`. This updates the Firecracker
+  version, crate dependencies and credits in preparation for a new release.
+- New `devtool` command: `tag`. This creates a new git tag for the specified
+  release number, based on the changelog contents.
+
 ### Changed
 
 - Dropped the JSON-formatted `context` command-line parameter from Firecracker
@@ -9,15 +16,23 @@
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
 
+### Removed
+
+- Removed the `seccomp.bad_syscalls` metric.
+
+## [0.15.2]
+
+### Fixed
+
+- Corrected the conditional compilation of the seccomp rule for `madvise`.
+
+## [0.15.1]
+
 ### Fixed
 
 - A `madvise` call issued by the `musl` allocator was added to the seccomp
   whitelist to prevent Firecracker from terminating abruptly when allocating
   memory in certain conditions.
-
-### Removed
-
-- Removed the `seccomp.bad_syscalls` metric.
 
 ## [0.15.0]
 
@@ -29,10 +44,6 @@
   `net.tx_spoofed_mac_count`.
 - New API call: `PATCH /network-interfaces/`, used to update the rate limiters
   on a network interface, after the start of a microVM.
-- New `devtool` command: `prepare_release`. This updates the Firecracker
-  version, crate dependencies and credits in preparation for a new release.
-- New `devtool` command: `tag`. This creates a new git tag for the specified
-  release number, based on the changelog contents.
 
 ### Changed
 


### PR DESCRIPTION
Description of changes:

We do not yet have a process for merging back the changelog changes
that are made by hot fixes releases. To keep the CHANGELOG.md up
to date, manually add the entries.

This manual update should be a one time thing (hopefully).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
