### PR TITLE
Typographical error fixes for rate_limiter

### DIFF
--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -281,7 +281,9 @@ impl fmt::Debug for RateLimiter {
 }
 
 impl RateLimiter {
-    // description
+    /// This function creates a `TokenBucket` wrapped in an `Option` with a given total capacity,
+    /// one time burst, and complete refill time (in miliseconds). If the total capacity or the
+    /// complete refill time are zero, then `None` is returned.
     fn make_bucket(
         total_capacity: u64,
         one_time_burst: Option<u64>,
@@ -426,7 +428,7 @@ impl RateLimiter {
     }
 
     /// Updates the parameters of the token buckets associated with this RateLimiter.
-    // TODO: Pls note that, right now, the buckets become full after being updated.
+    // TODO: Please note that, right now, the buckets become full after being updated.
     pub fn update_buckets(&mut self, bytes: Option<TokenBucket>, ops: Option<TokenBucket>) {
         // TODO: We should reconcile the create and update paths, such that they use the same data
         // format. Currently, the TokenBucket config data is used for create, but the live


### PR DESCRIPTION
Signed-off-by: Tamio-Vesa Nakajima <tamiove@amazon.com>

## Reason for This PR

The `RateLimiter::make_bucket` function had a dummy comment, and a typographical error had slipped into the rate_limiter crate. These should be fixed.

## Description of Changes

This PR fixes a minor typographical error in the rate_limiter crate, and fills in a missing comment.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] ~~Either~~ no docs need to be updated as part of this PR, ~~or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.~~
- [x] ~~Either~~ no code has been touched ~~, or, code-level documentation for touched
      code is included in this PR.~~
- [x] ~~ Either~~ no API changes are included in this PR ~~, or, the API changes are
      reflected in `firecracker/swagger.yaml`.~~
- [x] ~~Either~~ the changes in this PR have no user impact ~~, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file. ~~
