### PR TITLE
Remove testing redundancy.

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -39,6 +39,7 @@ KCOV_COVERAGE_REGEX = r'"covered":"(\d+\.\d)"'
 def test_coverage(test_session_root_path, test_session_tmp_path):
     """Test line coverage with kcov.
 
+    This test also implicitly tests all our unit tests on x86.
     The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
     after a coverage run.
     """

--- a/tests/integration_tests/build/test_doctests.py
+++ b/tests/integration_tests/build/test_doctests.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A test that ensures that all doctests pass at integration time."""
+
+import host_tools.cargo_build as host  # pylint:disable=import-error
+
+
+def test_doctests(test_session_root_path):
+    """Run doc tests for all supported targets."""
+    extra_env = ''
+    extra_args = "--target x86_64-unknown-linux-gnu --doc --exclude cpuid"
+    host.cargo_test(
+        test_session_root_path,
+        extra_args=extra_args,
+        extra_env=extra_env
+    )

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -23,19 +23,17 @@ TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
     "target",
     TARGETS
 )
+@pytest.mark.skipif(
+    platform.machine() == "x86_64",
+    reason="Unit tests are already tested by test_coverage.py on x86_64"
+)
 def test_unittests(test_session_root_path, target):
     """Run unit and doc tests for all supported targets."""
     extra_env = ''
-    extra_args = "--target {} ".format(target)
+    extra_args = "--target {} --exclude cpuid".format(target)
 
     if "musl" in target:
         extra_env += "TARGET_CC=musl-gcc"
-
-    if MACHINE == "x86_64":
-        extra_args += "--all-features "
-
-    if MACHINE == "aarch64":
-        extra_args += "--exclude cpuid "
 
     host.cargo_test(
         test_session_root_path,


### PR DESCRIPTION
## Reason for This PR

Testing coverage implicitly tests all unit tests (but not doc tests). This makes re-testing unit tests redundant. This redundancy should be removed.

## Description of Changes

This PR makes unit tests not be run on x86 (since, on this platform, coverage tests implicitly test them). It also explicitly tests doc tests in `test_doctests.py`, on x86 , since coverage tests do not implicitly test these tests. It does not effect testing behaviour on aarch64.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
