### PR TITLE
Add metric to test SIGBUS, SIGSEGV signal handler.

### DIFF
--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -359,6 +359,15 @@ pub struct MemoryMetrics {
     pub dirty_pages: SharedMetric,
 }
 
+/// Metrics related to signals.
+#[derive(Default, Serialize)]
+pub struct SignalMetrics {
+    /// Number of times that SIGBUS was handled.
+    pub sigbus: SharedMetric,
+    /// Number of times that SIGSEGV was handled.
+    pub sigsegv: SharedMetric,
+}
+
 // The sole purpose of this struct is to produce an UTC timestamp when an instance is serialized.
 #[derive(Default)]
 struct SerializeToUtcTimestampMs;
@@ -404,6 +413,8 @@ pub struct FirecrackerMetrics {
     pub uart: SerialDeviceMetrics,
     /// Memory usage metrics.
     pub memory: MemoryMetrics,
+    /// Metrics related to signals.
+    pub signals: SignalMetrics,
 }
 
 lazy_static! {


### PR DESCRIPTION
Issue #, if available: fixes #1205

Description of changes: Added testing and metrics for the SIGSEGV/SIGBUS signal handler. Also, refactors some of the signal handler testing to avoid some race conditions.

Signed-off-by: Tamio-Vesa Nakajima <tnk@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.