### PR TITLE
virtio generic device moves out ownership of Memory

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3408,6 +3408,12 @@ mod tests {
             ErrorKind::User
         );
         assert_eq!(
+            error_kind(StartMicrovmError::LoadCommandline(
+                kernel::cmdline::Error::CommandLineCopy
+            )),
+            ErrorKind::Internal
+        );
+        assert_eq!(
             error_kind(StartMicrovmError::MicroVMAlreadyRunning),
             ErrorKind::User
         );
@@ -3542,6 +3548,7 @@ mod tests {
 
         // Enum `ErrorKind`
 
+        assert_ne!(ErrorKind::User, ErrorKind::Internal);
         assert_eq!(format!("{:?}", ErrorKind::User), "User");
         assert_eq!(format!("{:?}", ErrorKind::Internal), "Internal");
 
@@ -3610,6 +3617,21 @@ mod tests {
                 )
             ),
             "SendCtrlAltDel(User, InternalBufferFull)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                VmmActionError::SendCtrlAltDel(
+                    ErrorKind::User,
+                    I8042DeviceError::InternalBufferFull
+                )
+            ),
+            I8042DeviceError::InternalBufferFull.to_string()
+        );
+        assert_eq!(
+            VmmActionError::SendCtrlAltDel(ErrorKind::User, I8042DeviceError::InternalBufferFull)
+                .kind(),
+            &ErrorKind::User
         );
         #[cfg(feature = "vsock")]
         assert_eq!(


### PR DESCRIPTION
The generic part of a virtio device only needs access to the guest memory to configure said device. Once configuration is complete and device is activated, move instead of cloning the memory object to the device implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
