### PR TITLE
Documentation for guest timekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   configuring and starting a microVM without sending any API requests.
 - The jailer adheres to the "end of command options" convention, meaning 
   all parameters specified after `--` are forwarded verbatim to Firecracker.
+- Added `KVM_PTP` support to the recommended guest kernel config.
+- Added entry in FAQ.md for Firecracker Guest timekeeping.
 
 ### Changed
 

--- a/resources/microvm-kernel-config
+++ b/resources/microvm-kernel-config
@@ -1460,11 +1460,12 @@ CONFIG_VIRTIO_CONSOLE=y
 #
 # PTP clock support
 #
-# CONFIG_PTP_1588_CLOCK is not set
+CONFIG_PTP_1588_CLOCK=y
 
 #
 # Enable PHYLIB and NETWORK_PHY_TIMESTAMPING to see the additional clocks.
 #
+CONFIG_PTP_1588_CLOCK_KVM=y
 # CONFIG_GPIOLIB is not set
 # CONFIG_W1 is not set
 # CONFIG_POWER_AVS is not set


### PR DESCRIPTION
## Description of Changes

Added KVM_PTP support in the recommended guest kernel config.

Added FAQ entry describing how to use KVM_PTP for guest timekeeping.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
