### PR TITLE
Allow API socket deactivation by passing no-api parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- New command-line parameter for `firecracker`, named `--no-api`, which 
+  will disable the API server thread. If set, the user won't be able to send 
+  any API requests, neither before, nor after the vm has booted. It must be 
+  paired with `--config-file` parameter. Also, when API server is disabled, 
+  MMDS is no longer available now.
 - New command-line parameter for `firecracker`, named `--config-file`, which 
   represents the path to a file that contains a JSON which can be used for 
   configuring and starting a microVM without sending any API requests.

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -79,12 +79,13 @@ impl ApiServer {
         mmds_info: Arc<Mutex<Mmds>>,
         vmm_shared_info: Arc<RwLock<InstanceInfo>>,
         api_request_sender: mpsc::Sender<Box<VmmAction>>,
+        kick_vmm_efd: EventFd,
     ) -> Result<Self> {
         Ok(ApiServer {
             mmds_info,
             vmm_shared_info,
             api_request_sender: Rc::new(api_request_sender),
-            efd: Rc::new(EventFd::new().map_err(Error::Eventfd)?),
+            efd: Rc::new(kick_vmm_efd),
         })
     }
 
@@ -154,10 +155,6 @@ impl ApiServer {
         // do something in their future chain). When this returns, ongoing connections will be
         // interrupted, and other futures will not complete, as the event loop stops working.
         core.run(f)
-    }
-
-    pub fn get_event_fd_clone(&self) -> Result<EventFd> {
-        self.efd.try_clone().map_err(Error::Eventfd)
     }
 }
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -7,6 +7,8 @@ the data store, and the minimalist HTTP/TCP/IPv4 stack (named *Dumbo*). They
 all exist within the Firecracker process, and outside the KVM boundary; the
 first is a part of the API server, the data store is a global entity for a
 single microVM, and the last is a part of the device model.
+When the API server is disabled by passing `--no-api` parameter to Firecracker, 
+MMDS is no longer available. 
 
 ## The MMDS backend
 

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -62,7 +62,7 @@ class JailerContext:
         """Cleanup this jailer context."""
         self.cleanup()
 
-    def construct_param_list(self, config_file):
+    def construct_param_list(self, config_file, no_api):
         """Create the list of parameters we want the jailer to start with.
 
         We want to be able to vary any parameter even the required ones as we
@@ -97,6 +97,8 @@ class JailerContext:
         if config_file is not None:
             jailer_param_list.extend(['--'])
             jailer_param_list.extend(['--config-file', str(config_file)])
+        if no_api:
+            jailer_param_list.append('--no-api')
         return jailer_param_list
 
     def chroot_base_with_id(self):

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -46,7 +46,8 @@ class Microvm:
         build_feature='',
         monitor_memory=True,
         bin_cloner_path=None,
-        config_file=None
+        config_file=None,
+        no_api=False,
     ):
         """Set up microVM attributes, paths, and data structures."""
         # Unique identifier for this machine.
@@ -99,6 +100,9 @@ class Microvm:
         # Optional file that contains a json for configuring microvm from
         # command line parameter.
         self.config_file = config_file
+
+        # Parameter set when user wants to disable API thread.
+        self.no_api = no_api
 
         # The ssh config dictionary is populated with information about how
         # to connect to a microVM that has ssh capability. The path of the
@@ -265,7 +269,8 @@ class Microvm:
         self.network = Network(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
 
-        jailer_param_list = self._jailer.construct_param_list(self.config_file)
+        jailer_param_list = self._jailer.construct_param_list(self.config_file,
+                                                              self.no_api)
 
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell. Going
@@ -340,7 +345,8 @@ class Microvm:
         # We expect the jailer to start within 80 ms. However, we wait for
         # 1 sec since we are rechecking the existence of the socket 5 times
         # and leave 0.2 delay between them.
-        self._wait_create()
+        if not self.no_api:
+            self._wait_create()
 
     @retry(delay=0.2, tries=5)
     def _wait_create(self):

--- a/tests/framework/vm_log_config.json
+++ b/tests/framework/vm_log_config.json
@@ -3,6 +3,10 @@
     "kernel_image_path": "vmlinux.bin",
     "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
   },
+  "logger": {
+    "log_fifo": "log_fifo",
+    "metrics_fifo": "metrics_fifo"
+  },
   "drives": [
     {
       "drive_id": "rootfs",

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.9
+COVERAGE_TARGET_PCT = 85.8
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.8
+COVERAGE_TARGET_PCT = 86.0
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -1,38 +1,26 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests microvm start with command line parameter."""
+"""Tests microvm start with configuration file as command line parameter."""
 
 import os
+from subprocess import run, PIPE
 
 import pytest
 
 import host_tools.logging as log_tools
 
 
-@pytest.mark.parametrize(
-    "vm_config_file",
-    ["framework/vm_config.json"]
-)
-def test_config_json_start(test_microvm_with_ssh, vm_config_file):
-    """Start a microvm using configuration sent as command line parameter.
+def _configure_vm_from_json(test_microvm, vm_config_file):
+    """Configure a microvm using a file sent as command line parameter.
 
-    Create resources needed for the configuration of the microvm, then
-    start a process which receives as command line parameter, one json
-    for that configuration.
+    Create resources needed for the configuration of the microvm and
+    set as configuration file a copy of the file that was passed as
+    parameter to this helper function.
     """
-    test_microvm = test_microvm_with_ssh
-
     test_microvm.create_jailed_resource(test_microvm.kernel_file,
                                         create_jail=True)
     test_microvm.create_jailed_resource(test_microvm.rootfs_file,
                                         create_jail=True)
-
-    log_fifo_path = os.path.join(test_microvm.path, 'log_fifo')
-    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
-    log_fifo = log_tools.Fifo(log_fifo_path)
-    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
-    test_microvm.create_jailed_resource(log_fifo.path, create_jail=True)
-    test_microvm.create_jailed_resource(metrics_fifo.path, create_jail=True)
 
     # vm_config_file is the source file that keeps the desired vmm
     # configuration. vm_config_path is the configuration file we
@@ -46,7 +34,57 @@ def test_config_json_start(test_microvm_with_ssh, vm_config_file):
                 f2.write(line)
     test_microvm.create_jailed_resource(vm_config_path, create_jail=True)
     test_microvm.config_file = os.path.basename(vm_config_file)
+
+
+@pytest.mark.parametrize(
+    "vm_config_file",
+    ["framework/vm_config.json"]
+)
+def test_config_start_with_api(test_microvm_with_ssh, vm_config_file):
+    """Test if a microvm configured from file boots successfully."""
+    test_microvm = test_microvm_with_ssh
+
+    _configure_vm_from_json(test_microvm, vm_config_file)
     test_microvm.spawn()
 
     response = test_microvm.machine_cfg.get()
     assert test_microvm.api_session.is_status_ok(response.status_code)
+
+
+@pytest.mark.parametrize(
+    "vm_config_file",
+    ["framework/vm_log_config.json"]
+)
+def test_config_start_no_api(test_microvm_with_ssh, vm_config_file):
+    """Test microvm start when API server thread is disabled."""
+    test_microvm = test_microvm_with_ssh
+
+    log_fifo_path = os.path.join(test_microvm.path, 'log_fifo')
+    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
+    log_fifo = log_tools.Fifo(log_fifo_path)
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+    test_microvm.create_jailed_resource(log_fifo.path, create_jail=True)
+    test_microvm.create_jailed_resource(metrics_fifo.path, create_jail=True)
+
+    _configure_vm_from_json(test_microvm, vm_config_file)
+    test_microvm.no_api = True
+    test_microvm.spawn()
+
+    # Get Firecracker PID so we can check the names of threads.
+    firecracker_pid = test_microvm.jailer_clone_pid
+
+    # Get names of threads in Firecracker.
+    cmd = 'ps -T --no-headers -p {} | awk \'{{print $5}}\''.format(
+        firecracker_pid
+    )
+    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
+    threads_out_lines = process.stdout.decode('utf-8').splitlines()
+
+    # Check that API server thread was not created.
+    assert 'fc_api' not in threads_out_lines
+    # Sanity check that main thread was created.
+    assert 'firecracker' in threads_out_lines
+
+    # Check that microvm was successfully booted.
+    lines = log_fifo.sequential_reader(1)
+    assert lines[0].startswith('Running Firecracker')

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2157,6 +2157,9 @@ impl PartialEq for VmmAction {
                 &InsertBlockDevice(ref block_device, _),
                 &InsertBlockDevice(ref other_other_block_device, _),
             ) => block_device == other_other_block_device,
+            (&SetVsockDevice(ref vsock_device, _), &SetVsockDevice(ref other_vsock_device, _)) => {
+                vsock_device == other_vsock_device
+            }
             (&ConfigureLogger(ref log, _), &ConfigureLogger(ref other_log, _)) => log == other_log,
             (
                 &SetVmConfiguration(ref vm_config, _),


### PR DESCRIPTION
Signed-off-by: Laura Loghin <lauralg@amazon.com>

## Reason for This PR

We want to allow the user to not use the API socket at all, if he configures the microvm with a configuration file and doesn't need to make post-boot operations (PATCH, GET calls).

Fixes: #1165

## Description of Changes

Added new command line parameter for Firecracker, named `--no-api` which will disable API server thread. Also, to avoid ambiguity, now the main thread is the VMM thread and the API thread is the one that is spawned from `main()`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] The required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched
      code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
