### PR TITLE
fixed slack invitation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Frequently asked questions are collected in our [FAQ doc](FAQ.md).
 You can get in touch with the Firecracker community in the following ways:
 - Security-related issues, see our [security policy document](SECURITY-POLICY.md).
 - Chat with us on our
-  [Slack workspace](https://tinyurl.com/firecracker-microvm). _Note: most of the
-  maintainers are on a European time zone._
+  [Slack workspace](https://join.slack.com/t/firecracker-microvm/shared_invite/enQtNDY2NTUwMzQ3MDE1LWIwMzA0OWFkMTZhMTlmMDZiMmFkYjMyODMxMGQ1ZjliMzJjNjJiNWRhNWNkOGEyNmUxNmRkMjZhYTc3MmVjZjM).
+  _Note: most of the maintainers are on a European time zone._
 - Open a GitHub issue in this repository.
 - Email the maintainers at
   [firecracker-maintainers@amazon.com](mailto:firecracker-maintainers@amazon.com).


### PR DESCRIPTION
## Reason for This PR

Fixes: https://github.com/firecracker-microvm/firecracker/issues/1298

## Description of Changes

Used a permanent invitation link in the README. This uglifies the
text version of the readme a bit, but the link never experies as
oppose to using tiny URLs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
