### PR TITLE
devices/net: fix busy spin when no RX buffers are available

### DIFF
--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -58,4 +58,5 @@ pub enum Error {
         event: DeviceEventT,
     },
     IoError(io::Error),
+    NoAvailBuffers,
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.0
+COVERAGE_TARGET_PCT = 84.1
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
**Description of changes**:

Fixes #1049 

If the guest virtio-net driver didn't make any RX buffers available, the virtio-net device would busy-spin on tap RX events, unable to consume them, causing host CPU usage to spike needlessly.

This PR changes the virtio-net device behavior to listen to tap RX events, only when there are RX buffers available.

**Note**: this PR is rebased on #1156 , so only the last two commits in here are of interest.

------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
