### PR TITLE
repo: expand PR template with checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-Issue #, if available:
-
-Description of changes:
-
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Reason for This PR
+
+`[Author TODO: add issue # or explain reasoning.]`
+
+## Description of Changes
+
+`[Author TODO: add description of changes.]`
+
+## License Acceptance
+
+By submitting this pull request, I confirm that my contribution is made under
+the terms of the Apache 2.0 license.
+
+## PR Checklist
+
+`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
+`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`
+
+- [ ] All commits in this PR are signed (`git commit -s`).
+- [ ] Either this PR is linked to an issue, or, the reason for this PR is
+      clearly provided. 
+- [ ] The description of changes is clear and encompassing.
+- [ ] Either no docs need to be updated as part of this PR, or, the required
+      doc changes are included in this PR. Docs in scope are all `*.md` files
+      located either in the repository root, or in the `docs/` directory.
+- [ ] Either no code has been touched, or, code-level documentation for touched
+      code is included in this PR.
+- [ ] Either no API changes are included in this PR, or, the API changes are
+      reflected in `firecracker/swagger.yaml`.
+- [ ] Either the changes in this PR have no user impact, or, the changes in
+      this PR have user impact and have been added to the `CHANGELOG.md` file.


### PR DESCRIPTION
## Reason for This PR

To ensure that the Firecracker docs and changelog are updated with each PR
where that's needed, the PR template Is extended with an appropriate checklist.

## Description of Changes

The PR template now includes a checklist that encourages both author and
reviewer to verify that:
- The PR's commits are signed.
- The PR is well reasoned.
- The PR has a clear description.
- The PR includes documentation updates (if needed).
- The PR includes swagger API definition updates (if needed).
- The PR includes changelog updates (if needed).

 ## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

 ## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (git commit -s).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] No code has been touched
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.