### PR TITLE
device/virtio: new queue processing pattern

### DIFF
--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -292,19 +292,18 @@ pub struct BlockEpollHandler {
 impl BlockEpollHandler {
     fn process_queue(&mut self, queue_index: usize) -> bool {
         let queue = &mut self.queues[queue_index];
-        let mut rate_limited = false;
+        let mut used_any = false;
 
-        let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
-        let mut used_count = 0;
-        for avail_desc in queue.iter(&self.mem) {
+        while let Some(head) = queue.pop(&self.mem) {
             let len;
-            match Request::parse(&avail_desc, &self.mem) {
+            match Request::parse(&head, &self.mem) {
                 Ok(request) => {
                     // If limiter.consume() fails it means there is no more TokenType::Ops
                     // budget and rate limiting is in effect.
                     if !self.rate_limiter.consume(1, TokenType::Ops) {
-                        rate_limited = true;
-                        // stop processing the queue
+                        // Stop processing the queue and return this descriptor chain to the
+                        // avail ring, for later processing.
+                        queue.undo_pop();
                         break;
                     }
                     // Exercise the rate limiter only if this request is of data transfer type.
@@ -317,10 +316,11 @@ impl BlockEpollHandler {
                             .rate_limiter
                             .consume(u64::from(request.data_len), TokenType::Bytes)
                         {
-                            rate_limited = true;
                             // Revert the OPS consume().
                             self.rate_limiter.manual_replenish(1, TokenType::Ops);
-                            // Stop processing the queue.
+                            // Stop processing the queue and return this descriptor chain to the
+                            // avail ring, for later processing.
+                            queue.undo_pop();
                             break;
                         }
                     }
@@ -353,19 +353,11 @@ impl BlockEpollHandler {
                     len = 0;
                 }
             }
-            used_desc_heads[used_count] = (avail_desc.index, len);
-            used_count += 1;
-        }
-        if rate_limited {
-            // If rate limiting kicked in, queue had advanced one element that we aborted
-            // processing; go back one element so it can be processed next time.
-            queue.go_to_previous_position();
+            queue.add_used(&self.mem, head.index, len);
+            used_any = true;
         }
 
-        for &(desc_index, len) in &used_desc_heads[..used_count] {
-            queue.add_used(&self.mem, desc_index, len);
-        }
-        used_count > 0
+        used_any
     }
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
@@ -878,7 +870,7 @@ mod tests {
                 .unwrap();
             m.write_obj_at_addr::<u64>(114, GuestAddress(0x1000 + 8))
                 .unwrap();
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::UnexpectedWriteOnlyDescriptor) => true,
                 _ => false,
             });
@@ -888,7 +880,7 @@ mod tests {
             let mut q = vq.create_queue();
             // chain too short; no data_desc
             vq.dtable[0].flags.set(0);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::DescriptorChainTooShort) => true,
                 _ => false,
             });
@@ -899,7 +891,7 @@ mod tests {
             // chain too short; no status desc
             vq.dtable[0].flags.set(VIRTQ_DESC_F_NEXT);
             vq.dtable[1].set(0x2000, 0x1000, 0, 2);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::DescriptorChainTooShort) => true,
                 _ => false,
             });
@@ -912,7 +904,7 @@ mod tests {
                 .flags
                 .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
             vq.dtable[2].set(0x3000, 0, 0, 0);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::UnexpectedWriteOnlyDescriptor) => true,
                 _ => false,
             });
@@ -924,7 +916,7 @@ mod tests {
             m.write_obj_at_addr::<u32>(VIRTIO_BLK_T_IN, GuestAddress(0x1000))
                 .unwrap();
             vq.dtable[1].flags.set(VIRTQ_DESC_F_NEXT);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::UnexpectedReadOnlyDescriptor) => true,
                 _ => false,
             });
@@ -936,7 +928,7 @@ mod tests {
             vq.dtable[1]
                 .flags
                 .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::UnexpectedReadOnlyDescriptor) => true,
                 _ => false,
             });
@@ -946,7 +938,7 @@ mod tests {
             let mut q = vq.create_queue();
             // status desc too small
             vq.dtable[2].flags.set(VIRTQ_DESC_F_WRITE);
-            assert!(match Request::parse(&q.iter(m).next().unwrap(), m) {
+            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
                 Err(Error::DescriptorLengthTooSmall) => true,
                 _ => false,
             });
@@ -956,7 +948,7 @@ mod tests {
             let mut q = vq.create_queue();
             // should be OK now
             vq.dtable[2].len.set(0x1000);
-            let r = Request::parse(&q.iter(m).next().unwrap(), m).unwrap();
+            let r = Request::parse(&q.pop(m).unwrap(), m).unwrap();
 
             assert_eq!(r.request_type, RequestType::In);
             assert_eq!(r.sector, 114);

--- a/devices/src/virtio/queue.rs
+++ b/devices/src/virtio/queue.rs
@@ -142,65 +142,6 @@ impl<'a> DescriptorChain<'a> {
     }
 }
 
-/// Consuming iterator over all available descriptor chain heads in the queue.
-pub struct AvailIter<'a, 'b> {
-    mem: &'a GuestMemory,
-    desc_table: GuestAddress,
-    avail_ring: GuestAddress,
-    next_index: Wrapping<u16>,
-    last_index: Wrapping<u16>,
-    queue_size: u16,
-    next_avail: &'b mut Wrapping<u16>,
-}
-
-impl<'a, 'b> AvailIter<'a, 'b> {
-    pub fn new(mem: &'a GuestMemory, q_next_avail: &'b mut Wrapping<u16>) -> AvailIter<'a, 'b> {
-        AvailIter {
-            mem,
-            desc_table: GuestAddress(0),
-            avail_ring: GuestAddress(0),
-            next_index: Wrapping(0),
-            last_index: Wrapping(0),
-            queue_size: 0,
-            next_avail: q_next_avail,
-        }
-    }
-}
-
-impl<'a, 'b> Iterator for AvailIter<'a, 'b> {
-    type Item = DescriptorChain<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.next_index == self.last_index {
-            return None;
-        }
-
-        let offset = (4 + (self.next_index.0 % self.queue_size) * 2) as usize;
-        let avail_addr = match self.mem.checked_offset(self.avail_ring, offset) {
-            Some(a) => a,
-            None => return None,
-        };
-        // This index is checked below in checked_new
-        let desc_index: u16 = match self.mem.read_obj_from_addr(avail_addr) {
-            Ok(ret) => ret,
-            Err(_) => {
-                // TODO log address
-                error!("Failed to read from memory");
-                return None;
-            }
-        };
-
-        self.next_index += Wrapping(1);
-
-        let ret =
-            DescriptorChain::checked_new(self.mem, self.desc_table, self.queue_size, desc_index);
-        if ret.is_some() {
-            *self.next_avail += Wrapping(1);
-        }
-        ret
-    }
-}
-
 #[derive(Clone)]
 /// A virtio queue's parameters.
 pub struct Queue {
@@ -307,36 +248,6 @@ impl Queue {
             false
         } else {
             true
-        }
-    }
-
-    /// A consuming iterator over all available descriptor chain heads offered by the driver.
-    pub fn iter<'a, 'b>(&'b mut self, mem: &'a GuestMemory) -> AvailIter<'a, 'b> {
-        let queue_size = self.actual_size();
-        let avail_ring = self.avail_ring;
-
-        let index_addr = match mem.checked_offset(avail_ring, 2) {
-            Some(ret) => ret,
-            None => {
-                // TODO log address
-                warn!("Invalid offset");
-                return AvailIter::new(mem, &mut self.next_avail);
-            }
-        };
-        // Note that last_index has no invalid values
-        let last_index: u16 = match mem.read_obj_from_addr::<u16>(index_addr) {
-            Ok(ret) => ret,
-            Err(_) => return AvailIter::new(mem, &mut self.next_avail),
-        };
-
-        AvailIter {
-            mem,
-            desc_table: self.desc_table,
-            avail_ring,
-            next_index: self.next_avail,
-            last_index: Wrapping(last_index),
-            queue_size,
-            next_avail: &mut self.next_avail,
         }
     }
 
@@ -751,7 +662,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_queue_and_iterator() {
+    fn test_queue_validation() {
         let m = &GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
@@ -799,60 +710,74 @@ pub mod tests {
         q.used_ring = GuestAddress(0x1001);
         assert!(!q.is_valid(m));
         q.used_ring = vq.used_start();
+    }
 
-        {
-            // an invalid queue should return an iterator with no next
-            q.ready = false;
-            let mut i = q.iter(m);
-            assert!(i.next().is_none());
-        }
+    #[test]
+    fn test_queue_processing() {
+        let m = &GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        let mut q = vq.create_queue();
 
         q.ready = true;
 
-        // now let's create two simple descriptor chains
+        // Let's create two simple descriptor chains.
 
-        {
-            for j in 0..5 {
-                vq.dtable[j].set(
-                    0x1000 * (j + 1) as u64,
-                    0x1000,
-                    VIRTQ_DESC_F_NEXT,
-                    (j + 1) as u16,
-                );
-            }
-
-            // the chains are (0, 1) and (2, 3, 4)
-            vq.dtable[1].flags.set(0);
-            vq.dtable[4].flags.set(0);
-            vq.avail.ring[0].set(0);
-            vq.avail.ring[1].set(2);
-            vq.avail.idx.set(2);
-
-            let mut i = q.iter(m);
-
-            {
-                let mut c = i.next().unwrap();
-                c = c.next_descriptor().unwrap();
-                assert!(!c.has_next());
-            }
-
-            {
-                let mut c = i.next().unwrap();
-                c = c.next_descriptor().unwrap();
-                c = c.next_descriptor().unwrap();
-                assert!(!c.has_next());
-            }
+        for j in 0..5 {
+            vq.dtable[j].set(
+                0x1000 * (j + 1) as u64,
+                0x1000,
+                VIRTQ_DESC_F_NEXT,
+                (j + 1) as u16,
+            );
         }
 
-        // also test go_to_previous_position() works as expected
-        {
-            assert!(q.iter(m).next().is_none());
-            q.undo_pop();
-            let mut c = q.iter(m).next().unwrap();
-            c = c.next_descriptor().unwrap();
-            c = c.next_descriptor().unwrap();
-            assert!(!c.has_next());
-        }
+        // the chains are (0, 1) and (2, 3, 4)
+        vq.dtable[1].flags.set(0);
+        vq.dtable[4].flags.set(0);
+        vq.avail.ring[0].set(0);
+        vq.avail.ring[1].set(2);
+        vq.avail.idx.set(2);
+
+        // We've just set up two chains.
+        assert_eq!(q.len(m), 2);
+
+        // The first chain should hold exactly two descriptors.
+        let d = q.pop(m).unwrap().next_descriptor().unwrap();
+        assert!(!d.has_next());
+        assert!(d.next_descriptor().is_none());
+
+        // We popped one chain, so there should be only one left.
+        assert_eq!(q.len(m), 1);
+
+        // The next chain holds three descriptors.
+        let d = q
+            .pop(m)
+            .unwrap()
+            .next_descriptor()
+            .unwrap()
+            .next_descriptor()
+            .unwrap();
+        assert!(!d.has_next());
+        assert!(d.next_descriptor().is_none());
+
+        // We've popped both chains, so the queue should be empty.
+        assert!(q.is_empty(m));
+        assert!(q.pop(m).is_none());
+
+        // Undoing the last pop should let us walk the last chain again.
+        q.undo_pop();
+        assert_eq!(q.len(m), 1);
+
+        // Walk the last chain again (three descriptors).
+        let d = q
+            .pop(m)
+            .unwrap()
+            .next_descriptor()
+            .unwrap()
+            .next_descriptor()
+            .unwrap();
+        assert!(!d.has_next());
+        assert!(d.next_descriptor().is_none());
     }
 
     #[test]

--- a/devices/src/virtio/queue.rs
+++ b/devices/src/virtio/queue.rs
@@ -340,6 +340,68 @@ impl Queue {
         }
     }
 
+    /// Returns the number of yet-to-be-popped descriptor chains in the avail ring.
+    pub fn len(&self, mem: &GuestMemory) -> u16 {
+        (self.avail_idx(mem) - self.next_avail).0
+    }
+
+    /// Checks if the driver has made any descriptor chains available in the avail ring.
+    pub fn is_empty(&self, mem: &GuestMemory) -> bool {
+        self.len(mem) == 0
+    }
+
+    /// Pop the first available descriptor chain from the avail ring.
+    pub fn pop<'a, 'b>(&'a mut self, mem: &'b GuestMemory) -> Option<DescriptorChain<'b>> {
+        if self.len(mem) == 0 {
+            return None;
+        }
+
+        // We'll need to find the first available descriptor, that we haven't yet popped.
+        // In a naive notation, that would be:
+        // `descriptor_table[avail_ring[next_avail]]`.
+        //
+        // First, we compute the byte-offset (into `self.avail_ring`) of the index of the next available
+        // descriptor. `self.avail_ring` stores the address of a `struct virtq_avail`, as defined by
+        // the VirtIO spec:
+        //
+        // ```C
+        // struct virtq_avail {
+        //   le16 flags;
+        //   le16 idx;
+        //   le16 ring[QUEUE_SIZE];
+        //   le16 used_event
+        // }
+        // ```
+        //
+        // We use `self.next_avail` to store the position, in `ring`, of the next available
+        // descriptor index, with a twist: we always only increment `self.next_avail`, so the
+        // actual position will be `self.next_avail % self.actual_size()`.
+        // We are now looking for the offset of `ring[self.next_avail % self.actual_size()]`.
+        // `ring` starts after `flags` and `idx` (4 bytes into `struct virtq_avail`), and holds
+        // 2-byte items, so the offset will be:
+        let index_offset = 4 + 2 * (self.next_avail.0 % self.actual_size());
+
+        // `self.is_valid()` already performed all the bound checks on the descriptor table
+        // and virtq rings, so it's safe to unwrap guest memory reads and to use unchecked
+        // offsets.
+        let desc_index: u16 = mem
+            .read_obj_from_addr(self.avail_ring.unchecked_add(usize::from(index_offset)))
+            .unwrap();
+
+        DescriptorChain::checked_new(mem, self.desc_table, self.actual_size(), desc_index).map(
+            |dc| {
+                self.next_avail += Wrapping(1);
+                dc
+            },
+        )
+    }
+
+    /// Undo the effects of the last `self.pop()` call.
+    /// The caller can use this, if it was unable to consume the last popped descriptor chain.
+    pub fn undo_pop(&mut self) {
+        self.next_avail -= Wrapping(1);
+    }
+
     /// Puts an available descriptor head into the used ring for use by the guest.
     pub fn add_used(&mut self, mem: &GuestMemory, desc_index: u16, len: u32) {
         if desc_index >= self.actual_size() {
@@ -374,6 +436,19 @@ impl Queue {
     /// of an iterator increment on the queue.
     pub fn go_to_previous_position(&mut self) {
         self.next_avail -= Wrapping(1);
+    }
+
+    /// Fetch the available ring index (`virtq_avail->idx`) from guest memory.
+    /// This is written by the driver, to indicate the next slot that will be filled in the avail
+    /// ring.
+    fn avail_idx(&self, mem: &GuestMemory) -> Wrapping<u16> {
+        // Bound checks for queue inner data have already been performed, at device activation time,
+        // via `self.is_valid()`, so it's safe to unwrap and use unchecked offsets here.
+        // Note: the `MmioDevice` code ensures that queue addresses cannot be changed by the guest
+        //       after device activation, so we can be certain that no change has occured since
+        //       the last `self.is_valid()` check.
+        let addr = self.avail_ring.unchecked_add(2);
+        Wrapping(mem.read_obj_from_addr::<u16>(addr).unwrap())
     }
 }
 
@@ -772,7 +847,7 @@ pub mod tests {
         // also test go_to_previous_position() works as expected
         {
             assert!(q.iter(m).next().is_none());
-            q.go_to_previous_position();
+            q.undo_pop();
             let mut c = q.iter(m).next().unwrap();
             c = c.next_descriptor().unwrap();
             c = c.next_descriptor().unwrap();

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.9
+COVERAGE_TARGET_PCT = 84.0
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
**Description of changes**:

Added a new VirtIO queue manipulation pattern, without the use of the currently employed available chain iterator. Available descriptor chains can now be popped straight from the queue.

The offending iterator used to hold a mutable reference to the VirtIO queue, which hindered the get_avail/add_used/maybe_rewind_iterator cycle, since that implied performing mutable actions on both the iterator and the queue itself. Workarounds included creating and dropping the iterator with each iteration (the `while let Some(desc) = queue.iter().next()` pattern).

This PR changes that behavior by dropping the iterator altogether, and replacing it with queue-provided manipulation methods, such as:
- `pop()` - fetch the next avail chain; and
- `undo_pop()` - place the last fetched chain back into the avail ring (previously known as `Queue::go_to_previous_position()`).

Also, the queue now exposes the number of available iterators via `len()` and `is_empty()`. This will be useful for the vsock code, as well as #1049 , where the absence of available descriptor chains must trigger a device action.

--

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
