### PR TITLE
Make the Vmm struct a bit more modular

### DIFF
--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -403,7 +403,7 @@ mod tests {
         let (_to_vmm, from_api) = channel();
         Vmm::new(
             shared_info,
-            EventFd::new().expect("cannot create eventFD"),
+            &EventFd::new().expect("cannot create eventFD"),
             from_api,
             0,
         )

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -406,6 +406,7 @@ mod tests {
             &EventFd::new().expect("cannot create eventFD"),
             from_api,
             0,
+            kvm_ioctls::Kvm::new().expect("Cannot create KVM object"),
         )
         .expect("Cannot Create VMM")
     }


### PR DESCRIPTION
## Reason for This PR

This PR introduces a couple of changes which make it easier to use the `Vmm` object by importing the appropriate crates at the code interface level. It simplifies decoupling the operation of the `Vmm` struct from the API server, enriching the interface to allow easier access to some inner objects, and adding the `pub` modifier to a number of methods, so it can be driven by outside modules as well.

## Description of Changes

Same as above. Descriptions also available as part of the individual commit messages.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
