### PR TITLE
The repos is now under `firecracker-microvm` org

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -146,10 +146,10 @@ Running on an EC2 `.metal` instance with an `Amazon Linux 2` AMI:
 ``` sh
 # Get firecracker
 yum install -y git
-git clone https://<user>:<token>@github.com/aws/<firecracker repo>.git
+git clone https://github.com/firecracker-microvm/firecracker.git
 
 # Run all tests
-cd <firecracker repo>
+cd firecracker
 tools/devtool test
 ```
 


### PR DESCRIPTION
Issue #, if available: NA

Description of changes:

The repos is now under `firecracker-microvm` org, but tests/README.md still mentions `aws` org.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
