### PR TITLE
Stop ignoring many clippy lints.

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -583,7 +583,7 @@ impl hyper::server::Service for ApiServerHttpService {
                         };
                         log_received_api_request(describe(&method_copy, &path, &body_desc));
 
-                        if send_to_vmm(sync_req, &api_request_sender, &vmm_send_event).is_err() {
+                        if send_to_vmm(*sync_req, &api_request_sender, &vmm_send_event).is_err() {
                             METRICS.api_server.sync_vmm_send_timeout_count.inc();
                             return Either::A(future::err(hyper::Error::Timeout));
                         }

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -74,28 +74,28 @@ impl IntoParsedRequest for ActionBody {
                 let block_device_id = self.payload.unwrap().as_str().unwrap().to_string();
                 let (sync_sender, sync_receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
-                    VmmAction::RescanBlockDevice(block_device_id, sync_sender),
+                    Box::new(VmmAction::RescanBlockDevice(block_device_id, sync_sender)),
                     sync_receiver,
                 ))
             }
             ActionType::FlushMetrics => {
                 let (sync_sender, sync_receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
-                    VmmAction::FlushMetrics(sync_sender),
+                    Box::new(VmmAction::FlushMetrics(sync_sender)),
                     sync_receiver,
                 ))
             }
             ActionType::InstanceStart => {
                 let (sync_sender, sync_receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
-                    VmmAction::StartMicroVm(sync_sender),
+                    Box::new(VmmAction::StartMicroVm(sync_sender)),
                     sync_receiver,
                 ))
             }
             ActionType::SendCtrlAltDel => {
                 let (sync_sender, sync_receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
-                    VmmAction::SendCtrlAltDel(sync_sender),
+                    Box::new(VmmAction::SendCtrlAltDel(sync_sender)),
                     sync_receiver,
                 ))
             }
@@ -181,7 +181,7 @@ mod tests {
               }"#;
             let (sender, receiver) = oneshot::channel();
             let req = ParsedRequest::Sync(
-                VmmAction::RescanBlockDevice("dummy_id".to_string(), sender),
+                Box::new(VmmAction::RescanBlockDevice("dummy_id".to_string(), sender)),
                 receiver,
             );
 
@@ -200,7 +200,8 @@ mod tests {
             }"#;
 
             let (sender, receiver) = oneshot::channel();
-            let req: ParsedRequest = ParsedRequest::Sync(VmmAction::StartMicroVm(sender), receiver);
+            let req: ParsedRequest =
+                ParsedRequest::Sync(Box::new(VmmAction::StartMicroVm(sender)), receiver);
             let result: Result<ActionBody, serde_json::Error> = serde_json::from_str(json);
             assert!(result.is_ok());
             assert!(result
@@ -217,7 +218,7 @@ mod tests {
 
             let (sender, receiver) = oneshot::channel();
             let req: ParsedRequest =
-                ParsedRequest::Sync(VmmAction::SendCtrlAltDel(sender), receiver);
+                ParsedRequest::Sync(Box::new(VmmAction::SendCtrlAltDel(sender)), receiver);
             let result: Result<ActionBody, serde_json::Error> = serde_json::from_str(json);
             assert!(result.is_ok());
             assert!(result
@@ -233,7 +234,8 @@ mod tests {
             }"#;
 
             let (sender, receiver) = oneshot::channel();
-            let req: ParsedRequest = ParsedRequest::Sync(VmmAction::FlushMetrics(sender), receiver);
+            let req: ParsedRequest =
+                ParsedRequest::Sync(Box::new(VmmAction::FlushMetrics(sender)), receiver);
             let result: Result<ActionBody, serde_json::Error> = serde_json::from_str(json);
             assert!(result.is_ok());
             assert!(result

--- a/api_server/src/request/boot_source.rs
+++ b/api_server/src/request/boot_source.rs
@@ -18,7 +18,7 @@ impl IntoParsedRequest for BootSourceConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            VmmAction::ConfigureBootSource(self, sender),
+            Box::new(VmmAction::ConfigureBootSource(self, sender)),
             receiver,
         ))
     }
@@ -42,7 +42,7 @@ mod tests {
         assert!(body
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::ConfigureBootSource(same_body, sender),
+                Box::new(VmmAction::ConfigureBootSource(same_body, sender)),
                 receiver
             ))))
     }

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -95,7 +95,11 @@ impl IntoParsedRequest for PatchDrivePayload {
 
                 let (sender, receiver) = oneshot::channel();
                 Ok(ParsedRequest::Sync(
-                    VmmAction::UpdateBlockDevicePath(drive_id, path_on_host, sender),
+                    Box::new(VmmAction::UpdateBlockDevicePath(
+                        drive_id,
+                        path_on_host,
+                        sender,
+                    )),
                     receiver,
                 ))
             }
@@ -119,7 +123,7 @@ impl IntoParsedRequest for BlockDeviceConfig {
         let (sender, receiver) = oneshot::channel();
         match method {
             Method::Put => Ok(ParsedRequest::Sync(
-                VmmAction::InsertBlockDevice(self, sender),
+                Box::new(VmmAction::InsertBlockDevice(self, sender)),
                 receiver,
             )),
             _ => Err(String::from("Invalid method.")),
@@ -237,7 +241,11 @@ mod tests {
             .clone()
             .into_parsed_request(Some("foo".to_string()), Method::Patch)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::UpdateBlockDevicePath("foo".to_string(), "dummy".to_string(), sender),
+                Box::new(VmmAction::UpdateBlockDevicePath(
+                    "foo".to_string(),
+                    "dummy".to_string(),
+                    sender
+                )),
                 receiver
             ))));
 
@@ -282,7 +290,7 @@ mod tests {
         assert!(desc
             .into_parsed_request(Some(String::from("foo")), Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::InsertBlockDevice(same_desc, sender),
+                Box::new(VmmAction::InsertBlockDevice(same_desc, sender)),
                 receiver
             ))));
     }

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -18,7 +18,7 @@ impl IntoParsedRequest for LoggerConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            VmmAction::ConfigureLogger(self, sender),
+            Box::new(VmmAction::ConfigureLogger(self, sender)),
             receiver,
         ))
     }
@@ -50,7 +50,7 @@ mod tests {
             .clone()
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::ConfigureLogger(desc, sender),
+                Box::new(VmmAction::ConfigureLogger(desc, sender)),
                 receiver
             ))));
     }

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -78,10 +78,6 @@ mod tests {
     use vmm::vmm_config::machine_config::CpuFeaturesTemplate;
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
-    // Allow assertions on constants is necessary because we cannot implement
-    // PartialEq on ParsedRequest due to the use of serde Value which doesn't
-    // implement PartialEq.
     fn test_into_parsed_request() {
         let body = VmConfig {
             vcpu_count: Some(8),
@@ -122,9 +118,10 @@ mod tests {
             ht_enabled: None,
             cpu_template: Some(CpuFeaturesTemplate::T2),
         };
-        match body.into_parsed_request(None, Method::Put) {
-            Ok(_) => assert!(false),
-            Err(e) => assert_eq!(e, String::from("Missing mandatory fields.")),
-        };
+        if let Err(e) = body.into_parsed_request(None, Method::Put) {
+            assert_eq!(e, String::from("Missing mandatory fields."));
+        } else {
+            panic!();
+        }
     }
 }

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -39,7 +39,7 @@ impl IntoParsedRequest for VmConfig {
         let (sender, receiver) = oneshot::channel();
         match method {
             Method::Get => Ok(ParsedRequest::Sync(
-                VmmAction::GetVmConfiguration(sender),
+                Box::new(VmmAction::GetVmConfiguration(sender)),
                 receiver,
             )),
             Method::Patch => {
@@ -51,7 +51,7 @@ impl IntoParsedRequest for VmConfig {
                     return Err(String::from("Empty PATCH request."));
                 }
                 Ok(ParsedRequest::Sync(
-                    VmmAction::SetVmConfiguration(self, sender),
+                    Box::new(VmmAction::SetVmConfiguration(self, sender)),
                     receiver,
                 ))
             }
@@ -63,7 +63,7 @@ impl IntoParsedRequest for VmConfig {
                     return Err(String::from("Missing mandatory fields."));
                 }
                 Ok(ParsedRequest::Sync(
-                    VmmAction::SetVmConfiguration(self, sender),
+                    Box::new(VmmAction::SetVmConfiguration(self, sender)),
                     receiver,
                 ))
             }
@@ -90,7 +90,7 @@ mod tests {
             .clone()
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::SetVmConfiguration(body, sender),
+                Box::new(VmmAction::SetVmConfiguration(body, sender)),
                 receiver
             ))));
 

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -18,13 +18,12 @@ use hyper::{Method, StatusCode};
 use http_service::{empty_response, json_fault_message, json_response};
 use vmm::{ErrorKind, OutcomeReceiver, VmmAction, VmmActionError, VmmData};
 
-#[allow(clippy::large_enum_variant)]
 pub enum ParsedRequest {
     GetInstanceInfo,
     GetMMDS,
     PatchMMDS(Value),
     PutMMDS(Value),
-    Sync(VmmAction, OutcomeReceiver),
+    Sync(Box<VmmAction>, OutcomeReceiver),
 }
 
 pub trait IntoParsedRequest {

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -25,7 +25,7 @@ impl IntoParsedRequest for NetworkInterfaceConfig {
 
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            VmmAction::InsertNetworkDevice(self, sender),
+            Box::new(VmmAction::InsertNetworkDevice(self, sender)),
             receiver,
         ))
     }
@@ -46,7 +46,7 @@ impl IntoParsedRequest for NetworkInterfaceUpdateConfig {
 
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            VmmAction::UpdateNetworkInterface(self, sender),
+            Box::new(VmmAction::UpdateNetworkInterface(self, sender)),
             receiver,
         ))
     }
@@ -105,7 +105,7 @@ mod tests {
         assert!(netif
             .into_parsed_request(Some(String::from("foo")), Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                VmmAction::InsertNetworkDevice(netif_clone, sender),
+                Box::new(VmmAction::InsertNetworkDevice(netif_clone, sender)),
                 receiver
             ))));
     }

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -18,7 +18,7 @@ impl IntoParsedRequest for VsockDeviceConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            VmmAction::SetVsockDevice(self, sender),
+            Box::new(VmmAction::SetVsockDevice(self, sender)),
             receiver,
         ))
     }

--- a/cpuid/src/brand_string.rs
+++ b/cpuid/src/brand_string.rs
@@ -309,7 +309,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
     fn test_brand_string() {
         #[inline]
         fn pack_u32(src: &[u8]) -> u32 {
@@ -403,10 +402,7 @@ mod tests {
                 let host_regs = unsafe { host_cpuid(0x8000_0000) };
                 assert!(host_regs.eax < 0x8000_0004);
             }
-            _ => assert!(
-                false,
-                "This function should not return another type of error"
-            ),
+            _ => panic!("This function should not return another type of error"),
         }
 
         // Test BrandString::from_vendor_id()

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -58,14 +58,13 @@ const CMD_WRITE_OUTP: u8 = 0xD1; // Write output port
 const CMD_RESET_CPU: u8 = 0xFE; // Reset CPU
 
 /// i8042 status register bits
-const SB_OUT_DATA_AVAIL: u8 = 1; // Data available at port 0x60
-const SB_I8042_CMD_DATA: u8 = 1 << 3; // i8042 expecting command parameter at port 0x60
-const SB_KBD_ENABLED: u8 = 1 << 4; // 1 = kbd enabled, 0 = kbd locked
+const SB_OUT_DATA_AVAIL: u8 = 0x0001; // Data available at port 0x60
+const SB_I8042_CMD_DATA: u8 = 0x0008; // i8042 expecting command parameter at port 0x60
+const SB_KBD_ENABLED: u8 = 0x0010; // 1 = kbd enabled, 0 = kbd locked
 
 /// i8042 control register bits
-#[allow(clippy::identity_op)]
-const CB_KBD_INT: u8 = 1 << 0; // kbd interrupt enabled
-const CB_POST_OK: u8 = 1 << 2; // POST ok (should always be 1)
+const CB_KBD_INT: u8 = 0x0001; // kbd interrupt enabled
+const CB_POST_OK: u8 = 0x0004; // POST ok (should always be 1)
 
 /// Key scan codes
 const KEY_CTRL: u16 = 0x0014;

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -703,10 +703,7 @@ mod tests {
         }
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    fn default_test_blockepollhandler<'a>(
-        mem: &'a GuestMemory,
-    ) -> (BlockEpollHandler, VirtQueue<'a>) {
+    fn default_test_blockepollhandler(mem: &GuestMemory) -> (BlockEpollHandler, VirtQueue) {
         let mut dummy = DummyBlock::new(false);
         let b = dummy.block();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -480,11 +480,8 @@ mod tests {
             &[16, 32]
         }
 
-        #[allow(clippy::needless_range_loop)]
         fn read_config(&self, offset: u64, data: &mut [u8]) {
-            for i in 0..data.len() {
-                data[i] = self.config_bytes[offset as usize + i];
-            }
+            data.copy_from_slice(&self.config_bytes[offset as usize..]);
         }
 
         fn write_config(&mut self, offset: u64, data: &[u8]) {

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -917,10 +917,6 @@ impl VirtioDevice for Net {
 }
 
 #[cfg(test)]
-// Allow assertions on constants is necessary because we cannot implement
-// PartialEq on ActivateError as we have references to std::io::Error which
-// don't implement the trait.
-#[allow(clippy::assertions_on_constants)]
 mod tests {
     use std::net::Ipv4Addr;
     use std::sync::mpsc::Receiver;

--- a/devices/src/virtio/vsock/csm/txbuf.rs
+++ b/devices/src/virtio/vsock/csm/txbuf.rs
@@ -61,7 +61,6 @@ impl TxBuf {
         // argument would always get evaluated (which implies a heap allocation), even though
         // it would later be discarded (when `self.data.is_some()`). Apparently, clippy fails
         // to see this, and insists on issuing some warning.
-        #[allow(clippy::redundant_closure)]
         let data = self.data.get_or_insert_with(||
                 // Using uninitialized memory here is quite safe, since we never read from any
                 // area of the buffer before writing to it. First we push, then we flush only

--- a/devices/src/virtio/vsock/unix/muxer.rs
+++ b/devices/src/virtio/vsock/unix/muxer.rs
@@ -286,14 +286,13 @@ impl VsockEpollListener for VsockMuxer {
         let mut epoll_events = vec![epoll::Event::new(epoll::Events::empty(), 0); 32];
         match epoll::wait(self.epoll_fd, 0, epoll_events.as_mut_slice()) {
             Ok(ev_cnt) => {
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..ev_cnt {
+                for ev in &epoll_events[0..ev_cnt] {
                     self.handle_event(
-                        epoll_events[i].data as RawFd,
+                        ev.data as RawFd,
                         // It's ok to unwrap here, since the `epoll_events[i].events` is filled
                         // in by `epoll::wait()`, and therefore contains only valid epoll
                         // flags.
-                        epoll::Events::from_bits(epoll_events[i].events).unwrap(),
+                        epoll::Events::from_bits(ev.events).unwrap(),
                     );
                 }
             }

--- a/dumbo/src/pdu/tcp.rs
+++ b/dumbo/src/pdu/tcp.rs
@@ -64,7 +64,6 @@ bitflags! {
         /// SYN flag.
         const SYN = 1 << 1;
         /// FIN flag.
-        #[allow(clippy::identity_op)]
         const FIN = 1;
     }
 }
@@ -662,7 +661,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::len_zero)]
     fn test_constructors() {
         let mut a = [1u8; 1460];
         let b = [2u8; 1000];
@@ -726,7 +724,7 @@ mod tests {
 
             // Payload was smaller than mss_left after options.
             assert_eq!(p.len(), header_len + b.len());
-            assert_eq!(p.is_empty(), p.len() == 0);
+            assert_eq!(p.is_empty(), p.is_empty());
 
             p.len()
             // Mutable borrow of a goes out of scope.

--- a/kernel/src/loader/elf.rs
+++ b/kernel/src/loader/elf.rs
@@ -90,7 +90,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::zero_ptr)]
     fn bindgen_test_layout_elf64_phdr() {
         assert_eq!(
             ::std::mem::size_of::<elf64_phdr>(),
@@ -103,7 +102,7 @@ mod tests {
             concat!("Alignment of ", stringify!(elf64_phdr))
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_type as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_type as *const _ as usize },
             0usize,
             concat!(
                 "Alignment of field: ",
@@ -113,7 +112,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_flags as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_flags as *const _ as usize },
             4usize,
             concat!(
                 "Alignment of field: ",
@@ -123,7 +122,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_offset as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_offset as *const _ as usize },
             8usize,
             concat!(
                 "Alignment of field: ",
@@ -133,7 +132,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_vaddr as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_vaddr as *const _ as usize },
             16usize,
             concat!(
                 "Alignment of field: ",
@@ -143,7 +142,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_paddr as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_paddr as *const _ as usize },
             24usize,
             concat!(
                 "Alignment of field: ",
@@ -153,7 +152,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_filesz as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_filesz as *const _ as usize },
             32usize,
             concat!(
                 "Alignment of field: ",
@@ -163,7 +162,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_memsz as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_memsz as *const _ as usize },
             40usize,
             concat!(
                 "Alignment of field: ",
@@ -173,7 +172,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_phdr)).p_align as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_phdr)).p_align as *const _ as usize },
             48usize,
             concat!(
                 "Alignment of field: ",
@@ -185,7 +184,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::zero_ptr)]
     fn bindgen_test_layout_elf64_hdr() {
         assert_eq!(
             ::std::mem::size_of::<elf64_hdr>(),
@@ -198,7 +196,7 @@ mod tests {
             concat!("Alignment of ", stringify!(elf64_hdr))
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_ident as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_ident as *const _ as usize },
             0usize,
             concat!(
                 "Alignment of field: ",
@@ -208,7 +206,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_type as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_type as *const _ as usize },
             16usize,
             concat!(
                 "Alignment of field: ",
@@ -218,7 +216,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_machine as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_machine as *const _ as usize },
             18usize,
             concat!(
                 "Alignment of field: ",
@@ -228,7 +226,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_version as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_version as *const _ as usize },
             20usize,
             concat!(
                 "Alignment of field: ",
@@ -238,7 +236,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_entry as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_entry as *const _ as usize },
             24usize,
             concat!(
                 "Alignment of field: ",
@@ -248,7 +246,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_phoff as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_phoff as *const _ as usize },
             32usize,
             concat!(
                 "Alignment of field: ",
@@ -258,7 +256,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_shoff as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_shoff as *const _ as usize },
             40usize,
             concat!(
                 "Alignment of field: ",
@@ -268,7 +266,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_flags as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_flags as *const _ as usize },
             48usize,
             concat!(
                 "Alignment of field: ",
@@ -278,7 +276,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_ehsize as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_ehsize as *const _ as usize },
             52usize,
             concat!(
                 "Alignment of field: ",
@@ -288,7 +286,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_phentsize as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_phentsize as *const _ as usize },
             54usize,
             concat!(
                 "Alignment of field: ",
@@ -298,7 +296,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_phnum as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_phnum as *const _ as usize },
             56usize,
             concat!(
                 "Alignment of field: ",
@@ -308,7 +306,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_shentsize as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_shentsize as *const _ as usize },
             58usize,
             concat!(
                 "Alignment of field: ",
@@ -318,7 +316,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_shnum as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_shnum as *const _ as usize },
             60usize,
             concat!(
                 "Alignment of field: ",
@@ -328,7 +326,7 @@ mod tests {
             )
         );
         assert_eq!(
-            unsafe { &(*(0 as *const elf64_hdr)).e_shstrndx as *const _ as usize },
+            unsafe { &(*(std::ptr::null() as *const elf64_hdr)).e_shstrndx as *const _ as usize },
             62usize,
             concat!(
                 "Alignment of field: ",

--- a/memory_model/src/guest_address.rs
+++ b/memory_model/src/guest_address.rs
@@ -109,13 +109,13 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::eq_op)]
     fn cmp() {
-        let a = GuestAddress(0x300);
-        let b = GuestAddress(0x301);
-        assert!(a < b);
-        assert!(b > a);
-        assert!(!(a < a));
+        for i in 1..10 {
+            for j in 1..10 {
+                assert_eq!(i < j, GuestAddress(i) < GuestAddress(j));
+                assert_eq!(i > j, GuestAddress(i) > GuestAddress(j));
+            }
+        }
     }
 
     #[test]

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -316,9 +316,6 @@ mod tests {
     }
 
     #[test]
-    // Allow assertions on constants so we can have asserts on the values returned
-    // when result is Ok.
-    #[allow(clippy::assertions_on_constants)]
     fn test_into_request_line() {
         let expected_request_line = RequestLine {
             http_version: Version::Http10,
@@ -327,10 +324,10 @@ mod tests {
         };
 
         let request_line = b"GET http://localhost/home HTTP/1.0";
-        match RequestLine::try_from(request_line) {
-            Ok(request) => assert_eq!(request, expected_request_line),
-            Err(_) => assert!(false),
-        };
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
 
         let expected_request_line = RequestLine {
             http_version: Version::Http11,
@@ -340,17 +337,17 @@ mod tests {
 
         // Happy case with request line ending in CRLF.
         let request_line = b"GET http://localhost/home HTTP/1.1";
-        match RequestLine::try_from(request_line) {
-            Ok(request) => assert_eq!(request, expected_request_line),
-            Err(_) => assert!(false),
-        };
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
 
         // Happy case with request line ending in LF instead of CRLF.
         let request_line = b"GET http://localhost/home HTTP/1.1";
-        match RequestLine::try_from(request_line) {
-            Ok(request) => assert_eq!(request, expected_request_line),
-            Err(_) => assert!(false),
-        };
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap(),
+            expected_request_line
+        );
 
         // Test for invalid method.
         let request_line = b"POST http://localhost/home HTTP/1.0";

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -147,8 +147,7 @@ impl Tap {
     /// Set the offload flags for the tap interface.
     pub fn set_offload(&self, flags: c_uint) -> Result<()> {
         // ioctl is safe. Called with a valid tap fd, and we check the return.
-        #[allow(clippy::cast_lossless)]
-        let ret = unsafe { ioctl_with_val(&self.tap_file, TUNSETOFFLOAD(), flags as c_ulong) };
+        let ret = unsafe { ioctl_with_val(&self.tap_file, TUNSETOFFLOAD(), c_ulong::from(flags)) };
         if ret < 0 {
             return Err(Error::IoctlError(IoError::last_os_error()));
         }
@@ -170,9 +169,8 @@ impl Tap {
         }
 
         // ioctl is safe. Called with a valid sock fd, and we check the return.
-        #[allow(clippy::cast_lossless)]
         let ret =
-            unsafe { ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFFLAGS as c_ulong, &ifreq) };
+            unsafe { ioctl_with_ref(&sock, c_ulong::from(net_gen::sockios::SIOCSIFFLAGS), &ifreq) };
         if ret < 0 {
             return Err(Error::IoctlError(IoError::last_os_error()));
         }
@@ -295,9 +293,9 @@ mod tests {
             }
 
             // ioctl is safe. Called with a valid sock fd, and we check the return.
-            #[allow(clippy::cast_lossless)]
-            let ret =
-                unsafe { ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFADDR as c_ulong, &ifreq) };
+            let ret = unsafe {
+                ioctl_with_ref(&sock, c_ulong::from(net_gen::sockios::SIOCSIFADDR), &ifreq)
+            };
             if ret < 0 {
                 return Err(Error::IoctlError(IoError::last_os_error()));
             }
@@ -319,9 +317,12 @@ mod tests {
             }
 
             // ioctl is safe. Called with a valid sock fd, and we check the return.
-            #[allow(clippy::cast_lossless)]
             let ret = unsafe {
-                ioctl_with_ref(&sock, net_gen::sockios::SIOCSIFNETMASK as c_ulong, &ifreq)
+                ioctl_with_ref(
+                    &sock,
+                    c_ulong::from(net_gen::sockios::SIOCSIFNETMASK),
+                    &ifreq,
+                )
             };
             if ret < 0 {
                 return Err(Error::IoctlError(IoError::last_os_error()));

--- a/sys_util/src/ioctl.rs
+++ b/sys_util/src/ioctl.rs
@@ -15,12 +15,13 @@ use std::os::unix::io::AsRawFd;
 macro_rules! ioctl_ioc_nr {
     ($name:ident, $dir:expr, $ty:expr, $nr:expr, $size:expr) => {
         #[allow(non_snake_case)]
-        #[allow(clippy::cast_lossless)]
         pub fn $name() -> ::std::os::raw::c_ulong {
-            (($dir << $crate::ioctl::_IOC_DIRSHIFT)
-                | ($ty << $crate::ioctl::_IOC_TYPESHIFT)
-                | ($nr << $crate::ioctl::_IOC_NRSHIFT)
-                | ($size << $crate::ioctl::_IOC_SIZESHIFT)) as ::std::os::raw::c_ulong
+            ::std::os::raw::c_ulong::from(
+                ($dir << $crate::ioctl::_IOC_DIRSHIFT)
+                    | ($ty << $crate::ioctl::_IOC_TYPESHIFT)
+                    | ($nr << $crate::ioctl::_IOC_NRSHIFT)
+                    | ($size << $crate::ioctl::_IOC_SIZESHIFT),
+            )
         }
     };
 }

--- a/sys_util/src/signal.rs
+++ b/sys_util/src/signal.rs
@@ -216,7 +216,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::empty_loop)]
     fn test_register_vcpu_handler() {
         // Error case: invalid vCPU signal.
         unsafe {
@@ -235,7 +234,7 @@ mod tests {
                 .expect("failed to register vcpu signal handler");
         }
 
-        let killable = thread::spawn(|| loop {});
+        let killable = thread::spawn(thread::park);
 
         let res = killable.kill(SIGRTMAX());
         assert!(res.is_err());

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -389,7 +389,6 @@ impl Display for VmmActionError {
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.), together with an OutcomeSender, which is always present.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum VmmAction {
     /// Configure the boot source of the microVM using as input the `ConfigureBootSource`. This
     /// action can only be called before the microVM has booted. The response is sent using the


### PR DESCRIPTION
## Reason for This PR

#1287 , #1142
This does not fully fix #1287, but approximately halves the number of ignored clippy lints.

## Description of Changes

This PR does mainly stylistic refactoring in order to remove many occurrences ```#[allow(clippy::...)]```. The only meaningful change is a change in the definition of ```ParsedRequest```, boxing the largest enum variant. This will make our code more efficient, as the enum will no longer be forced to have its largest possible size at all times.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
