### PR TITLE
Release v0.18.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,3 +7,4 @@ Radu Weiss <raduweis@amazon.com> <31901393+raduweiss@users.noreply.github.com>
 Rolf Neugebauer <neugebar@amazon.com> <rn@rneugeba.io>
 Serban Iorga <seriorga@amazon.com> <serban300@gmail.com>
 Julian Stecklina <js@alien8.de> <jsteckli@amazon.de>
+Tamio-Vesa Nakajima <tamiove@amazon.com> <tnk@amazon.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@
 
 ### Added
 
-- New device: virtio-vsock, backed by Unix domain sockets. See
-  `docs/vsock.md`.
+- New device: virtio-vsock, backed by Unix domain sockets (GitHub issue #650).
+  See `docs/vsock.md`.
 
 ### Fixed
 
-- Corrected firecracker-experimental.yaml indentation issues that
-  prevented code generation.
 - Updated the documentation for integration tests.
+- Fixed high CPU usage before guest network interface is brought up (GitHub
+  issue #1049).
+- Fixed an issue that caused the wrong date (month) to appear in the log.
+- Fixed a bug that caused the seccomp filter to reject legit syscalls in some
+  rare cases (GitHub issue #1206).
+- Docs: updated the production host setup guide.
+- Docs: updated the rootfs and kernel creation guide.
 
 ### Removed
 - Removed experimental support for vhost-based vsock devices.
@@ -28,7 +33,8 @@
   the process upon intercepting the signal.
 - Added documentation for signal handling utilities.
 - Added [alpha] aarch64 support.
-- Added metrics for successful read and write operations of MMDS, Net and Block devices.
+- Added metrics for successful read and write operations of MMDS, Net and Block
+  devices.
 
 ### Changed
 
@@ -58,8 +64,8 @@
   in favor of individual classic command-line parameters.
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
-- `PUT` and `PATCH` requests on `/mmds` with data containing any value type other
-  than `String`, `Array`, `Object` will return status code 400.
+- `PUT` and `PATCH` requests on `/mmds` with data containing any value type
+  other than `String`, `Array`, `Object` will return status code 400.
 - Improved multiple error messages.
 - Removed all kernel modules from the recommended kernel config.
 
@@ -167,7 +173,8 @@
   called `memory.dirty_pages` is computed as the number of pages dirtied by the
   guest since the last time the metric was flushed.
 - Log messages on both graceful and forceful termination.
-- Availability of the list of dependencies for each commit inside the code base.
+- Availability of the list of dependencies for each commit inside the code
+  base.
 - Documentation on vsock experimental feature and host setup recommendations.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.18.0]
 
 ### Added
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,18 +40,26 @@ Contributors to the Firecracker repository:
 * Dan Horobeanu <dhr@amazon.com>
 * Dan Lemmond <d.j.lemmond@gmail.com>
 * Deepesh Pathak <deepshpathak@gmail.com>
+* Denis Andrejew <da.colonel@gmail.com>
 * Diana Popa <dpopa@amazon.com>
 * Dmitrii <dmitrii.ustiugov@epfl.ch>
 * Filippo Sironi <sironi@amazon.de>
 * Gabe Jackson <gj@mail.co.de>
+* Garrett Squire <garrettsquire@gmail.com>
+* George Pisaltu <gpl@amazon.com>
 * german gomez <germangb42@gmail.com>
 * Greg Dunn <gregdunn@amazon.com>
+* Gábor Lipták <gliptak@gmail.com>
+* hatf0 <harrison@0xcc.pw>
 * Henri Yandell <hyandell@users.noreply.github.com>
+* Hermes <hermes.espinola@gmail.com>
 * Iggy Jackson <iggy@theiggy.com>
+* Ishwor Gurung <me@ishworgurung.com>
 * James Turnbull <james@lovedthanlost.net>
 * Javier Romero <xavinux@gmail.com>
 * Josh Abraham <sinisterpatrician@gmail.com>
 * Julian Stecklina <js@alien8.de>
+* Kazuyoshi Kato <katokazu@amazon.com>
 * Liu Jiang <gerry@linux.alibaba.com>
 * Lloyd <lloydmeta@gmail.com>
 * lloydmeta <lloydmeta@gmail.com>
@@ -72,16 +80,20 @@ Contributors to the Firecracker repository:
 * Ram Sripracha <ramsri@amazon.com>
 * Rob Devereux <robdevereux92@gmail.com>
 * Robert Grimes <rmzgrimes@gmail.com>
+* Rodrigue Chakode <rodrigue.chakode@continental-corporation.com>
 * Rolf Neugebauer <neugebar@amazon.com>
 * Sam Jackson <sam@clique.app>
 * Sean Lavine <freewil@users.noreply.github.com>
 * Serban Iorga <seriorga@amazon.com>
+* Shen Jiale <shenjiale@baidu.com>
 * Sripracha <ramsri@amazon.com>
+* Tamio-Vesa Nakajima <tamiove@amazon.com>
 * Tim Bannister <tim@scalefactory.com>
 * Tim Deegan <tdeegan@amazon.com>
 * Tyler Anton <tyler@debian.anton>
 * Urvil Patel <patelurvil38@gmail.com>
 * Weixiao Huang <hwx.simle@gmail.com>
 * xibz <impactbchang@gmail.com>
+* xiekeyang <keyang.xie@gmail.com>
 * YLyu <lyuyuan92@gmail.com>
 * Yuval Kohavi <yuval.kohavi@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,13 +195,13 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
- "jailer 0.17.0",
+ "jailer 0.18.0",
  "logger 0.1.0",
  "mmds 0.1.0",
  "seccomp 0.1.0",
@@ -304,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fc_util 0.1.0",
@@ -593,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,7 +604,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -734,7 +734,7 @@ name = "serde_derive"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -759,7 +759,7 @@ name = "syn"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1081,7 +1081,7 @@ dependencies = [
 "checksum pnet_sys 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "682b2eca84cc440bce8336813f78eb6d3cb0fed89fe0e87ae22acfca8363f176"
 "checksum pnet_transport 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5faa55dcf725487a699adcff88dfea8f17ea34fa2640528866d9acbb4e3a104f"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
-"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
+"checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
                The API is accessible through HTTP calls on specific URLs
                carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.17.0
+  version: 0.18.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/docs/vsock.md
+++ b/docs/vsock.md
@@ -13,7 +13,7 @@ This document assumes the reader is familiar with running Firecracker and
 issuing API commands over its API socket. For a more details on how to run
 Firecracker, check out the [getting started guide](getting-started.md).
 
-Familiarty with socket programming, in particular Unix sockets, is also
+Familiarity with socket programming, in particular Unix sockets, is also
 assumed.
 
 ## Firecracker Virtio-vsock Design
@@ -21,7 +21,7 @@ assumed.
 The Firecracker vsock device aims to provide full virtio-vsock support to
 software running inside the guest VM, while bypassing vhost kernel code on the
 host. To that end, Firecracker implements the virtio-vsock device model, and
-mediate communication between AF_UNIX sockets (on the host end) and AF_VSOCK
+mediates communication between AF_UNIX sockets (on the host end) and AF_VSOCK
 sockets (on the guest end). 
 
 In order to provide channel multiplexing, AF_VSOCK ports are translated into

--- a/jailer/Cargo.toml
+++ b/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]


### PR DESCRIPTION
## Reason for This PR

Release v0.18.0.

## Description of Changes

- Fixed some typos left behind in `docs/vsock.md`.
- Updated `CHANGELOG.md` with all user-facing changes since v0.17.0.
- Fixed `CHANGELOG.md` (line length) formatting.
- Updated Firecracker version via `devtool prepare_release`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
