### PR TITLE
CI: improve output of kcov test

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -30,6 +30,12 @@ KCOV_COVERAGE_FILE = 'index.js'
 KCOV_COVERAGE_REGEX = r'"covered":"(\d+\.\d)"'
 """Regex for extracting coverage data from a kcov output file."""
 
+KCOV_COVERED_LINES_REGEX = r'"covered_lines":"(\d+)"'
+"""Regex for extracting number of total covered lines found by kcov."""
+
+KCOV_TOTAL_LINES_REGEX = r'"total_lines" : "(\d+)"'
+"""Regex for extracting number of total executable lines found by kcov."""
+
 
 @pytest.mark.timeout(400)
 @pytest.mark.skipif(
@@ -75,8 +81,13 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
 
     coverage_file = os.path.join(test_session_tmp_path, KCOV_COVERAGE_FILE)
     with open(coverage_file) as cov_output:
-        coverage = float(re.findall(KCOV_COVERAGE_REGEX, cov_output.read())[0])
-    print("Coverage is: " + str(coverage))
+        contents = cov_output.read()
+        coverage = float(re.findall(KCOV_COVERAGE_REGEX, contents)[0])
+        covered_lines = int(re.findall(KCOV_COVERED_LINES_REGEX, contents)[0])
+        total_lines = int(re.findall(KCOV_TOTAL_LINES_REGEX, contents)[0])
+    print("Number of executable lines: " + str(total_lines))
+    print("Number of covered lines: " + str(covered_lines))
+    print("Thus, coverage is: " + str(coverage))
 
     coverage_low_msg = (
         'Current code coverage ({}%) is below the target ({}%).'


### PR DESCRIPTION
## Reason for This PR

Remove some of the frustration that comes with
a PR failing this test by actually showing what
numbers lead to the coverage value obtained.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Description of Changes

Two more variables are now displayed in the CI output that explain
the number associated with the kcov percentage.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
