### PR TITLE
Improve failure message for vsock device creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### Added
 
-- New command-line parameter for `firecracker`, named `--no-api`, which 
-  will disable the API server thread. If set, the user won't be able to send 
-  any API requests, neither before, nor after the vm has booted. It must be 
-  paired with `--config-file` parameter. Also, when API server is disabled, 
+- New command-line parameter for `firecracker`, named `--no-api`, which
+  will disable the API server thread. If set, the user won't be able to send
+  any API requests, neither before, nor after the vm has booted. It must be
+  paired with `--config-file` parameter. Also, when API server is disabled,
   MMDS is no longer available now.
-- New command-line parameter for `firecracker`, named `--config-file`, which 
-  represents the path to a file that contains a JSON which can be used for 
+- New command-line parameter for `firecracker`, named `--config-file`, which
+  represents the path to a file that contains a JSON which can be used for
   configuring and starting a microVM without sending any API requests.
-- The jailer adheres to the "end of command options" convention, meaning 
+- The jailer adheres to the "end of command options" convention, meaning
   all parameters specified after `--` are forwarded verbatim to Firecracker.
 
 ### Changed
 
-- Vsock API call: `PUT /vsocks/{id}` changed to `PUT /vsock` and no longer 
+- Vsock API call: `PUT /vsocks/{id}` changed to `PUT /vsock` and no longer
   appear to support multiple vsock devices. Any subsequent calls to this API endpoint
   will override the previous vsock device configuration.
 
@@ -25,6 +25,7 @@
 
 - Fixed serial console on aarch64 (GitHub issue #1147).
 - Upon panic, the terminal is now reset to canonical mode.
+- Explicit error upon failure of vsock device creation.
 
 ## [0.18.0]
 
@@ -50,6 +51,7 @@
 - Docs: updated the rootfs and kernel creation guide.
 
 ### Removed
+
 - Removed experimental support for vhost-based vsock devices.
 
 ## [0.17.0]
@@ -125,6 +127,7 @@
 ## [0.15.0]
 
 ### Added
+
 - New API action: SendCtrlAltDel, used to initiate a graceful shutdown,
   if the guest has driver support for i8042 and AT Keyboard. See
   [the docs](docs/api_requests/actions.md#sendctrlaltdel) for details.
@@ -142,6 +145,7 @@
   i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd`.
 
 ### Fixed
+
 - virtio-blk: VIRTIO_BLK_T_FLUSH now working as expected.
 - Vsock devices can be attached when starting Firecracker using the jailer.
 - Vsock devices work properly when seccomp filtering is enabled.

--- a/devices/src/virtio/vsock/mod.rs
+++ b/devices/src/virtio/vsock/mod.rs
@@ -14,7 +14,7 @@ mod unix;
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::EVENT_COUNT as VSOCK_EVENTS_COUNT;
 pub use self::device::Vsock;
-pub use self::unix::VsockUnixBackend;
+pub use self::unix::{Error as VsockUnixBackendError, VsockUnixBackend};
 
 use std::os::unix::io::RawFd;
 use std::sync::mpsc;

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -58,8 +58,10 @@ pub enum StartMicrovmError {
     CreateNetDevice(devices::virtio::Error),
     /// Failed to create a `RateLimiter` object.
     CreateRateLimiter(std::io::Error),
+    /// Failed to create the backend for the vsock device.
+    CreateVsockBackend(devices::virtio::vsock::VsockUnixBackendError),
     /// Failed to create the vsock device.
-    CreateVsockDevice,
+    CreateVsockDevice(devices::virtio::vsock::VsockError),
     /// The device manager was not configured.
     DeviceManager,
     /// Cannot read from an Event file descriptor.
@@ -137,7 +139,10 @@ impl Display for StartMicrovmError {
                 err
             ),
             CreateRateLimiter(ref err) => write!(f, "Cannot create RateLimiter: {}", err),
-            CreateVsockDevice => write!(f, "Cannot create vsock device."),
+            CreateVsockBackend(ref err) => {
+                write!(f, "Cannot create backend for vsock device: {:?}", err)
+            }
+            CreateVsockDevice(ref err) => write!(f, "Cannot create vsock device: {:?}", err),
             CreateNetDevice(ref err) => {
                 let mut err_msg = format!("{:?}", err);
                 err_msg = err_msg.replace("\"", "");


### PR DESCRIPTION
## Reason for This PR

The `CreateVsockDevice` error does not propagated
the error that triggers it.
Also this would be used for creation of the
backend and also for the device itself. These
changes also adds two different errors for those
different scenarios.
Fixes #1279.

## Description of Changes
* Split `CreateVsockDevice` into `CreateVsockBackend` and `CreateVsockDevice`
* Propagate error for the above mentioned errors
The Error message from #1279 now looks like this:
`  "fault_message": "Cannot create backend for vsock device: UnixBind(Os { code: 98, kind: AddrInUse, message: "Address in use" })"
`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
