### PR TITLE
[RFC] Add one single API call for configuring microvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,21 @@
 
 ### Added
 
-- New command-line parameter for `firecracker`, named `--no-api`, which
-  will disable the API server thread. If set, the user won't be able to send
-  any API requests, neither before, nor after the vm has booted. It must be
-  paired with `--config-file` parameter. Also, when API server is disabled,
-  MMDS is no longer available now.
 - New command-line parameter for `firecracker`, named `--config-file`, which
   represents the path to a file that contains a JSON which can be used for
   configuring and starting a microVM without sending any API requests.
 - The jailer adheres to the "end of command options" convention, meaning
   all parameters specified after `--` are forwarded verbatim to Firecracker.
+- New command-line parameter for `firecracker`, named `--no-api`, which
+  will disable the API server thread. If set, the user won't be able to send
+  any API requests, neither before, nor after the vm has booted. It must be
+  paired with `--config-file` parameter. Also, when API server is disabled,
+  MMDS is no longer available now.
 - Added `KVM_PTP` support to the recommended guest kernel config.
 - Added entry in FAQ.md for Firecracker Guest timekeeping.
+- New API call, `PUT /vm-config`, which configures and starts a microVM.
+  The JSON from the body of this request should contain the desired configuration
+  for all of the microVM's resources.
 
 ### Changed
 

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -353,6 +353,31 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /vm-config:
+    put:
+      summary: Creates and starts a microvm.
+      description:
+        Configures and starts a microvm from one single json.
+      operationId: putVmConfig
+      parameters:
+        - name: body
+          in: body
+          description: Guest vm properties
+          required: true
+          schema:
+            $ref: "#/definitions/VmConfig"
+      responses:
+        204:
+          description: Vm created
+        400:
+          description: Vm cannot be created due to bad input
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+
   /vsock:
     put:
       summary: Creates/updates a vsock device.
@@ -639,6 +664,29 @@ definitions:
         format: int64
         description: The amount of milliseconds it takes for the bucket to refill.
         minimum: 0
+
+  VmConfig:
+    type: object
+    required:
+      - boot-source
+      - drives
+    properties:
+      boot-source:
+        $ref: "#/definitions/BootSource"
+      drives:
+        type: array
+        items:
+          $ref: "#/definitions/Drive"
+      network-interfaces:
+        type: array
+        items:
+          $ref: "#/definitions/NetworkInterface"
+      logger:
+        $ref: "#/definitions/Logger"
+      machine-config:
+        $ref: "#/definitions/MachineConfiguration"
+      vsock:
+        $ref: "#/definitions/Vsock"
 
   Vsock:
     type: object

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -265,6 +265,24 @@ You can find an example of configuration file at `tests/framework/vm_config.json
 After the machine is booted, you can still use the socket to send API requests
 for post-boot operations.
 
+#### Configuring the microVM by sending one API request
+
+If you don't want to send separate PUT requests for every resource, you could use 
+a PUT request on `/vm-config` for configuring and starting a microVM. The command 
+will look like this:
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i  \
+    -X PUT 'http://localhost/vm-config' \
+    -H 'Accept: application/json'            \
+    -H 'Content-Type: application/json'      \
+    -d 'JSON_BODY'
+```
+
+where `JSON_BODY` represents the JSON which will be used for the configuration of 
+the microVM. The content of this JSON should follow the same constraints as the one 
+from the configuration file mentioned in the previous section. 
+
 ## Building From Source
 
 The quickest way to build and test Firecracker is by using our development

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -143,6 +143,8 @@ pub struct PutRequestsMetrics {
     pub network_count: SharedMetric,
     /// Number of failures in creating a new network interface.
     pub network_fails: SharedMetric,
+    /// Number of failures in configuring the microVM.
+    pub vm_cfg_fails: SharedMetric,
 }
 
 /// Metrics specific to PATCH API Requests for counting user triggered actions and/or failures.

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -24,7 +24,7 @@ from framework.defs import MICROVM_KERNEL_RELPATH, MICROVM_FSFILES_RELPATH
 from framework.http import Session
 from framework.jailer import JailerContext
 from framework.resources import Actions, BootSource, Drive, Logger, MMDS, \
-    MachineConfigure, Network, Vsock
+    MachineConfigure, Network, Vsock, VmConfig
 
 
 class Microvm:
@@ -96,6 +96,7 @@ class Microvm:
         self.network = None
         self.machine_cfg = None
         self.vsock = None
+        self.vm_config = None
 
         # Optional file that contains a json for configuring microvm from
         # command line parameter.
@@ -268,6 +269,7 @@ class Microvm:
         self.mmds = MMDS(self._api_socket, self._api_session)
         self.network = Network(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
+        self.vm_config = VmConfig(self._api_socket, self._api_session)
 
         jailer_param_list = self._jailer.construct_param_list(self.config_file,
                                                               self.no_api)

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -383,6 +383,57 @@ class Network:
         return datax
 
 
+class VmConfig:
+    """Facility for configuring a microVM."""
+
+    VM_CFG_RESOURCE = 'vm-config'
+
+    __vm_cfg_url = None
+    __api_session = None
+
+    def __init__(self, api_usocket_full_name, api_session):
+        """Specify the information needed for sending API requests."""
+        url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
+        api_url = API_USOCKET_URL_PREFIX + url_encoded_path + '/'
+        type(self).__vm_cfg_url = api_url + self.VM_CFG_RESOURCE
+        type(self).__api_session = api_session
+
+    @classmethod
+    def put(cls, **args):
+        """Configure a new vm."""
+        datax = cls.create_json(**args)
+        return VmConfig.__api_session.put(
+            VmConfig.__vm_cfg_url,
+            json=datax
+        )
+
+    @staticmethod
+    def create_json(
+            boot_source=None,
+            block_devices=None,
+            net_devices=None,
+            logger=None,
+            machine_config=None,
+            vsock_device=None
+
+    ):
+        """Compose the json associated to this type of API request."""
+        datax = {}
+        if boot_source is not None:
+            datax['boot-source'] = boot_source
+        if block_devices is not None:
+            datax['drives'] = block_devices
+        if net_devices is not None:
+            datax['network-interfaces'] = net_devices
+        if logger is not None:
+            datax['logger'] = logger
+        if machine_config is not None:
+            datax['machine-config'] = machine_config
+        if vsock_device is not None:
+            datax['vsock'] = vsock_device
+        return datax
+
+
 class Vsock:
     """Facility for handling vsock configuration for a microvm."""
 


### PR DESCRIPTION
Signed-off-by: Laura Loghin <lauralg@amazon.com>

## Reason for This PR

We want to allow the user to configure and start a microVM by sending only one PUT request to the API server.

## Description of Changes

Added a new type of PUT request `/vm-config` for configuring a microVM. The JSON body of this request will contain the whole configuration for the vm. Sending this type of request will also start the microVM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched code is included in this PR.
- [x] The API changes are reflected in `firecracker/swagger.yaml`.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
