### PR TITLE
 Set each VmmActionError kind based on inner error

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -66,7 +66,7 @@ impl GenerateHyperResponse for VmmActionError {
     fn generate_response(&self) -> hyper::Response {
         use self::ErrorKind::*;
 
-        let status_code = match self.get_kind() {
+        let status_code = match self.kind() {
             User => StatusCode::BadRequest,
             Internal => StatusCode::InternalServerError,
         };

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,7 +18,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.7
+COVERAGE_TARGET_PCT = 83.9
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Formatter, Result};
-use std::io;
 use std::result;
 
 use super::super::Error as VmmInternalError;
@@ -91,8 +90,6 @@ pub enum NetworkInterfaceError {
     DeviceIdNotFound,
     /// Cannot open/create tap device.
     OpenTap(TapError),
-    /// Downstream error from a RateLimiter.
-    RateLimiterError(io::Error),
     /// Error updating (patching) the rate limiters.
     RateLimiterUpdateFailed(devices::Error),
     /// The update is not allowed after booting the microvm.
@@ -129,9 +126,6 @@ impl Display for NetworkInterfaceError {
                     "Cannot open TAP device. Invalid name/permissions. ".to_string(),
                     tap_err
                 )
-            }
-            RateLimiterError(ref e) => {
-                write!(f, "Unable to create rate limiter: {}", e.to_string())
             }
             RateLimiterUpdateFailed(ref e) => write!(f, "Unable to update rate limiter: {:?}", e),
             UpdateNotAllowedPostBoot => {
@@ -285,6 +279,7 @@ impl NetworkInterfaceConfigs {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::str;
 
     use super::*;
@@ -456,11 +451,6 @@ mod tests {
             "{}{:?}",
             NetworkInterfaceError::OpenTap(TapError::InvalidIfname),
             NetworkInterfaceError::OpenTap(TapError::InvalidIfname)
-        );
-        let _ = format!(
-            "{}{:?}",
-            NetworkInterfaceError::RateLimiterError(io::Error::last_os_error()),
-            NetworkInterfaceError::RateLimiterError(io::Error::last_os_error())
         );
         let _ = format!(
             "{}{:?}",


### PR DESCRIPTION
Implement `std::convert::From<T> for VmmActionError` and mark each `VmmActionError` with the correct `ErrorKind`.

Fixes issue: https://github.com/firecracker-microvm/firecracker/issues/1062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
