### PR TITLE
gicv2 support

### DIFF
--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -1,15 +1,12 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io, result};
+use std::{boxed::Box, io, result};
 
 use kvm_ioctls::{DeviceFd, VmFd};
 
-// Unfortunately bindgen omits defines that are based on other defines.
-// See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
-const SZ_64K: u64 = 0x0001_0000;
-const KVM_VGIC_V3_DIST_SIZE: u64 = SZ_64K;
-const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * SZ_64K);
+use super::gicv2::GICv2;
+use super::gicv3::GICv3;
 
 /// Errors thrown while setting up the GIC.
 #[derive(Debug)]
@@ -21,104 +18,130 @@ pub enum Error {
 }
 type Result<T> = result::Result<T, Error>;
 
-/// Create a GICv3 device.
+/// Trait for GIC devices.
+pub trait GICDevice {
+    /// Returns the file descriptor of the GIC device
+    fn device_fd(&self) -> &DeviceFd;
+
+    /// Returns an array with GIC device properties
+    fn device_properties(&self) -> &[u64];
+
+    /// Returns the number of vCPUs this GIC handles
+    fn vcpu_count(&self) -> u64;
+
+    /// Returns the fdt compatibility property of the device
+    fn fdt_compatibility(&self) -> &str;
+
+    /// Returns the maint_irq fdt property of the device
+    fn fdt_maint_irq(&self) -> u32;
+
+    /// Returns the GIC version of the device
+    fn version() -> u32
+    where
+        Self: Sized;
+
+    /// Create the GIC device object
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice>
+    where
+        Self: Sized;
+
+    /// Setup the device-specific attributes
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized;
+
+    /// Initialize a GIC device
+    fn init_device(vm: &VmFd) -> Result<DeviceFd>
+    where
+        Self: Sized,
+    {
+        let mut gic_device = kvm_bindings::kvm_create_device {
+            type_: Self::version(),
+            fd: 0,
+            flags: 0,
+        };
+
+        vm.create_device(&mut gic_device).map_err(Error::CreateGIC)
+    }
+
+    /// Set a GIC device attribute
+    fn set_device_attribute(
+        fd: &DeviceFd,
+        group: u32,
+        attr: u64,
+        addr: u64,
+        flags: u32,
+    ) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let attr = kvm_bindings::kvm_device_attr {
+            group: group,
+            attr: attr,
+            addr: addr,
+            flags: flags,
+        };
+        fd.set_device_attr(&attr)
+            .map_err(Error::SetDeviceAttribute)?;
+
+        Ok(())
+    }
+
+    /// Finalize the setup of a GIC device
+    fn finalize_device(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized,
+    {
+        /* We need to tell the kernel how many irqs to support with this vgic.
+         * See the `layout` module for details.
+         */
+        let nr_irqs: u32 = super::layout::IRQ_MAX - super::layout::IRQ_BASE + 1;
+        let nr_irqs_ptr = &nr_irqs as *const u32;
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+            0,
+            nr_irqs_ptr as u64,
+            0,
+        )?;
+
+        /* Finalize the GIC.
+         * See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
+         */
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+            u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+            0,
+            0,
+        )?;
+
+        Ok(())
+    }
+
+    /// Method to initialize the GIC device
+    fn new(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>>
+    where
+        Self: Sized,
+    {
+        let vgic_fd = Self::init_device(vm)?;
+
+        let device = Self::create_device(vgic_fd, vcpu_count);
+
+        Self::init_device_attributes(&device)?;
+
+        Self::finalize_device(&device)?;
+
+        Ok(device)
+    }
+}
+
+/// Create a GIC device.
 ///
-/// Logic from this function is based on virt/kvm/arm/vgic/vgic-kvm-device.c from linux kernel.
-pub fn create_gicv3(vm: &VmFd, vcpu_count: u8) -> Result<DeviceFd> {
-    /* We are creating a V3 GIC.
-     As per https://static.docs.arm.com/dai0492/b/GICv3_Software_Overview_Official_Release_B.pdf,
-     section 3.5 Programmers' model, the register interface of a GICv3 interrupt controller is split
-     into three groups: distributor, redistributor, CPU.
-     As per Figure 9 from same section, there is 1 Distributor and multiple redistributors (one per
-     each CPU).
-    */
-    let mut gic_device = kvm_bindings::kvm_create_device {
-        type_: kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
-        fd: 0,
-        flags: 0,
-    };
-
-    let vgic_fd = vm
-        .create_device(&mut gic_device)
-        .map_err(Error::CreateGIC)?;
-
-    /* Setting up the distributor attribute.
-     We are placing the GIC below 1GB so we need to substract the size of the distributor.
-    */
-    let dist_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
-        attr: u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
-        addr: &get_dist_addr() as *const u64 as u64,
-        flags: 0,
-    };
-    vgic_fd
-        .set_device_attr(&dist_attr)
-        .map_err(Error::SetDeviceAttribute)?;
-
-    /* Setting up the redistributors' attribute.
-    We are calculating here the start of the redistributors address. We have one per CPU.
-    */
-    let redists_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
-        attr: u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
-        addr: &get_redists_addr(u64::from(vcpu_count)) as *const u64 as u64,
-        flags: 0,
-    };
-    vgic_fd
-        .set_device_attr(&redists_attr)
-        .map_err(Error::SetDeviceAttribute)?;
-
-    /* We need to tell the kernel how many irqs to support with this vgic.
-    See the `layout` module for details.
-    */
-    let nr_irqs: u32 = super::layout::IRQ_MAX - super::layout::IRQ_BASE + 1;
-    let nr_irqs_ptr = &nr_irqs as *const u32;
-    let nr_irqs_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
-        attr: 0,
-        addr: nr_irqs_ptr as u64,
-        flags: 0,
-    };
-    vgic_fd
-        .set_device_attr(&nr_irqs_attr)
-        .map_err(Error::SetDeviceAttribute)?;
-
-    /* Finalize the GIC.
-         See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
-    */
-    let init_gic_attr = kvm_bindings::kvm_device_attr {
-        group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
-        attr: u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
-        addr: 0,
-        flags: 0,
-    };
-    vgic_fd
-        .set_device_attr(&init_gic_attr)
-        .map_err(Error::SetDeviceAttribute)?;
-
-    Ok(vgic_fd)
-}
-
-// Auxiliary functions for getting addresses and size of where the distributor and redistributor
-// are placed.
-/// Get the address of the GIC distributor.
-pub fn get_dist_addr() -> u64 {
-    super::layout::MAPPED_IO_START - KVM_VGIC_V3_DIST_SIZE
-}
-
-/// Get the size of the GIC distributor.
-pub fn get_dist_size() -> u64 {
-    KVM_VGIC_V3_DIST_SIZE
-}
-
-/// Get the address of the GIC redistributors.
-pub fn get_redists_addr(vcpu_count: u64) -> u64 {
-    get_dist_addr() - get_redists_size(vcpu_count)
-}
-
-/// Get the size of the GIC redistributors.
-pub fn get_redists_size(vcpu_count: u64) -> u64 {
-    vcpu_count * KVM_VGIC_V3_REDIST_SIZE
+/// It will try to create by default a GICv3 device. If that fails it will try
+/// to fall-back to a GICv2 device.
+pub fn create_gic(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>> {
+    GICv3::new(vm, vcpu_count).or_else(|_| GICv2::new(vm, vcpu_count))
 }
 
 #[cfg(test)]
@@ -128,9 +151,9 @@ mod tests {
     use kvm_ioctls::Kvm;
 
     #[test]
-    fn test_create_gicv3() {
+    fn test_create_gic() {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
-        assert!(create_gicv3(&vm, 1).is_ok());
+        assert!(create_gic(&vm, 1).is_ok());
     }
 }

--- a/arch/src/aarch64/gicv2.rs
+++ b/arch/src/aarch64/gicv2.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::{DeviceFd, VmFd};
+
+use super::gic::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+/// Represent a GIC v2 device
+pub struct GICv2 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv2 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const KVM_VGIC_V2_DIST_SIZE: u64 = 0x1000;
+    const KVM_VGIC_V2_CPU_SIZE: u64 = 0x2000;
+
+    // Device trees specific constants
+    const ARCH_GIC_V2_MAINT_IRQ: u32 = 8;
+
+    /// Get the address of the GICv2 distributor.
+    const fn get_dist_addr() -> u64 {
+        super::layout::MAPPED_IO_START - GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the size of the GIC_v2 distributor.
+    const fn get_dist_size() -> u64 {
+        GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the address of the GIC_v2 CPU.
+    const fn get_cpu_addr() -> u64 {
+        GICv2::get_dist_addr() - GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+
+    /// Get the size of the GIC_v2 CPU.
+    const fn get_cpu_size() -> u64 {
+        GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+}
+
+impl GICDevice for GICv2 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-400"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv2::ARCH_GIC_V2_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv2 {
+            fd: fd,
+            properties: [
+                GICv2::get_dist_addr(),
+                GICv2::get_dist_size(),
+                GICv2::get_cpu_addr(),
+                GICv2::get_cpu_size(),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+        We are placing the GIC below 1GB so we need to substract the size of the distributor. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_DIST),
+            &GICv2::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the CPU attribute. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_CPU),
+            &GICv2::get_cpu_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/arch/src/aarch64/gicv3.rs
+++ b/arch/src/aarch64/gicv3.rs
@@ -1,0 +1,117 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::{DeviceFd, VmFd};
+
+use super::gic::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+pub struct GICv3 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv3 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const SZ_64K: u64 = 0x0001_0000;
+    const KVM_VGIC_V3_DIST_SIZE: u64 = GICv3::SZ_64K;
+    const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * GICv3::SZ_64K);
+
+    // Device trees specific constants
+    const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
+
+    /// Get the address of the GIC distributor.
+    fn get_dist_addr() -> u64 {
+        super::layout::MAPPED_IO_START - GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the size of the GIC distributor.
+    fn get_dist_size() -> u64 {
+        GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the address of the GIC redistributors.
+    fn get_redists_addr(vcpu_count: u64) -> u64 {
+        GICv3::get_dist_addr() - GICv3::get_redists_size(vcpu_count)
+    }
+
+    /// Get the size of the GIC redistributors.
+    fn get_redists_size(vcpu_count: u64) -> u64 {
+        vcpu_count * GICv3::KVM_VGIC_V3_REDIST_SIZE
+    }
+}
+
+impl GICDevice for GICv3 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-v3"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv3::ARCH_GIC_V3_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv3 {
+            fd: fd,
+            properties: [
+                GICv3::get_dist_addr(),
+                GICv3::get_dist_size(),
+                GICv3::get_redists_addr(vcpu_count),
+                GICv3::get_redists_size(vcpu_count),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+         We are placing the GIC below 1GB so we need to substract the size of the distributor.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
+            &GICv3::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the redistributors' attribute.
+        We are calculating here the start of the redistributors address. We have one per CPU.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
+            &GICv3::get_redists_addr(u64::from(gic_device.vcpu_count())) as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -4,6 +4,8 @@
 mod fdt;
 /// Module for the global interrupt controller configuration.
 pub mod gic;
+mod gicv2;
+mod gicv3;
 /// Layout for this aarch64 system.
 pub mod layout;
 /// Logic for configuring aarch64 registers.
@@ -14,6 +16,7 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
 
+use self::gic::GICDevice;
 use memory_model::{GuestAddress, GuestMemory};
 
 /// Errors thrown while configuring aarch64 system.
@@ -46,9 +49,16 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
     cmdline_cstring: &CStr,
     num_cpus: u8,
     device_info: Option<&HashMap<(DeviceType, String), T>>,
+    gic_device: &Box<dyn GICDevice>,
 ) -> super::Result<()> {
-    fdt::create_fdt(guest_mem, u32::from(num_cpus), cmdline_cstring, device_info)
-        .map_err(Error::SetupFDT)?;
+    fdt::create_fdt(
+        guest_mem,
+        u32::from(num_cpus),
+        cmdline_cstring,
+        device_info,
+        gic_device,
+    )
+    .map_err(Error::SetupFDT)?;
     Ok(())
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1040,6 +1040,7 @@ impl Vmm {
                     .map_err(LoadCommandline)?,
                 vcpu_count,
                 self.get_mmio_device_info(),
+                self.vm.get_irqchip(),
             )
             .map_err(ConfigureSystem)?;
         }
@@ -2824,6 +2825,10 @@ mod tests {
 
         assert!(vmm.init_guest_memory().is_ok());
         assert!(vmm.vm.get_memory().is_some());
+
+        // We need this so that configure_system finds a properly setup GIC device
+        #[cfg(target_arch = "aarch64")]
+        assert!(vmm.vm.setup_irqchip(1).is_ok());
 
         assert!(vmm.configure_system().is_ok());
         vmm.stdin_handle.lock().set_canon_mode().unwrap();


### PR DESCRIPTION
## Reason for This PR

This PR is meant to address #1196 for supporting GICv2 devices on aarch64 architecture.

## Description of Changes

This makes the GIC-related code more flexible and implements a GICv2 device. It introduces a `GICDevice` Trait which needs to be implement by GIC device implementations. We implement the Trait for GICv3 and GICv2 devices. When creating the GIC device for the microVM we initially try to create a v3 device and if that fails, we fall back to creating a v2 device.

I have tried this on a Hikey970 board and it works, so far. I 'm trying this out on a RPi4 as well to double check everything is working. In any case, I'm not greatly familiar with the GIC architecture (I did some research for this PR), so any comments on what I 've done so far is more that welcome.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
