### PR TITLE
net_gen: move away code that is not bindgen'd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,9 +475,6 @@ dependencies = [
 [[package]]
 name = "net_gen"
 version = "0.1.0"
-dependencies = [
- "sys_util 0.1.0",
-]
 
 [[package]]
 name = "net_util"

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -2,6 +2,3 @@
 name = "net_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-
-[dependencies]
-sys_util = { path = "../sys_util" }

--- a/net_gen/src/lib.rs
+++ b/net_gen/src/lib.rs
@@ -7,9 +7,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-#[macro_use]
-extern crate sys_util;
-
 // generated with bindgen /usr/include/linux/if.h --no-unstable-rust
 // --constified-enum '*' --with-derive-default -- -D __UAPI_DEF_IF_IFNAMSIZ -D
 // __UAPI_DEF_IF_NET_DEVICE_FLAGS -D __UAPI_DEF_IF_IFREQ -D __UAPI_DEF_IF_IFMAP
@@ -32,30 +29,3 @@ pub use if_tun::*;
 pub use iff::*;
 pub use inn::*;
 pub use sockios::*;
-
-pub const TUNTAP: ::std::os::raw::c_uint = 84;
-
-ioctl_iow_nr!(TUNSETNOCSUM, TUNTAP, 200, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETDEBUG, TUNTAP, 201, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETIFF, TUNTAP, 202, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETPERSIST, TUNTAP, 203, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETOWNER, TUNTAP, 204, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETLINK, TUNTAP, 205, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETGROUP, TUNTAP, 206, ::std::os::raw::c_int);
-ioctl_ior_nr!(TUNGETFEATURES, TUNTAP, 207, ::std::os::raw::c_uint);
-ioctl_iow_nr!(TUNSETOFFLOAD, TUNTAP, 208, ::std::os::raw::c_uint);
-ioctl_iow_nr!(TUNSETTXFILTER, TUNTAP, 209, ::std::os::raw::c_uint);
-ioctl_ior_nr!(TUNGETIFF, TUNTAP, 210, ::std::os::raw::c_uint);
-ioctl_ior_nr!(TUNGETSNDBUF, TUNTAP, 211, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETSNDBUF, TUNTAP, 212, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNATTACHFILTER, TUNTAP, 213, sock_fprog);
-ioctl_iow_nr!(TUNDETACHFILTER, TUNTAP, 214, sock_fprog);
-ioctl_ior_nr!(TUNGETVNETHDRSZ, TUNTAP, 215, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETVNETHDRSZ, TUNTAP, 216, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETQUEUE, TUNTAP, 217, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETIFINDEX, TUNTAP, 218, ::std::os::raw::c_uint);
-ioctl_ior_nr!(TUNGETFILTER, TUNTAP, 219, sock_fprog);
-ioctl_iow_nr!(TUNSETVNETLE, TUNTAP, 220, ::std::os::raw::c_int);
-ioctl_ior_nr!(TUNGETVNETLE, TUNTAP, 221, ::std::os::raw::c_int);
-ioctl_iow_nr!(TUNSETVNETBE, TUNTAP, 222, ::std::os::raw::c_int);
-ioctl_ior_nr!(TUNGETVNETBE, TUNTAP, 223, ::std::os::raw::c_int);

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -14,6 +14,7 @@ extern crate libc;
 extern crate serde;
 
 extern crate net_gen;
+#[macro_use]
 extern crate sys_util;
 
 mod mac;

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -31,6 +31,11 @@ pub enum Error {
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 
+const TUNTAP: ::std::os::raw::c_uint = 84;
+ioctl_iow_nr!(TUNSETIFF, TUNTAP, 202, ::std::os::raw::c_int);
+ioctl_iow_nr!(TUNSETOFFLOAD, TUNTAP, 208, ::std::os::raw::c_uint);
+ioctl_iow_nr!(TUNSETVNETHDRSZ, TUNTAP, 216, ::std::os::raw::c_int);
+
 /// Handle for a network tap interface.
 ///
 /// For now, this simply wraps the file descriptor for the tap device so methods
@@ -102,7 +107,7 @@ impl Tap {
 
         // ioctl is safe since we call it with a valid tap fd and check the return
         // value.
-        let ret = unsafe { ioctl_with_mut_ref(&tuntap, net_gen::TUNSETIFF(), &mut ifreq) };
+        let ret = unsafe { ioctl_with_mut_ref(&tuntap, TUNSETIFF(), &mut ifreq) };
 
         if ret < 0 {
             return Err(Error::CreateTap(IoError::last_os_error()));
@@ -172,8 +177,7 @@ impl Tap {
     pub fn set_offload(&self, flags: c_uint) -> Result<()> {
         // ioctl is safe. Called with a valid tap fd, and we check the return.
         #[allow(clippy::cast_lossless)]
-        let ret =
-            unsafe { ioctl_with_val(&self.tap_file, net_gen::TUNSETOFFLOAD(), flags as c_ulong) };
+        let ret = unsafe { ioctl_with_val(&self.tap_file, TUNSETOFFLOAD(), flags as c_ulong) };
         if ret < 0 {
             return Err(Error::IoctlError(IoError::last_os_error()));
         }
@@ -208,7 +212,7 @@ impl Tap {
     /// Set the size of the vnet hdr.
     pub fn set_vnet_hdr_size(&self, size: c_int) -> Result<()> {
         // ioctl is safe. Called with a valid tap fd, and we check the return.
-        let ret = unsafe { ioctl_with_ref(&self.tap_file, net_gen::TUNSETVNETHDRSZ(), &size) };
+        let ret = unsafe { ioctl_with_ref(&self.tap_file, TUNSETVNETHDRSZ(), &size) };
         if ret < 0 {
             return Err(Error::IoctlError(IoError::last_os_error()));
         }


### PR DESCRIPTION
Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

#603

## Description of Changes

Code that was not generated with bindgen was moved away from `net_gen` to the associated crate.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR
- [x] Code-level documentation for touched code is included (not applicable).
- [x] No API changes are included in this PR
- [x] The changes in this PR have no user impact