### PR TITLE
Add mandatory "ht_enabled" field for doc example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -237,7 +237,8 @@ curl --unix-socket /tmp/firecracker.socket -i  \
     -H 'Content-Type: application/json'      \
     -d '{
         "vcpu_count": 2,
-        "mem_size_mib": 1024
+        "mem_size_mib": 1024,
+        "ht_enabled": false
     }'
 ```
 


### PR DESCRIPTION
Since v0.16.0 @YLyu add more limitations.
Sending machine-config as this doc will trigger this error:
`{"fault_message": "Missing mandatory fields."}`

Signed-off-by: Shen Jiale <shenjiale@baidu.com>

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
