### PR TITLE
Enhanced micro_http implementation

### DIFF
--- a/dumbo/src/tcp/endpoint.rs
+++ b/dumbo/src/tcp/endpoint.rs
@@ -430,8 +430,7 @@ mod tests {
         // again, for a relatively large number of iterations.
 
         let complete_request = b"GET http://169.254.169.255/asdfghjkl HTTP/1.1\r\n\r\n";
-        // For last request, we also try writing the newlines as "\n\n" instead of "\r\n\r\n".
-        let last_request = b"GET http://169.254.169.255/asdfghjkl HTTP/1.1\n\n123";
+        let last_request = b"GET http://169.254.169.255/asdfghjkl HTTP/1.1\r\n\r\n123";
 
         // Send one request for each byte in receive_buf, just to be sure.
         let max_iter = e.receive_buf.len();
@@ -464,7 +463,6 @@ mod tests {
                 assert_eq!(s.inner().ack_number(), remote_first_not_sent);
 
                 let response = from_utf8(s.inner().payload()).unwrap();
-
                 assert!(response.contains("404"));
 
                 endpoint_first_not_sent =

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -1,10 +1,9 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::io::{Error as WriteError, Write};
+use std::result::Result;
 
-use ascii::{COLON, CR, LF, SP};
+use RequestError;
 
 /// Wrapper over an HTTP Header type.
 #[derive(Debug, Eq, Hash, PartialEq)]
@@ -13,63 +12,226 @@ pub enum Header {
     ContentLength,
     /// Header `Content-Type`.
     ContentType,
+    /// Header `Expect`.
+    Expect,
+    /// Header `Transfer-Encoding`.
+    TransferEncoding,
 }
 
 impl Header {
-    fn raw(&self) -> &'static [u8] {
+    pub fn raw(&self) -> &'static [u8] {
         match self {
             Header::ContentLength => b"Content-Length",
             Header::ContentType => b"Content-Type",
+            Header::Expect => b"Expect",
+            Header::TransferEncoding => b"Transfer-Encoding",
+        }
+    }
+
+    fn try_from(string: &[u8]) -> Result<Self, RequestError> {
+        if let Ok(utf8_string) = String::from_utf8(string.to_vec()) {
+            match utf8_string.trim() {
+                "Content-Length" => Ok(Header::ContentLength),
+                "Content-Type" => Ok(Header::ContentType),
+                "Expect" => Ok(Header::Expect),
+                "Transfer-Encoding" => Ok(Header::TransferEncoding),
+                _ => Err(RequestError::InvalidHeader),
+            }
+        } else {
+            Err(RequestError::InvalidRequest)
         }
     }
 }
 
-/// Wrapper over the list of headers associated with a Request/Response.
+/// Wrapper over the list of headers associated with a Request that we need
+/// in order to parse the request correctly and be able to respond to it.
+///
+/// The only `Content-Type`s supported are `text/plain` and `application/json`, which are both
+/// in plain text actually and don't influence our parsing process.
+///
+/// All the other possible header fields are not necessary in order to serve this connection
+/// and, thus, are not of interest to us. However, we still look for header fields that might
+/// invalidate our request as we don't support the full set of HTTP/1.1 specification.
+/// Such header entries are "Transfer-Encoding: identity; q=0", which means a compression
+/// algorithm is applied to the body of the request, or "Expect: 103-checkpoint".
 #[derive(Debug)]
 pub struct Headers {
-    headers: HashMap<Header, String>,
+    /// The `Content-Length` header field tells us how many bytes we need to receive
+    /// from the source after the headers.
+    content_length: i32,
+    /// The `Expect` header field is set when the headers contain the entry "Expect: 100-continue".
+    /// This means that, per HTTP/1.1 specifications, we must send a response with the status code
+    /// 100 after we have received the headers in order to receive the body of the request. This
+    /// field should be known immediately after parsing the headers.
+    expect: bool,
+    /// `Chunked` is a possible value of the `Transfer-Encoding` header field and every HTTP/1.1
+    /// server must support it. It is useful only when receiving the body of the request and should
+    /// be known immediately after parsing the headers.
+    chunked: bool,
 }
 
 impl Headers {
     /// By default Requests are created with no headers.
     pub fn default() -> Headers {
         Headers {
-            headers: HashMap::new(),
+            content_length: 0,
+            expect: false,
+            chunked: false,
         }
     }
 
-    /// Adds a new header to the list.
-    pub fn add(&mut self, header: Header, value: String) {
-        self.headers.insert(header, value);
+    /// Expects one header line and parses it, updating the header structure or returning an
+    /// error if the header is invalid.
+    ///
+    /// # Errors
+    /// `UnsupportedHeader` is returned when the parsed header line is not of interest
+    /// to us or when it is unrecognizable.
+    /// `InvalidHeader` is returned when the parsed header is formatted incorrectly or suggests
+    /// that the client is using HTTP features that we do not support in this implementation,
+    /// which invalidates the request.
+    pub fn parse_header_line(&mut self, header_line: &[u8]) -> Result<(), RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        match std::str::from_utf8(header_line) {
+            Ok(headers_str) => {
+                let entry = headers_str.split(": ").collect::<Vec<&str>>();
+                if entry.len() != 2 {
+                    return Err(RequestError::InvalidHeader);
+                }
+                if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
+                    match head {
+                        Header::ContentLength => {
+                            let try_numeric: Result<i32, std::num::ParseIntError> =
+                                std::str::FromStr::from_str(entry[1].trim());
+                            if try_numeric.is_ok() {
+                                self.content_length = try_numeric.unwrap();
+                                Ok(())
+                            } else {
+                                Err(RequestError::InvalidHeader)
+                            }
+                        }
+                        Header::ContentType => {
+                            match MediaType::try_from(entry[1].trim().as_bytes()) {
+                                Ok(_) => Ok(()),
+                                Err(_) => Err(RequestError::InvalidHeader),
+                            }
+                        }
+                        Header::TransferEncoding => match entry[1].trim() {
+                            "chunked" => {
+                                self.chunked = true;
+                                Ok(())
+                            }
+                            "identity; q=0" => Err(RequestError::InvalidHeader),
+                            _ => Err(RequestError::UnsupportedHeader),
+                        },
+                        Header::Expect => match entry[1].trim() {
+                            "100-continue" => {
+                                self.expect = true;
+                                Ok(())
+                            }
+                            _ => Err(RequestError::InvalidHeader),
+                        },
+                    }
+                } else {
+                    Err(RequestError::UnsupportedHeader)
+                }
+            }
+            _ => Err(RequestError::InvalidHeader),
+        }
     }
 
-    /// Writes the headers to `buf` using the HTTP specification.
-    pub fn write_all<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
-        for (key, val) in &self.headers {
-            buf.write_all(key.raw())?;
-            buf.write_all(&[COLON, SP])?;
-            buf.write_all(&val.as_bytes())?;
-            buf.write_all(&[CR, LF])?;
+    /// Returns the content length of the body.
+    pub fn content_length(&self) -> i32 {
+        self.content_length
+    }
+
+    /// Returns `true` if the transfer encoding is chunked.
+    #[allow(unused)]
+    pub fn chunked(&self) -> bool {
+        self.chunked
+    }
+
+    /// Returns `true` if the client is expecting the code 100.
+    #[allow(unused)]
+    pub fn expect(&self) -> bool {
+        self.expect
+    }
+
+    /// Parses a byte slice into a Headers structure for a HTTP request.
+    ///
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Header Lines "<header_line> CRLF"- Optional </br>
+    /// There can be any number of request headers, including none, followed by
+    /// an extra sequence of Carriage Return and Line Feed.
+    /// All header fields are parsed. However, only the ones present in the
+    /// [`Headers`](struct.Headers.html) struct are relevant to us and stored
+    /// for future use.
+    ///
+    /// # Errors
+    /// The function returns `InvalidHeader` when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::Headers;
+    ///
+    /// let request_headers = Headers::try_from(b"Content-Length: 55\r\n\r\n");
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<Headers, RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            let mut headers = Headers::default();
+
+            let header_lines = text.split("\r\n");
+            for header_line in header_lines {
+                if header_line.is_empty() {
+                    break;
+                }
+                match headers.parse_header_line(header_line.as_bytes()) {
+                    Ok(_) | Err(RequestError::UnsupportedHeader) => continue,
+                    Err(e) => return Err(e),
+                };
+            }
+            return Ok(headers);
         }
-
-        // The header section ends with a CRLF.
-        buf.write_all(&[CR, LF])?;
-
-        Ok(())
+        Err(RequestError::InvalidRequest)
     }
 }
 
 /// Wrapper over supported Media Types.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MediaType {
     /// Media Type: "text/plain".
     PlainText,
+    /// Media Type: "application/json".
+    ApplicationJson,
+}
+
+impl Default for MediaType {
+    fn default() -> Self {
+        MediaType::PlainText
+    }
 }
 
 impl MediaType {
+    fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidRequest);
+        }
+        let utf8_slice =
+            String::from_utf8(bytes.to_vec()).map_err(|_| RequestError::InvalidRequest)?;
+        match utf8_slice.as_str() {
+            "text/plain" => Ok(MediaType::PlainText),
+            "application/json" => Ok(MediaType::ApplicationJson),
+            _ => Err(RequestError::InvalidRequest),
+        }
+    }
+
     /// Returns a static string representation of the object.
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             MediaType::PlainText => "text/plain",
+            MediaType::ApplicationJson => "application/json",
         }
     }
 }
@@ -80,49 +242,142 @@ mod tests {
 
     #[test]
     fn test_default() {
-        assert!(Headers::default().headers == HashMap::new());
+        let headers = Headers::default();
+        assert_eq!(headers.content_length(), 0);
+        assert_eq!(headers.chunked(), false);
+        assert_eq!(headers.expect(), false);
     }
 
     #[test]
-    fn test_add_headers() {
-        let mut headers = Headers::default();
-
-        headers.add(Header::ContentType, "text/plain".to_string());
-        headers.add(Header::ContentLength, "120".to_string());
-
-        assert!(headers.headers.contains_key(&Header::ContentType));
+    fn test_try_from_media() {
         assert_eq!(
-            &headers.headers[&Header::ContentType],
-            &"text/plain".to_string()
+            MediaType::try_from(b"application/json").unwrap(),
+            MediaType::ApplicationJson
         );
-        assert!(headers.headers.contains_key(&Header::ContentLength));
-        assert_eq!(&headers.headers[&Header::ContentLength], &"120".to_string());
 
-        // Test that adding a Header with the same key, updates the value.
-        headers.add(Header::ContentLength, "130".to_string());
-        assert_eq!(&headers.headers[&Header::ContentLength], &"130".to_string());
+        assert_eq!(
+            MediaType::try_from(b"text/plain").unwrap(),
+            MediaType::PlainText
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"application/json-patch").unwrap_err(),
+            RequestError::InvalidRequest
+        );
     }
 
     #[test]
-    fn test_write_headers() {
-        // Test write empty headers object
-        {
-            let headers = Headers::default();
-            let mut response_buf: [u8; 2] = [0_u8; 2];
+    fn test_media_as_str() {
+        let media_type = MediaType::ApplicationJson;
+        assert_eq!(media_type.as_str(), "application/json");
 
-            assert!(headers.write_all(&mut response_buf.as_mut()).is_ok());
-            assert_eq!(response_buf, [CR, LF]);
-        }
+        let media_type = MediaType::PlainText;
+        assert_eq!(media_type.as_str(), "text/plain");
+    }
 
-        // Test write with one header
-        {
-            let mut headers = Headers::default();
-            headers.add(Header::ContentLength, "10".to_string());
-            let expected: &'static [u8] = b"Content-Length: 10\r\n\r\n";
-            let mut response_buf = [0_u8; 22];
+    #[test]
+    fn test_try_from_headers() {
+        // Valid headers.
+        assert_eq!(
+            Headers::try_from(
+                b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: 55\r\n\r\n"
+            )
+            .unwrap()
+            .content_length,
+            55
+        );
 
-            assert!(headers.write_all(&mut response_buf.as_mut()).is_ok());
-            assert_eq!(expected, response_buf.as_ref());
-        }
+        let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        // Invalid headers.
+        assert!(Headers::try_from(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn test_parse_header_line() {
+        let mut header = Headers::default();
+
+        // Invalid header syntax.
+        assert_eq!(
+            header.parse_header_line(b"Expect"),
+            Err(RequestError::InvalidHeader)
+        );
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: five"),
+            Err(RequestError::InvalidHeader)
+        );
+
+        // Invalid transfer encoding.
+        assert_eq!(
+            header.parse_header_line(b"Transfer-Encoding: gzip"),
+            Err(RequestError::UnsupportedHeader)
+        );
+
+        // Invalid expect.
+        assert_eq!(
+            header
+                .parse_header_line(b"Expect: 102-processing")
+                .unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid media type.
+        assert_eq!(
+            header
+                .parse_header_line(b"Content-Type: application/json-patch")
+                .unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid input format.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            header.parse_header_line(&input[..]).unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Test valid transfer encoding.
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding: chunked")
+            .is_ok());
+        assert!(header.chunked());
+
+        // Test valid expect.
+        assert!(header.parse_header_line(b"Expect: 100-continue").is_ok());
+        assert!(header.expect());
+
+        // Test valid media type.
+        assert!(header
+            .parse_header_line(b"Content-Type: application/json")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_header_try_from() {
+        // Bad header.
+        assert_eq!(
+            Header::try_from(b"Encoding").unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid encoding.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            Header::try_from(&input[..]).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test valid headers.
+        let header = Header::try_from(b"Expect").unwrap();
+        assert_eq!(header.raw(), b"Expect");
+
+        let header = Header::try_from(b"Transfer-Encoding").unwrap();
+        assert_eq!(header.raw(), b"Transfer-Encoding");
     }
 }

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -11,23 +11,33 @@
 //! compression.
 //!
 //! ## Supported Headers
-//! The **micro_http** crate does not have support for parsing **Request**
-//! headers.
+//! The **micro_http** crate has support for parsing the following **Request**
+//! headers:
+//! - Content-Length
+//! - Expect
+//! - Transfer-Encoding
 //!
 //! The **Response** does not have a public interface for adding headers, but whenever
 //! a write to the **Body** is made, the headers **ContentLength** and **MediaType**
 //! are automatically updated.
 //!
 //! ### Media Types
-//! The only supported media type is **text/plain**.
+//! The supported media types are:
+//! - text/plain
+//! - application/json
 //!
 //! ## Supported Methods
-//! The only supported HTTP Method is **GET**.
+//! The supported HTTP Methods are:
+//! - GET
+//! - PUT
+//! - PATCH
 //!
 //! ## Supported Status Codes
 //! The supported status codes are:
 //!
+//! - Continue - 100
 //! - OK - 200
+//! - No Content - 204
 //! - Bad Request - 400
 //! - Not Found - 404
 //! - Internal Server Error - 500
@@ -38,7 +48,7 @@
 //! extern crate micro_http;
 //! use micro_http::{Request, Version};
 //!
-//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n").unwrap();
+//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
 //! assert_eq!(http_request.http_version(), Version::Http10);
 //! assert_eq!(http_request.uri().get_abs_path(), "/home");
 //! ```
@@ -56,7 +66,7 @@
 //! assert_eq!(response.body().unwrap(), Body::new(body));
 //! assert_eq!(response.http_version(), Version::Http10);
 //!
-//! let mut response_buf: [u8; 77] = [0; 77];
+//! let mut response_buf: [u8; 122] = [0; 122];
 //! assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
 //! ```
 mod common;
@@ -68,4 +78,5 @@ use common::headers;
 pub use request::{Request, RequestError};
 pub use response::{Response, StatusCode};
 
+pub use common::headers::Headers;
 pub use common::{Body, Version};

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.1
+COVERAGE_TARGET_PCT = 84.2
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
The current version of `micro_http` now supports the GET, PUT and
PATCH methods. Aside from this, we also added specific header
support and refactored the parsing.

Issue #, if available: fixes #1191

Signed-off-by: George Pisaltu <gpl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
