### PR TITLE
remove kernel_loader dependency on memory_model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,6 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
- "memory_model 0.1.0",
  "sys_util 0.1.0",
 ]
 

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -322,15 +322,11 @@ mod tests {
             StartMicrovmError::KernelLoader(kernel::loader::Error::BigEndianElfOnLittle),
         );
         check_error_response(vmm_resp, StatusCode::BadRequest);
-        let vmm_resp = VmmActionError::StartMicrovm(
-            ErrorKind::User,
-            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineCopy),
-        );
-        check_error_response(vmm_resp, StatusCode::BadRequest);
-        let vmm_resp = VmmActionError::StartMicrovm(
-            ErrorKind::User,
-            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineOverflow),
-        );
+        let vmm_resp =
+            VmmActionError::StartMicrovm(ErrorKind::Internal, StartMicrovmError::CommandLineCopy);
+        check_error_response(vmm_resp, StatusCode::InternalServerError);
+        let vmm_resp =
+            VmmActionError::StartMicrovm(ErrorKind::User, StartMicrovmError::CommandLineOverflow);
         check_error_response(vmm_resp, StatusCode::BadRequest);
         let vmm_resp = VmmActionError::StartMicrovm(
             ErrorKind::User,

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -3,5 +3,4 @@ name = "kernel"
 version = "0.1.0"
 
 [dependencies]
-memory_model = { path = "../memory_model" }
 sys_util = { path = "../sys_util" }

--- a/kernel/src/cmdline/mod.rs
+++ b/kernel/src/cmdline/mod.rs
@@ -108,7 +108,17 @@ impl Cmdline {
         assert!(self.line.len() < self.capacity);
     }
 
-    /// Validates and inserts a key value pair into this command line
+    /// Returns the length of the command line.
+    pub fn len(&self) -> usize {
+        self.line.len()
+    }
+
+    /// Returns whether the command line is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Validates and inserts a key value pair into this command line.
     pub fn insert<T: AsRef<str>>(&mut self, key: T, val: T) -> Result<()> {
         let k = key.as_ref();
         let v = val.as_ref();
@@ -126,7 +136,7 @@ impl Cmdline {
         Ok(())
     }
 
-    /// Validates and inserts a string to the end of the current command line
+    /// Validates and inserts a string to the end of the current command line.
     pub fn insert_str<T: AsRef<str>>(&mut self, slug: T) -> Result<()> {
         let s = slug.as_ref();
         valid_str(s)?;
@@ -140,7 +150,7 @@ impl Cmdline {
         Ok(())
     }
 
-    /// Returns the cmdline in progress without nul termination
+    /// Returns the cmdline in progress without nul termination.
     pub fn as_str(&self) -> &str {
         self.line.as_str()
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -8,5 +8,4 @@
 pub mod cmdline;
 pub mod loader;
 
-extern crate memory_model;
 extern crate sys_util;

--- a/kernel/src/loader/mod.rs
+++ b/kernel/src/loader/mod.rs
@@ -5,13 +5,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+//! Helper for loading a kernel image in the guest memory.
+
 use std;
-use std::ffi::CStr;
 use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
 
-use memory_model::{GuestAddress, GuestMemory};
 use sys_util;
 
 #[allow(non_camel_case_types)]
@@ -66,23 +66,26 @@ impl fmt::Display for Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Loads a kernel from a vmlinux elf image to a slice
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// Loads a kernel from a vmlinux elf image using a given callback.
 ///
 /// # Arguments
 ///
-/// * `guest_mem` - The guest memory region the kernel is written to.
 /// * `kernel_image` - Input vmlinux image.
 /// * `start_address` - For x86_64, this is the start of the high memory. Kernel should reside above it.
+/// * `write_to_memory` - Closure to write the contents of the image.
+///                      The closure is called with the following arguments:
+///                      dst-offset-in-guest-mem, src, size
 ///
 /// Returns the entry address of the kernel.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub fn load_kernel<F>(
-    guest_mem: &GuestMemory,
-    kernel_image: &mut F,
+pub fn load_kernel<R, F>(
+    kernel_image: &mut R,
     start_address: usize,
-) -> Result<GuestAddress>
+    write_to_memory: F,
+) -> Result<usize>
 where
-    F: Read + Seek,
+    R: Read + Seek,
+    F: Fn(usize, &mut R, usize) -> Result<()>,
 {
     let mut ehdr: elf::Elf64_Ehdr = Default::default();
     kernel_image
@@ -134,27 +137,36 @@ where
             .seek(SeekFrom::Start(phdr.p_offset))
             .map_err(|_| Error::SeekKernelStart)?;
 
-        let mem_offset = GuestAddress(phdr.p_paddr as usize);
-        if mem_offset.offset() < start_address {
+        if (phdr.p_paddr as usize) < start_address {
             return Err(Error::InvalidProgramHeaderAddress);
         }
 
-        guest_mem
-            .read_to_memory(mem_offset, kernel_image, phdr.p_filesz as usize)
-            .map_err(|_| Error::ReadKernelImage)?;
+        write_to_memory(phdr.p_paddr as usize, kernel_image, phdr.p_filesz as usize)?;
     }
 
-    Ok(GuestAddress(ehdr.e_entry as usize))
+    Ok(ehdr.e_entry as usize)
 }
 
 #[cfg(target_arch = "aarch64")]
-pub fn load_kernel<F>(
-    guest_mem: &GuestMemory,
-    kernel_image: &mut F,
+/// Loads a kernel from a vmlinux image using a given callback.
+///
+/// # Arguments
+///
+/// * `kernel_image` - Input vmlinux image.
+/// * `start_address` - Kernel start address in the guest memory.
+/// * `write_to_memory` - Closure to write the contents of the image.
+///                      The closure is called with the following arguments:
+///                      dst-offset-in-guest-mem, src, size
+///
+/// Returns the entry address of the kernel.
+pub fn load_kernel<R, F>(
+    kernel_image: &mut R,
     start_address: usize,
-) -> Result<GuestAddress>
+    write_to_memory: F,
+) -> Result<usize>
 where
-    F: Read + Seek,
+    R: Read + Seek,
+    F: Fn(usize, &mut R, usize) -> Result<()>,
 {
     /* Kernel boot protocol is specified in the kernel docs
     Documentation/arm/Booting and Documentation/arm64/booting.txt.
@@ -216,59 +228,15 @@ where
         .map_err(|_| Error::SeekKernelImage)?;
 
     kernel_load_offset = kernel_load_offset + start_address;
-    guest_mem
-        .read_to_memory(
-            GuestAddress(kernel_load_offset),
-            kernel_image,
-            kernel_size as usize,
-        )
-        .map_err(|_| Error::ReadKernelImage)?;
+    write_to_memory(kernel_load_offset, kernel_image, kernel_size as usize)?;
 
-    Ok(GuestAddress(kernel_load_offset))
-}
-
-/// Writes the command line string to the given memory slice.
-///
-/// # Arguments
-///
-/// * `guest_mem` - A u8 slice that will be partially overwritten by the command line.
-/// * `guest_addr` - The address in `guest_mem` at which to load the command line.
-/// * `cmdline` - The kernel command line.
-pub fn load_cmdline(
-    guest_mem: &GuestMemory,
-    guest_addr: GuestAddress,
-    cmdline: &CStr,
-) -> Result<()> {
-    let len = cmdline.to_bytes().len();
-    if len == 0 {
-        return Ok(());
-    }
-
-    let end = guest_addr
-        .checked_add(len + 1)
-        .ok_or(Error::CommandLineOverflow)?; // Extra for null termination.
-    if end > guest_mem.end_addr() {
-        return Err(Error::CommandLineOverflow)?;
-    }
-
-    guest_mem
-        .write_slice_at_addr(cmdline.to_bytes_with_nul(), guest_addr)
-        .map_err(|_| Error::CommandLineCopy)?;
-
-    Ok(())
+    Ok(kernel_load_offset)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use memory_model::{GuestAddress, GuestMemory};
     use std::io::Cursor;
-
-    const MEM_SIZE: usize = 0x18_0000;
-
-    fn create_guest_mem() -> GuestMemory {
-        GuestMemory::new(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
-    }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn make_test_bin() -> Vec<u8> {
@@ -283,43 +251,30 @@ mod tests {
     #[test]
     // Tests that loading the kernel is successful on different archs.
     fn test_load_kernel() {
-        let gm = create_guest_mem();
         let image = make_test_bin();
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         let load_addr = 0x10_0000;
         #[cfg(target_arch = "aarch64")]
         let load_addr = 0x8_0000;
         assert_eq!(
-            Ok(GuestAddress(load_addr)),
-            load_kernel(&gm, &mut Cursor::new(&image), 0)
-        );
-    }
-
-    #[test]
-    fn test_load_kernel_no_memory() {
-        let gm = GuestMemory::new(&[(GuestAddress(0x0), 79)]).unwrap();
-        let image = make_test_bin();
-        assert_eq!(
-            Err(Error::ReadKernelImage),
-            load_kernel(&gm, &mut Cursor::new(&image), 0)
+            Ok(load_addr),
+            load_kernel(&mut Cursor::new(&image), 0, |_, _, _| Ok(()))
         );
     }
 
     #[cfg(target_arch = "aarch64")]
     #[test]
     fn test_load_bad_kernel() {
-        let gm = create_guest_mem();
         let mut bad_image = make_test_bin();
         bad_image.truncate(56);
         assert_eq!(
             Err(Error::ReadProgramHeader),
-            load_kernel(&gm, &mut Cursor::new(&bad_image), 0)
+            load_kernel(&mut Cursor::new(&bad_image), 0, |_, _, _| Ok(()))
         );
     }
 
     #[test]
     fn test_bad_kernel_magic() {
-        let gm = create_guest_mem();
         let mut bad_image = make_test_bin();
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         let offset = 0x1;
@@ -328,7 +283,7 @@ mod tests {
         bad_image[offset] = 0x33;
         assert_eq!(
             Err(Error::InvalidElfMagicNumber),
-            load_kernel(&gm, &mut Cursor::new(&bad_image), 0)
+            load_kernel(&mut Cursor::new(&bad_image), 0, |_, _, _| Ok(()))
         );
     }
 
@@ -336,12 +291,11 @@ mod tests {
     #[test]
     fn test_bad_kernel_endian() {
         // Only little endian is supported.
-        let gm = create_guest_mem();
         let mut bad_image = make_test_bin();
         bad_image[0x5] = 2;
         assert_eq!(
             Err(Error::BigEndianElfOnLittle),
-            load_kernel(&gm, &mut Cursor::new(&bad_image), 0)
+            load_kernel(&mut Cursor::new(&bad_image), 0, |_, _, _| Ok(()))
         );
     }
 
@@ -349,54 +303,11 @@ mod tests {
     #[test]
     fn test_bad_kernel_phoff() {
         // program header has to be past the end of the elf header
-        let gm = create_guest_mem();
         let mut bad_image = make_test_bin();
         bad_image[0x20] = 0x10;
         assert_eq!(
             Err(Error::InvalidProgramHeaderOffset),
-            load_kernel(&gm, &mut Cursor::new(&bad_image), 0)
+            load_kernel(&mut Cursor::new(&bad_image), 0, |_, _, _| Ok(()))
         );
-    }
-
-    #[test]
-    fn test_cmdline_overflow() {
-        let gm = create_guest_mem();
-        let cmdline_address = GuestAddress(MEM_SIZE - 5);
-        assert_eq!(
-            Err(Error::CommandLineOverflow),
-            load_cmdline(
-                &gm,
-                cmdline_address,
-                CStr::from_bytes_with_nul(b"12345\0").unwrap(),
-            )
-        );
-    }
-
-    #[test]
-    fn test_cmdline_write_end() {
-        let gm = create_guest_mem();
-        let mut cmdline_address = GuestAddress(45);
-        assert_eq!(
-            Ok(()),
-            load_cmdline(
-                &gm,
-                cmdline_address,
-                CStr::from_bytes_with_nul(b"1234\0").unwrap(),
-            )
-        );
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, b'1');
-        cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, b'2');
-        cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, b'3');
-        cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, b'4');
-        cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
-        assert_eq!(val, b'\0');
     }
 }

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -44,6 +44,10 @@ pub struct InstanceInfo {
 // TODO: add error kind to these variants because not all these errors are user or internal.
 #[derive(Debug)]
 pub enum StartMicrovmError {
+    /// Cannot copy the command line string to guest memory.
+    CommandLineCopy,
+    /// Command line string overflows guest memory.
+    CommandLineOverflow,
     /// This error is thrown by the minimal boot loader implementation.
     /// It is related to a faulty memory configuration.
     ConfigureSystem(arch::Error),
@@ -73,8 +77,6 @@ pub enum StartMicrovmError {
     KernelLoader(kernel_loader::Error),
     /// Cannot add devices to the Legacy I/O Bus.
     LegacyIOBus(device_manager::legacy::Error),
-    /// Cannot load command line string.
-    LoadCommandline(kernel_loader::Error),
     /// The start command was issued more than once.
     MicroVMAlreadyRunning,
     /// Cannot start the VM because the kernel was not configured.
@@ -108,6 +110,8 @@ impl Display for StartMicrovmError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use self::StartMicrovmError::*;
         match *self {
+            CommandLineCopy => write!(f, "Failed to copy the command line string to guest memory."),
+            CommandLineOverflow => write!(f, "Command line string overflows guest memory."),
             ConfigureSystem(ref err) => {
                 let mut err_msg = format!("{:?}", err);
                 err_msg = err_msg.replace("\"", "");
@@ -164,11 +168,6 @@ impl Display for StartMicrovmError {
                 err_msg = err_msg.replace("\"", "");
 
                 write!(f, "Cannot add devices to the legacy I/O Bus. {}", err_msg)
-            }
-            LoadCommandline(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-                write!(f, "Cannot load command line string. {}", err_msg)
             }
             MicroVMAlreadyRunning => write!(f, "Microvm already running."),
             MissingKernelConfig => write!(f, "Cannot start microvm without kernel configuration."),


### PR DESCRIPTION
Remove dependency on the memory_model crate in the kernel crate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
