### PR TITLE
Updated Firecracker doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ the Linux Kernel Virtual Machine (KVM) to create and run microVMs. Firecracker
 has a minimalist design. It excludes unnecessary devices and guest-facing
 functionality to reduce the memory footprint and attack surface area of each
 microVM. This improves security, decreases the startup time, and increases
-hardware utilization. Firecracker currently supports Intel CPUs, with planned
-AMD and Arm support. Firecracker will also be integrated with popular container
-runtimes.
-
+hardware utilization. Firecracker currently supports Intel, AMD (beta) and Arm
+(beta) CPUs. Firecracker can also be integrated in container runtimes. Checkout
+[Kata Containers with Firecracker.](https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support)
+ 
 Firecracker was developed at Amazon Web Services to accelerate the speed and
 efficiency of services like [AWS Lambda](https://aws.amazon.com/lambda/) and
 [AWS Fargate](https://aws.amazon.com/fargate/). Firecracker is open
@@ -43,10 +43,11 @@ development container) as follows:
 git clone https://github.com/firecracker-microvm/firecracker
 cd firecracker
 tools/devtool build
+toolchain="$(uname -m)-unkown-linux-musl"
 ```
 
-The Firecracker binary will be placed at `build/debug/firecracker`. For more
-information on building, testing, and running Firecracker, go to the
+The Firecracker binary will be placed at `build/cargo_target/${toolchain}/debug/firecracker`. 
+For more information on building, testing, and running Firecracker, go to the
 [quickstart guide](docs/getting-started.md).
 
 The overall security of Firecracker microVMs, including the ability to meet the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -295,12 +295,15 @@ git checkout tags/v0.10.1
 Within the Firecracker repository root directory:
 
 1. with the default musl target: ```tools/devtool build```
-1. using the gnu target: ```tools/devtool build -l gnu```
+2. using the gnu target: ```tools/devtool build -l gnu```
 
-This will build and place the two Firecracker binaries at
-`build/debug/firecracker` and `build/debug/jailer`. The default build profile
-is `debug`. If you want to build the release binaries (optimized and stripped
-of debug info), use the `--release` option:
+This will build and place the two Firecracker binaries at:
+- `build/cargo_target/${toolchain}/debug/firecracker` and
+- `build/cargo_target/${toolchain}/debug/jailer`. 
+
+The default build profile is `debug`. If you want to build 
+the release binaries (optimized and stripped of debug info), 
+use the `--release` option:
 
 ```bash
 tools/devtool build --release


### PR DESCRIPTION
Updated README.md Firecracker documentation

## Reason for This PR

Documentation should be updated to reflect current FC implementation.

## Description of Changes

README.md documentation was falling behind current Firecracker implementation. Now,
Firecracker supports AMD and ARM CPUs. Also, after building FC, the resulted binaries will
reside in a different directory than the one specified in the current documentation.
Changes: README.md, docs/getting-started.md

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
