### PR TITLE
Remove pnet dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.0"
 dependencies = [
  "arch 0.1.0",
  "devices 0.1.0",
+ "dumbo 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
  "kernel 0.1.0",
@@ -66,11 +67,6 @@ dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -153,7 +149,8 @@ dependencies = [
  "fc_util 0.1.0",
  "logger 0.1.0",
  "mmds 0.1.0",
- "net_util 0.1.0",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,19 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ipnetwork"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,15 +219,6 @@ version = "0.1.0"
 dependencies = [
  "memory_model 0.1.0",
  "sys_util 0.1.0",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -270,14 +245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "log"
@@ -338,93 +305,12 @@ version = "0.1.0"
 name = "net_util"
 version = "0.1.0"
 dependencies = [
+ "dumbo 0.1.0",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",
- "pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",
-]
-
-[[package]]
-name = "pnet"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_base"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "pnet_datalink"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_macros_support"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_packet"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros_support 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -531,11 +417,6 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,51 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntex"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_errors"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_pos"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syntex_syntax"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sys_util"
 version = "0.1.0"
 dependencies = [
@@ -646,15 +482,6 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -688,11 +515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -712,6 +534,7 @@ dependencies = [
  "arch 0.1.0",
  "cpuid 0.1.0",
  "devices 0.1.0",
+ "dumbo 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
  "kernel 0.1.0",
@@ -747,22 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -774,20 +587,10 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
@@ -797,25 +600,13 @@ dependencies = [
 "checksum device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 "checksum epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f0680f2a6f2a17fa7a8668a27c54e45e1ad1cf8a632f56a7c19b9e4e3bbe8a"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
 "checksum kvm-ioctls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e647ed90b0f5214eb938601fc2e7aad2fc624fde62f13c0c2e672407b8ce7b"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)" = "74dfca3d9957906e8d1e6a0b641dc9a59848e793f1da2165889fd4f62d10d79c"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d693c84430248366146e3181ff9d330243464fa9e6146c372b2f3eb2e2d8e7"
-"checksum pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4df28acf2fcc77436dd2b91a9a0c2bb617f9ca5f2acefee1a4135058b9f9801f"
-"checksum pnet_datalink 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b34f8ca857599d05b6b082e9baff8d27c54cb9c26568cf3c0993a5755816966"
-"checksum pnet_macros 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f16d1fa7fd0edebc36055587b8b5af8a109bbc29a55fb484a37e2029b971a7"
-"checksum pnet_macros_support 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84684f2cddefc37a06f2fe2ca4dcc3457fc3b282734b5246507d8ee75d2780ae"
-"checksum pnet_packet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a6cdcdaddc5174f18286298842a4e31cd3cc018933d42af51434b1fa07dcbe"
-"checksum pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "682b2eca84cc440bce8336813f78eb6d3cb0fed89fe0e87ae22acfca8363f176"
-"checksum pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5faa55dcf725487a699adcff88dfea8f17ea34fa2640528866d9acbb4e3a104f"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -828,30 +619,20 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
-"checksum syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
-"checksum syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
-"checksum syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"
-"checksum syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum timerfd 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9a7822e546fa39d0b5ae14a93a33903975b62af6597288aea77f0580a6abbe"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 "checksum vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b75440f66b299f66acf005431d5f13be6e6a8d02b4dcaa83be5144e88762d010"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -19,6 +19,7 @@ vmm = { path = "../vmm" }
 [dev-dependencies]
 arch = { path = "../arch" }
 devices = { path = "../devices" }
+dumbo = { path = "../dumbo" }
 kernel = { path = "../kernel" }
 memory_model = { path = "../memory_model" }
 net_util = { path = "../net_util" }

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -55,10 +55,10 @@ pub fn parse_patch_net(body: &Body, id_from_path: Option<&&str>) -> Result<Parse
 
 #[cfg(test)]
 mod tests {
-    extern crate net_util;
+    extern crate dumbo;
     extern crate vmm;
 
-    use self::net_util::MacAddr;
+    use self::dumbo::MacAddr;
     use super::*;
 
     use serde_json;

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -19,11 +19,11 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::vec::Vec;
 
-use dumbo::{ns::MmdsNetworkStack, pdu::ethernet::EthernetFrame};
+use dumbo::{ns::MmdsNetworkStack, EthernetFrame, MacAddr, MAC_ADDR_LEN};
 use logger::{Metric, METRICS};
 use memory_model::{GuestAddress, GuestMemory};
 use net_gen;
-use net_util::{MacAddr, Tap, TapError, MAC_ADDR_LEN};
+use net_util::{Tap, TapError};
 use rate_limiter::{RateLimiter, TokenBucket, TokenType};
 use sys_util::EventFd;
 use virtio_gen::virtio_net::*;
@@ -924,7 +924,7 @@ mod tests {
     use std::time::Duration;
     use std::u32;
 
-    use dumbo::pdu::{arp, ethernet};
+    use dumbo::{EthIPv4ArpFrame, EthernetFrame, ETHERTYPE_ARP, ETH_IPV4_FRAME_LEN};
     use libc;
     use memory_model::GuestAddress;
     use rate_limiter::TokenBucket;
@@ -1308,24 +1308,22 @@ mod tests {
         let packet_len;
         {
             // Create an ethernet frame.
-            let eth_frame_i = ethernet::EthernetFrame::write_incomplete(
+            let eth_frame_i = EthernetFrame::write_incomplete(
                 frame_bytes_from_buf_mut(&mut h.tx.frame_buf),
                 tha,
                 sha,
-                ethernet::ETHERTYPE_ARP,
+                ETHERTYPE_ARP,
             )
             .ok()
             .unwrap();
             // Set its length to hold an ARP request.
-            let mut eth_frame_complete =
-                eth_frame_i.with_payload_len_unchecked(arp::ETH_IPV4_FRAME_LEN);
+            let mut eth_frame_complete = eth_frame_i.with_payload_len_unchecked(ETH_IPV4_FRAME_LEN);
 
             // Save the total frame length.
-            packet_len =
-                vnet_hdr_len() + eth_frame_complete.payload_offset() + arp::ETH_IPV4_FRAME_LEN;
+            packet_len = vnet_hdr_len() + eth_frame_complete.payload_offset() + ETH_IPV4_FRAME_LEN;
 
             // Create the ARP request.
-            let arp_req = arp::EthIPv4ArpFrame::write_request(
+            let arp_req = EthIPv4ArpFrame::write_request(
                 eth_frame_complete.payload_mut(),
                 sha,
                 spa,
@@ -1372,24 +1370,22 @@ mod tests {
         let packet_len;
         {
             // Create an ethernet frame.
-            let eth_frame_i = ethernet::EthernetFrame::write_incomplete(
+            let eth_frame_i = EthernetFrame::write_incomplete(
                 frame_bytes_from_buf_mut(&mut h.tx.frame_buf),
                 dst_mac,
                 guest_mac,
-                ethernet::ETHERTYPE_ARP,
+                ETHERTYPE_ARP,
             )
             .ok()
             .unwrap();
             // Set its length to hold an ARP request.
-            let mut eth_frame_complete =
-                eth_frame_i.with_payload_len_unchecked(arp::ETH_IPV4_FRAME_LEN);
+            let mut eth_frame_complete = eth_frame_i.with_payload_len_unchecked(ETH_IPV4_FRAME_LEN);
 
             // Save the total frame length.
-            packet_len =
-                vnet_hdr_len() + eth_frame_complete.payload_offset() + arp::ETH_IPV4_FRAME_LEN;
+            packet_len = vnet_hdr_len() + eth_frame_complete.payload_offset() + ETH_IPV4_FRAME_LEN;
 
             // Create the ARP request.
-            let arp_req = arp::EthIPv4ArpFrame::write_request(
+            let arp_req = EthIPv4ArpFrame::write_request(
                 eth_frame_complete.payload_mut(),
                 guest_mac,
                 guest_ip,

--- a/dumbo/Cargo.toml
+++ b/dumbo/Cargo.toml
@@ -6,8 +6,11 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 [dependencies]
 bitflags = ">=1.0.4"
 byteorder = ">=1.2.1"
+serde = ">=1.0.27"
 
 fc_util = { path = "../fc_util" }
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
-net_util = { path = "../net_util" }
+
+[dev-dependencies]
+serde_json = ">=1.0.9"

--- a/dumbo/src/lib.rs
+++ b/dumbo/src/lib.rs
@@ -12,21 +12,27 @@ extern crate byteorder;
 extern crate fc_util;
 extern crate logger;
 extern crate mmds;
-extern crate net_util;
+extern crate serde;
 
+mod mac;
 pub mod ns;
-pub mod pdu;
-pub mod tcp;
+mod pdu;
+mod tcp;
 
+pub use mac::{MacAddr, MAC_ADDR_LEN};
+pub use pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
+pub use pdu::ethernet::{
+    EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4, PAYLOAD_OFFSET as ETHERNET_PAYLOAD_OFFSET,
+};
+pub use pdu::ipv4::{IPv4Packet, PROTOCOL_TCP, PROTOCOL_UDP};
+pub use pdu::udp::{UdpDatagram, UDP_HEADER_SIZE};
 use std::ops::Index;
 
 /// Represents a generalization of a borrowed `[u8]` slice.
+#[allow(clippy::len_without_is_empty)]
 pub trait ByteBuffer: Index<usize, Output = u8> {
     /// Returns the length of the buffer.
     fn len(&self) -> usize;
-
-    /// Checks if the buffer is empty.
-    fn is_empty(&self) -> bool;
 
     /// Reads `buf.len()` bytes from `buf` into the inner buffer, starting at `offset`.
     ///
@@ -40,11 +46,6 @@ impl ByteBuffer for [u8] {
     #[inline]
     fn len(&self) -> usize {
         self.len()
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     #[inline]

--- a/dumbo/src/mac.rs
+++ b/dumbo/src/mac.rs
@@ -5,6 +5,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+//! Contains support for parsing and constructing MAC addresses
+//! More information about MAC addresses can be found [here]
+//!
+//! [here]: https://en.wikipedia.org/wiki/MAC_address
+
 use std::fmt;
 use std::result::Result;
 
@@ -14,6 +19,7 @@ use serde::ser::{Serialize, Serializer};
 /// The number of tuples (the ones separated by ":") contained in a MAC address.
 pub const MAC_ADDR_LEN: usize = 6;
 
+/// Represents a MAC address
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// Representation of a MAC address.
 pub struct MacAddr {
@@ -40,9 +46,9 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate net_util;
+    /// extern crate dumbo;
     ///
-    /// use self::net_util::MacAddr;
+    /// use self::dumbo::MacAddr;
     /// MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
     /// ```
     pub fn parse_str<S>(s: &S) -> Result<MacAddr, &str>
@@ -74,9 +80,9 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate net_util;
+    /// extern crate dumbo;
     ///
-    /// use self::net_util::MacAddr;
+    /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes_unchecked(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
     /// println!("{}", mac.to_string());
     /// ```
@@ -98,9 +104,9 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate net_util;
+    /// extern crate dumbo;
     ///
-    /// use self::net_util::MacAddr;
+    /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// println!("{}", mac.to_string());
     /// ```
@@ -116,9 +122,9 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate net_util;
+    /// extern crate dumbo;
     ///
-    /// use self::net_util::MacAddr;
+    /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// assert_eq!([0x01, 0x02, 0x03, 0x04, 0x05, 0x06], mac.get_bytes());
     /// ```

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -9,9 +9,9 @@ use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 use std::result::Result;
 
+use crate::MacAddr;
 use fc_util::time::timestamp_cycles;
 use logger::{Metric, METRICS};
-use net_util::MacAddr;
 use pdu::arp::{test_speculative_tpa, Error as ArpFrameError, EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
 use pdu::ethernet::{Error as EthernetFrameError, EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4};
 use pdu::ipv4::{test_speculative_dst_addr, Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};

--- a/dumbo/src/pdu/ipv4.rs
+++ b/dumbo/src/pdu/ipv4.rs
@@ -27,14 +27,19 @@ const SOURCE_ADDRESS_OFFSET: usize = 12;
 const DESTINATION_ADDRESS_OFFSET: usize = 16;
 const OPTIONS_OFFSET: usize = 20;
 
-const IPV4_VERSION: u8 = 0x04;
-const DEFAULT_TTL: u8 = 200;
+/// Indicates version 4 of the IP protocol
+pub const IPV4_VERSION: u8 = 0x04;
+/// Default TTL value
+pub const DEFAULT_TTL: u8 = 200;
 
 /// The IP protocol number associated with TCP.
 pub const PROTOCOL_TCP: u8 = 0x06;
 
+/// The IP protocol number associated with UDP.
+pub const PROTOCOL_UDP: u8 = 0x11;
+
 /// Describes the errors which may occur while handling IPv4 packets.
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// The header checksum is invalid.
     Checksum,
@@ -55,6 +60,7 @@ pub struct IPv4Packet<'a, T: 'a> {
     bytes: InnerBytes<'a, T>,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<'a, T: NetworkBytes> IPv4Packet<'a, T> {
     /// Interpret `bytes` as an IPv4Packet without checking the validity of the header fields, and
     /// the length of the inner byte sequence.
@@ -210,12 +216,6 @@ impl<'a, T: NetworkBytes> IPv4Packet<'a, T> {
     #[inline]
     pub fn len(&self) -> usize {
         self.bytes.len()
-    }
-
-    /// Checks if the inner byte sequence is empty or not
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.bytes.len() == 0
     }
 
     /// Computes and returns the packet header checksum using the provided header length.
@@ -469,7 +469,7 @@ pub fn test_speculative_dst_addr(buf: &[u8], addr: Ipv4Addr) -> bool {
 mod tests {
     use std::fmt;
 
-    use net_util::MacAddr;
+    use crate::MacAddr;
 
     use super::*;
 
@@ -556,7 +556,6 @@ mod tests {
             assert_eq!(p.version_and_header_len(), (IPV4_VERSION, header_len));
             assert_eq!(p.dscp_and_ecn(), (0, 0));
             assert_eq!(p.total_len() as usize, buf_len);
-            assert_eq!(p.is_empty(), false);
             assert_eq!(p.identification(), 0);
             assert_eq!(p.flags_and_fragment_offset(), (0, 0));
             assert_eq!(p.ttl(), DEFAULT_TTL);

--- a/dumbo/src/pdu/mod.rs
+++ b/dumbo/src/pdu/mod.rs
@@ -7,11 +7,17 @@
 //! protocol. Ethernet frames, IP packets, and TCP segments are all examples of protocol data
 //! units.
 
+use std::net::Ipv4Addr;
+
+use pdu::bytes::NetworkBytes;
+use pdu::ipv4::{PROTOCOL_TCP, PROTOCOL_UDP};
+
 pub mod arp;
 pub mod bytes;
 pub mod ethernet;
 pub mod ipv4;
 pub mod tcp;
+pub mod udp;
 
 /// This is the baseline definition of the `Incomplete` struct, which wraps a PDU that does is
 /// still missing some values or content.
@@ -42,4 +48,68 @@ impl<T> Incomplete<T> {
     pub fn inner_mut(&mut self) -> &mut T {
         &mut self.inner
     }
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq)]
+enum ChecksumProto {
+    Tcp = PROTOCOL_TCP,
+    Udp = PROTOCOL_UDP,
+}
+
+/// Computes the checksum of a TCP/UDP packet. Since both protocols use
+/// the same algorithm to compute the checksum.
+///
+/// # Arguments
+/// * `bytes` - Raw bytes of a TCP packet or a UDP datagram
+/// * `src_addr` - IPv4 source address
+/// * `dst_addr` - IPv4 destination address
+/// * `protocol` - **must** be either `PROTOCOL_TCP` or `PROTOCOL_UDP` defined in
+/// `ipv4` module
+///
+/// More details about TCP checksum computation can be found [here].
+///
+/// [here]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Checksum_computation
+#[inline]
+fn compute_checksum<T: NetworkBytes>(
+    bytes: &T,
+    src_addr: Ipv4Addr,
+    dst_addr: Ipv4Addr,
+    protocol: ChecksumProto,
+) -> u16 {
+    // TODO: Is u32 enough to prevent overflow for the code in this function? I think so, but it
+    // would be nice to double-check.
+    let mut sum = 0u32;
+
+    let a = u32::from(src_addr);
+    sum += a & 0xffff;
+    sum += a >> 16;
+
+    let b = u32::from(dst_addr);
+    sum += b & 0xffff;
+    sum += b >> 16;
+
+    let len = bytes.len();
+    sum += protocol as u32;
+    sum += len as u32;
+
+    for i in 0..len / 2 {
+        sum += u32::from(bytes.ntohs_unchecked(i * 2));
+    }
+
+    if len % 2 != 0 {
+        sum += u32::from(bytes[len - 1]) << 8;
+    }
+
+    while sum >> 16 != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+
+    let mut csum = !(sum as u16);
+    // If a UDP packet checksum is 0, an all ones value is transmitted
+    if protocol == ChecksumProto::Udp && csum == 0x0 {
+        csum = !csum;
+    }
+
+    csum
 }

--- a/dumbo/src/pdu/tcp.rs
+++ b/dumbo/src/pdu/tcp.rs
@@ -544,6 +544,7 @@ impl<'a, T: NetworkBytesMut> TcpSegment<'a, T> {
 impl<'a, T: NetworkBytesMut> Incomplete<TcpSegment<'a, T>> {
     /// Transforms `self` into a `TcpSegment<T>` by specifying values for the `source port`,
     /// `destination port`, and (optionally) the information required to compute the TCP checksum.
+    #[inline]
     pub fn finalize(
         mut self,
         src_port: u16,

--- a/dumbo/src/pdu/udp.rs
+++ b/dumbo/src/pdu/udp.rs
@@ -131,11 +131,7 @@ impl<'a, T: NetworkBytesMut> UdpDatagram<'a, T> {
     /// * `payload` - Datagram payload.
     #[inline]
     pub fn write_incomplete_datagram(buf: T, payload: &[u8]) -> Result<Incomplete<Self>, Error> {
-        let mut packet = match UdpDatagram::from_bytes(buf, None) {
-            Ok(packet) => packet,
-            Err(e) => return Err(e),
-        };
-
+        let mut packet = UdpDatagram::from_bytes(buf, None)?;
         let len = payload.len() + UDP_HEADER_SIZE;
 
         // TODO working with IPv4 only for now

--- a/dumbo/src/pdu/udp.rs
+++ b/dumbo/src/pdu/udp.rs
@@ -1,0 +1,324 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains support for parsing and writing User Datagram Protocol (UDP) packets,
+//! with no support for jumbograms.
+//!
+//! Details of the UDP packet specification can be found at [1] [2].
+//!
+//! [1]: https://tools.ietf.org/html/rfc768
+//! [2]: https://tools.ietf.org/html/rfc5405
+
+use std::net::Ipv4Addr;
+
+use pdu::bytes::NetworkBytesMut;
+use pdu::{ChecksumProto, Incomplete};
+
+use super::bytes::{InnerBytes, NetworkBytes};
+
+const SOURCE_PORT_OFFSET: usize = 0;
+const DESTINATION_PORT_OFFSET: usize = 2;
+const LENGTH_OFFSET: usize = 4;
+const CHECKSUM_OFFSET: usize = 6;
+const PAYLOAD_OFFSET: usize = 8;
+/// The header length is 8 octets (bytes).
+pub const UDP_HEADER_SIZE: usize = 8;
+
+// A UDP datagram is carried in a single IP packet and is hence limited
+// to a maximum payload of 65,507 bytes for IPv4 and 65,527 bytes for IPv6 [2]
+const IPV4_MAX_UDP_PACKET_SIZE: usize = 65507;
+
+/// Represents errors which may occur while parsing or writing a datagram.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// Invalid checksum.
+    Checksum,
+    /// The specified byte sequence is shorter than the Ethernet header length.
+    DatagramTooShort,
+    /// The payload to be added to the UDP packet exceeds the size allowed
+    /// by the used IP version.
+    PayloadTooBig,
+}
+
+/// Interprets the inner bytes as a UDP datagram.
+pub struct UdpDatagram<'a, T: 'a> {
+    bytes: InnerBytes<'a, T>,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<'a, T: NetworkBytes> UdpDatagram<'a, T> {
+    /// Interprets `bytes` as a UDP datagram without any validity checks.
+    ///
+    /// # Panics
+    ///
+    ///  This method does not panic, but further method calls on the resulting object may panic if
+    /// `bytes` contains invalid input.
+    #[inline]
+    pub fn from_bytes_unchecked(bytes: T) -> Self {
+        UdpDatagram {
+            bytes: InnerBytes::new(bytes),
+        }
+    }
+
+    /// Interprets `bytes` as a UDP datagram if possible or returns
+    /// the reason for failing to do so.
+    #[inline]
+    pub fn from_bytes(
+        bytes: T,
+        verify_checksum: Option<(Ipv4Addr, Ipv4Addr)>,
+    ) -> Result<Self, Error> {
+        if bytes.len() < UDP_HEADER_SIZE {
+            return Err(Error::DatagramTooShort);
+        }
+
+        let datagram = UdpDatagram::from_bytes_unchecked(bytes);
+        if let Some((src_addr, dst_addr)) = verify_checksum {
+            // Since compute_checksum is shared between TCP and UDP and the UDP's RFC
+            // requires that a computed checksum of 0 is transmitted as all ones value, we're
+            // checking against 0xffff not 0
+            if datagram.checksum() != 0 && datagram.compute_checksum(src_addr, dst_addr) != 0xffff {
+                return Err(Error::Checksum);
+            }
+        }
+
+        Ok(datagram)
+    }
+
+    /// Returns the source port of the UDP datagram.
+    #[inline]
+    pub fn source_port(&self) -> u16 {
+        self.bytes.ntohs_unchecked(SOURCE_PORT_OFFSET)
+    }
+
+    /// Returns the destination port of the UDP datagram.
+    #[inline]
+    pub fn destination_port(&self) -> u16 {
+        self.bytes.ntohs_unchecked(DESTINATION_PORT_OFFSET)
+    }
+
+    /// Returns the length of the datagram from its header.
+    #[inline]
+    pub fn len(&self) -> u16 {
+        self.bytes.ntohs_unchecked(LENGTH_OFFSET)
+    }
+
+    /// Returns the checksum value of the packet.
+    #[inline]
+    pub fn checksum(&self) -> u16 {
+        self.bytes.ntohs_unchecked(CHECKSUM_OFFSET)
+    }
+
+    /// Returns the payload of the UDP datagram as an `[&u8]` slice.
+    #[inline]
+    pub fn payload(&self) -> &[u8] {
+        // Payload offset is header len.
+        self.bytes.split_at(PAYLOAD_OFFSET).1
+    }
+
+    /// Computes the checksum of a UDP datagram.
+    #[inline]
+    pub fn compute_checksum(&self, src_addr: Ipv4Addr, dst_addr: Ipv4Addr) -> u16 {
+        crate::pdu::compute_checksum(&self.bytes, src_addr, dst_addr, ChecksumProto::Udp)
+    }
+}
+
+impl<'a, T: NetworkBytesMut> UdpDatagram<'a, T> {
+    /// Writes an incomplete UDP datagram, which is missing the `checksum`, `src_port` and `dst_port` fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `buf` - A buffer containing `NetworkBytesMut` representing a datagram.
+    /// * `payload` - Datagram payload.
+    #[inline]
+    pub fn write_incomplete_datagram(buf: T, payload: &[u8]) -> Result<Incomplete<Self>, Error> {
+        let mut packet = match UdpDatagram::from_bytes(buf, None) {
+            Ok(packet) => packet,
+            Err(e) => return Err(e),
+        };
+
+        let len = payload.len() + UDP_HEADER_SIZE;
+
+        // TODO working with IPv4 only for now
+        if len > IPV4_MAX_UDP_PACKET_SIZE {
+            return Err(Error::PayloadTooBig);
+        }
+
+        packet.bytes.shrink_unchecked(len as usize);
+        packet.payload_mut().copy_from_slice(payload);
+        packet.set_len(len as u16);
+
+        Ok(Incomplete::new(packet))
+    }
+
+    /// Sets the source port of the UDP datagram.
+    #[inline]
+    pub fn set_source_port(&mut self, src_port: u16) -> &mut Self {
+        self.bytes.htons_unchecked(SOURCE_PORT_OFFSET, src_port);
+        self
+    }
+
+    /// Sets the destination port of the UDP datagram.
+    #[inline]
+    pub fn set_destination_port(&mut self, dst_port: u16) -> &mut Self {
+        self.bytes
+            .htons_unchecked(DESTINATION_PORT_OFFSET, dst_port);
+        self
+    }
+
+    /// Sets the payload of the UDP datagram.
+    #[inline]
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[PAYLOAD_OFFSET..]
+    }
+
+    /// Sets the length field in the UDP datagram header.
+    #[inline]
+    pub fn set_len(&mut self, len: u16) -> &mut Self {
+        self.bytes.htons_unchecked(LENGTH_OFFSET, len);
+        self
+    }
+
+    /// Sets the checksum of a UDP datagram.
+    #[inline]
+    pub fn set_checksum(&mut self, checksum: u16) -> &mut Self {
+        self.bytes.htons_unchecked(CHECKSUM_OFFSET, checksum);
+        self
+    }
+}
+
+impl<'a, T: NetworkBytesMut> Incomplete<UdpDatagram<'a, T>> {
+    /// Transforms `self` into a `UdpDatagram<T>` by specifying values for the `source port`,
+    /// `destination port`, and (optionally) the information required to compute the checksum.
+    #[inline]
+    pub fn finalize(
+        mut self,
+        src_port: u16,
+        dst_port: u16,
+        compute_checksum: Option<(Ipv4Addr, Ipv4Addr)>,
+    ) -> UdpDatagram<'a, T> {
+        self.inner.set_source_port(src_port);
+        self.inner.set_destination_port(dst_port);
+        self.inner.set_checksum(0);
+
+        if let Some((src_addr, dst_addr)) = compute_checksum {
+            let checksum = self.inner.compute_checksum(src_addr, dst_addr);
+            self.inner.set_checksum(checksum);
+        }
+
+        self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+
+    use pdu::udp::UdpDatagram;
+
+    use super::*;
+
+    impl<'a, T: NetworkBytes> fmt::Debug for UdpDatagram<'a, T> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "(UDP datagram)")
+        }
+    }
+
+    impl<'a, T: NetworkBytes> fmt::Debug for Incomplete<UdpDatagram<'a, T>> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "(Incomplete UDP datagram)")
+        }
+    }
+
+    #[test]
+    #[allow(clippy::len_zero)]
+    fn test_set_get() {
+        let mut raw = [0u8; 30];
+        let total_len = raw.len();
+        let mut p: UdpDatagram<&mut [u8]> = UdpDatagram::from_bytes_unchecked(raw.as_mut());
+
+        assert_eq!(p.source_port(), 0);
+        let src_port: u16 = 213;
+        p.set_source_port(src_port);
+        assert_eq!(p.source_port(), src_port);
+
+        assert_eq!(p.destination_port(), 0);
+        let dst_port: u16 = 64193;
+        p.set_destination_port(dst_port);
+        assert_eq!(p.destination_port(), dst_port);
+
+        assert_eq!(p.len(), 0);
+        let len = 12;
+        p.set_len(len);
+        assert_eq!(p.len(), len);
+
+        assert_eq!(p.checksum(), 0);
+        let checksum: u16 = 32;
+        p.set_checksum(32);
+        assert_eq!(p.checksum(), checksum);
+
+        let payload_length = total_len - UDP_HEADER_SIZE;
+        assert_eq!(p.payload().len(), payload_length);
+
+        let payload: Vec<u8> = (0..(payload_length as u8)).collect();
+        p.payload_mut().copy_from_slice(&payload);
+        assert_eq!(*p.payload(), payload[..]);
+    }
+
+    #[test]
+    fn test_failing_construction() {
+        let mut raw = [0u8; 8];
+        let huge_payload = [0u8; IPV4_MAX_UDP_PACKET_SIZE];
+
+        assert_eq!(
+            UdpDatagram::write_incomplete_datagram(raw.as_mut(), &huge_payload).unwrap_err(),
+            Error::PayloadTooBig
+        );
+
+        let mut short_header = [0u8; UDP_HEADER_SIZE - 1];
+        assert_eq!(
+            UdpDatagram::from_bytes(short_header.as_mut(), None).unwrap_err(),
+            Error::DatagramTooShort
+        )
+    }
+
+    #[test]
+    fn test_construction() {
+        let mut packet = [0u8; 32 + UDP_HEADER_SIZE]; // 32-byte payload
+        let payload: Vec<u8> = (0..32).collect();
+        let src_port = 32133;
+        let dst_port = 22113;
+        let src_addr = Ipv4Addr::new(10, 100, 11, 21);
+        let dst_addr = Ipv4Addr::new(192, 168, 121, 35);
+        let p = UdpDatagram::write_incomplete_datagram(packet.as_mut(), &payload[..]).unwrap();
+        let mut p = p.finalize(src_port, dst_port, Some((src_addr, dst_addr)));
+
+        let checksum = p.checksum();
+        let c = p.compute_checksum(src_addr, dst_addr);
+        assert_eq!(c, 0xffff);
+
+        p.set_checksum(0);
+        let computed_checksum = p.compute_checksum(src_addr, dst_addr);
+        assert_eq!(checksum, computed_checksum);
+
+        let mut a = [1u8; 128];
+        let checksum = UdpDatagram::from_bytes_unchecked(a.as_mut()).checksum();
+        // Modify bytes in a by making a fake packet,
+        // to allow us to modify the checksum manually
+        let _ =
+            UdpDatagram::from_bytes_unchecked(a.as_mut()).set_checksum(checksum.wrapping_add(1));
+        let p_err = UdpDatagram::from_bytes(a.as_mut(), Some((src_addr, dst_addr))).unwrap_err();
+        assert_eq!(p_err, Error::Checksum);
+    }
+
+    #[test]
+    fn test_checksum() {
+        let mut bytes = [0u8; (2 + UDP_HEADER_SIZE)]; // 2-byte payload
+        let correct_checksum: u16 = 0x14de;
+        let payload_bytes = b"bb";
+        let src_ip = Ipv4Addr::new(152, 1, 51, 27);
+        let dst_ip = Ipv4Addr::new(152, 14, 94, 75);
+        let p = UdpDatagram::write_incomplete_datagram(bytes.as_mut(), payload_bytes).unwrap();
+        let p = p.finalize(41103, 9876, Some((src_ip, dst_ip)));
+        assert_eq!(p.checksum(), correct_checksum);
+    }
+}

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -11,5 +11,5 @@ net_gen = { path = "../net_gen" }
 sys_util = { path = "../sys_util" }
 
 [dev-dependencies]
-pnet = ">=0.21.0"
+dumbo = { path = "../dumbo" }
 serde_json = ">=1.0.9"

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -11,6 +11,8 @@
 //! Provides tools for representing and handling network related concepts like MAC addresses and
 //! network interfaces.
 
+#[cfg(test)]
+extern crate dumbo;
 extern crate libc;
 extern crate serde;
 
@@ -18,8 +20,6 @@ extern crate net_gen;
 #[macro_use]
 extern crate sys_util;
 
-mod mac;
 mod tap;
 
-pub use mac::{MacAddr, MAC_ADDR_LEN};
 pub use tap::{Error as TapError, Tap};

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -11,8 +11,6 @@
 //! Provides tools for representing and handling network related concepts like MAC addresses and
 //! network interfaces.
 
-#[cfg(test)]
-extern crate dumbo;
 extern crate libc;
 extern crate serde;
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.7
+COVERAGE_TARGET_PCT = 85.8
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -15,6 +15,7 @@ timerfd = ">=1.0"
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }
+dumbo = { path = "../dumbo" }
 fc_util = { path = "../fc_util" }
 kernel = { path = "../kernel" }
 logger = { path = "../logger" }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -27,6 +27,7 @@ extern crate fc_util;
 extern crate kernel;
 #[macro_use]
 extern crate logger;
+extern crate dumbo;
 extern crate memory_model;
 extern crate net_util;
 extern crate rate_limiter;
@@ -1692,7 +1693,7 @@ mod tests {
     use self::tempfile::NamedTempFile;
     use arch::DeviceType;
     use devices::virtio::{ActivateResult, MmioDevice, Queue};
-    use net_util::MacAddr;
+    use dumbo::MacAddr;
     use vmm_config::drive::DriveError;
     use vmm_config::machine_config::CpuFeaturesTemplate;
     use vmm_config::{RateLimiterConfig, TokenBucketConfig};

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -7,7 +7,8 @@ use std::result;
 use super::super::error::Error as VmmInternalError;
 use super::RateLimiterConfig;
 use devices;
-use net_util::{MacAddr, Tap, TapError};
+use dumbo::MacAddr;
+use net_util::{Tap, TapError};
 
 /// This struct represents the strongly typed equivalent of the json body from net iface
 /// related requests.
@@ -264,7 +265,6 @@ mod tests {
     use std::str;
 
     use super::*;
-    use net_util::MacAddr;
 
     fn create_netif(id: &str, name: &str, mac: &str) -> NetworkInterfaceConfig {
         NetworkInterfaceConfig {


### PR DESCRIPTION
## Reason for This PR

Fixes #612 

## Description of Changes

1. parse UDP datagrams
2. replace pnet::packet with dumbo's sutff
3. move MacAddr from `net_util` to dumbo
4. use UdpSocket in `test_write`, `test_read` in `tap.rs` ARP reply construction was needed to make this work
5. Use host-IPs instead of hardcoded ones since the packets will be routed
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
