### PR TITLE
logger/src, vmm: Fixed typo and added `filter_cpuid` metric

### DIFF
--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -370,7 +370,7 @@ pub struct VcpuMetrics {
     /// Number of errors during this VCPU's run.
     pub failures: SharedMetric,
     /// Failures in configuring the CPUID.
-    pub fitler_cpuid: SharedMetric,
+    pub filter_cpuid: SharedMetric,
 }
 
 /// Metrics specific to the machine manager as a whole.

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -264,7 +264,11 @@ impl Vcpu {
         )
         .map_err(Error::CpuId)?;
 
-        filter_cpuid(&mut self.cpuid, &cpuid_vm_spec).map_err(Error::CpuId)?;
+        filter_cpuid(&mut self.cpuid, &cpuid_vm_spec).map_err(|e| {
+            METRICS.vcpu.filter_cpuid.inc();
+            error!("Failure in configuring CPUID for vcpu {}: {:?}", self.id, e);
+            Error::CpuId(e)
+        })?;
 
         if let Some(template) = machine_config.cpu_template {
             match template {


### PR DESCRIPTION
Issue #, if available: fixes #1121
Description of changes: Fixes a typo where filter_cpuid was called fitler_cpuid. Also fixed an issue where the filter_cpuid metric wasn't incremented anywhere; also, adds an error log in this case.

Signed-off-by: Tamio-Vesa Nakajima tnk@amazon.com

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
