### PR TITLE
docs: README.md: vsock is no longer experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ The **API endpoint** can be used to:
 - Configure the logging and metric system.
 - `[BETA]` Configure the data tree of the guest-facing metadata service. The
   service is only available to the guest if this resource is configured.
-- `[EXPERIMENTAL]` Add one or more [vsock sockets](docs/experimental-vsock.md)
-  to the microVM. Check the complete vsock API definition in
-  [firecracker-experimental.yaml](api_server/swagger/firecracker-experimental.yaml).
+- Add a [vsock socket](docs/vsock.md) to the microVM.
 - Start the microVM using a given kernel image, root file system, and boot
   arguments.
 - Stop the microVM.

--- a/docs/api_requests/patch-network-interface.md
+++ b/docs/api_requests/patch-network-interface.md
@@ -54,6 +54,7 @@ Accept: application/json
             "refill_time": 1000
         }
     }
+}
 ```
 
 The full specification of the data structures available for this call can be
@@ -88,4 +89,5 @@ Accept: application/json
             "refill_time": 0
         }
     }
+}
 ```


### PR DESCRIPTION
## Reason for This PR

Update outdated information in the `README`.

## Description of Changes

README.md: vsock is no longer experimental

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
