### PR TITLE
Removed dependency on time and chrono crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ name = "api_server"
 version = "0.1.0"
 dependencies = [
  "arch 0.1.0",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "fc_util 0.1.0",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -130,17 +129,6 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "chrono"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +158,7 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dumbo 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fc_util 0.1.0",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "memory_model 0.1.0",
@@ -178,7 +167,6 @@ dependencies = [
  "rate_limiter 0.1.0",
  "sys_util 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost_backend 0.1.0",
  "vhost_gen 0.1.0",
  "virtio_gen 0.1.0",
@@ -218,7 +206,6 @@ version = "0.17.0"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
  "jailer 0.17.0",
@@ -399,7 +386,7 @@ dependencies = [
 name = "logger"
 version = "0.1.0"
 dependencies = [
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fc_util 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,7 +394,6 @@ dependencies = [
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,23 +496,6 @@ dependencies = [
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -686,9 +655,9 @@ dependencies = [
 name = "rate_limiter"
 version = "0.1.0"
 dependencies = [
+ "fc_util 0.1.0",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "timerfd 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1053,7 +1022,6 @@ name = "vmm"
 version = "0.1.0"
 dependencies = [
  "arch 0.1.0",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuid 0.1.0",
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1074,7 +1042,6 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "timerfd 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1129,7 +1096,6 @@ dependencies = [
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 "checksum epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f0680f2a6f2a17fa7a8668a27c54e45e1ad1cf8a632f56a7c19b9e4e3bbe8a"
@@ -1158,8 +1124,6 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
-"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pnet 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3961c514be0c95233bdccdee9831aadd887a889ebc22e57d73e14d1cedb670"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 backtrace = {version = "0.3", features = ["libunwind", "libbacktrace", "std"], default-features = false}
-chrono = ">=0.4"
 clap = { version = ">=2.27.1", default-features = false}
 
 api_server = { path = "api_server" }

--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-chrono = ">=0.4"
 futures = { version = "=0.1.18", default-features = false}
 hyper = { version = "=0.11.16", default-features = false }
 serde = ">=1.0.27"

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate chrono;
 extern crate futures;
 extern crate hyper;
 extern crate serde;
@@ -103,7 +102,7 @@ impl ApiServer {
         let listener = UnixListener::bind(path, &handle).map_err(Error::Io)?;
 
         if let Some(start_time) = start_time_us {
-            let delta_us = (chrono::Utc::now().timestamp_nanos() / 1000) as u64 - start_time;
+            let delta_us = (fc_util::get_time(fc_util::ClockType::Monotonic) / 1000) - start_time;
             METRICS
                 .api_server
                 .process_startup_time_us
@@ -111,7 +110,8 @@ impl ApiServer {
         }
 
         if let Some(cpu_start_time) = start_time_cpu_us {
-            let delta_us = fc_util::now_cputime_us() - cpu_start_time;
+            let delta_us =
+                fc_util::get_time(fc_util::ClockType::ProcessCpu) / 1000 - cpu_start_time;
             METRICS
                 .api_server
                 .process_startup_time_cpu_us

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["The Chromium OS Authors"]
 byteorder = ">=1.2.1"
 epoll = "=4.0.1"
 libc = ">=0.2.39"
-time = ">=0.1.39"
 
 dumbo = { path = "../dumbo" }
+fc_util = { path = "../fc_util" }
 logger = { path = "../logger" }
 memory_model = { path = "../memory_model" }
 net_util = { path = "../net_util" }

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -9,7 +9,6 @@
 extern crate byteorder;
 extern crate epoll;
 extern crate libc;
-extern crate time;
 
 extern crate dumbo;
 #[macro_use]

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -860,7 +860,7 @@ impl VirtioDevice for Net {
             let tx_queue = queues.remove(0);
             let rx_queue_evt = queue_evts.remove(0);
             let tx_queue_evt = queue_evts.remove(0);
-            let mut mmds_ns = if self.allow_mmds_requests {
+            let mmds_ns = if self.allow_mmds_requests {
                 Some(MmdsNetworkStack::new_with_defaults())
             } else {
                 None

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -333,7 +333,7 @@ mod tests {
                 )
                 .unwrap();
 
-                let mut segment_len = TcpSegment::write_incomplete_segment::<[u8]>(
+                let segment_len = TcpSegment::write_incomplete_segment::<[u8]>(
                     packet.inner_mut().payload_mut(),
                     SEQ_NUMBER,
                     1234,

--- a/dumbo/src/tcp/connection.rs
+++ b/dumbo/src/tcp/connection.rs
@@ -929,7 +929,7 @@ impl Connection {
 
             // We can only send data if it's within both the send buffer and the remote rwnd, and
             // before the sequence number of the local FIN (if the connection is closing).
-            let mut actual_end = if seq_at_or_after(self.remote_rwnd_edge, payload_end) {
+            let actual_end = if seq_at_or_after(self.remote_rwnd_edge, payload_end) {
                 payload_end
             } else {
                 self.remote_rwnd_edge

--- a/fc_util/src/lib.rs
+++ b/fc_util/src/lib.rs
@@ -3,8 +3,112 @@
 
 extern crate libc;
 
+use std::fmt;
+
 pub mod validators;
 
+/// Constant to convert seconds to nanoseconds.
+pub const NANOS_PER_SECOND: u64 = 1_000_000_000;
+
+/// Wrapper over `libc::clockid_t` to specify Linux Kernel clock source.
+pub enum ClockType {
+    /// Equivalent to `libc::CLOCK_MONOTONIC`.
+    Monotonic,
+    /// Equivalent to `libc::CLOCK_REALTIME`.
+    Real,
+    /// Equivalent to `libc::CLOCK_PROCESS_CPUTIME_ID`.
+    ProcessCpu,
+    /// Equivalent to `libc::CLOCK_THREAD_CPUTIME_ID`.
+    ThreadCpu,
+}
+
+impl Into<libc::clockid_t> for ClockType {
+    fn into(self) -> libc::clockid_t {
+        match self {
+            ClockType::Monotonic => libc::CLOCK_MONOTONIC,
+            ClockType::Real => libc::CLOCK_REALTIME,
+            ClockType::ProcessCpu => libc::CLOCK_PROCESS_CPUTIME_ID,
+            ClockType::ThreadCpu => libc::CLOCK_THREAD_CPUTIME_ID,
+        }
+    }
+}
+
+/// Structure representing the date in local time with nanosecond precision.
+pub struct LocalTime {
+    /// Seconds in current minute.
+    sec: i32,
+    /// Minutes in current hour.
+    min: i32,
+    /// Hours in current day, 24H format.
+    hour: i32,
+    /// Days in current month.
+    mday: i32,
+    /// Months in current year.
+    mon: i32,
+    /// Years passed since 1900 BC.
+    year: i32,
+    /// Nanoseconds in current second.
+    nsec: i64,
+}
+
+impl LocalTime {
+    /// Returns the [LocalTime](struct.LocalTime.html) structure for the calling moment.
+    pub fn now() -> LocalTime {
+        let mut timespec = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let mut tm: libc::tm = libc::tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 0,
+            tm_mon: 0,
+            tm_year: 0,
+            tm_wday: 0,
+            tm_yday: 0,
+            tm_isdst: 0,
+            tm_gmtoff: 0,
+            tm_zone: std::ptr::null(),
+        };
+
+        // Safe because the parameters are valid.
+        unsafe {
+            libc::clock_gettime(libc::CLOCK_REALTIME, &mut timespec);
+            libc::localtime_r(&timespec.tv_sec, &mut tm);
+        }
+
+        LocalTime {
+            sec: tm.tm_sec,
+            min: tm.tm_min,
+            hour: tm.tm_hour,
+            mday: tm.tm_mday,
+            mon: tm.tm_mon,
+            year: tm.tm_year,
+            nsec: timespec.tv_nsec,
+        }
+    }
+}
+
+impl fmt::Display for LocalTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}",
+            self.year + 1900,
+            self.mon,
+            self.mday,
+            self.hour,
+            self.min,
+            self.sec,
+            self.nsec
+        )
+    }
+}
+
+/// Returns a timestamp in nanoseconds from a monotonic clock.
+///
+/// Uses `_rdstc` on `x86_64` and [`get_time`](fn.get_time.html) on other architectures.
 pub fn timestamp_cycles() -> u64 {
     #[cfg(target_arch = "x86_64")]
     // Safe because there's nothing that can go wrong with this call.
@@ -13,47 +117,95 @@ pub fn timestamp_cycles() -> u64 {
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        let mut ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-
-        unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
-        }
-        (ts.tv_sec as u64) * 1000000000 + (ts.tv_nsec as u64)
+        get_time(ClockType::Monotonic)
     }
 }
 
-fn timespec_to_us(time_struct: &libc::timespec) -> u64 {
-    (time_struct.tv_sec as u64) * 1_000_000 + (time_struct.tv_nsec as u64) / 1000
-}
-
-pub fn now_cputime_us() -> u64 {
+/// Returns a timestamp in nanoseconds based on the provided clock type.
+///
+/// # Arguments
+///
+/// * `clock_type` - Identifier of the Linux Kernel clock on which to act.
+pub fn get_time(clock_type: ClockType) -> u64 {
     let mut time_struct = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
     // Safe because the parameters are valid.
-    unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, &mut time_struct) };
-    timespec_to_us(&time_struct)
+    unsafe { libc::clock_gettime(clock_type.into(), &mut time_struct) };
+    seconds_to_nanoseconds(time_struct.tv_sec).unwrap() as u64 + (time_struct.tv_nsec as u64)
+}
+
+/// Converts a timestamp in seconds to an equivalent one in nanoseconds.
+/// Returns `None` if the conversion overflows.
+///
+/// # Arguments
+///
+/// * `value` - Timestamp in seconds.
+pub fn seconds_to_nanoseconds(value: i64) -> Option<i64> {
+    value.checked_mul(NANOS_PER_SECOND as i64)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cmp::Ordering;
 
     #[test]
-    fn test_timestamp_cycles() {
+    fn test_get_time() {
         for _ in 0..1000 {
-            assert!(timestamp_cycles() < timestamp_cycles());
+            assert!(get_time(ClockType::Monotonic) <= get_time(ClockType::Monotonic));
         }
+
+        for _ in 0..1000 {
+            assert!(get_time(ClockType::ProcessCpu) <= get_time(ClockType::ProcessCpu));
+        }
+
+        for _ in 0..1000 {
+            assert!(get_time(ClockType::ThreadCpu) <= get_time(ClockType::ThreadCpu));
+        }
+
+        assert_ne!(get_time(ClockType::Real), 0);
     }
 
     #[test]
-    fn test_now_cputime_us() {
-        for _ in 0..1000 {
-            assert!(now_cputime_us() <= now_cputime_us());
-        }
+    fn test_local_time_display() {
+        let local_time = LocalTime {
+            sec: 30,
+            min: 15,
+            hour: 10,
+            mday: 4,
+            mon: 7,
+            year: 119,
+            nsec: 123_456_789,
+        };
+        assert_eq!(
+            String::from("2019-07-04T10:15:30.123456789").cmp(&local_time.to_string()),
+            Ordering::Equal
+        );
+
+        let local_time = LocalTime {
+            sec: 5,
+            min: 5,
+            hour: 5,
+            mday: 23,
+            mon: 8,
+            year: 44,
+            nsec: 123,
+        };
+        assert_eq!(
+            String::from("1944-08-23T05:05:05.000000123"),
+            local_time.to_string()
+        );
+    }
+
+    #[test]
+    fn test_seconds_to_nanos() {
+        assert_eq!(
+            seconds_to_nanoseconds(100).unwrap() as u64,
+            100 * NANOS_PER_SECOND
+        );
+
+        assert!(seconds_to_nanoseconds(9_223_372_037).is_none());
     }
 }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-chrono = ">=0.4"
 lazy_static = ">=1.2"
 libc = ">=0.2.39"
 log = { version = "0.4", features = ["std"] }
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-time = ">=0.1.39"
+
+fc_util = { path = "../fc_util" }
 
 [dev-dependencies]
 tempfile = ">=3.0.2"

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -136,7 +136,6 @@
 //! metric will get increased.
 //! Metrics are only logged to pipes. Logs can be flushed either to stdout/stderr or to a pipe.
 
-extern crate chrono;
 // workaround to macro_reexport
 #[macro_use]
 extern crate lazy_static;
@@ -146,7 +145,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-extern crate time;
+
+extern crate fc_util;
 
 pub mod error;
 pub mod metrics;
@@ -159,10 +159,10 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard, RwLock};
 
-use chrono::Local;
 use serde_json::Value;
 
 use error::LoggerError;
+use fc_util::LocalTime;
 pub use log::Level::*;
 pub use log::*;
 use log::{set_logger, set_max_level, Log, Metadata, Record};
@@ -185,9 +185,6 @@ const INITIALIZING: usize = 2;
 const INITIALIZED: usize = 3;
 
 static STATE: AtomicUsize = AtomicUsize::new(0);
-
-// Time format
-const TIME_FMT: &str = "%Y-%m-%dT%H:%M:%S.%f";
 
 lazy_static! {
     static ref _LOGGER_INNER: Logger = Logger::new();
@@ -786,7 +783,7 @@ impl Log for Logger {
         if self.enabled(record.metadata()) {
             let msg = format!(
                 "{}{}{}{}",
-                Local::now().format(TIME_FMT),
+                LocalTime::now(),
                 self.create_prefix(&record),
                 MSG_SEPARATOR,
                 record.args()

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -26,7 +26,6 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use chrono;
 use serde::{Serialize, Serializer};
 
 /// Used for defining new types of metrics that can be either incremented with an unit
@@ -395,7 +394,8 @@ struct SerializeToUtcTimestampMs;
 
 impl Serialize for SerializeToUtcTimestampMs {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_i64(chrono::Utc::now().timestamp_millis())
+        serializer
+            .serialize_i64(fc_util::get_time(fc_util::ClockType::Monotonic) as i64 / 1_000_000)
     }
 }
 

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -215,11 +215,7 @@ impl GuestMemory {
     ///     Ok(())
     /// # }
     /// ```
-    pub fn read_slice_at_addr(
-        &self,
-        mut buf: &mut [u8],
-        guest_addr: GuestAddress,
-    ) -> Result<usize> {
+    pub fn read_slice_at_addr(&self, buf: &mut [u8], guest_addr: GuestAddress) -> Result<usize> {
         self.do_in_region_partial(guest_addr, move |mapping, offset| {
             mapping
                 .read_slice(buf, offset)

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 libc = ">=0.2.39"
-time = ">=0.1.39"
 timerfd = "1.0"
 
+fc_util = { path = "../fc_util" }
 logger = { path = "../logger" }

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -84,7 +84,7 @@ fn gcd(x: u64, y: u64) -> u64 {
 
 /// TokenBucket provides a lower level interface to rate limiting with a
 /// configurable capacity, refill-rate and initial burst.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TokenBucket {
     // Bucket defining traits.
     size: u64,

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -45,14 +45,14 @@
 //! needs to be called by the user on every event on the rate limiter's `AsRawFd` FD.
 //!
 
-extern crate time;
 extern crate timerfd;
 
+extern crate fc_util;
 #[macro_use]
 extern crate logger;
 
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{fmt, io};
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 
@@ -95,7 +95,7 @@ pub struct TokenBucket {
 
     // Internal state descriptors.
     budget: u64,
-    last_update: u64,
+    last_update: Instant,
 
     // Fields used for pre-processing optimizations.
     processed_capacity: u64,
@@ -134,7 +134,7 @@ impl TokenBucket {
             // Start off full.
             budget: size,
             // Last updated is now.
-            last_update: time::precise_time_ns(),
+            last_update: Instant::now(),
             processed_capacity,
             processed_refill_time,
         }
@@ -150,7 +150,7 @@ impl TokenBucket {
                 // We still have burst budget for *all* tokens requests.
                 if *otb >= tokens {
                     *otb -= tokens;
-                    self.last_update = time::precise_time_ns();
+                    self.last_update = Instant::now();
                     // No need to continue to the refill process, we still have burst budget to consume from.
                     return true;
                 } else {
@@ -162,9 +162,8 @@ impl TokenBucket {
             }
         }
         // Compute time passed since last refill/update.
-        let now = time::precise_time_ns();
-        let time_delta = now - self.last_update;
-        self.last_update = now;
+        let time_delta = self.last_update.elapsed().as_nanos() as u64;
+        self.last_update = Instant::now();
 
         // At each 'time_delta' nanoseconds the bucket should refill with:
         // refill_amount = (time_delta * size) / (complete_refill_time_ms * 1_000_000)
@@ -488,11 +487,11 @@ mod tests {
         // Resets the token bucket: budget set to max capacity and last-updated set to now.
         fn reset(&mut self) {
             self.budget = self.size;
-            self.last_update = time::precise_time_ns();
+            self.last_update = Instant::now();
         }
 
-        fn get_last_update(&self) -> u64 {
-            self.last_update
+        fn get_last_update(&self) -> &Instant {
+            &self.last_update
         }
 
         fn get_processed_capacity(&self) -> u64 {
@@ -515,12 +514,13 @@ mod tests {
 
     #[test]
     fn test_token_bucket_create() {
-        let before = time::precise_time_ns();
+        let before = Instant::now();
         let tb = TokenBucket::new(1000, None, 1000);
         assert_eq!(tb.capacity(), 1000);
         assert_eq!(tb.budget(), 1000);
-        assert!(tb.get_last_update() >= before);
-        assert!(tb.get_last_update() <= time::precise_time_ns());
+        assert!(*tb.get_last_update() >= before);
+        let after = Instant::now();
+        assert!(*tb.get_last_update() <= after);
         assert_eq!(tb.get_processed_capacity(), 1);
         assert_eq!(tb.get_processed_refill_time(), 1_000_000);
     }
@@ -569,12 +569,13 @@ mod tests {
         thread::sleep(Duration::from_millis(500));
         assert!(tb.reduce(500));
 
-        let before = time::precise_time_ns();
+        let before = Instant::now();
         tb.reset();
         assert_eq!(tb.capacity(), 1000);
         assert_eq!(tb.budget(), 1000);
-        assert!(tb.get_last_update() >= before);
-        assert!(tb.get_last_update() <= time::precise_time_ns());
+        assert!(*tb.get_last_update() >= before);
+        let after = Instant::now();
+        assert!(*tb.get_last_update() <= after);
     }
 
     #[test]

--- a/src/bin/jailer.rs
+++ b/src/bin/jailer.rs
@@ -1,7 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate chrono;
 extern crate clap;
 
 extern crate fc_util;
@@ -10,8 +8,8 @@ extern crate jailer;
 fn main() {
     if let Err(error) = jailer::run(
         jailer::clap_app().get_matches(),
-        (chrono::Utc::now().timestamp_nanos() / 1000) as u64,
-        fc_util::now_cputime_us(),
+        fc_util::get_time(fc_util::ClockType::Monotonic) / 1000,
+        fc_util::get_time(fc_util::ClockType::ProcessCpu) / 1000,
     ) {
         panic!("Jailer error: {}", error);
     }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-chrono = ">=0.4"
 kvm-bindings = "0.1"
 kvm-ioctls = "0.2"
 libc = ">=0.2.39"
@@ -13,7 +12,6 @@ futures = ">=0.1.18"
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-time = ">=0.1.39"
 timerfd = ">=1.0"
 
 arch = { path = "../arch" }


### PR DESCRIPTION
Instead of using the time and chrono crates, we implemented some functionality in the 'fc_util' crate. It uses the UNIX syscall 'clock_gettime', which is also what time and chrono used on Linux, so no precision is lost. Where possible, we used 'Instant' from 'std::time' to measure elapsed time, as the time crate was deprecated and it is at least as accurate. However, we could not use 'std::time' everywhere as it doesn't support getting CPU clocks and system wall time.

Issue #, if available: fixes #1123 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
