### PR TITLE
vmm: decouple legacy dev init from IRQCHIP creation

### DIFF
--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -324,12 +324,12 @@ mod tests {
         check_error_response(vmm_resp, StatusCode::BadRequest);
         let vmm_resp = VmmActionError::StartMicrovm(
             ErrorKind::User,
-            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineCopy),
+            StartMicrovmError::LoadCommandline(kernel::cmdline::Error::CommandLineCopy),
         );
         check_error_response(vmm_resp, StatusCode::BadRequest);
         let vmm_resp = VmmActionError::StartMicrovm(
             ErrorKind::User,
-            StartMicrovmError::LoadCommandline(kernel::loader::Error::CommandLineOverflow),
+            StartMicrovmError::LoadCommandline(kernel::cmdline::Error::CommandLineOverflow),
         );
         check_error_response(vmm_resp, StatusCode::BadRequest);
         let vmm_resp = VmmActionError::StartMicrovm(

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -330,7 +330,10 @@ mod tests {
         );
         assert_eq!(
             format!("{}", e),
-            "unable to add device to kernel command line: string contains an equals sign"
+            format!(
+                "unable to add device to kernel command line: {}",
+                kernel_cmdline::Error::HasEquals
+            ),
         );
         assert_eq!(
             format!("{}", Error::UpdateFailed),

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -74,7 +74,7 @@ pub enum StartMicrovmError {
     /// Cannot add devices to the Legacy I/O Bus.
     LegacyIOBus(device_manager::legacy::Error),
     /// Cannot load command line string.
-    LoadCommandline(kernel_loader::Error),
+    LoadCommandline(kernel::cmdline::Error),
     /// The start command was issued more than once.
     MicroVMAlreadyRunning,
     /// Cannot start the VM because the kernel was not configured.


### PR DESCRIPTION
Register legacy devices IRQs as part of legacy device registration, do IRQCHIP and PIT creation independently as part of (kvm) VM init.

Also do a bit of refactoring around kernel cmdline to move some ugly logic out of vmm.

Setting up an interrupt controller should, well.. set up an interrupt controller (irqchip) without having a dependency on a particular list of devices that will eventually use it.

Move the registering of legacy devs irqs to `attach_legacy_devices()` which already does the registering of legacy devs bus addrs.

Before this patch the implementation was not just spaghetti but also incorrect because it would register irqs for devices not yet attached.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
