### PR TITLE
api_server/swagger: Fix yaml file with correct parameter vsock_id

### DIFF
--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -661,7 +661,7 @@ definitions:
       - guest_cid
       - uds_path
     properties:
-      id:
+      vsock_id:
         type: string
       guest_cid:
         type: integer


### PR DESCRIPTION
The parameter "id" changed into "vsock_id" with the recent virtio-vsock
changes. This needs to be applied to the yaml file describing the client
API, otherwise swagger tool complains when generating the code.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.