### PR TITLE
firecracker-experimental: Fix indentation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected firecracker-experimental.yaml indentation issues that
+  prevented code generation
+
 ## [0.17.0]
 
 ### Added

--- a/api_server/swagger/firecracker-experimental.yaml
+++ b/api_server/swagger/firecracker-experimental.yaml
@@ -354,38 +354,38 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-    /vsocks/{id}:
-      put:
-        summary: Creates new vsock with ID specified by the id parameter.
-        description:
-          If the vsock device with the specified ID already exists, its body will
-          be updated based on the new input. May fail if update is not possible.
-        operationId: putGuestVsockByID
-        parameters:
-        - name: id
-          in: path
-          description: The id of the vsock device
-          required: true
-          type: string
-        - name: body
-          in: body
-          description: Guest vsock properties
-          required: true
-          schema:
-            $ref: "#/definitions/Vsock"
-        responses:
-          201:
-            description: Vsock created
-          204:
-            description: Vsock updated
-          400:
-            description: Vsock cannot be created due to bad input
-            schema:
-              $ref: "#/definitions/Error"
-          default:
-            description: Internal server error
-            schema:
-              $ref: "#/definitions/Error"
+  /vsocks/{id}:
+     put:
+       summary: Creates new vsock with ID specified by the id parameter.
+       description:
+         If the vsock device with the specified ID already exists, its body will
+         be updated based on the new input. May fail if update is not possible.
+       operationId: putGuestVsockByID
+       parameters:
+       - name: id
+         in: path
+         description: The id of the vsock device
+         required: true
+         type: string
+       - name: body
+         in: body
+         description: Guest vsock properties
+         required: true
+         schema:
+           $ref: "#/definitions/Vsock"
+       responses:
+         201:
+           description: Vsock created
+         204:
+           description: Vsock updated
+         400:
+           description: Vsock cannot be created due to bad input
+           schema:
+             $ref: "#/definitions/Error"
+         default:
+           description: Internal server error
+           schema:
+             $ref: "#/definitions/Error"
 
 definitions:
   BootSource:
@@ -647,15 +647,15 @@ definitions:
         description: The amount of milliseconds it takes for the bucket to refill.
         minimum: 0
 
-    Vsock:
-      type: object
-      required:
-        - id
-        - guest_cid
-      properties:
-        id:
-          type: string
-        guest_cid:
-          type: integer
-          minimum: 3
-          description: Guest Vsock CID
+  Vsock:
+     type: object
+     required:
+       - id
+       - guest_cid
+     properties:
+       id:
+         type: string
+       guest_cid:
+         type: integer
+         minimum: 3
+         description: Guest Vsock CID


### PR DESCRIPTION
Description of changes: Due to indentation issues swagger was unable to generate code.
Fix the indentation issues with vsock fields.

The error was

```
 swagger generate client -f ./firecracker-experimental.yaml --model-package=client/models --client-package=client
2019/06/18 17:20:06 validating spec ./firecracker-experimental.yaml
The swagger spec at "./firecracker-experimental.yaml" is invalid against swagger specification 2.0. see errors :
- definitions.TokenBucket.Vsock in body is a forbidden property
- paths./network-interfaces/{iface_id}./vsocks/{id} in body is a forbidden property
```

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
