### PR TITLE
Refactor device configurations.

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -87,6 +87,7 @@ use net_util::TapError;
 use serde_json::Value;
 use sys_util::{EventFd, Terminal};
 use vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
+use vmm_config::device_config::DeviceConfigs;
 use vmm_config::drive::{BlockDeviceConfig, BlockDeviceConfigs, DriveError};
 use vmm_config::instance_info::{InstanceInfo, InstanceState, StartMicrovmError};
 use vmm_config::logger::{LoggerConfig, LoggerConfigError, LoggerLevel};
@@ -768,11 +769,7 @@ struct Vmm {
     pio_device_manager: PortIODeviceManager,
 
     // Device configurations.
-    // If there is a Root Block Device, this should be added as the first element of the list.
-    // This is necessary because we want the root to always be mounted on /dev/vda.
-    block_device_configs: BlockDeviceConfigs,
-    network_interface_configs: NetworkInterfaceConfigs,
-    vsock_device_config: Option<VsockDeviceConfig>,
+    device_configs: DeviceConfigs,
 
     epoll_context: EpollContext,
 
@@ -810,7 +807,11 @@ impl Vmm {
             )
             .expect("Cannot add write metrics TimerFd to epoll.");
 
-        let block_device_configs = BlockDeviceConfigs::new();
+        let device_configs = DeviceConfigs::new(
+            BlockDeviceConfigs::new(),
+            NetworkInterfaceConfigs::new(),
+            None,
+        );
         let kvm = KvmContext::new()?;
         let vm = Vm::new(kvm.fd()).map_err(Error::Vm)?;
 
@@ -826,9 +827,7 @@ impl Vmm {
             vm,
             mmio_device_manager: None,
             pio_device_manager: PortIODeviceManager::new().map_err(Error::CreateLegacyDevice)?,
-            block_device_configs,
-            network_interface_configs: NetworkInterfaceConfigs::new(),
-            vsock_device_config: None,
+            device_configs,
             epoll_context,
             api_event_fd,
             from_api,
@@ -860,12 +859,12 @@ impl Vmm {
         let kernel_config = self.kernel_config.as_mut().ok_or(MissingKernelConfig)?;
 
         // If no PARTUUID was specified for the root device, try with the /dev/vda.
-        if self.block_device_configs.has_root_block_device()
-            && !self.block_device_configs.has_partuuid_root()
+        if self.device_configs.block.has_root_block_device()
+            && !self.device_configs.block.has_partuuid_root()
         {
             kernel_config.cmdline.insert_str("root=/dev/vda")?;
 
-            let flags = if self.block_device_configs.has_read_only_root() {
+            let flags = if self.device_configs.block.has_read_only_root() {
                 "ro"
             } else {
                 "rw"
@@ -879,7 +878,7 @@ impl Vmm {
         // device manager has been initialized.
         let device_manager = self.mmio_device_manager.as_mut().unwrap();
 
-        for drive_config in self.block_device_configs.config_list.iter_mut() {
+        for drive_config in self.device_configs.block.config_list.iter_mut() {
             // Add the block device from file.
             let block_file = OpenOptions::new()
                 .read(true)
@@ -947,7 +946,7 @@ impl Vmm {
         // device manager has been initialized.
         let device_manager = self.mmio_device_manager.as_mut().unwrap();
 
-        for cfg in self.network_interface_configs.iter_mut() {
+        for cfg in self.device_configs.network_interface.iter_mut() {
             let epoll_config = self.epoll_context.allocate_tokens_for_virtio_device(
                 TYPE_NET,
                 &cfg.iface_id,
@@ -1008,7 +1007,7 @@ impl Vmm {
         // device manager has been initialized.
         let device_manager = self.mmio_device_manager.as_mut().unwrap();
 
-        if let Some(cfg) = &self.vsock_device_config {
+        if let Some(cfg) = &self.device_configs.vsock {
             let backend = devices::virtio::vsock::VsockUnixBackend::new(
                 u64::from(cfg.guest_cid),
                 cfg.uds_path.clone(),
@@ -1725,7 +1724,8 @@ impl Vmm {
         if self.is_instance_initialized() {
             Err(NetworkInterfaceError::UpdateNotAllowedPostBoot)?;
         }
-        self.network_interface_configs
+        self.device_configs
+            .network_interface
             .insert(body)
             .map(|_| VmmData::Empty)
             .map_err(|e| VmmActionError::NetworkConfig(ErrorKind::User, e))
@@ -1739,7 +1739,8 @@ impl Vmm {
             // VM not started yet, so we only need to update the device configs, not the actual
             // live device.
             let old_cfg = self
-                .network_interface_configs
+                .device_configs
+                .network_interface
                 .iter_mut()
                 .find(|&&mut ref c| c.iface_id == new_cfg.iface_id)
                 .ok_or(NetworkInterfaceError::DeviceIdNotFound)?;
@@ -1804,7 +1805,7 @@ impl Vmm {
                 VsockError::UpdateNotAllowedPostBoot,
             ))
         } else {
-            self.vsock_device_config = Some(config);
+            self.device_configs.vsock = Some(config);
             Ok(VmmData::Empty)
         }
     }
@@ -1816,7 +1817,8 @@ impl Vmm {
     ) -> std::result::Result<VmmData, VmmActionError> {
         // Get the block device configuration specified by drive_id.
         let block_device_index = self
-            .block_device_configs
+            .device_configs
+            .block
             .get_index_of_drive_id(&drive_id)
             .ok_or(DriveError::InvalidBlockDeviceID)?;
 
@@ -1824,12 +1826,12 @@ impl Vmm {
         // Try to open the file specified by path_on_host using the permissions of the block_device.
         let disk_file = OpenOptions::new()
             .read(true)
-            .write(!self.block_device_configs.config_list[block_device_index].is_read_only())
+            .write(!self.device_configs.block.config_list[block_device_index].is_read_only())
             .open(&file_path)
             .map_err(|_| DriveError::CannotOpenBlockDevice)?;
 
         // Update the path of the block device with the specified path_on_host.
-        self.block_device_configs.config_list[block_device_index].path_on_host = file_path;
+        self.device_configs.block.config_list[block_device_index].path_on_host = file_path;
 
         // When the microvm is running, we also need to update the drive handler and send a
         // rescan command to the drive.
@@ -1852,7 +1854,7 @@ impl Vmm {
         // Safe to unwrap() because mmio_device_manager is initialized in init_devices(), which is
         // called before the guest boots, and this function is called after boot.
         let device_manager = self.mmio_device_manager.as_ref().unwrap();
-        for drive_config in self.block_device_configs.config_list.iter() {
+        for drive_config in self.device_configs.block.config_list.iter() {
             if drive_config.drive_id == *drive_id {
                 let metadata = metadata(&drive_config.path_on_host)
                     .map_err(|_| DriveError::BlockDeviceUpdateFailed)?;
@@ -1883,7 +1885,8 @@ impl Vmm {
         if self.is_instance_initialized() {
             Err(DriveError::UpdateNotAllowedPostBoot)?;
         }
-        self.block_device_configs
+        self.device_configs
+            .block
             .insert(block_device_config)
             .map(|_| VmmData::Empty)
             .map_err(VmmActionError::from)
@@ -2187,7 +2190,7 @@ mod tests {
         }
 
         fn update_block_device_path(&mut self, block_device_id: &str, new_path: PathBuf) {
-            for config in self.block_device_configs.config_list.iter_mut() {
+            for config in self.device_configs.block.config_list.iter_mut() {
                 if config.drive_id == block_device_id {
                     config.path_on_host = new_path;
                     break;
@@ -2196,7 +2199,7 @@ mod tests {
         }
 
         fn change_id(&mut self, prev_id: &str, new_id: &str) {
-            for config in self.block_device_configs.config_list.iter_mut() {
+            for config in self.device_configs.block.config_list.iter_mut() {
                 if config.drive_id == prev_id {
                     config.drive_id = new_id.to_string();
                     break;
@@ -2308,7 +2311,8 @@ mod tests {
         };
         assert!(vmm.insert_block_device(root_block_device.clone()).is_ok());
         assert!(vmm
-            .block_device_configs
+            .device_configs
+            .block
             .config_list
             .contains(&root_block_device));
 
@@ -2323,7 +2327,8 @@ mod tests {
         };
         assert!(vmm.insert_block_device(root_block_device.clone()).is_ok());
         assert!(vmm
-            .block_device_configs
+            .device_configs
+            .block
             .config_list
             .contains(&root_block_device));
 
@@ -2474,8 +2479,12 @@ mod tests {
         .unwrap();
 
         {
-            let nic_1: &mut NetworkInterfaceConfig =
-                vmm.network_interface_configs.iter_mut().next().unwrap();
+            let nic_1: &mut NetworkInterfaceConfig = vmm
+                .device_configs
+                .network_interface
+                .iter_mut()
+                .next()
+                .unwrap();
             // The RX bandwidth should be unaffected.
             assert_eq!(nic_1.rx_rate_limiter.unwrap().bandwidth.unwrap(), tbc_1mtps);
             // The RX ops should be set to 2mtps.

--- a/vmm/src/vmm_config/device_config.rs
+++ b/vmm/src/vmm_config/device_config.rs
@@ -1,0 +1,34 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(warnings)]
+
+use vmm_config::drive::*;
+use vmm_config::net::*;
+use vmm_config::vsock::*;
+
+/// A data structure that encapsulates the device configurations
+/// held in the Vmm.
+pub struct DeviceConfigs {
+    /// The configurations for block devices.
+    pub block: BlockDeviceConfigs,
+    /// The configurations for network interface devices.
+    pub network_interface: NetworkInterfaceConfigs,
+    /// The configurations for vsock devices.
+    pub vsock: Option<VsockDeviceConfig>,
+}
+
+impl DeviceConfigs {
+    /// Construct a `DeviceConfigs` structure from its constituent parts.
+    pub fn new(
+        block: BlockDeviceConfigs,
+        network_interface: NetworkInterfaceConfigs,
+        vsock: Option<VsockDeviceConfig>,
+    ) -> DeviceConfigs {
+        DeviceConfigs {
+            block,
+            network_interface,
+            vsock,
+        }
+    }
+}

--- a/vmm/src/vmm_config/mod.rs
+++ b/vmm/src/vmm_config/mod.rs
@@ -6,6 +6,8 @@ use std::io;
 
 /// Wrapper for configuring the microVM boot source.
 pub mod boot_source;
+/// Wrapper for device configurations.
+pub mod device_config;
 /// Wrapper for configuring the block devices.
 pub mod drive;
 /// Wrapper over the microVM general information attached to the microVM.


### PR DESCRIPTION
## Reason for This PR

This pull request refactors device configurations, encapsulating them all in a single wrapper class, thus providing greater readability and extensibillity.

## Description of Changes

This pull request does the following:

* Adds a `DeviceConfigs` class in `vmm/src/vmm_config/device_configs.rs`.
* Refactors `vmm/src/lib.rs` to use this to hold device configurations.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
