### PR TITLE
Fix warnings with rust 1.37

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -476,7 +476,7 @@ impl hyper::server::Service for ApiServerHttpService {
     type Request = hyper::Request;
     type Response = hyper::Response;
     type Error = hyper::error::Error;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     // This function returns a future that will resolve at some point to the response for
     // the HTTP request contained in req.

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -89,7 +89,7 @@ impl PartialOrd for BusRange {
 /// only restriction is that no two devices can overlap in this address space.
 #[derive(Clone, Default)]
 pub struct Bus {
-    devices: BTreeMap<BusRange, Arc<Mutex<BusDevice>>>,
+    devices: BTreeMap<BusRange, Arc<Mutex<dyn BusDevice>>>,
 }
 
 impl Bus {
@@ -100,7 +100,7 @@ impl Bus {
         }
     }
 
-    fn first_before(&self, addr: u64) -> Option<(BusRange, &Mutex<BusDevice>)> {
+    fn first_before(&self, addr: u64) -> Option<(BusRange, &Mutex<dyn BusDevice>)> {
         // for when we switch to rustc 1.17: self.devices.range(..addr).iter().rev().next()
         for (range, dev) in self.devices.iter().rev() {
             if range.0 <= addr {
@@ -110,7 +110,7 @@ impl Bus {
         None
     }
 
-    pub fn get_device(&self, addr: u64) -> Option<(u64, &Mutex<BusDevice>)> {
+    pub fn get_device(&self, addr: u64) -> Option<(u64, &Mutex<dyn BusDevice>)> {
         if let Some((BusRange(start, len), dev)) = self.first_before(addr) {
             let offset = addr - start;
             if offset < len {
@@ -121,7 +121,7 @@ impl Bus {
     }
 
     /// Puts the given device at the given address space.
-    pub fn insert(&mut self, device: Arc<Mutex<BusDevice>>, base: u64, len: u64) -> Result<()> {
+    pub fn insert(&mut self, device: Arc<Mutex<dyn BusDevice>>, base: u64, len: u64) -> Result<()> {
         if len == 0 {
             return Err(Error::Overlap);
         }

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -66,11 +66,11 @@ pub struct Serial {
     scratch: u8,
     baud_divisor: u16,
     in_buffer: VecDeque<u8>,
-    out: Option<Box<io::Write + Send>>,
+    out: Option<Box<dyn io::Write + Send>>,
 }
 
 impl Serial {
-    fn new(interrupt_evt: EventFd, out: Option<Box<io::Write + Send>>) -> Serial {
+    fn new(interrupt_evt: EventFd, out: Option<Box<dyn io::Write + Send>>) -> Serial {
         Serial {
             interrupt_enable: 0,
             interrupt_identification: DEFAULT_INTERRUPT_IDENTIFICATION,
@@ -87,7 +87,7 @@ impl Serial {
     }
 
     /// Constructs a Serial port ready for output.
-    pub fn new_out(interrupt_evt: EventFd, out: Box<io::Write + Send>) -> Serial {
+    pub fn new_out(interrupt_evt: EventFd, out: Box<dyn io::Write + Send>) -> Serial {
         Self::new(interrupt_evt, Some(out))
     }
 

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -428,11 +428,15 @@ pub struct EpollConfig {
     q_avail_token: u64,
     rate_limiter_token: u64,
     epoll_raw_fd: RawFd,
-    sender: mpsc::Sender<Box<EpollHandler>>,
+    sender: mpsc::Sender<Box<dyn EpollHandler>>,
 }
 
 impl EpollConfigConstructor for EpollConfig {
-    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
+    fn new(
+        first_token: u64,
+        epoll_raw_fd: RawFd,
+        sender: mpsc::Sender<Box<dyn EpollHandler>>,
+    ) -> Self {
         EpollConfig {
             q_avail_token: first_token + u64::from(QUEUE_AVAIL_EVENT),
             rate_limiter_token: first_token + u64::from(RATE_LIMITER_EVENT),

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -284,7 +284,7 @@ impl MmioDevice {
 impl BusDevice for MmioDevice {
     fn read(&mut self, offset: u64, data: &mut [u8]) {
         match offset {
-            0x00...0xff if data.len() == 4 => {
+            0x00..=0xff if data.len() == 4 => {
                 let v = match offset {
                     0x0 => MMIO_MAGIC_VALUE,
                     0x04 => MMIO_VERSION,
@@ -309,7 +309,7 @@ impl BusDevice for MmioDevice {
                 };
                 LittleEndian::write_u32(data, v);
             }
-            0x100...0xfff => self.device.read_config(offset - 0x100, data),
+            0x100..=0xfff => self.device.read_config(offset - 0x100, data),
             _ => {
                 warn!(
                     "invalid virtio mmio read: 0x{:x}:0x{:x}",
@@ -330,7 +330,7 @@ impl BusDevice for MmioDevice {
         }
 
         match offset {
-            0x00...0xff if data.len() == 4 => {
+            0x00..=0xff if data.len() == 4 => {
                 let v = LittleEndian::read_u32(data);
                 match offset {
                     0x14 => self.features_select = v,
@@ -370,7 +370,7 @@ impl BusDevice for MmioDevice {
                     }
                 }
             }
-            0x100...0xfff => {
+            0x100..=0xfff => {
                 if self.check_driver_status(DEVICE_DRIVER, DEVICE_FAILED) {
                     self.device.write_config(offset - 0x100, data)
                 } else {

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -86,7 +86,7 @@ pub trait VirtioDevice: Send {
 /// Typically one page (4096 bytes) of MMIO address space is sufficient to handle this transport
 /// and inner virtio device.
 pub struct MmioDevice {
-    device: Box<VirtioDevice>,
+    device: Box<dyn VirtioDevice>,
     device_activated: bool,
 
     features_select: u32,
@@ -103,7 +103,7 @@ pub struct MmioDevice {
 
 impl MmioDevice {
     /// Constructs a new MMIO transport for the given virtio device.
-    pub fn new(mem: GuestMemory, device: Box<VirtioDevice>) -> std::io::Result<MmioDevice> {
+    pub fn new(mem: GuestMemory, device: Box<dyn VirtioDevice>) -> std::io::Result<MmioDevice> {
         let mut queue_evts = Vec::new();
         for _ in device.queue_max_sizes().iter() {
             queue_evts.push(EventFd::new()?)

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -56,21 +56,25 @@ pub enum ActivateError {
 pub type ActivateResult = std::result::Result<(), ActivateError>;
 
 pub trait EpollConfigConstructor {
-    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self;
+    fn new(
+        first_token: u64,
+        epoll_raw_fd: RawFd,
+        sender: mpsc::Sender<Box<dyn EpollHandler>>,
+    ) -> Self;
 }
 
 /// Trait that helps in upcasting an object to Any
 pub trait AsAny {
-    fn as_any(&self) -> &Any;
+    fn as_any(&self) -> &dyn Any;
 
-    fn as_mut_any(&mut self) -> &mut Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
 }
 impl<T: Any> AsAny for T {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn as_mut_any(&mut self) -> &mut Any {
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
 }

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -652,11 +652,15 @@ pub struct EpollConfig {
     rx_rate_limiter_token: u64,
     tx_rate_limiter_token: u64,
     epoll_raw_fd: RawFd,
-    sender: mpsc::Sender<Box<EpollHandler>>,
+    sender: mpsc::Sender<Box<dyn EpollHandler>>,
 }
 
 impl EpollConfigConstructor for EpollConfig {
-    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
+    fn new(
+        first_token: u64,
+        epoll_raw_fd: RawFd,
+        sender: mpsc::Sender<Box<dyn EpollHandler>>,
+    ) -> Self {
         EpollConfig {
             rx_tap_token: first_token + u64::from(RX_TAP_EVENT),
             rx_queue_token: first_token + u64::from(RX_QUEUE_EVENT),

--- a/devices/src/virtio/vsock/mod.rs
+++ b/devices/src/virtio/vsock/mod.rs
@@ -130,11 +130,15 @@ pub struct EpollConfig {
     evq_token: u64,
     backend_token: u64,
     epoll_raw_fd: RawFd,
-    sender: mpsc::Sender<Box<EpollHandler>>,
+    sender: mpsc::Sender<Box<dyn EpollHandler>>,
 }
 
 impl EpollConfigConstructor for EpollConfig {
-    fn new(first_token: u64, epoll_raw_fd: RawFd, sender: mpsc::Sender<Box<EpollHandler>>) -> Self {
+    fn new(
+        first_token: u64,
+        epoll_raw_fd: RawFd,
+        sender: mpsc::Sender<Box<dyn EpollHandler>>,
+    ) -> Self {
         EpollConfig {
             rxq_token: first_token + u64::from(defs::RXQ_EVENT),
             txq_token: first_token + u64::from(defs::TXQ_EVENT),

--- a/kernel/src/cmdline/mod.rs
+++ b/kernel/src/cmdline/mod.rs
@@ -50,7 +50,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 fn valid_char(c: char) -> bool {
     match c {
-        ' '...'~' => true,
+        ' '..='~' => true,
         _ => false,
     }
 }

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -81,7 +81,7 @@ pub struct MMIODeviceManager {
     irq: u32,
     last_irq: u32,
     id_to_dev_info: HashMap<(DeviceType, String), MMIODeviceInfo>,
-    raw_io_handlers: HashMap<(DeviceType, String), Arc<Mutex<RawIOHandler>>>,
+    raw_io_handlers: HashMap<(DeviceType, String), Arc<Mutex<dyn RawIOHandler>>>,
 }
 
 impl MMIODeviceManager {
@@ -109,7 +109,7 @@ impl MMIODeviceManager {
     pub fn register_virtio_device(
         &mut self,
         vm: &VmFd,
-        device: Box<devices::virtio::VirtioDevice>,
+        device: Box<dyn devices::virtio::VirtioDevice>,
         cmdline: &mut kernel_cmdline::Cmdline,
         type_id: u32,
         device_id: &str,
@@ -264,7 +264,7 @@ impl MMIODeviceManager {
         &self,
         device_type: DeviceType,
         device_id: &str,
-    ) -> Option<&Mutex<BusDevice>> {
+    ) -> Option<&Mutex<dyn BusDevice>> {
         if let Some(dev_info) = self
             .id_to_dev_info
             .get(&(device_type, device_id.to_string()))
@@ -278,7 +278,10 @@ impl MMIODeviceManager {
 
     // Used only on 'aarch64', but needed by unit tests on all platforms.
     #[allow(dead_code)]
-    pub fn get_raw_io_device(&self, device_type: DeviceType) -> Option<&Arc<Mutex<RawIOHandler>>> {
+    pub fn get_raw_io_device(
+        &self,
+        device_type: DeviceType,
+    ) -> Option<&Arc<Mutex<dyn RawIOHandler>>> {
         self.raw_io_handlers
             .get(&(device_type, device_type.to_string()))
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -372,7 +372,7 @@ impl Display for VmmActionError {
         use self::VmmActionError::*;
 
         let error = match *self {
-            BootSource(_, ref err) => err as &ToString,
+            BootSource(_, ref err) => err as &dyn ToString,
             DriveConfig(_, ref err) => err,
             Logger(_, ref err) => err,
             MachineConfig(_, ref err) => err,
@@ -538,12 +538,12 @@ enum EpollDispatch {
 }
 
 struct MaybeHandler {
-    handler: Option<Box<EpollHandler>>,
-    receiver: Receiver<Box<EpollHandler>>,
+    handler: Option<Box<dyn EpollHandler>>,
+    receiver: Receiver<Box<dyn EpollHandler>>,
 }
 
 impl MaybeHandler {
-    fn new(receiver: Receiver<Box<EpollHandler>>) -> Self {
+    fn new(receiver: Receiver<Box<dyn EpollHandler>>) -> Self {
         MaybeHandler {
             handler: None,
             receiver,
@@ -656,7 +656,7 @@ impl EpollContext {
     /// This device's handler will be added to the end of `device_handlers`.
     /// This returns the index of the first token, and a channel on which to
     /// send an epoll handler for the relevant device.
-    fn allocate_tokens_for_device(&mut self, count: usize) -> (u64, Sender<Box<EpollHandler>>) {
+    fn allocate_tokens_for_device(&mut self, count: usize) -> (u64, Sender<Box<dyn EpollHandler>>) {
         let dispatch_base = self.dispatch_table.len() as u64;
         let device_idx = self.device_handlers.len();
         let (sender, receiver) = channel();
@@ -692,7 +692,7 @@ impl EpollContext {
         T::new(dispatch_base, self.epoll_raw_fd, sender)
     }
 
-    fn get_device_handler_by_handler_id(&mut self, id: usize) -> Result<&mut EpollHandler> {
+    fn get_device_handler_by_handler_id(&mut self, id: usize) -> Result<&mut dyn EpollHandler> {
         let maybe = &mut self.device_handlers[id];
         match maybe.handler {
             Some(ref mut v) => Ok(v.as_mut()),
@@ -818,7 +818,7 @@ impl Vmm {
     /// Creates a new VMM object.
     pub fn new(
         api_shared_info: Arc<RwLock<InstanceInfo>>,
-        control_fd: &AsRawFd,
+        control_fd: &dyn AsRawFd,
         from_api: Receiver<Box<VmmAction>>,
         seccomp_level: u32,
         kvm: Kvm,
@@ -1167,7 +1167,7 @@ impl Vmm {
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn get_serial_device(&self) -> Option<Arc<Mutex<RawIOHandler>>> {
+    fn get_serial_device(&self) -> Option<Arc<Mutex<dyn RawIOHandler>>> {
         Some(self.pio_device_manager.stdio_serial.clone())
     }
 


### PR DESCRIPTION
## Reason for This PR

Rust 1.37 warns about using `Trait` instead of `dyn Trait` (https://github.com/rust-lang/rust/pull/61203/) and inclusive ranges with `...` syntax ranges instead of `..=` syntax (https://github.com/rust-lang/rust/issues/28237). 

## Description of Changes

I've fixed the specific instances where these two warnings appear in the firecracker code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
