### PR TITLE
Completely decouple the vmm from the api_server

### DIFF
--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -13,6 +13,7 @@ use futures::{Future, Stream};
 use hyper::{self, Chunk, Headers, Method, StatusCode};
 use serde_json;
 
+use super::VmmRequest;
 use logger::{Metric, METRICS};
 use mmds::data_store::{self, Mmds};
 use request::actions::ActionBody;
@@ -26,7 +27,6 @@ use vmm::vmm_config::logger::LoggerConfig;
 use vmm::vmm_config::machine_config::VmConfig;
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
-use vmm::VmmRequest;
 
 fn build_response_base<B: Into<hyper::Body>>(
     status: StatusCode,

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -676,6 +676,7 @@ mod tests {
     extern crate net_util;
 
     use self::net_util::MacAddr;
+    use super::super::VmmAction;
     use super::*;
 
     use serde_json::{Map, Value};
@@ -687,7 +688,6 @@ mod tests {
     use hyper::Body;
     use vmm::vmm_config::logger::LoggerLevel;
     use vmm::vmm_config::machine_config::CpuFeaturesTemplate;
-    use vmm::VmmAction;
 
     impl<'a> std::fmt::Debug for Error<'a> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -44,6 +44,7 @@ use vmm::vmm_config::logger::LoggerConfig;
 use vmm::vmm_config::machine_config::VmConfig;
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
+use vmm::VmmActionError;
 
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.).
@@ -90,10 +91,20 @@ pub enum VmmAction {
     UpdateNetworkInterface(NetworkInterfaceUpdateConfig),
 }
 
+/// The enum represents the response sent by the VMM in case of success. The response is either
+/// empty, when no data needs to be sent, or an internal VMM structure.
+#[derive(Debug)]
+pub enum VmmData {
+    /// No data is sent on the channel.
+    Empty,
+    /// The microVM configuration represented by `VmConfig`.
+    MachineConfiguration(VmConfig),
+}
+
 /// One shot channel used by VMM to send a response.
-pub type ResponseSender = oneshot::Sender<vmm::VmmRequestOutcome>;
+pub type ResponseSender = oneshot::Sender<std::result::Result<VmmData, VmmActionError>>;
 /// One shot channel used to receive a response from the VMM.
-pub type ResponseReceiver = oneshot::Receiver<vmm::VmmRequestOutcome>;
+pub type ResponseReceiver = oneshot::Receiver<std::result::Result<VmmData, VmmActionError>>;
 
 /// Wrapper over requested action to be done by the VMM and sender where the response will go.
 /// This is wrapped in a struct to allow custom PartialEq.

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -37,7 +37,7 @@ use mmds::data_store::Mmds;
 use sys_util::EventFd;
 use vmm::default_syscalls;
 use vmm::vmm_config::instance_info::InstanceInfo;
-use vmm::VmmAction;
+use vmm::VmmRequest;
 
 pub enum Error {
     Io(io::Error),
@@ -70,7 +70,7 @@ pub struct ApiServer {
     // VMM instance info directly accessible from the API thread.
     vmm_shared_info: Arc<RwLock<InstanceInfo>>,
     // Sender which allows passing messages to the VMM.
-    api_request_sender: Rc<mpsc::Sender<Box<VmmAction>>>,
+    api_request_sender: Rc<mpsc::Sender<VmmRequest>>,
     efd: Rc<EventFd>,
 }
 
@@ -78,7 +78,7 @@ impl ApiServer {
     pub fn new(
         mmds_info: Arc<Mutex<Mmds>>,
         vmm_shared_info: Arc<RwLock<InstanceInfo>>,
-        api_request_sender: mpsc::Sender<Box<VmmAction>>,
+        api_request_sender: mpsc::Sender<VmmRequest>,
         kick_vmm_efd: EventFd,
     ) -> Result<Self> {
         Ok(ApiServer {

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -7,8 +7,9 @@ use futures::sync::oneshot;
 use hyper::Method;
 use serde_json::Value;
 
+use super::VmmRequest;
 use request::{IntoParsedRequest, ParsedRequest};
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 // The names of the members from this enum must precisely correspond (as a string) to the possible
 // values of "action_type" from the json request body. This is useful to get a strongly typed

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -7,9 +7,8 @@ use futures::sync::oneshot;
 use hyper::Method;
 use serde_json::Value;
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use request::{IntoParsedRequest, ParsedRequest};
-use vmm::VmmAction;
 
 // The names of the members from this enum must precisely correspond (as a string) to the possible
 // values of "action_type" from the json request body. This is useful to get a strongly typed

--- a/api_server/src/request/boot_source.rs
+++ b/api_server/src/request/boot_source.rs
@@ -8,7 +8,7 @@ use hyper::Method;
 
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::boot_source::BootSourceConfig;
-use vmm::VmmAction;
+use vmm::{VmmAction, VmmRequest};
 
 impl IntoParsedRequest for BootSourceConfig {
     fn into_parsed_request(
@@ -18,7 +18,7 @@ impl IntoParsedRequest for BootSourceConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            Box::new(VmmAction::ConfigureBootSource(self, sender)),
+            VmmRequest::new(VmmAction::ConfigureBootSource(self), sender),
             receiver,
         ))
     }
@@ -42,7 +42,7 @@ mod tests {
         assert!(body
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                Box::new(VmmAction::ConfigureBootSource(same_body, sender)),
+                VmmRequest::new(VmmAction::ConfigureBootSource(same_body), sender),
                 receiver
             ))))
     }

--- a/api_server/src/request/boot_source.rs
+++ b/api_server/src/request/boot_source.rs
@@ -6,10 +6,9 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::boot_source::BootSourceConfig;
-use vmm::VmmAction;
 
 impl IntoParsedRequest for BootSourceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/boot_source.rs
+++ b/api_server/src/request/boot_source.rs
@@ -6,9 +6,10 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
+use super::VmmRequest;
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::boot_source::BootSourceConfig;
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 impl IntoParsedRequest for BootSourceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -7,8 +7,9 @@ use futures::sync::oneshot;
 use hyper::Method;
 use serde_json::{Map, Value};
 
+use super::VmmRequest;
 use vmm::vmm_config::drive::BlockDeviceConfig;
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 use request::{IntoParsedRequest, ParsedRequest};
 

--- a/api_server/src/request/drive.rs
+++ b/api_server/src/request/drive.rs
@@ -7,9 +7,8 @@ use futures::sync::oneshot;
 use hyper::Method;
 use serde_json::{Map, Value};
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use vmm::vmm_config::drive::BlockDeviceConfig;
-use vmm::VmmAction;
 
 use request::{IntoParsedRequest, ParsedRequest};
 

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -6,9 +6,10 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
+use super::VmmRequest;
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::logger::LoggerConfig;
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 impl IntoParsedRequest for LoggerConfig {
     fn into_parsed_request(

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -8,7 +8,7 @@ use hyper::Method;
 
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::logger::LoggerConfig;
-use vmm::VmmAction;
+use vmm::{VmmAction, VmmRequest};
 
 impl IntoParsedRequest for LoggerConfig {
     fn into_parsed_request(
@@ -18,7 +18,7 @@ impl IntoParsedRequest for LoggerConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            Box::new(VmmAction::ConfigureLogger(self, sender)),
+            VmmRequest::new(VmmAction::ConfigureLogger(self), sender),
             receiver,
         ))
     }
@@ -50,7 +50,7 @@ mod tests {
             .clone()
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                Box::new(VmmAction::ConfigureLogger(desc, sender)),
+                VmmRequest::new(VmmAction::ConfigureLogger(desc), sender),
                 receiver
             ))));
     }

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -6,10 +6,9 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::logger::LoggerConfig;
-use vmm::VmmAction;
 
 impl IntoParsedRequest for LoggerConfig {
     fn into_parsed_request(

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -6,11 +6,10 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::{Method, Response, StatusCode};
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use http_service::json_response;
 use request::{GenerateHyperResponse, IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::machine_config::VmConfig;
-use vmm::VmmAction;
 
 impl GenerateHyperResponse for VmConfig {
     fn generate_response(&self) -> Response {

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -6,10 +6,11 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::{Method, Response, StatusCode};
 
+use super::VmmRequest;
 use http_service::json_response;
 use request::{GenerateHyperResponse, IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::machine_config::VmConfig;
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 impl GenerateHyperResponse for VmConfig {
     fn generate_response(&self) -> Response {

--- a/api_server/src/request/machine_configuration.rs
+++ b/api_server/src/request/machine_configuration.rs
@@ -9,7 +9,7 @@ use hyper::{Method, Response, StatusCode};
 use http_service::json_response;
 use request::{GenerateHyperResponse, IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::machine_config::VmConfig;
-use vmm::VmmAction;
+use vmm::{VmmAction, VmmRequest};
 
 impl GenerateHyperResponse for VmConfig {
     fn generate_response(&self) -> Response {
@@ -39,7 +39,7 @@ impl IntoParsedRequest for VmConfig {
         let (sender, receiver) = oneshot::channel();
         match method {
             Method::Get => Ok(ParsedRequest::Sync(
-                Box::new(VmmAction::GetVmConfiguration(sender)),
+                VmmRequest::new(VmmAction::GetVmConfiguration, sender),
                 receiver,
             )),
             Method::Patch => {
@@ -51,7 +51,7 @@ impl IntoParsedRequest for VmConfig {
                     return Err(String::from("Empty PATCH request."));
                 }
                 Ok(ParsedRequest::Sync(
-                    Box::new(VmmAction::SetVmConfiguration(self, sender)),
+                    VmmRequest::new(VmmAction::SetVmConfiguration(self), sender),
                     receiver,
                 ))
             }
@@ -63,7 +63,7 @@ impl IntoParsedRequest for VmConfig {
                     return Err(String::from("Missing mandatory fields."));
                 }
                 Ok(ParsedRequest::Sync(
-                    Box::new(VmmAction::SetVmConfiguration(self, sender)),
+                    VmmRequest::new(VmmAction::SetVmConfiguration(self), sender),
                     receiver,
                 ))
             }
@@ -90,7 +90,7 @@ mod tests {
             .clone()
             .into_parsed_request(None, Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                Box::new(VmmAction::SetVmConfiguration(body, sender)),
+                VmmRequest::new(VmmAction::SetVmConfiguration(body), sender),
                 receiver
             ))));
 

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -15,9 +15,9 @@ use std::result;
 use hyper;
 use hyper::{Method, StatusCode};
 
-use super::{ResponseReceiver, VmmAction, VmmRequest};
+use super::{ResponseReceiver, VmmAction, VmmData, VmmRequest};
 use http_service::{empty_response, json_fault_message, json_response};
-use vmm::{ErrorKind, VmmActionError, VmmData};
+use vmm::{ErrorKind, VmmActionError};
 
 pub enum ParsedRequest {
     GetInstanceInfo,

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -15,7 +15,7 @@ use std::result;
 use hyper;
 use hyper::{Method, StatusCode};
 
-use super::{ResponseReceiver, VmmRequest};
+use super::{ResponseReceiver, VmmAction, VmmRequest};
 use http_service::{empty_response, json_fault_message, json_response};
 use vmm::{ErrorKind, VmmActionError, VmmData};
 

--- a/api_server/src/request/mod.rs
+++ b/api_server/src/request/mod.rs
@@ -15,8 +15,9 @@ use std::result;
 use hyper;
 use hyper::{Method, StatusCode};
 
+use super::{ResponseReceiver, VmmRequest};
 use http_service::{empty_response, json_fault_message, json_response};
-use vmm::{ErrorKind, ResponseReceiver, VmmActionError, VmmData, VmmRequest};
+use vmm::{ErrorKind, VmmActionError, VmmData};
 
 pub enum ParsedRequest {
     GetInstanceInfo,
@@ -107,7 +108,15 @@ mod tests {
                     &ParsedRequest::Sync(ref sync_req, _),
                     &ParsedRequest::Sync(ref other_sync_req, _),
                 ) => sync_req == other_sync_req,
-                _ => self == other,
+                (&ParsedRequest::GetInstanceInfo, &ParsedRequest::GetInstanceInfo) => true,
+                (&ParsedRequest::GetMMDS, &ParsedRequest::GetMMDS) => true,
+                (&ParsedRequest::PutMMDS(ref val), &ParsedRequest::PutMMDS(ref other_val)) => {
+                    val == other_val
+                }
+                (&ParsedRequest::PatchMMDS(ref val), &ParsedRequest::PatchMMDS(ref other_val)) => {
+                    val == other_val
+                }
+                _ => false,
             }
         }
     }

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -6,9 +6,10 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
+use super::VmmRequest;
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 impl IntoParsedRequest for NetworkInterfaceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -8,7 +8,7 @@ use hyper::Method;
 
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
-use vmm::VmmAction;
+use vmm::{VmmAction, VmmRequest};
 
 impl IntoParsedRequest for NetworkInterfaceConfig {
     fn into_parsed_request(
@@ -25,7 +25,7 @@ impl IntoParsedRequest for NetworkInterfaceConfig {
 
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            Box::new(VmmAction::InsertNetworkDevice(self, sender)),
+            VmmRequest::new(VmmAction::InsertNetworkDevice(self), sender),
             receiver,
         ))
     }
@@ -46,7 +46,7 @@ impl IntoParsedRequest for NetworkInterfaceUpdateConfig {
 
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            Box::new(VmmAction::UpdateNetworkInterface(self, sender)),
+            VmmRequest::new(VmmAction::UpdateNetworkInterface(self), sender),
             receiver,
         ))
     }
@@ -105,7 +105,7 @@ mod tests {
         assert!(netif
             .into_parsed_request(Some(String::from("foo")), Method::Put)
             .eq(&Ok(ParsedRequest::Sync(
-                Box::new(VmmAction::InsertNetworkDevice(netif_clone, sender)),
+                VmmRequest::new(VmmAction::InsertNetworkDevice(netif_clone), sender),
                 receiver
             ))));
     }

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -6,10 +6,9 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
-use vmm::VmmAction;
 
 impl IntoParsedRequest for NetworkInterfaceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -6,10 +6,9 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
-use super::VmmRequest;
+use super::{VmmAction, VmmRequest};
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
-use vmm::VmmAction;
 
 impl IntoParsedRequest for VsockDeviceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -6,9 +6,10 @@ use std::result;
 use futures::sync::oneshot;
 use hyper::Method;
 
+use super::VmmRequest;
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
-use vmm::{VmmAction, VmmRequest};
+use vmm::VmmAction;
 
 impl IntoParsedRequest for VsockDeviceConfig {
     fn into_parsed_request(

--- a/api_server/src/request/vsock.rs
+++ b/api_server/src/request/vsock.rs
@@ -8,7 +8,7 @@ use hyper::Method;
 
 use request::{IntoParsedRequest, ParsedRequest};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
-use vmm::VmmAction;
+use vmm::{VmmAction, VmmRequest};
 
 impl IntoParsedRequest for VsockDeviceConfig {
     fn into_parsed_request(
@@ -18,7 +18,7 @@ impl IntoParsedRequest for VsockDeviceConfig {
     ) -> result::Result<ParsedRequest, String> {
         let (sender, receiver) = oneshot::channel();
         Ok(ParsedRequest::Sync(
-            Box::new(VmmAction::SetVsockDevice(self, sender)),
+            VmmRequest::new(VmmAction::SetVsockDevice(self), sender),
             receiver,
         ))
     }

--- a/logger/src/metrics.rs
+++ b/logger/src/metrics.rs
@@ -98,7 +98,7 @@ pub struct ApiServerMetrics {
     /// Measures the cpu's startup time in microseconds.
     pub process_startup_time_cpu_us: SharedMetric,
     /// Number of failures on API requests triggered by internal errors.
-    pub sync_outcome_fails: SharedMetric,
+    pub sync_response_fails: SharedMetric,
     /// Number of timeouts during communication with the VMM.
     pub sync_vmm_send_timeout_count: SharedMetric,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,30 +315,42 @@ fn vmm_control_event(
             use api_server::VmmAction::*;
             let (action_request, sender) = vmm_request.unpack();
             let response = match action_request {
-                ConfigureBootSource(boot_source_body) => vmm.configure_boot_source(
-                    boot_source_body.kernel_image_path,
-                    boot_source_body.boot_args,
-                ),
-                ConfigureLogger(logger_description) => vmm.init_logger(logger_description),
-                FlushMetrics => vmm.flush_metrics(),
-                GetVmConfiguration => {
-                    Ok(vmm::VmmData::MachineConfiguration(vmm.vm_config().clone()))
-                }
-                InsertBlockDevice(block_device_config) => {
-                    vmm.insert_block_device(block_device_config)
-                }
-                InsertNetworkDevice(netif_body) => vmm.insert_net_device(netif_body),
-                SetVsockDevice(vsock_cfg) => vmm.set_vsock_device(vsock_cfg),
-                RescanBlockDevice(drive_id) => vmm.rescan_block_device(&drive_id),
-                StartMicroVm => vmm.start_microvm(),
-                SendCtrlAltDel => vmm.send_ctrl_alt_del(),
-                SetVmConfiguration(machine_config_body) => {
-                    vmm.set_vm_configuration(machine_config_body)
-                }
-                UpdateBlockDevicePath(drive_id, path_on_host) => {
-                    vmm.set_block_device_path(drive_id, path_on_host)
-                }
-                UpdateNetworkInterface(netif_update) => vmm.update_net_device(netif_update),
+                ConfigureBootSource(boot_source_body) => vmm
+                    .configure_boot_source(
+                        boot_source_body.kernel_image_path,
+                        boot_source_body.boot_args,
+                    )
+                    .map(|_| api_server::VmmData::Empty),
+                ConfigureLogger(logger_description) => vmm
+                    .init_logger(logger_description)
+                    .map(|_| api_server::VmmData::Empty),
+                FlushMetrics => vmm.flush_metrics().map(|_| api_server::VmmData::Empty),
+                GetVmConfiguration => Ok(api_server::VmmData::MachineConfiguration(
+                    vmm.vm_config().clone(),
+                )),
+                InsertBlockDevice(block_device_config) => vmm
+                    .insert_block_device(block_device_config)
+                    .map(|_| api_server::VmmData::Empty),
+                InsertNetworkDevice(netif_body) => vmm
+                    .insert_net_device(netif_body)
+                    .map(|_| api_server::VmmData::Empty),
+                SetVsockDevice(vsock_cfg) => vmm
+                    .set_vsock_device(vsock_cfg)
+                    .map(|_| api_server::VmmData::Empty),
+                RescanBlockDevice(drive_id) => vmm
+                    .rescan_block_device(&drive_id)
+                    .map(|_| api_server::VmmData::Empty),
+                StartMicroVm => vmm.start_microvm().map(|_| api_server::VmmData::Empty),
+                SendCtrlAltDel => vmm.send_ctrl_alt_del().map(|_| api_server::VmmData::Empty),
+                SetVmConfiguration(machine_config_body) => vmm
+                    .set_vm_configuration(machine_config_body)
+                    .map(|_| api_server::VmmData::Empty),
+                UpdateBlockDevicePath(drive_id, path_on_host) => vmm
+                    .set_block_device_path(drive_id, path_on_host)
+                    .map(|_| api_server::VmmData::Empty),
+                UpdateNetworkInterface(netif_update) => vmm
+                    .update_net_device(netif_update)
+                    .map(|_| api_server::VmmData::Empty),
             };
             // Run the requested action and send back the result.
             sender

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -334,7 +334,6 @@ mod tests {
     use kernel_cmdline;
     use memory_model::{GuestAddress, GuestMemory};
     use std::sync::atomic::AtomicUsize;
-    use std::sync::mpsc::channel;
     use std::sync::{Arc, RwLock};
     use sys_util::EventFd;
     const QUEUE_SIZES: &[u16] = &[64];
@@ -413,13 +412,10 @@ mod tests {
             vmm_version: "1.0".to_string(),
         }));
 
-        let (_to_vmm, from_api) = channel();
         Vmm::new(
             shared_info,
             &EventFd::new().expect("cannot create eventFD"),
-            from_api,
             0,
-            kvm_ioctls::Kvm::new().expect("Cannot create KVM object"),
         )
         .expect("Cannot Create VMM")
     }


### PR DESCRIPTION
## Description of changes

- moves the vmm driving logic outside the vmm for more maneuverability,
- completely decouples the vmm from the api_server, the vmm can now be controlled using whichever control method the external driver chooses.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
