### PR TITLE
Disable timing on vsock integration tests

### DIFF
--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -47,14 +47,26 @@ class Session(requests_unixsocket.Session):
     @decorators.timed_request
     def get(self, url, **kwargs):
         """Wrap the GET call with duration limit."""
+        # pylint: disable=method-hidden
+        # The `untime` method overrides this, and pylint disapproves.
         return super(Session, self).get(url, **kwargs)
 
     @decorators.timed_request
     def patch(self, url, data=None, **kwargs):
         """Wrap the PATCH call with duration limit."""
+        # pylint: disable=method-hidden
+        # The `untime` method overrides this, and pylint disapproves.
         return super(Session, self).patch(url, data=data, **kwargs)
 
     @decorators.timed_request
     def put(self, url, data=None, **kwargs):
         """Wrap the PUT call with duration limit."""
+        # pylint: disable=method-hidden
+        # The `untime` method overrides this, and pylint disapproves.
         return super(Session, self).put(url, data=data, **kwargs)
+
+    def untime(self):
+        """Restore the HTTP methods to their un-timed selves."""
+        self.get = super(Session, self).get
+        self.patch = super(Session, self).patch
+        self.put = super(Session, self).put

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -249,6 +249,10 @@ class Microvm:
         self._api_socket = self._jailer.api_socket_path()
         self._api_session = Session()
 
+        # Don't time requests on vsock builds.
+        if self.build_feature == 'vsock':
+            self._api_session.untime()
+
         self.actions = Actions(self._api_socket, self._api_session)
         self.boot = BootSource(self._api_socket, self._api_session)
         self.drive = Drive(self._api_socket, self._api_session)

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -6,8 +6,9 @@ import os
 import re
 import time
 
-from framework import decorators
+import pytest
 
+from framework import decorators
 import host_tools.logging as log_tools
 
 # The maximum acceptable boot time in us.
@@ -21,6 +22,10 @@ NO_OF_MICROVMS = 10
 
 def test_single_microvm_boottime_no_network(test_microvm_with_boottime):
     """Check guest boottime of microvm without network."""
+    # Skip on vsock builds.
+    if test_microvm_with_boottime.build_feature == 'vsock':
+        pytest.skip('The vsock feature is enabled.')
+
     log_fifo, _ = _configure_vm(test_microvm_with_boottime)
     time.sleep(0.4)
     boottime_us = _test_microvm_boottime(log_fifo)
@@ -69,6 +74,10 @@ def test_single_microvm_boottime_with_network(
         network_config
 ):
     """Check guest boottime of microvm with network."""
+    # Skip on vsock builds.
+    if test_microvm_with_boottime.build_feature == 'vsock':
+        pytest.skip('The vsock feature is enabled.')
+
     log_fifo, _tap = _configure_vm(test_microvm_with_boottime, {
         "config": network_config, "iface_id": "1"
     })


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Disabled timing in timed tests on vsock builds.
* Disabled boot time test on the single microVM fixture - it doesn't appear to run at all on the multiple microVM fixture.
* Disabled timing API requests because `InstanceStart` (maybe others?) sometimes takes more with vsock.
* The option to disable timing on API requests is separate and can be used on other potentially long running APIs (I'm thinking MMDS).

### Testing done

#### Testing single microVM boot time

```bash
pytest integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network -vv
Boot time with no network is: 108668 us
PASSED
integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal-vsock] SKIPPED
0.71s call     integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal]
0.24s setup    integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal]
0.04s setup    integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal-vsock]
0.00s teardown integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal]
0.00s teardown integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal-vsock]
0.00s call     integration_tests/performance/test_boottime.py::test_single_microvm_boottime_no_network[minimal-vsock]
```

#### Testing multiple microVMs boot times

```bash
pytest integration_tests/performance/test_boottime.py::test_multiple_microvm_boottime_no_network -vv
.
PASSED
3.63s call     integration_tests/performance/test_boottime.py::test_multiple_microvm_boottime_no_network[minimal, 10 instance(s)]
0.25s setup    integration_tests/performance/test_boottime.py::test_multiple_microvm_boottime_no_network[minimal, 10 instance(s)]
0.03s teardown integration_tests/performance/test_boottime.py::test_multiple_microvm_boottime_no_network[minimal, 10 instance(s)]
```

#### Testing timed API requests

Slightly modified `put` API:

```diff
diff --git a/tests/framework/http.py b/tests/framework/http.py
index cd5f888..ebec4f1 100644
--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -57,6 +57,8 @@ class Session(requests_unixsocket.Session):
     @decorators.timed_request
     def put(self, url, data=None, **kwargs):
         """Wrap the PUT call with duration limit."""
+        import time
+        time.sleep(0.5)
         return super(Session, self).put(url, data=data, **kwargs)
 
     def untime(self):
```

```bash
pytest integration_tests/functional/test_api.py::test_api_happy_start -vv
integration_tests/functional/test_api.py::test_api_happy_start[ubuntu]
FAILED
integration_tests/functional/test_api.py::test_api_happy_start[ubuntu-vsock]
PASSED

======================================================================================== FAILURES ========================================================================================
______________________________________________________________________________ test_api_happy_start[ubuntu] ______________________________________________________________________________
integration_tests/functional/test_api.py:22: in test_api_happy_start
    test_microvm.basic_config()
framework/microvm.py:363: in basic_config
    mem_size_mib=mem_size_mib
framework/resources.py:248: in put
    json=datax
framework/decorators.py:46: in timed
    payload
E   framework.decorators.timed_request.<locals>.ApiTimeoutException: API call exceeded maximum duration: 510.87 ms.
E   Call: PUT /machine-config {'vcpu_count': 2, 'mem_size_mib': 256, 'ht_enabled': False}
```