### PR TITLE
aarch64: setup the interrupt controller (GIC)

### DIFF
--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -1,0 +1,117 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{io, result};
+
+use kvm_ioctls::{DeviceFd, VmFd};
+
+// Unfortunately bindgen omits defines that are based on other defines.
+// See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+const SZ_64K: u64 = 0x0001_0000;
+const KVM_VGIC_V3_DIST_SIZE: u64 = SZ_64K;
+const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * SZ_64K);
+
+#[derive(Debug)]
+pub enum Error {
+    /// Error while calling KVM ioctl for setting up the global interrupt controller.
+    CreateGIC(io::Error),
+    /// Error while setting device attributes for the GIC.
+    SetDeviceAttribute(io::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// Create a GICv3 device.
+///
+/// Logic from this function is based on virt/kvm/arm/vgic/vgic-kvm-device.c from linux kernel.
+pub fn create_gicv3(vm: &VmFd, vcpu_count: u8) -> Result<DeviceFd> {
+    /* We are creating a V3 GIC.
+     As per https://static.docs.arm.com/dai0492/b/GICv3_Software_Overview_Official_Release_B.pdf,
+     section 3.5 Programmers' model, the register interface of a GICv3 interrupt controller is split
+     into three groups: distributor, redistributor, CPU.
+     As per Figure 9 from same section, there is 1 Distributor and multiple redistributors (one per
+     each CPU).
+    */
+    let mut gic_device = kvm_bindings::kvm_create_device {
+        type_: kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+        fd: 0,
+        flags: 0,
+    };
+
+    let vgic_fd = vm
+        .create_device(&mut gic_device)
+        .map_err(Error::CreateGIC)?;
+
+    /* Setting up the distributor attribute.
+     We are placing the GIC below 1GB so we need to substract the size of the distributor.
+    */
+    let dist_if_addr: u64 = super::layout::MAPPED_IO_START - KVM_VGIC_V3_DIST_SIZE;
+    let dist_attr = kvm_bindings::kvm_device_attr {
+        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+        attr: u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
+        addr: &dist_if_addr as *const u64 as u64,
+        flags: 0,
+    };
+    vgic_fd
+        .set_device_attr(&dist_attr)
+        .map_err(Error::SetDeviceAttribute)?;
+
+    /* Setting up the redistributors' attribute.
+    We are calculating here the start of the redistributors address. We have one per CPU.
+    */
+    let redists_addr: u64 = dist_if_addr - u64::from(vcpu_count) * KVM_VGIC_V3_REDIST_SIZE;
+    let redists_attr = kvm_bindings::kvm_device_attr {
+        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+        attr: u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
+        addr: &redists_addr as *const u64 as u64,
+        flags: 0,
+    };
+    vgic_fd
+        .set_device_attr(&redists_attr)
+        .map_err(Error::SetDeviceAttribute)?;
+
+    /* We need to tell the kernel how many irqs to support with this vgic.
+    See the `layout` module for details.
+    */
+    let nr_irqs: u32 = super::layout::IRQ_MAX - super::layout::IRQ_BASE + 1;
+    let nr_irqs_ptr = &nr_irqs as *const u32;
+    let nr_irqs_attr = kvm_bindings::kvm_device_attr {
+        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+        attr: 0,
+        addr: nr_irqs_ptr as u64,
+        flags: 0,
+    };
+    vgic_fd
+        .set_device_attr(&nr_irqs_attr)
+        .map_err(Error::SetDeviceAttribute)?;
+
+    /* Finalize the GIC.
+         See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
+    */
+    let init_gic_attr = kvm_bindings::kvm_device_attr {
+        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+        attr: u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+        addr: 0,
+        flags: 0,
+    };
+    vgic_fd
+        .set_device_attr(&init_gic_attr)
+        .map_err(Error::SetDeviceAttribute)?;
+
+    Ok(vgic_fd)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use kvm::Kvm;
+
+    #[test]
+    fn test_create_gicv3() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        assert!(create_gicv3(&vm, 1).is_ok());
+    }
+
+}

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -70,3 +70,6 @@ pub const IRQ_BASE: u32 = 32;
 
 /// Last usable interrupt on aarch64.
 pub const IRQ_MAX: u32 = 159;
+
+/// Below this address will reside the GIC, above this address will reside the MMIO devices.
+pub const MAPPED_IO_START: u64 = (1 << 30); // 1 GB

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod gic;
 pub mod layout;
 
 use std::cmp::min;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -963,6 +963,7 @@ impl Vmm {
         Ok(())
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn setup_interrupt_controller(&mut self) -> std::result::Result<(), StartMicrovmError> {
         self.vm
             .setup_irqchip(
@@ -974,6 +975,18 @@ impl Vmm {
         #[cfg(target_arch = "x86_64")]
         self.vm
             .create_pit()
+            .map_err(StartMicrovmError::ConfigureVm)?;
+        Ok(())
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn setup_interrupt_controller(&mut self) -> std::result::Result<(), StartMicrovmError> {
+        let vcpu_count = self
+            .vm_config
+            .vcpu_count
+            .ok_or(StartMicrovmError::VcpusNotConfigured)?;
+        self.vm
+            .setup_irqchip(vcpu_count)
             .map_err(StartMicrovmError::ConfigureVm)?;
         Ok(())
     }
@@ -2912,6 +2925,7 @@ mod tests {
             level: LoggerLevel::Warning,
             show_level: true,
             show_log_origin: true,
+            #[cfg(target_arch = "x86_64")]
             options: Value::Array(vec![]),
         };
 
@@ -2928,6 +2942,7 @@ mod tests {
             level: LoggerLevel::Warning,
             show_level: false,
             show_log_origin: false,
+            #[cfg(target_arch = "x86_64")]
             options: Value::Array(vec![]),
         };
         assert!(vmm.init_logger(desc).is_err());
@@ -2939,6 +2954,7 @@ mod tests {
             level: LoggerLevel::Warning,
             show_level: false,
             show_log_origin: false,
+            #[cfg(target_arch = "x86_64")]
             options: Value::Array(vec![Value::String("foobar".to_string())]),
         };
         assert!(vmm.init_logger(desc).is_err());
@@ -2952,6 +2968,7 @@ mod tests {
             level: LoggerLevel::Info,
             show_level: true,
             show_log_origin: true,
+            #[cfg(target_arch = "x86_64")]
             options: Value::Array(vec![Value::String("LogDirtyPages".to_string())]),
         };
         // Flushing metrics before initializing logger is erroneous.


### PR DESCRIPTION
Implements the GICv3 for handling interrupts on aarch64.

===CAUTION===
This PR will initially fail the CI cause it is based on #1039 getting fixed.

Edit1: Unit tests were added and cargo test inside vmm crate is succesful except for the test_run_vcpu which will be succesful after `configure` is implemented for the vcpu.

Signed-off-by: Diana Popa <dpopa@amazon.com>

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
