### PR TITLE
VirtIO: Make it easy to access the BusDevice and EpollHandler starting from a device id

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -25,6 +25,7 @@ impl From<Error> for super::Error {
 }
 
 pub use self::fdt::DeviceInfoForFDT;
+use DeviceType;
 
 /// Returns a Vec of the valid memory addresses for aarch64.
 /// See [`layout`](layout) module for a drawing of the specific memory model for this platform.
@@ -45,7 +46,7 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
     guest_mem: &GuestMemory,
     cmdline_cstring: &CStr,
     num_cpus: u8,
-    device_info: Option<&HashMap<String, T>>,
+    device_info: Option<&HashMap<(DeviceType, String), T>>,
 ) -> super::Result<()> {
     fdt::create_fdt(guest_mem, u32::from(num_cpus), cmdline_cstring, device_info)
         .map_err(Error::SetupFDT)?;

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -41,9 +41,9 @@ pub use x86_64::{
 };
 
 /// Types of devices that can get attached to this platform.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DeviceType {
-    Virtio,
+    Virtio(u32),
     #[cfg(target_arch = "aarch64")]
     Serial,
     #[cfg(target_arch = "aarch64")]

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -61,7 +61,6 @@ pub trait EpollHandler: Send {
     fn handle_event(
         &mut self,
         device_event: DeviceEventT,
-        event_flags: u32,
         payload: EpollHandlerPayload,
     ) -> Result<()>;
 }

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -396,7 +396,6 @@ impl EpollHandler for BlockEpollHandler {
     fn handle_event(
         &mut self,
         device_event: DeviceEventT,
-        _: u32,
         payload: EpollHandlerPayload,
     ) -> result::Result<(), DeviceError> {
         match device_event {
@@ -808,7 +807,7 @@ mod tests {
         // trigger the queue event
         h.queue_evt.write(1).unwrap();
         // handle event
-        h.handle_event(QUEUE_AVAIL_EVENT, 0, EpollHandlerPayload::Empty)
+        h.handle_event(QUEUE_AVAIL_EVENT, EpollHandlerPayload::Empty)
             .unwrap();
         // validate the queue operation finished successfully
         assert_eq!(h.interrupt_evt.read().unwrap(), 2);
@@ -1098,7 +1097,6 @@ mod tests {
         let (mut h, _vq) = default_test_blockepollhandler(&m);
         let r = h.handle_event(
             BLOCK_EVENTS_COUNT as DeviceEventT,
-            0,
             EpollHandlerPayload::Empty,
         );
         match r {
@@ -1119,7 +1117,7 @@ mod tests {
         let m = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _vq) = default_test_blockepollhandler(&m);
         // This should panic because payload is empty for event type FS_UPDATE_EVENT.
-        let r = h.handle_event(FS_UPDATE_EVENT, 0, EpollHandlerPayload::Empty);
+        let r = h.handle_event(FS_UPDATE_EVENT, EpollHandlerPayload::Empty);
         match r {
             Err(DeviceError::PayloadExpected) => (),
             _ => panic!("invalid"),
@@ -1433,7 +1431,7 @@ mod tests {
                 h.interrupt_evt.write(1).unwrap();
                 // trigger the attempt to write
                 h.queue_evt.write(1).unwrap();
-                h.handle_event(QUEUE_AVAIL_EVENT, 0, EpollHandlerPayload::Empty)
+                h.handle_event(QUEUE_AVAIL_EVENT, EpollHandlerPayload::Empty)
                     .unwrap();
 
                 // assert that limiter is blocked
@@ -1452,7 +1450,7 @@ mod tests {
             {
                 // leave at least one event here so that reading it later won't block
                 h.interrupt_evt.write(1).unwrap();
-                h.handle_event(RATE_LIMITER_EVENT, 0, EpollHandlerPayload::Empty)
+                h.handle_event(RATE_LIMITER_EVENT, EpollHandlerPayload::Empty)
                     .unwrap();
                 // validate the rate_limiter is no longer blocked
                 assert!(!h.get_rate_limiter().is_blocked());
@@ -1494,7 +1492,7 @@ mod tests {
                 h.interrupt_evt.write(1).unwrap();
                 // trigger the attempt to write
                 h.queue_evt.write(1).unwrap();
-                h.handle_event(QUEUE_AVAIL_EVENT, 0, EpollHandlerPayload::Empty)
+                h.handle_event(QUEUE_AVAIL_EVENT, EpollHandlerPayload::Empty)
                     .unwrap();
 
                 // assert that limiter is blocked
@@ -1511,7 +1509,7 @@ mod tests {
                 h.interrupt_evt.write(1).unwrap();
                 // trigger the attempt to write
                 h.queue_evt.write(1).unwrap();
-                h.handle_event(QUEUE_AVAIL_EVENT, 0, EpollHandlerPayload::Empty)
+                h.handle_event(QUEUE_AVAIL_EVENT, EpollHandlerPayload::Empty)
                     .unwrap();
 
                 // assert that limiter is blocked
@@ -1530,7 +1528,7 @@ mod tests {
             {
                 // leave at least one event here so that reading it later won't block
                 h.interrupt_evt.write(1).unwrap();
-                h.handle_event(RATE_LIMITER_EVENT, 0, EpollHandlerPayload::Empty)
+                h.handle_event(RATE_LIMITER_EVENT, EpollHandlerPayload::Empty)
                     .unwrap();
                 // validate the rate_limiter is no longer blocked
                 assert!(!h.get_rate_limiter().is_blocked());
@@ -1566,7 +1564,7 @@ mod tests {
                 .open(path)
                 .unwrap();
             let payload = EpollHandlerPayload::DrivePayload(file);
-            h.handle_event(FS_UPDATE_EVENT, 0, payload).unwrap();
+            h.handle_event(FS_UPDATE_EVENT, payload).unwrap();
 
             assert_eq!(h.disk_image.metadata().unwrap().st_ino(), mdata.st_ino());
             assert_eq!(h.disk_image_id, id);

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -25,6 +25,7 @@ use logger::{Metric, METRICS};
 use memory_model::{GuestAddress, GuestMemory, GuestMemoryError};
 use rate_limiter::{RateLimiter, TokenType};
 use sys_util::EventFd;
+use virtio::EpollConfigConstructor;
 use virtio_gen::virtio_blk::*;
 use {DeviceEventT, EpollHandler};
 
@@ -447,12 +448,8 @@ pub struct EpollConfig {
     sender: mpsc::Sender<Box<EpollHandler>>,
 }
 
-impl EpollConfig {
-    pub fn new(
-        first_token: u64,
-        epoll_raw_fd: RawFd,
-        sender: mpsc::Sender<Box<EpollHandler>>,
-    ) -> Self {
+impl EpollConfigConstructor for EpollConfig {
+    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
         EpollConfig {
             q_avail_token: first_token + u64::from(QUEUE_AVAIL_EVENT),
             rate_limiter_token: first_token + u64::from(RATE_LIMITER_EVENT),

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -8,6 +8,8 @@
 //! Implements virtio devices, queues, and transport mechanisms.
 use std;
 use std::io::Error as IOError;
+use std::os::unix::io::RawFd;
+use std::sync::mpsc;
 
 pub mod block;
 mod mmio;
@@ -23,6 +25,7 @@ pub use self::queue::*;
 #[cfg(feature = "vsock")]
 pub use self::vhost::vsock::*;
 
+use super::EpollHandler;
 use super::EpollHandlerPayload;
 
 const DEVICE_INIT: u32 = 0x0;
@@ -54,3 +57,7 @@ pub enum ActivateError {
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;
+
+pub trait EpollConfigConstructor {
+    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self;
+}

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -36,8 +36,8 @@ const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_FAILED: u32 = 0x80;
 
 /// Types taken from linux/virtio_ids.h.
-const TYPE_NET: u32 = 1;
-const TYPE_BLOCK: u32 = 2;
+pub const TYPE_NET: u32 = 1;
+pub const TYPE_BLOCK: u32 = 2;
 
 /// Interrupt flags (re: interrupt status & acknowledge registers).
 /// See linux/virtio_mmio.h.

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -36,6 +36,7 @@ const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_FAILED: u32 = 0x80;
 
 /// Types taken from linux/virtio_ids.h.
+/// Type 0 is not used by virtio. Use it as wildcard for non-virtio devices
 pub const TYPE_NET: u32 = 1;
 pub const TYPE_BLOCK: u32 = 2;
 

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -32,6 +32,7 @@ use net_gen;
 use net_util::{MacAddr, Tap, TapError, MAC_ADDR_LEN};
 use rate_limiter::{RateLimiter, TokenType};
 use sys_util::EventFd;
+use virtio::EpollConfigConstructor;
 use virtio_gen::virtio_net::*;
 use {DeviceEventT, EpollHandler};
 
@@ -633,12 +634,8 @@ pub struct EpollConfig {
     sender: mpsc::Sender<Box<EpollHandler>>,
 }
 
-impl EpollConfig {
-    pub fn new(
-        first_token: u64,
-        epoll_raw_fd: RawFd,
-        sender: mpsc::Sender<Box<EpollHandler>>,
-    ) -> Self {
+impl EpollConfigConstructor for EpollConfig {
+    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
         EpollConfig {
             rx_tap_token: first_token + u64::from(RX_TAP_EVENT),
             rx_queue_token: first_token + u64::from(RX_QUEUE_EVENT),

--- a/devices/src/virtio/vhost/handle.rs
+++ b/devices/src/virtio/vhost/handle.rs
@@ -10,6 +10,7 @@ use super::INTERRUPT_STATUS_USED_RING;
 
 use sys_util::EventFd;
 use vhost_backend::Vhost;
+use virtio::EpollConfigConstructor;
 use DeviceEventT;
 use EpollHandler;
 
@@ -116,18 +117,6 @@ pub struct VhostEpollConfig {
 }
 
 impl VhostEpollConfig {
-    pub fn new(
-        first_token: u64,
-        epoll_raw_fd: RawFd,
-        sender: mpsc::Sender<Box<EpollHandler>>,
-    ) -> Self {
-        VhostEpollConfig {
-            queue_evt_token: first_token,
-            kill_token: first_token + 1,
-            epoll_raw_fd,
-            sender,
-        }
-    }
     pub fn get_sender(&self) -> mpsc::Sender<Box<EpollHandler>> {
         self.sender.clone()
     }
@@ -142,5 +131,16 @@ impl VhostEpollConfig {
 
     pub fn get_queue_evt_token(&self) -> u64 {
         self.queue_evt_token
+    }
+}
+
+impl EpollConfigConstructor for VhostEpollConfig {
+    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
+        VhostEpollConfig {
+            queue_evt_token: first_token,
+            kill_token: first_token + 1,
+            epoll_raw_fd,
+            sender,
+        }
     }
 }

--- a/devices/src/virtio/vhost/handle.rs
+++ b/devices/src/virtio/vhost/handle.rs
@@ -81,7 +81,6 @@ where
     fn handle_event(
         &mut self,
         device_event: DeviceEventT,
-        _: u32,
         _: EpollHandlerPayload,
     ) -> std::result::Result<(), DeviceError> {
         match device_event {

--- a/devices/src/virtio/vhost/mod.rs
+++ b/devices/src/virtio/vhost/mod.rs
@@ -54,4 +54,4 @@ pub enum Error {
 }
 type Result<T> = std::result::Result<T, Error>;
 const INTERRUPT_STATUS_USED_RING: u32 = 0x1;
-const TYPE_VSOCK: u32 = 19;
+pub const TYPE_VSOCK: u32 = 19;

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,7 +18,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.8
+COVERAGE_TARGET_PCT = 84.9
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;


### PR DESCRIPTION
Issue #, if available: #1110 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
