### PR TITLE
Implement debug and display trait for errors that can generate panics

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -660,10 +660,10 @@ fn log_received_api_request(api_description: String) {
 fn describe(method: &Method, path: &str, body: &Option<String>) -> String {
     match body {
         Some(value) => format!(
-            "synchronous {:?} request on {:?} with body {:?}",
+            "synchronous {} request on {} with body {}.",
             method, path, value
         ),
-        None => format!("synchronous {:?} request on {:?}", method, path),
+        None => format!("synchronous {} request on {}.", method, path),
     }
 }
 
@@ -1458,14 +1458,14 @@ mod tests {
         let msj = describe(&Method::Get, &String::from("/foo/bar"), &Some(body.clone()));
         assert_eq!(
             msj,
-            "synchronous Get request on \"/foo/bar\" with body \"{ \\\"foo\\\": \\\"bar\\\" }\""
+            "synchronous GET request on /foo/bar with body { \"foo\": \"bar\" }."
         );
         let msj = describe(&Method::Put, &String::from("/foo/bar"), &Some(body));
         assert_eq!(
             msj,
-            "synchronous Put request on \"/foo/bar\" with body \"{ \\\"foo\\\": \\\"bar\\\" }\""
+            "synchronous PUT request on /foo/bar with body { \"foo\": \"bar\" }."
         );
         let msj = describe(&Method::Patch, &String::from("/foo/bar"), &None);
-        assert_eq!(msj, "synchronous Patch request on \"/foo/bar\"")
+        assert_eq!(msj, "synchronous PATCH request on /foo/bar.")
     }
 }

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -47,8 +47,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Io(ref err) => write!(f, "IO error: {}", err),
-            Error::Eventfd(ref err) => write!(f, "EventFd error: {}", err),
+            Error::Io(ref err) => write!(f, "{}", err),
+            Error::Eventfd(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -56,8 +56,8 @@ impl fmt::Display for Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Io(ref err) => write!(f, "IO error: {}", err),
-            Error::Eventfd(ref err) => write!(f, "EventFd error: {}", err),
+            Error::Io(ref err) => write!(f, "{}", err),
+            Error::Eventfd(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -132,6 +132,7 @@ impl ApiServer {
                     self.api_request_sender.clone(),
                     self.efd.clone(),
                 );
+
                 let connection = http.serve_connection(stream, service);
                 // todo: is spawn() any better/worse than execute()?
                 // We have to adjust the future item and error, to fit spawn()'s definition.
@@ -167,12 +168,12 @@ mod tests {
         let e = Error::Io(io::Error::from_raw_os_error(0));
         assert_eq!(
             format!("{}", e),
-            format!("IO error: {}", io::Error::from_raw_os_error(0))
+            format!("{}", io::Error::from_raw_os_error(0))
         );
         let e = Error::Eventfd(io::Error::from_raw_os_error(0));
         assert_eq!(
             format!("{}", e),
-            format!("EventFd error: {}", io::Error::from_raw_os_error(0))
+            format!("{}", io::Error::from_raw_os_error(0))
         );
     }
 
@@ -181,12 +182,12 @@ mod tests {
         let e = Error::Io(io::Error::from_raw_os_error(0));
         assert_eq!(
             format!("{:?}", e),
-            format!("IO error: {}", io::Error::from_raw_os_error(0))
+            format!("{}", io::Error::from_raw_os_error(0))
         );
         let e = Error::Eventfd(io::Error::from_raw_os_error(0));
         assert_eq!(
             format!("{:?}", e),
-            format!("EventFd error: {}", io::Error::from_raw_os_error(0))
+            format!("{}", io::Error::from_raw_os_error(0))
         );
     }
 }

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -146,7 +146,7 @@ impl ApiServer {
         // altogether is the desired behaviour.
         if let Err(e) = default_syscalls::set_seccomp_level(seccomp_level) {
             panic!(
-                "Failed to set the requested seccomp filters on the API thread: Error: {:?}",
+                "Failed to set the requested seccomp filters on the API thread: Error: {}",
                 e
             );
         }

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -66,7 +66,6 @@ pub trait DeviceInfoForFDT {
 }
 
 /// Errors thrown while configuring the Flattened Device Tree for aarch64.
-#[derive(Debug)]
 pub enum Error {
     /// Failed to append node to the FDT.
     AppendFDTNode(io::Error),
@@ -566,7 +565,8 @@ mod tests {
     #[test]
     fn test_create_fdt_with_devices() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
 
         let dev_info: HashMap<(DeviceType, std::string::String), MMIODeviceInfo> = [
             (
@@ -603,14 +603,15 @@ mod tests {
     #[test]
     fn test_create_fdt() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
         let mut dtb = create_fdt(
             &mem,
             1,
             &CString::new("console=tty0").unwrap(),
             None::<&std::collections::HashMap<(DeviceType, std::string::String), MMIODeviceInfo>>,
         )
-        .unwrap();
+        .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
 
         /* Use this code when wanting to generate a new DTB sample.
         {

--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -4,7 +4,6 @@
 use std::{fmt, io, result};
 
 use kvm_ioctls::{DeviceFd, VmFd};
-use std::fmt::Formatter;
 
 // Unfortunately bindgen omits defines that are based on other defines.
 // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
@@ -22,7 +21,7 @@ pub enum Error {
 type Result<T> = result::Result<T, Error>;
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::CreateGIC(err) => write!(f, "KVM ioctl for creating GIC failed: {}", err),
             Error::SetDeviceAttribute(err) => write!(

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -12,18 +12,26 @@ pub mod regs;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 
 use memory_model::{GuestAddress, GuestMemory};
 
 /// Errors thrown while configuring aarch64 system.
-#[derive(Debug)]
 pub enum Error {
     /// Failed to create a Flattened Device Tree for this aarch64 microVM.
     SetupFDT(fdt::Error),
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::SetupFDT(err) => write!(f, "FDT setup failed: {}", err),
+        }
+    }
+}
+
 pub use self::fdt::DeviceInfoForFDT;
+use std::fmt;
 use DeviceType;
 
 /// Returns a Vec of the valid memory addresses for aarch64.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -107,15 +107,18 @@ mod tests {
     #[test]
     fn test_get_fdt_addr() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }
 }

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -5,21 +5,30 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::{io, mem, result};
+use std::{fmt, io, mem, result};
 
 use kvm_ioctls::VcpuFd;
 
 use super::get_fdt_addr;
 use kvm_bindings::{user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64};
 use memory_model::GuestMemory;
+use std::fmt::Formatter;
 
 /// Errors thrown while setting aarch64 registers.
-#[derive(Debug)]
 pub enum Error {
     /// Failed to set core register (PC, PSTATE or general purpose ones).
     SetCoreRegister(io::Error),
 }
-type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::SetCoreRegister(err) => write!(f, "Failed to set core register: {}", err),
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
 
 #[allow(non_upper_case_globals)]
 // PSR (Processor State Register) bits.

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -131,7 +131,8 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemory::new(&regions)
+            .unwrap_or_else(|err| panic!("Cannot initialize memory: {}", err));
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {
             Error::SetCoreRegister(ref e) => assert_eq!(e.raw_os_error(), Some(libc::ENOEXEC)),

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -28,6 +28,7 @@ impl fmt::Display for Error {
     }
 }
 
+/// Type for returning public functions outcome.
 pub type Result<T> = result::Result<T, Error>;
 
 #[allow(non_upper_case_globals)]
@@ -142,5 +143,19 @@ mod tests {
         vcpu.vcpu_init(&kvi).unwrap();
 
         assert!(setup_regs(&vcpu, 0, 0x0, &mem).is_ok());
+    }
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SetCoreRegister(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Failed to set core register: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
     }
 }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -12,8 +12,7 @@ extern crate libc;
 extern crate arch_gen;
 extern crate memory_model;
 
-use std::fmt;
-use std::result;
+use std::{fmt, result};
 
 /// Module for aarch64 related functionality.
 #[cfg(target_arch = "aarch64")]

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -95,6 +95,7 @@ pub fn set_lint(vcpu: &VcpuFd) -> Result<()> {
 #[cfg(test)]
 mod tests {
     extern crate rand;
+
     use self::rand::Rng;
 
     use super::*;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -223,7 +223,8 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let gm =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let config_err = configure_system(&gm, GuestAddress(0), 0, 1);
         assert!(config_err.is_err());
         assert_eq!(
@@ -234,19 +235,19 @@ mod tests {
         // Now assigning some memory that falls before the 32bit memory hole.
         let mem_size = 128 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemory::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemory::new(&arch_mem_regions).unwrap_or_else(|err| panic!("{}", err));
         configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemory::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemory::new(&arch_mem_regions).unwrap_or_else(|err| panic!("{}", err));
         configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemory::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemory::new(&arch_mem_regions).unwrap_or_else(|err| panic!("{}", err));
         configure_system(&gm, GuestAddress(0), 0, no_vcpus).unwrap();
     }
 

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -442,4 +442,52 @@ mod tests {
         let result = setup_mptable(&mem, cpus as u8).unwrap_err();
         assert_eq!(result, Error::TooManyCpus);
     }
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!("{}", Error::NotEnoughMemory),
+            "There was too little guest memory to store the entire MP table."
+        );
+        assert_eq!(
+            format!("{}", Error::AddressOverflow),
+            "The MP table has too little address space to be stored."
+        );
+        assert_eq!(
+            format!("{}", Error::Clear),
+            "Failure while zeroing out the memory for the MP table."
+        );
+        assert_eq!(
+            format!("{}", Error::TooManyCpus),
+            "Number of CPUs exceeds the maximum supported CPUs."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpfIntel),
+            "Failure to write the MP floating pointer."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcCpu),
+            "Failure to write MP CPU entry."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcIoapic),
+            "Failure to write MP ioapic entry."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcBus),
+            "Failure to write MP bus entry."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcIntsrc),
+            "Failure to write MP interrupt source entry."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcLintsrc),
+            "Failure to write MP local interrupt source entry."
+        );
+        assert_eq!(
+            format!("{}", Error::WriteMpcTable),
+            "Failure to write MP table header."
+        );
+    }
 }

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -5,15 +5,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::io;
 use std::mem;
 use std::result;
 use std::slice;
+use std::{fmt, io};
 
 use libc::c_char;
 
 use arch_gen::x86::mpspec;
 use memory_model::{DataInit, GuestAddress, GuestMemory};
+use std::fmt::Formatter;
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `DataInit`) where:
@@ -71,6 +72,31 @@ pub enum Error {
     WriteMpcLintsrc,
     /// Failure to write MP table header.
     WriteMpcTable,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::NotEnoughMemory => write!(
+                f,
+                "There was too little guest memory to store the entire MP table."
+            ),
+            Error::AddressOverflow => {
+                write!(f, "The MP table has too little address space to be stored.")
+            }
+            Error::Clear => write!(f, "Failure while zeroing out the memory for the MP table."),
+            Error::TooManyCpus => write!(f, "Number of CPUs exceeds the maximum supported CPUs."),
+            Error::WriteMpfIntel => write!(f, "Failure to write the MP floating pointer."),
+            Error::WriteMpcCpu => write!(f, "Failure to write MP CPU entry."),
+            Error::WriteMpcIoapic => write!(f, "Failure to write MP ioapic entry."),
+            Error::WriteMpcBus => write!(f, "Failure to write MP bus entry."),
+            Error::WriteMpcIntsrc => write!(f, "Failure to write MP interrupt source entry."),
+            Error::WriteMpcLintsrc => {
+                write!(f, "Failure to write MP local interrupt source entry.")
+            }
+            Error::WriteMpcTable => write!(f, "Failure to write MP table header."),
+        }
+    }
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -482,4 +482,87 @@ mod tests {
         validate_segments_and_sregs(&gm, &sregs);
         validate_page_tables(&gm, &sregs);
     }
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::GetStatusRegisters(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Failed to get SREGs for this CPU: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SetBaseRegisters(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Failed to set base registers for this CPU: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SetFPURegisters(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Failed to configure the FPU: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SetModelSpecificRegisters(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Setting up MSRs failed: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SetStatusRegisters(io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Failed to set SREGs for this CPU: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!("{}", Error::WriteGDT),
+            "Writing the GDT to RAM failed.".to_string()
+        );
+
+        assert_eq!(
+            format!("{}", Error::WriteIDT),
+            "Writing the IDT to RAM failed.".to_string()
+        );
+
+        assert_eq!(
+            format!("{}", Error::WritePDPTEAddress),
+            "Writing PDPTE to RAM failed.".to_string()
+        );
+
+        assert_eq!(
+            format!("{}", Error::WritePDEAddress),
+            "Writing PDE to RAM failed.".to_string()
+        );
+
+        assert_eq!(
+            format!("{}", Error::WritePML4Address),
+            "Writing PML4 to RAM failed.".to_string()
+        );
+    }
 }

--- a/cpuid/src/common.rs
+++ b/cpuid/src/common.rs
@@ -8,19 +8,18 @@ use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
 
 use cpu_leaf::*;
 use std::fmt;
-use std::fmt::Formatter;
 
 pub const VENDOR_ID_INTEL: &[u8; 12] = b"GenuineIntel";
 pub const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum Error {
     InvalidParameters(String),
     NotSupported,
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::InvalidParameters(err_msg) => write!(f, "{}", err_msg),
             Error::NotSupported => write!(

--- a/cpuid/src/common.rs
+++ b/cpuid/src/common.rs
@@ -143,4 +143,17 @@ pub mod tests {
             _ => false,
         });
     }
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!("{}", Error::InvalidParameters("Error message".to_string())),
+            "Error message".to_string()
+        );
+
+        assert_eq!(
+            format!("{}", Error::NotSupported),
+            "CpuId instruction is not supported on the current target arch."
+        );
+    }
 }

--- a/cpuid/src/common.rs
+++ b/cpuid/src/common.rs
@@ -7,6 +7,8 @@ use std::arch::x86::{CpuidResult, __cpuid_count, __get_cpuid_max};
 use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
 
 use cpu_leaf::*;
+use std::fmt;
+use std::fmt::Formatter;
 
 pub const VENDOR_ID_INTEL: &[u8; 12] = b"GenuineIntel";
 pub const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
@@ -15,6 +17,18 @@ pub const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
 pub enum Error {
     InvalidParameters(String),
     NotSupported,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidParameters(err_msg) => write!(f, "{}", err_msg),
+            Error::NotSupported => write!(
+                f,
+                "CpuId instruction is not supported on the current target arch."
+            ),
+        }
+    }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/cpuid/src/lib.rs
+++ b/cpuid/src/lib.rs
@@ -49,9 +49,9 @@ mod brand_string;
 /// let kvm = Kvm::new().unwrap();
 /// let mut kvm_cpuid: CpuId = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
 ///
-/// let vm_spec = VmSpec::new(0, 1, true).unwrap();
+/// let vm_spec = VmSpec::new(0, 1, true).unwrap_or_else(|err| panic!("{}", err));
 ///
-/// filter_cpuid(&mut kvm_cpuid, &vm_spec).unwrap();
+/// filter_cpuid(&mut kvm_cpuid, &vm_spec).unwrap_or_else(|err| panic!("{}", err));
 ///
 /// // Get expected `kvm_cpuid` entries.
 /// let entries = kvm_cpuid.mut_entries_slice();

--- a/cpuid/src/transformer/amd.rs
+++ b/cpuid/src/transformer/amd.rs
@@ -160,7 +160,8 @@ mod test {
         use cpu_leaf::leaf_0x7::index0::*;
 
         // Check that if index == 0 the entry is processed
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: leaf_0x7::LEAF_NUM,
             index: 0,
@@ -185,7 +186,8 @@ mod test {
     fn test_update_largest_extended_fn_entry() {
         use cpu_leaf::leaf_0x80000000::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -211,7 +213,8 @@ mod test {
     fn test_update_extended_feature_info_entry() {
         use cpu_leaf::leaf_0x80000001::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -231,7 +234,8 @@ mod test {
     fn check_update_amd_features_entry(cpu_count: u8, ht_enabled: bool) {
         use cpu_leaf::leaf_0x80000008::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -264,7 +268,8 @@ mod test {
     ) {
         use cpu_leaf::leaf_0x8000001e::*;
 
-        let vm_spec = VmSpec::new(cpu_id, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(cpu_id, cpu_count, ht_enabled)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -307,7 +312,8 @@ mod test {
 
     #[test]
     fn test_update_extended_cache_topology_entry() {
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: leaf_0x8000001d::LEAF_NUM,
             index: 0,

--- a/cpuid/src/transformer/common.rs
+++ b/cpuid/src/transformer/common.rs
@@ -150,10 +150,22 @@ mod test {
 
     #[test]
     fn test_get_max_cpus_per_package() {
-        assert_eq!(get_max_cpus_per_package(1).unwrap(), 1);
-        assert_eq!(get_max_cpus_per_package(2).unwrap(), 2);
-        assert_eq!(get_max_cpus_per_package(4).unwrap(), 4);
-        assert_eq!(get_max_cpus_per_package(6).unwrap(), 8);
+        assert_eq!(
+            get_max_cpus_per_package(1).unwrap_or_else(|err| panic!("{}", err)),
+            1
+        );
+        assert_eq!(
+            get_max_cpus_per_package(2).unwrap_or_else(|err| panic!("{}", err)),
+            2
+        );
+        assert_eq!(
+            get_max_cpus_per_package(4).unwrap_or_else(|err| panic!("{}", err)),
+            4
+        );
+        assert_eq!(
+            get_max_cpus_per_package(6).unwrap_or_else(|err| panic!("{}", err)),
+            8
+        );
 
         assert!(get_max_cpus_per_package(u8::max_value()).is_err());
     }
@@ -161,7 +173,8 @@ mod test {
     fn check_update_feature_info_entry(cpu_count: u8, expected_htt: bool) {
         use cpu_leaf::leaf_0x1::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,
@@ -186,7 +199,8 @@ mod test {
     ) {
         use cpu_leaf::leaf_cache_parameters::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,

--- a/cpuid/src/transformer/intel.rs
+++ b/cpuid/src/transformer/intel.rs
@@ -165,7 +165,8 @@ mod test {
     fn test_update_feature_info_entry() {
         use cpu_leaf::leaf_0x1::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: leaf_0x1::LEAF_NUM,
             index: 0,
@@ -184,7 +185,8 @@ mod test {
 
     #[test]
     fn test_update_perf_mon_entry() {
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: leaf_0xa::LEAF_NUM,
             index: 0,
@@ -212,7 +214,8 @@ mod test {
     ) {
         use cpu_leaf::leaf_0x4::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,
@@ -244,7 +247,8 @@ mod test {
     ) {
         use cpu_leaf::leaf_0xb::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled)
+            .unwrap_or_else(|err| panic!("Error creating vm_spec: {}", err));
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index,

--- a/cpuid/src/transformer/mod.rs
+++ b/cpuid/src/transformer/mod.rs
@@ -11,6 +11,8 @@ use kvm_ioctls::CpuId;
 use brand_string::BrandString;
 use brand_string::Reg as BsReg;
 use common::get_vendor_id;
+use std::fmt;
+use std::fmt::Formatter;
 
 /// Structure containing the specifications of the VM
 ///
@@ -59,6 +61,21 @@ pub enum Error {
     SizeLimitExceeded,
     /// A call to an internal helper method failed
     InternalError(super::common::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::VcpuCountOverflow => write!(
+                f,
+                "The maximum number of addressable logical CPUs cannot be stored in an `u8`."
+            ),
+            Error::SizeLimitExceeded => write!(f, "The max size has been exceeded."),
+            Error::InternalError(err) => {
+                write!(f, "A call to an internal helper method failed: {}", err)
+            }
+        }
+    }
 }
 
 pub type EntryTransformerFn =

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -20,23 +20,20 @@ pub enum Error {
     KbdInterruptFailure(io::Error),
     InternalBufferFull,
 }
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::CloneCpuResetEvt(io_err) => write!(
-                f,
-                "Could not clone CPU reset eventfd: {}.",
-                io_err.to_string()
-            ),
-            Error::KbdInterruptDisabled => {
-                write!(f, "Keyboard interrupt disabled by guest driver.",)
+            Error::CloneCpuResetEvt(io_err) => {
+                write!(f, "Could not clone CPU reset eventfd: {}", io_err)
             }
-            Error::KbdInterruptFailure(io_err) => write!(
-                f,
-                "Could not trigger keyboard interrupt: {}.",
-                io_err.to_string()
-            ),
-            Error::InternalBufferFull => write!(f, "i8042 internal buffer full."),
+            Error::KbdInterruptDisabled => {
+                write!(f, "Keyboard interrupt disabled by guest driver.")
+            }
+            Error::KbdInterruptFailure(io_err) => {
+                write!(f, "Could not trigger keyboard interrupt: {}", io_err)
+            }
+            Error::InternalBufferFull => write!(f, "I8042 internal buffer full."),
         }
     }
 }
@@ -221,7 +218,7 @@ impl BusDevice for I8042Device {
                 // port 0x60.
                 if (self.status & SB_OUT_DATA_AVAIL) != 0 {
                     if let Err(Error::KbdInterruptFailure(err)) = self.trigger_kbd_interrupt() {
-                        warn!("Failed to trigger i8042 kbd interrupt {:?}", err);
+                        warn!("Failed to trigger i8042 kbd interrupt {}", err);
                     }
                 }
             }
@@ -249,7 +246,7 @@ impl BusDevice for I8042Device {
                 // our exit event fd. Meaning Firecracker will be exiting as soon as the VMM
                 // thread wakes up to handle this event.
                 if let Err(e) = self.reset_evt.write(1) {
-                    error!("Failed to trigger i8042 reset event: {:?}", e);
+                    error!("Failed to trigger i8042 reset event: {}", e);
                     METRICS.i8042.error_count.inc();
                 }
                 METRICS.i8042.reset_count.inc();
@@ -311,7 +308,7 @@ impl BusDevice for I8042Device {
                 // Buffer is empty, push() will always succeed.
                 self.push_byte(0xFA).unwrap();
                 if let Err(Error::KbdInterruptFailure(err)) = self.trigger_kbd_interrupt() {
-                    warn!("Failed to trigger i8042 kbd interrupt {:?}", err);
+                    warn!("Failed to trigger i8042 kbd interrupt {}", err);
                 }
             }
             _ => {

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -1610,4 +1610,49 @@ mod tests {
             assert_eq!(h.disk_image_id, id);
         }
     }
+
+    #[test]
+    fn test_error_messsages() {
+        assert_eq!(
+            format!("{}", Error::UnexpectedWriteOnlyDescriptor),
+            "Received a write only descriptor that protocol says to read from."
+        );
+        assert_eq!(
+            format!("{}", Error::UnexpectedReadOnlyDescriptor),
+            "Received a read only descriptor that protocol says to write to."
+        );
+        assert_eq!(
+            format!("{}", Error::DescriptorChainTooShort),
+            "Received too few descriptors in a descriptor chain."
+        );
+        assert_eq!(
+            format!("{}", Error::DescriptorLengthTooSmall),
+            "Received a descriptor that was too short to use."
+        );
+        assert_eq!(
+            format!("{}", Error::GetFileMetadata),
+            "Getting a block's metadata failed."
+        );
+        assert_eq!(
+            format!("{}", Error::InvalidOffset),
+            "The requested operation would cause a seek beyond disk end."
+        );
+
+        assert_eq!(
+            format!("{}", ExecuteError::BadRequest(Error::InvalidOffset)),
+            format!("{}", Error::InvalidOffset)
+        );
+        assert_eq!(
+            format!("{}", ExecuteError::Flush(io::Error::from_raw_os_error(0))),
+            format!("{}", std::io::Error::from_raw_os_error(0))
+        );
+        assert_eq!(
+            format!("{}", ExecuteError::Seek(io::Error::from_raw_os_error(0))),
+            format!("{}", std::io::Error::from_raw_os_error(0))
+        );
+        assert_eq!(
+            format!("{}", ExecuteError::Unsupported(0)),
+            format!("Unsupported request: {}", 0)
+        );
+    }
 }

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -285,7 +285,7 @@ impl MmioDevice {
                                     self.queues.clone(),
                                     self.queue_evts.split_off(0),
                                 )
-                                .expect("Failed to activate device");
+                                .unwrap_or_else(|err| panic!("Failed to activate device: {}", err));
                             self.device_activated = true;
                         }
                     }

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -524,11 +524,12 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
         let mut dummy = DummyDevice::new();
         // Validate reset is no-op.
         assert!(dummy.reset().is_none());
-        let mut d = MmioDevice::new(m, Box::new(dummy)).unwrap();
+        let mut d = MmioDevice::new(m, Box::new(dummy)).unwrap_or_else(|err| panic!("{}", err));
 
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
@@ -566,8 +567,10 @@ mod tests {
 
     #[test]
     fn test_bus_device_read() {
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
+        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new()))
+            .unwrap_or_else(|err| panic!("{}", err));
 
         let mut buf = vec![0xff, 0, 0xfe, 0];
         let buf_copy = buf.to_vec();
@@ -644,13 +647,14 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_bus_device_write() {
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
 
         let mut dummy_box = Box::new(DummyDevice::new());
         let dummy_dev_acked_features = &dummy_box.acked_features as *const u64;
         let dummy_dev_avail_features = &mut dummy_box.avail_features as *mut u64;
 
-        let mut d = MmioDevice::new(m, dummy_box).unwrap();
+        let mut d = MmioDevice::new(m, dummy_box).unwrap_or_else(|err| panic!("{}", err));
 
         let mut buf = vec![0; 5];
         LittleEndian::write_u32(&mut buf[..4], 1);
@@ -798,8 +802,10 @@ mod tests {
 
     #[test]
     fn test_bus_device_activate() {
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
+        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new()))
+            .unwrap_or_else(|err| panic!("{}", err));
 
         assert!(!d.are_queues_valid());
         assert!(!d.device_activated);
@@ -893,8 +899,10 @@ mod tests {
 
     #[test]
     fn test_bus_device_reset() {
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
+        let mut d = MmioDevice::new(m, Box::new(DummyDevice::new()))
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut buf = vec![0; 4];
 
         assert!(!d.are_queues_valid());

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -25,6 +25,8 @@ pub use self::queue::*;
 pub use self::vsock::*;
 
 use super::EpollHandler;
+use std::fmt;
+use std::fmt::Formatter;
 
 const DEVICE_INIT: u32 = 0x0;
 const DEVICE_ACKNOWLEDGE: u32 = 0x01;
@@ -47,10 +49,20 @@ pub const VIRTIO_MMIO_INT_CONFIG: u32 = 0x02;
 /// queue events.
 pub const NOTIFY_REG_OFFSET: u32 = 0x50;
 
-#[derive(Debug)]
 pub enum ActivateError {
     EpollCtl(IOError),
     BadActivate,
+}
+
+impl fmt::Display for ActivateError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            ActivateError::EpollCtl(err) => write!(f, "{}", err),
+            ActivateError::BadActivate => write!(f, "Device bad activate."),
+            #[cfg(feature = "vsock")]
+            ActivateError::BadVhostActivate(err) => write!(f, "{}", err),
+        }
+    }
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -59,8 +59,6 @@ impl fmt::Display for ActivateError {
         match self {
             ActivateError::EpollCtl(err) => write!(f, "{}", err),
             ActivateError::BadActivate => write!(f, "Device bad activate."),
-            #[cfg(feature = "vsock")]
-            ActivateError::BadVhostActivate(err) => write!(f, "{}", err),
         }
     }
 }
@@ -88,5 +86,26 @@ impl<T: Any> AsAny for T {
 
     fn as_mut_any(&mut self) -> &mut dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::virtio::ActivateError;
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!(
+                "{}",
+                ActivateError::EpollCtl(std::io::Error::from_raw_os_error(0))
+            ),
+            format!("{}", std::io::Error::from_raw_os_error(0))
+        );
+
+        assert_eq!(
+            format!("{}", ActivateError::BadActivate),
+            "Device bad activate."
+        );
     }
 }

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -74,8 +74,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Error::TapOpen(err) => write!(f, "Open tap device failed: {}", err),
-            Error::TapSetIp(err) => write!(f, "Setting tap IP failed: {}", err),
-            Error::TapSetNetmask(err) => write!(f, "Setting tap netmask failed: {}", err),
             Error::TapSetOffload(err) => {
                 write!(f, "Setting tap interface offload flags failed: {}", err)
             }

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -56,7 +56,6 @@ const TX_RATE_LIMITER_EVENT: DeviceEventT = 4;
 // Number of DeviceEventT events supported by this implementation.
 pub const NET_EVENTS_COUNT: usize = 5;
 
-#[derive(Debug)]
 pub enum Error {
     /// Open tap device failed.
     TapOpen(TapError),
@@ -251,7 +250,7 @@ impl NetEpollHandler {
                             write_count += sz;
                         }
                         Err(e) => {
-                            error!("Failed to write slice: {:?}", e);
+                            error!("Failed to write slice: {}", e);
                             METRICS.net.rx_fails.inc();
                             break;
                         }
@@ -468,7 +467,7 @@ impl NetEpollHandler {
                         METRICS.net.tx_count.inc();
                     }
                     Err(e) => {
-                        error!("Failed to read slice: {:?}", e);
+                        error!("Failed to read slice: {}", e);
                         METRICS.net.tx_fails.inc();
                         break;
                     }
@@ -1032,7 +1031,7 @@ mod tests {
                     ),
                     true,
                 )
-                .unwrap(),
+                .unwrap_or_else(|err| panic!("{}", err)),
                 epoll_raw_fd,
                 _receiver,
             }
@@ -1094,7 +1093,8 @@ mod tests {
     }
 
     fn activate_some_net(n: &mut Net, bad_qlen: bool, bad_evtlen: bool) -> ActivateResult {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let interrupt_evt = EventFd::new().unwrap();
         let status = Arc::new(AtomicUsize::new(0));
 
@@ -1311,7 +1311,8 @@ mod tests {
 
     #[test]
     fn test_mmds_detour_and_injection() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let sha = MacAddr::parse_str("11:11:11:11:11:11").unwrap();
@@ -1374,7 +1375,8 @@ mod tests {
 
     #[test]
     fn test_mac_spoofing_detection() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let guest_mac = MacAddr::parse_str("11:11:11:11:11:11").unwrap();
@@ -1443,7 +1445,8 @@ mod tests {
 
     #[test]
     fn test_handler_error_cases() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         // RX rate limiter events should error since the limiter is not blocked.
@@ -1465,7 +1468,8 @@ mod tests {
 
     #[test]
     fn test_invalid_event_handler() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let bad_event = 1000;
@@ -1489,7 +1493,8 @@ mod tests {
         let test_mutators = TestMutators {
             tap_read_fail: true,
         };
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, rxq) = default_test_netepollhandler(&mem, test_mutators);
         h.register_tap_rx_listener().unwrap();
 
@@ -1511,7 +1516,8 @@ mod tests {
 
     #[test]
     fn test_rx_rate_limited_event_handler() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
         let rl = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
         h.set_rx_rate_limiter(rl);
@@ -1524,7 +1530,8 @@ mod tests {
 
     #[test]
     fn test_tx_rate_limited_event_handler() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
         let rl = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
         h.set_tx_rate_limiter(rl);
@@ -1537,7 +1544,8 @@ mod tests {
 
     #[test]
     fn test_handler() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1677,7 +1685,8 @@ mod tests {
             let test_mutators = TestMutators {
                 tap_read_fail: true,
             };
-            let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)])
+                .unwrap_or_else(|err| panic!("{}", err));
             let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, test_mutators);
 
             check_metric_after_block!(&METRICS.net.rx_fails, 1, h.process_rx());
@@ -1686,7 +1695,8 @@ mod tests {
 
     #[test]
     fn test_bandwidth_rate_limiter() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1794,7 +1804,8 @@ mod tests {
 
     #[test]
     fn test_ops_rate_limiter() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1904,7 +1915,8 @@ mod tests {
 
     #[test]
     fn test_patch_rate_limiters() {
-        let mem = GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem =
+            GuestMemory::new(&[(GuestAddress(0), 0x10000)]).unwrap_or_else(|err| panic!("{}", err));
         let (mut h, _, _) = default_test_netepollhandler(&mem, TestMutators::default());
 
         h.set_rx_rate_limiter(RateLimiter::new(10, None, 10, 2, None, 2).unwrap());

--- a/devices/src/virtio/vsock/device.rs
+++ b/devices/src/virtio/vsock/device.rs
@@ -278,7 +278,7 @@ mod tests {
         );
         match bad_activate {
             Err(ActivateError::BadActivate) => (),
-            other => panic!("{:?}", other),
+            other => panic!("{}", other.unwrap_err()),
         }
 
         // Test a correct activation.
@@ -298,7 +298,7 @@ mod tests {
                     EventFd::new().unwrap(),
                 ],
             )
-            .unwrap();
+            .unwrap_or_else(|err| panic!("{}", err));
     }
 
 }

--- a/devices/src/virtio/vsock/epoll_handler.rs
+++ b/devices/src/virtio/vsock/epoll_handler.rs
@@ -68,7 +68,7 @@ where
         self.interrupt_status
             .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
         self.interrupt_evt.write(1).map_err(|e| {
-            error!("Failed to signal used queue: {:?}", e);
+            error!("Failed to signal used queue: {}", e);
             DeviceError::FailedSignalingUsedQueue(e)
         })
     }
@@ -94,7 +94,7 @@ where
                     }
                 }
                 Err(e) => {
-                    warn!("vsock: RX queue error: {:?}", e);
+                    warn!("vsock: RX queue error: {}", e);
                     0
                 }
             };
@@ -118,7 +118,7 @@ where
             let pkt = match VsockPacket::from_tx_virtq_head(&head) {
                 Ok(pkt) => pkt,
                 Err(e) => {
-                    error!("vsock: error reading TX packet: {:?}", e);
+                    error!("vsock: error reading TX packet: {}", e);
                     have_used = true;
                     self.txvq.add_used(&self.mem, head.index, 0);
                     continue;

--- a/devices/src/virtio/vsock/unix/muxer.rs
+++ b/devices/src/virtio/vsock/unix/muxer.rs
@@ -800,7 +800,7 @@ mod tests {
             let pkt = VsockPacket::from_rx_virtq_head(
                 &handler_ctx.handler.rxvq.pop(&vsock_test_ctx.mem).unwrap(),
             )
-            .unwrap();
+            .unwrap_or_else(|err| panic!("{}", err));
             let uds_path = format!("test_vsock_{}.sock", name);
             let muxer = VsockMuxer::new(PEER_CID, uds_path).unwrap();
 
@@ -839,11 +839,15 @@ mod tests {
         }
 
         fn send(&mut self) {
-            self.muxer.send_pkt(&self.pkt).unwrap();
+            self.muxer
+                .send_pkt(&self.pkt)
+                .unwrap_or_else(|err| panic!("{}", err));
         }
 
         fn recv(&mut self) {
-            self.muxer.recv_pkt(&mut self.pkt).unwrap();
+            self.muxer
+                .recv_pkt(&mut self.pkt)
+                .unwrap_or_else(|err| panic!("{}", err));
         }
 
         fn notify_muxer(&mut self) {

--- a/kernel/src/cmdline/mod.rs
+++ b/kernel/src/cmdline/mod.rs
@@ -34,12 +34,16 @@ impl fmt::Display for Error {
             f,
             "{}",
             match *self {
-                Error::CommandLineCopy => "Failed to copy the command line string to guest memory",
-                Error::CommandLineOverflow => "Command line string overflows guest memory",
-                Error::InvalidAscii => "Command line string contains non-printable ASCII character",
-                Error::HasSpace => "Command line string contains a space",
-                Error::HasEquals => "Command line string contains an equals sign",
-                Error::TooLarge => "Command line inserting string would make command line too long",
+                Error::CommandLineCopy => "Failed to copy the command line string to guest memory.",
+                Error::CommandLineOverflow => "Command line string overflows guest memory.",
+                Error::InvalidAscii => {
+                    "Command line string contains non-printable ASCII character."
+                }
+                Error::HasSpace => "Command line string contains a space.",
+                Error::HasEquals => "Command line string contains an equals sign.",
+                Error::TooLarge => {
+                    "Command line inserting string would make command line too long."
+                }
             }
         )
     }
@@ -257,27 +261,27 @@ mod tests {
     fn display_errors() {
         assert_eq!(
             Error::CommandLineCopy.to_string().as_str(),
-            "Failed to copy the command line string to guest memory"
+            "Failed to copy the command line string to guest memory."
         );
         assert_eq!(
             Error::CommandLineOverflow.to_string().as_str(),
-            "Command line string overflows guest memory"
+            "Command line string overflows guest memory."
         );
         assert_eq!(
             Error::InvalidAscii.to_string().as_str(),
-            "Command line string contains non-printable ASCII character"
+            "Command line string contains non-printable ASCII character."
         );
         assert_eq!(
             Error::HasSpace.to_string().as_str(),
-            "Command line string contains a space"
+            "Command line string contains a space."
         );
         assert_eq!(
             Error::HasEquals.to_string().as_str(),
-            "Command line string contains an equals sign"
+            "Command line string contains an equals sign."
         );
         assert_eq!(
             Error::TooLarge.to_string().as_str(),
-            "Command line inserting string would make command line too long"
+            "Command line inserting string would make command line too long."
         );
     }
 }

--- a/kernel/src/loader/mod.rs
+++ b/kernel/src/loader/mod.rs
@@ -268,7 +268,7 @@ mod tests {
     const MEM_SIZE: usize = 0x18_0000;
 
     fn create_guest_mem() -> GuestMemory {
-        GuestMemory::new(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+        GuestMemory::new(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap_or_else(|err| panic!("{}", err))
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -298,7 +298,8 @@ mod tests {
 
     #[test]
     fn test_load_kernel_no_memory() {
-        let gm = GuestMemory::new(&[(GuestAddress(0x0), 79)]).unwrap();
+        let gm =
+            GuestMemory::new(&[(GuestAddress(0x0), 79)]).unwrap_or_else(|err| panic!("{}", err));
         let image = make_test_bin();
         assert_eq!(
             Err(Error::ReadKernelImage),
@@ -405,19 +406,29 @@ mod tests {
         cmdline.insert_str("1234").unwrap();
         let cmdline = cmdline.as_cstring().unwrap();
         assert_eq!(Ok(()), load_cmdline(&gm, cmdline_address, &cmdline));
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
+        let val: u8 = gm
+            .read_obj_from_addr(cmdline_address)
+            .unwrap_or_else(|err| panic!("{}", err));
         assert_eq!(val, b'1');
         cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
+        let val: u8 = gm
+            .read_obj_from_addr(cmdline_address)
+            .unwrap_or_else(|err| panic!("{}", err));
         assert_eq!(val, b'2');
         cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
+        let val: u8 = gm
+            .read_obj_from_addr(cmdline_address)
+            .unwrap_or_else(|err| panic!("{}", err));
         assert_eq!(val, b'3');
         cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
+        let val: u8 = gm
+            .read_obj_from_addr(cmdline_address)
+            .unwrap_or_else(|err| panic!("{}", err));
         assert_eq!(val, b'4');
         cmdline_address = cmdline_address.unchecked_add(1);
-        let val: u8 = gm.read_obj_from_addr(cmdline_address).unwrap();
+        let val: u8 = gm
+            .read_obj_from_addr(cmdline_address)
+            .unwrap_or_else(|err| panic!("{}", err));
         assert_eq!(val, b'\0');
     }
 }

--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -9,10 +9,11 @@
 
 use std::io::{Read, Write};
 use std::sync::Arc;
-use std::{mem, result};
+use std::{fmt, mem, result};
 
 use guest_address::GuestAddress;
 use mmap::{self, MemoryMapping};
+use std::fmt::Formatter;
 use DataInit;
 
 /// Errors associated with handling guest memory regions.
@@ -34,6 +35,40 @@ pub enum Error {
     NoMemoryRegions,
 }
 type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidGuestAddress(_) => write!(
+                f,
+                "Failure in finding guest address in any memory regions \
+                 mapped by this guest."
+            ),
+            Error::InvalidGuestAddressRange(_, _) => write!(
+                f,
+                "Failure in finding a guest address in range in any \
+                 memory regions mapped by this guest."
+            ),
+            Error::MemoryAccess(_, err) => write!(
+                f,
+                "Failed to access the memory located guest address: {}",
+                err
+            ),
+            Error::MemoryMappingFailed(err) => write!(
+                f,
+                "Failure in creating an anonymous shared mapping: {}",
+                err
+            ),
+            Error::MemoryNotInitialized => write!(f, "Failure in initializing guest memory."),
+            Error::MemoryRegionOverlap => write!(f, "Two of the memory regions are overlapping."),
+            Error::NoMemoryRegions => write!(
+                f,
+                "No memory regions were provided for initializing the \
+                 guest memory."
+            ),
+        }
+    }
+}
 
 /// Tracks a mapping of anonymous memory in the current process and the corresponding base address
 /// in the guest's memory space.

--- a/memory_model/src/mmap.rs
+++ b/memory_model/src/mmap.rs
@@ -15,7 +15,6 @@ use std::ptr::null_mut;
 use libc;
 
 use std::fmt;
-use std::fmt::Formatter;
 use DataInit;
 
 /// Errors associated with memory mapping.
@@ -37,7 +36,7 @@ pub enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::InvalidAddress => write!(f, "Requested memory out of range."),
             Error::InvalidRange(_, _) => write!(
@@ -51,7 +50,7 @@ impl fmt::Display for Error {
                  source: {}",
                 err
             ),
-            Error::SystemCallFailed(err) => write!(f, "`mmap` failed: {}", err),
+            Error::SystemCallFailed(err) => write!(f, "{}", err),
             Error::WriteToMemory(err) => write!(f, "Writing to memory failed: {}", err),
             Error::ReadFromMemory(err) => write!(f, "Reading from memory failed: {}", err),
         }
@@ -431,5 +430,30 @@ mod tests {
             mem_map.write_from_memory(2, &mut sink, mem::size_of::<u32>())
         );
         assert_eq!(sink, vec![0; mem::size_of::<u32>()]);
+    }
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::SystemCallFailed(io::Error::from_raw_os_error(0))
+            ),
+            format!("{}", io::Error::from_raw_os_error(0))
+        );
+        assert_eq!(
+            format!("{}", Error::WriteToMemory(io::Error::from_raw_os_error(0))),
+            format!(
+                "Writing to memory failed: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+        assert_eq!(
+            format!("{}", Error::ReadFromMemory(io::Error::from_raw_os_error(0))),
+            format!(
+                "Reading from memory failed: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
     }
 }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use std::fmt;
 use std::fs::File;
 use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::net::UdpSocket;
@@ -14,6 +15,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use libc;
 
 use net_gen;
+use std::fmt::Formatter;
 use sys_util::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
 // As defined in the Linux UAPI:
@@ -42,6 +44,17 @@ ioctl_iow_nr!(TUNSETIFF, TUNTAP, 202, ::std::os::raw::c_int);
 ioctl_iow_nr!(TUNSETOFFLOAD, TUNTAP, 208, ::std::os::raw::c_uint);
 ioctl_iow_nr!(TUNSETVNETHDRSZ, TUNTAP, 216, ::std::os::raw::c_int);
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Error::CreateSocket(err) => write!(f, "Failed to create a socket: {}", err),
+            Error::CreateTap(err) => write!(f, "Unable to create tap interface: {}", err),
+            Error::InvalidIfname => write!(f, "Invalid interface name."),
+            Error::IoctlError(err) => write!(f, "Ioctl failed: {}", err),
+            Error::OpenTun(err) => write!(f, "Couldn't open /dev/net/tun: {}", err),
+        }
+    }
+}
 /// Handle for a network tap interface.
 ///
 /// For now, this simply wraps the file descriptor for the tap device so methods

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 86.0
+COVERAGE_TARGET_PCT = 86.3
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -205,11 +205,11 @@ def test_api_requests_logs(test_microvm_with_api):
     # We are not interested in the actual body. Just check that the log
     # message also has the string "body" in it.
     expected_log_strings.append(
-        "The API server received a synchronous Patch request "
-        "on \"/machine-config\" with body"
+        "The API server received a synchronous PATCH request "
+        "on /machine-config with body"
     )
 
-    # Check that a Put request on /machine-config is logged.
+    # Check that a PUT request on /machine-config is logged.
     response = microvm.machine_cfg.put(
         vcpu_count=4,
         ht_enabled=False,
@@ -217,17 +217,17 @@ def test_api_requests_logs(test_microvm_with_api):
     )
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Put request "
-        "on \"/machine-config\" with body"
+        "The API server received a synchronous PUT request "
+        "on /machine-config with body"
     )
 
-    # Check that a Get request on /machine-config is logged without the
+    # Check that a GET request on /machine-config is logged without the
     # body.
     response = microvm.machine_cfg.get()
     assert microvm.api_session.is_status_ok(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Get request "
-        "on \"/machine-config\"."
+        "The API server received a synchronous GET request "
+        "on /machine-config."
     )
 
     # Check that all requests on /mmds are logged without the body.
@@ -241,19 +241,19 @@ def test_api_requests_logs(test_microvm_with_api):
     response = microvm.mmds.put(json=dummy_json)
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Put request on \"/mmds\"."
+        "The API server received a synchronous PUT request on /mmds."
     )
 
     response = microvm.mmds.patch(json=dummy_json)
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Patch request on \"/mmds\"."
+        "The API server received a synchronous PATCH request on /mmds."
     )
 
     response = microvm.mmds.get()
     assert microvm.api_session.is_status_ok(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Get request on \"/mmds\"."
+        "The API server received a synchronous GET request on /mmds."
     )
 
     assert log_file_contains_strings(log_fifo, expected_log_strings)

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    fn test_debug_error() {
+    fn test_error_messages() {
         assert_eq!(
             format!("{}", Error::BusError(devices::BusError::Overlap)),
             format!(

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -427,7 +427,8 @@ mod tests {
     fn test_register_virtio_device() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
@@ -445,7 +446,8 @@ mod tests {
     fn test_register_too_many_devices() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
@@ -489,7 +491,8 @@ mod tests {
         assert_eq!(dummy.queue_max_sizes(), QUEUE_SIZES);
 
         // test activate
-        let m = GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m =
+            GuestMemory::new(&[(GuestAddress(0), 0x1000)]).unwrap_or_else(|err| panic!("{}", err));
         let ievt = EventFd::new().unwrap();
         let stat = Arc::new(AtomicUsize::new(0));
         let queue_evts = vec![EventFd::new().unwrap()];
@@ -501,7 +504,8 @@ mod tests {
     fn test_error_messages() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -535,8 +539,10 @@ mod tests {
                 "{}",
                 Error::CreateMmioDevice(io::Error::from_raw_os_error(0))
             ),
-            format!("Failed to create mmio device: {}",
-            io::Error::from_raw_os_error(0))
+            format!(
+                "Failed to create mmio device: {}",
+                io::Error::from_raw_os_error(0)
+            )
         );
         assert_eq!(
             format!("{}", Error::IrqsExhausted),
@@ -559,7 +565,8 @@ mod tests {
     fn test_update_drive() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -581,7 +588,8 @@ mod tests {
     fn test_device_info() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -619,7 +627,8 @@ mod tests {
     fn test_raw_io_device() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let guest_mem = GuestMemory::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)])
+            .unwrap_or_else(|err| panic!("{}", err));
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let dummy_device = Arc::new(Mutex::new(DummyDevice { dummy: 0 }));

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -480,7 +480,7 @@ mod tests {
                     )
                     .unwrap_err()
             ),
-            "No more IRQs are available.".to_string()
+            "No more IRQs are available."
         );
     }
 
@@ -524,7 +524,7 @@ mod tests {
         );
         assert_eq!(
             format!("{}", e),
-            "Unable to add device to kernel command line: Command line string contains an equals sign"
+            "Unable to add device to kernel command line: Command line string contains an equals sign."
         );
         assert_eq!(
             format!("{}", Error::UpdateFailed),
@@ -553,11 +553,30 @@ mod tests {
                 "{}",
                 Error::RegisterIoEvent(io::Error::from_raw_os_error(0))
             ),
-            "Failed to register IO event: No error information (os error 0)"
+            format!(
+                "Failed to register IO event: {}",
+                io::Error::from_raw_os_error(0)
+            )
         );
         assert_eq!(
             format!("{}", Error::RegisterIrqFd(io::Error::from_raw_os_error(0))),
-            "Failed to register irqfd: No error information (os error 0)"
+            format!(
+                "Failed to register irqfd: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!("{}", Error::EventFd(io::Error::from_raw_os_error(0))),
+            format!(
+                "Failed to create or clone event descriptor: {}",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!("{}", Error::DeviceNotFound),
+            "The device couldn't be found."
         );
     }
 

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -21,7 +21,6 @@ use kvm_ioctls::{IoEventAddress, VmFd};
 use memory_model::GuestMemory;
 
 /// Errors for MMIO device manager.
-#[derive(Debug)]
 pub enum Error {
     /// Failed to perform an operation on the bus.
     BusError(devices::BusError),
@@ -46,17 +45,17 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::BusError(ref e) => write!(f, "failed to perform bus operation: {}", e),
-            Error::CreateMmioDevice(ref e) => write!(f, "failed to create mmio device: {}", e),
+            Error::BusError(ref e) => write!(f, "Failed to perform bus operation: {}", e),
+            Error::CreateMmioDevice(ref e) => write!(f, "Failed to create mmio device: {}", e),
             Error::Cmdline(ref e) => {
-                write!(f, "unable to add device to kernel command line: {}", e)
+                write!(f, "Unable to add device to kernel command line: {}", e)
             }
-            Error::EventFd(ref e) => write!(f, "failed to create or clone event descriptor: {}", e),
-            Error::IrqsExhausted => write!(f, "no more IRQs are available"),
-            Error::RegisterIoEvent(ref e) => write!(f, "failed to register IO event: {}", e),
-            Error::RegisterIrqFd(ref e) => write!(f, "failed to register irqfd: {}", e),
-            Error::DeviceNotFound => write!(f, "the device couldn't be found"),
-            Error::UpdateFailed => write!(f, "failed to update the mmio device"),
+            Error::EventFd(ref e) => write!(f, "Failed to create or clone event descriptor: {}", e),
+            Error::IrqsExhausted => write!(f, "No more IRQs are available."),
+            Error::RegisterIoEvent(ref e) => write!(f, "Failed to register IO event: {}", e),
+            Error::RegisterIrqFd(ref e) => write!(f, "Failed to register irqfd: {}", e),
+            Error::DeviceNotFound => write!(f, "The device couldn't be found."),
+            Error::UpdateFailed => write!(f, "Failed to update the mmio device."),
         }
     }
 }
@@ -421,7 +420,7 @@ mod tests {
             0,
             kvm_ioctls::Kvm::new().expect("Cannot create KVM object"),
         )
-        .expect("Cannot Create VMM")
+        .unwrap_or_else(|err| panic!("Can not create VMM: {}", err))
     }
 
     #[test]
@@ -464,7 +463,7 @@ mod tests {
                     0,
                     "dummy1",
                 )
-                .unwrap();
+                .unwrap_or_else(|err| panic!("{}", err));
         }
         assert_eq!(
             format!(
@@ -479,7 +478,7 @@ mod tests {
                     )
                     .unwrap_err()
             ),
-            "no more IRQs are available".to_string()
+            "No more IRQs are available.".to_string()
         );
     }
 
@@ -521,52 +520,38 @@ mod tests {
         );
         assert_eq!(
             format!("{}", e),
-            format!(
-                "unable to add device to kernel command line: {}",
-                kernel_cmdline::Error::HasEquals
-            ),
+            "Unable to add device to kernel command line: Command line string contains an equals sign"
         );
         assert_eq!(
             format!("{}", Error::UpdateFailed),
-            "failed to update the mmio device"
+            "Failed to update the mmio device."
         );
         assert_eq!(
             format!("{}", Error::BusError(devices::BusError::Overlap)),
-            format!(
-                "failed to perform bus operation: {}",
-                devices::BusError::Overlap
-            )
+            "Failed to perform bus operation: New device overlaps with an old device."
         );
         assert_eq!(
             format!(
                 "{}",
                 Error::CreateMmioDevice(io::Error::from_raw_os_error(0))
             ),
-            format!(
-                "failed to create mmio device: {}",
-                io::Error::from_raw_os_error(0)
-            )
+            format!("Failed to create mmio device: {}",
+            io::Error::from_raw_os_error(0))
         );
         assert_eq!(
             format!("{}", Error::IrqsExhausted),
-            "no more IRQs are available"
+            "No more IRQs are available."
         );
         assert_eq!(
             format!(
                 "{}",
                 Error::RegisterIoEvent(io::Error::from_raw_os_error(0))
             ),
-            format!(
-                "failed to register IO event: {}",
-                io::Error::from_raw_os_error(0)
-            )
+            "Failed to register IO event: No error information (os error 0)"
         );
         assert_eq!(
             format!("{}", Error::RegisterIrqFd(io::Error::from_raw_os_error(0))),
-            format!(
-                "failed to register irqfd: {}",
-                io::Error::from_raw_os_error(0)
-            )
+            "Failed to register irqfd: No error information (os error 0)"
         );
     }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3407,7 +3407,7 @@ mod tests {
         // `KVM_CREATE_VCPU` fails if the irqchip is not created beforehand. This is x86_64 speciifc.
         vmm.vm
             .setup_irqchip()
-            .expect("Cannot create IRQCHIP or PIT");
+            .unwrap_or_else(|err| panic!("Cannot create IRQCHIP or PIT: {}", err));
 
         assert!(vmm
             .create_vcpus(GuestAddress(0x0), TimestampUs::default())
@@ -4300,7 +4300,8 @@ mod tests {
 
         assert!(vmm.guest_memory().is_none());
 
-        let mem = GuestMemory::new(&[(GuestAddress(0x1000), 0x100)]).unwrap();
+        let mem = GuestMemory::new(&[(GuestAddress(0x1000), 0x100)])
+            .unwrap_or_else(|err| panic!("{}", err));
         vmm.set_guest_memory(mem);
 
         let mem_ref = vmm.guest_memory().unwrap();

--- a/vmm/src/vmm_config/boot_source.rs
+++ b/vmm/src/vmm_config/boot_source.rs
@@ -17,13 +17,12 @@ pub struct BootSourceConfig {
 }
 
 /// Errors associated with actions on `BootSourceConfig`.
-#[derive(Debug)]
 pub enum BootSourceConfigError {
     /// The kernel file cannot be opened.
     InvalidKernelPath,
     /// The kernel command line is invalid.
     InvalidKernelCommandLine,
-    /// The boot source cannot be update post boot.
+    /// The boot source cannot be updated post boot.
     UpdateNotAllowedPostBoot,
 }
 
@@ -36,7 +35,7 @@ impl Display for BootSourceConfigError {
                 "The kernel file cannot be opened due to invalid kernel path or \
                  invalid permissions.",
             ),
-            InvalidKernelCommandLine => write!(f, "The kernel command line is invalid!"),
+            InvalidKernelCommandLine => write!(f, "The kernel command line is invalid."),
             UpdateNotAllowedPostBoot => {
                 write!(f, "The update operation is not allowed after boot.")
             }

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -40,7 +40,7 @@ impl Display for DriveError {
             CannotOpenBlockDevice => {
                 write!(f, "Cannot open block device. Invalid permission/path.")
             }
-            InvalidBlockDeviceID => write!(f, "Invalid block device id."),
+            InvalidBlockDeviceID => write!(f, "Invalid block device ID."),
             InvalidBlockDevicePath => write!(f, "Invalid block device path."),
             BlockDevicePathAlreadyExists => write!(
                 f,

--- a/vmm/src/vmm_config/drive.rs
+++ b/vmm/src/vmm_config/drive.rs
@@ -36,23 +36,24 @@ pub enum DriveError {
 impl Display for DriveError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::DriveError::*;
-        write!(
-            f,
-            "{}",
-            match *self {
-                CannotOpenBlockDevice => "Cannot open block device. Invalid permission/path.",
-                InvalidBlockDeviceID => "Invalid block device ID!",
-                InvalidBlockDevicePath => "Invalid block device path!",
-                BlockDevicePathAlreadyExists => {
-                    "The block device path was already added to a different drive!"
-                }
-                EpollHandlerNotFound => "Error retrieving device epoll handler!",
-                BlockDeviceUpdateFailed => "The update operation failed!",
-                OperationNotAllowedPreBoot => "Operation not allowed pre-boot!",
-                RootBlockDeviceAlreadyAdded => "A root block device already exists!",
-                UpdateNotAllowedPostBoot => "The update operation is not allowed after boot.",
+        match *self {
+            CannotOpenBlockDevice => {
+                write!(f, "Cannot open block device. Invalid permission/path.")
             }
-        )
+            InvalidBlockDeviceID => write!(f, "Invalid block device id."),
+            InvalidBlockDevicePath => write!(f, "Invalid block device path."),
+            BlockDevicePathAlreadyExists => write!(
+                f,
+                "The block device path was already added to a different drive."
+            ),
+            EpollHandlerNotFound => write!(f, "Error retrieving device epoll handler."),
+            BlockDeviceUpdateFailed => write!(f, "The update operation failed."),
+            OperationNotAllowedPreBoot => write!(f, "Operation not allowed pre-boot."),
+            RootBlockDeviceAlreadyAdded => write!(f, "A root block device already exists."),
+            UpdateNotAllowedPostBoot => {
+                write!(f, "The update operation is not allowed after boot.")
+            }
+        }
     }
 }
 

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -176,3 +176,32 @@ impl Display for StartMicrovmError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use vmm_config::instance_info::StartMicrovmError;
+
+    #[test]
+    fn test_error_messages() {
+        assert_eq!(
+            format!(
+                "{}",
+                StartMicrovmError::CreateRateLimiter(std::io::Error::from_raw_os_error(0))
+            ),
+            format!(
+                "Cannot create RateLimiter: {}",
+                std::io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            format!("{}", StartMicrovmError::CreateVsockDevice),
+            "Cannot create vsock device."
+        );
+
+        assert_eq!(
+            format!("{}", StartMicrovmError::DeviceManager),
+            "The device manager was not configured."
+        );
+    }
+}

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -42,7 +42,6 @@ pub struct InstanceInfo {
 
 /// Errors associated with starting the instance.
 // TODO: add error kind to these variants because not all these errors are user or internal.
-#[derive(Debug)]
 pub enum StartMicrovmError {
     /// This error is thrown by the minimal boot loader implementation.
     /// It is related to a faulty memory configuration.
@@ -118,18 +117,8 @@ impl Display for StartMicrovmError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use self::StartMicrovmError::*;
         match *self {
-            ConfigureSystem(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Faulty memory configuration. {}", err_msg)
-            }
-            ConfigureVm(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot configure virtual machine. {}", err_msg)
-            }
+            ConfigureSystem(ref err) => write!(f, "Faulty memory configuration: {}", err),
+            ConfigureVm(ref err) => write!(f, "Cannot configure virtual machine: {}", err),
             CreateBlockDevice(ref err) => write!(
                 f,
                 "Unable to seek the block device backing file due to invalid permissions or \
@@ -138,115 +127,52 @@ impl Display for StartMicrovmError {
             ),
             CreateRateLimiter(ref err) => write!(f, "Cannot create RateLimiter: {}", err),
             CreateVsockDevice => write!(f, "Cannot create vsock device."),
-            CreateNetDevice(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot create network device. {}", err_msg)
-            }
+            CreateNetDevice(ref err) => write!(f, "Cannot create network device: {}", err),
             DeviceManager => write!(f, "The device manager was not configured."),
             EventFd => write!(f, "Cannot read from an Event file descriptor."),
-            GuestMemory(ref err) => {
-                // Remove imbricated quotes from error message.
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-                write!(f, "Invalid Memory Configuration: {}", err_msg)
-            }
+            GuestMemory(ref err) => write!(f, "Invalid memory configuration: {}", err),
             KernelCmdline(ref err) => write!(f, "Invalid kernel command line: {}", err),
-            KernelLoader(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-                write!(
-                    f,
-                    "Cannot load kernel due to invalid memory configuration or invalid kernel \
-                     image. {}",
-                    err_msg
-                )
-            }
-            LegacyIOBus(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot add devices to the legacy I/O Bus. {}", err_msg)
-            }
-            LoadCommandline(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-                write!(f, "Cannot load command line string. {}", err_msg)
-            }
+            KernelLoader(ref err) => write!(
+                f,
+                "Cannot load kernel due to invalid memory configuration or invalid kernel \
+                 image: {}",
+                err
+            ),
+            LegacyIOBus(ref err) => write!(f, "Cannot add devices to the legacy I/O Bus: {}", err),
+            LoadCommandline(ref err) => write!(f, "Cannot load command line string: {}", err),
             MicroVMAlreadyRunning => write!(f, "Microvm already running."),
             MissingKernelConfig => write!(f, "Cannot start microvm without kernel configuration."),
             NetDeviceNotConfigured => {
                 write!(f, "The net device configuration is missing the tap device.")
             }
             OpenBlockDevice(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot open the block device backing file. {}", err_msg)
+                write!(f, "Cannot open the block device backing file: {}", err)
             }
-            RegisterBlockDevice(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-                write!(
-                    f,
-                    "Cannot initialize a MMIO Block Device or add a device to the MMIO Bus. {}",
-                    err_msg
-                )
-            }
+            RegisterBlockDevice(ref err) => write!(
+                f,
+                "Cannot initialize a MMIO Block Device or add a device to the MMIO Bus: {}",
+                err
+            ),
             RegisterEvent => write!(f, "Cannot add event to Epoll."),
             RegisterMMIODevice(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot add a device to the MMIO Bus. {}", err_msg)
+                write!(f, "Cannot add a device to the MMIO Bus: {}", err)
             }
-            RegisterNetDevice(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(
-                    f,
-                    "Cannot initialize a MMIO Network Device or add a device to the MMIO Bus. {}",
-                    err_msg
-                )
-            }
-            RegisterVsockDevice(ref err) => {
-                let mut err_msg = format!("{}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(
-                    f,
-                    "Cannot initialize a MMIO Vsock Device or add a device to the MMIO Bus. {}",
-                    err_msg
-                )
-            }
-            SeccompFilters(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot build seccomp filters. {}", err_msg)
-            }
-            Vcpu(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot create a new vCPU. {}", err_msg)
-            }
-            VcpuConfigure(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "vCPU configuration failed. {}", err_msg)
-            }
+            RegisterNetDevice(ref err) => write!(
+                f,
+                "Cannot initialize a MMIO Network Device or add a device to the MMIO Bus: {}",
+                err
+            ),
+            RegisterVsockDevice(ref err) => write!(
+                f,
+                "Cannot initialize a MMIO Vsock Device or add a device to the MMIO Bus: {}",
+                err
+            ),
+            SeccompFilters(ref err) => write!(f, "Cannot build seccomp filters: {}", err),
+            Vcpu(ref err) => write!(f, "Cannot create a new vCPU: {}", err),
+            VcpuConfigure(ref err) => write!(f, "vCPU configuration failed: {}", err),
             VcpusNotConfigured => write!(f, "vCPUs were not configured."),
-            VcpuSpawn(ref err) => {
-                let mut err_msg = format!("{:?}", err);
-                err_msg = err_msg.replace("\"", "");
-
-                write!(f, "Cannot spawn vCPU thread. {}", err_msg)
-            }
             StdinHandle(ref err) => write!(f, "Failed to set mode for terminal: {}", err),
+            VcpuSpawn(ref err) => write!(f, "Cannot spawn vCPU thread: {}", err),
         }
     }
 }

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -110,7 +110,6 @@ fn default_log_options() -> Value {
 }
 
 /// Errors associated with actions on the `LoggerConfig`.
-#[derive(Debug)]
 pub enum LoggerConfigError {
     /// Cannot initialize the logger due to bad user input.
     InitializationFailure(String),
@@ -122,8 +121,8 @@ impl Display for LoggerConfigError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::LoggerConfigError::*;
         match *self {
-            InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
-            FlushMetrics(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
+            InitializationFailure(ref err_msg) => write!(f, "Initialization failure: {}", err_msg),
+            FlushMetrics(ref err_msg) => write!(f, "Flush metrics: {}", err_msg),
         }
     }
 }

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -74,7 +74,6 @@ pub struct NetworkInterfaceUpdateConfig {
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
-#[derive(Debug)]
 pub enum NetworkInterfaceError {
     /// The MAC address is already in use.
     GuestMacAddressInUse(String),
@@ -102,7 +101,7 @@ impl Display for NetworkInterfaceError {
                 format!("The guest MAC address {} is already in use.", mac_addr)
             ),
             EpollHandlerNotFound(ref e) => {
-                write!(f, "Error retrieving device epoll handler: {:?}", e)
+                write!(f, "Error retrieving device epoll handler: {}", e)
             }
             HostDeviceNameInUse(ref host_dev_name) => write!(
                 f,
@@ -401,12 +400,12 @@ mod tests {
     #[test]
     fn test_error_display() {
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::GuestMacAddressInUse("00:00:00:00:00:00".to_string()),
             NetworkInterfaceError::GuestMacAddressInUse("00:00:00:00:00:00".to_string())
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::EpollHandlerNotFound(
                 VmmInternalError::DeviceEventHandlerNotFound
             ),
@@ -415,22 +414,22 @@ mod tests {
             )
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::HostDeviceNameInUse("hostdev".to_string()),
             NetworkInterfaceError::HostDeviceNameInUse("hostdev".to_string())
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::DeviceIdNotFound,
             NetworkInterfaceError::DeviceIdNotFound
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::OpenTap(TapError::InvalidIfname),
             NetworkInterfaceError::OpenTap(TapError::InvalidIfname)
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::RateLimiterUpdateFailed(devices::Error::IoError(
                 io::Error::last_os_error()
             )),
@@ -439,7 +438,7 @@ mod tests {
             ))
         );
         let _ = format!(
-            "{}{:?}",
+            "{}{}",
             NetworkInterfaceError::UpdateNotAllowedPostBoot,
             NetworkInterfaceError::UpdateNotAllowedPostBoot
         );

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -112,15 +112,7 @@ impl Display for NetworkInterfaceError {
             OpenTap(ref e) => {
                 // We are propagating the Tap Error. This error can contain
                 // imbricated quotes which would result in an invalid json.
-                let mut tap_err = format!("{:?}", e);
-                tap_err = tap_err.replace("\"", "");
-
-                write!(
-                    f,
-                    "{}{}",
-                    "Cannot open TAP device. Invalid name/permissions. ".to_string(),
-                    tap_err
-                )
+                write!(f, "Cannot open TAP device. Invalid name/permissions: {}", e)
             }
             RateLimiterUpdateFailed(ref e) => write!(f, "Unable to update rate limiter: {:?}", e),
             UpdateNotAllowedPostBoot => {

--- a/vmm/src/vmm_config/vsock.rs
+++ b/vmm/src/vmm_config/vsock.rs
@@ -17,7 +17,6 @@ pub struct VsockDeviceConfig {
 }
 
 /// Errors associated with `VsockDeviceConfig`.
-#[derive(Debug)]
 pub enum VsockError {
     /// The update is not allowed after booting the microvm.
     UpdateNotAllowedPostBoot,


### PR DESCRIPTION
## Reason for This PR

Implement Debug & Display for Errors that can generate panics #856

## Description of Changes

I've added mostly Display traits to describe friendlier user-facing errors from api_server, which inherits errors from vmm, devices, arch etc.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
