### PR TITLE
Remove `Tap` device from `NetworkDeviceConfig`.

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -1250,7 +1250,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
 
         match netif.into_parsed_request(Some(net_id), Method::Put) {

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -76,7 +76,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         }
     }
 
@@ -120,7 +119,6 @@ mod tests {
             rx_rate_limiter: Some(RateLimiterConfig::default()),
             tx_rate_limiter: Some(RateLimiterConfig::default()),
             allow_mmds_requests: true,
-            tap: None,
         };
 
         // This is the json encoding of the netif variable.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1000,8 +1000,8 @@ impl Vmm {
                 .map_err(CreateRateLimiter)?;
 
             let vm_fd = self.vm.get_fd();
-            cfg.take_tap()
-                .ok_or(NetDeviceNotConfigured)
+            cfg.open_tap()
+                .map_err(|_| NetDeviceNotConfigured)
                 .and_then(|tap| {
                     let net_box = Box::new(
                         devices::virtio::Net::new_with_tap(
@@ -2555,7 +2555,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
         assert!(vmm.insert_net_device(network_interface).is_ok());
 
@@ -2568,7 +2567,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
         assert!(vmm.insert_net_device(network_interface).is_ok());
 
@@ -2580,7 +2578,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
         assert!(vmm.insert_net_device(network_interface).is_err());
 
@@ -2593,7 +2590,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
         assert!(vmm.insert_net_device(network_interface).is_err());
     }
@@ -2623,7 +2619,6 @@ mod tests {
             }),
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         })
         .unwrap();
 
@@ -3066,7 +3061,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
 
         assert!(vmm.insert_net_device(network_interface).is_ok());
@@ -3456,7 +3450,6 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
-            tap: None,
         };
 
         assert!(vmm.insert_net_device(network_interface).is_ok());

--- a/vmm/src/vmm_config/net.rs
+++ b/vmm/src/vmm_config/net.rs
@@ -31,9 +31,6 @@ pub struct NetworkInterfaceConfig {
     /// same address are intercepted by the device model, and do not reach
     /// the associated TAP device.
     pub allow_mmds_requests: bool,
-    /// Handle for a network tap interface created using `host_dev_name`.
-    #[serde(skip)]
-    pub tap: Option<Tap>,
 }
 
 // Serde does not allow specifying a default value for a field
@@ -44,10 +41,9 @@ fn default_allow_mmds_requests() -> bool {
 }
 
 impl NetworkInterfaceConfig {
-    /// Returns the tap device if it was configured. This function has side effects as it takes
-    /// the value from `self.tap` and leaves None in its place.
-    pub fn take_tap(&mut self) -> Option<Tap> {
-        self.tap.take()
+    /// Returns the tap device that `host_dev_name` refers to.
+    pub fn open_tap(&self) -> result::Result<Tap, NetworkInterfaceError> {
+        Tap::open_named(self.host_dev_name.as_str()).map_err(NetworkInterfaceError::OpenTap)
     }
 
     /// Returns a reference to the mac address. It the mac address is not configured, it
@@ -213,25 +209,13 @@ impl NetworkInterfaceConfigs {
     fn update(
         &mut self,
         index: usize,
-        mut updated_netif_config: NetworkInterfaceConfig,
+        updated_netif_config: NetworkInterfaceConfig,
     ) -> result::Result<(), NetworkInterfaceError> {
         self.validate_update(index, &updated_netif_config)?;
-
-        // We are ignoring the tap field of the network interface we want to update. We are
-        // manually setting this field to a newly created tap (corresponding to the host_dev_name)
-        // or to the old tap device of the network interface we are trying to update.
-        updated_netif_config.tap =
-            if self.if_list[index].host_dev_name != updated_netif_config.host_dev_name {
-                Some(
-                    Tap::open_named(&updated_netif_config.host_dev_name.as_str())
-                        .map_err(NetworkInterfaceError::OpenTap)?,
-                )
-            } else {
-                self.if_list[index].tap.take()
-            };
         self.if_list[index] = updated_netif_config;
 
-        Ok(())
+        // Check that the tap can be opened.
+        self.if_list[index].open_tap().map(|_| ())
     }
 
     fn validate_create(
@@ -259,7 +243,8 @@ impl NetworkInterfaceConfigs {
             ));
         }
 
-        Ok(())
+        // Check that the tap refered to in `new_config` can be opened.
+        new_config.open_tap().map(|_| ())
     }
 
     fn create(
@@ -267,12 +252,8 @@ impl NetworkInterfaceConfigs {
         netif_config: NetworkInterfaceConfig,
     ) -> result::Result<(), NetworkInterfaceError> {
         self.validate_create(&netif_config)?;
-        let tap = Tap::open_named(netif_config.host_dev_name.as_str())
-            .map_err(NetworkInterfaceError::OpenTap)?;
         self.if_list.push(netif_config);
 
-        let index = self.if_list.len() - 1;
-        self.if_list[index].tap = Some(tap);
         Ok(())
     }
 }
@@ -293,12 +274,9 @@ mod tests {
             rx_rate_limiter: Some(RateLimiterConfig::default()),
             tx_rate_limiter: Some(RateLimiterConfig::default()),
             allow_mmds_requests: false,
-            tap: None,
         }
     }
 
-    // This implementation is used only in tests. We cannot directly derive clone because
-    // Tap and RateLimiter do not implement clone.
     impl Clone for NetworkInterfaceConfig {
         fn clone(&self) -> Self {
             NetworkInterfaceConfig {
@@ -308,7 +286,6 @@ mod tests {
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
                 allow_mmds_requests: self.allow_mmds_requests,
-                tap: None,
             }
         }
     }


### PR DESCRIPTION
## Reason for This PR

#1167 

## Description of Changes

This PR removes the `Tap` device from `NetworkDeviceConfig`. Instead of explicitly holding the device file all the time, we now re-open it when we either explicitly need it, or want to check if it is openable. This makes it so that `NetworkDeviceConfig` holds no live data.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
