### PR TITLE
README update in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixed
 
 - Corrected firecracker-experimental.yaml indentation issues that
-  prevented code generation
+  prevented code generation.
+- Updated the documentation for integration tests.
 
 ## [0.17.0]
 


### PR DESCRIPTION
Description of changes: The integration tests' README has fallen behind, made no mention of running the integration tests with the dev container, and wasn't very helpful with the howto for adding new image capabilities. Updated usage examples and features to reflect running tests in the container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
