### PR TITLE
CI: run cargo audit on Cargo.lock deps

### DIFF
--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests ensuring security vulnerabilities are not present in dependencies."""
+
+from subprocess import run, PIPE
+
+import os
+import platform
+
+import pytest
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="The audit is based on cargo.lock which "
+           "is identical on all platforms"
+)
+def test_cargo_audit():
+    """Fail if there are crates with security vulnerabilities."""
+    cargo_lock_path = os.path.normpath(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            '../../../Cargo.lock')
+    )
+    process = run(
+        'cargo audit -f {}'.format(cargo_lock_path),
+        shell=True,
+        check=True,
+        stdout=PIPE
+    )
+    assert "Success No vulnerable packages found" \
+           in process.stdout.decode('utf-8')

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -72,6 +72,7 @@ RUN mkdir "$TMP_BUILD_DIR" \
         && rustup component add clippy-preview \
         && cd "$TMP_BUILD_DIR" \
             && cargo install cargo-kcov \
+            && cargo install cargo-audit \
             && cargo kcov --print-install-kcov-sh | sh \
         && rm -rf "$CARGO_HOME/registry" \
         && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v8"
+DEVCTR_IMAGE="fcuvm/dev:v9"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
Signed-off-by: Diana Popa <dpopa@amazon.com>

Issue #, if available:

Description of changes: See [doc](https://github.com/RustSec/cargo-audit).
New docker image with tag **v9** was added to docker repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
