### PR TITLE
swagger: Fix swagger definition for machine-config

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -494,6 +494,10 @@ definitions:
     description:
       Describes the number of vCPUs, memory size, Hyperthreading capabilities and
       the CPU template.
+    required:
+      - vcpu_count
+      - mem_size_mib
+      - ht_enabled
     properties:
       vcpu_count:
         type: integer


### PR DESCRIPTION
Mark the mandatory fields in machine-config as required.
This will ensure that swagger code generators will not omit
boolean fields when set to false.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
