### PR TITLE
Fix for off-by-one error in checked_offset

### DIFF
--- a/memory_model/src/guest_memory.rs
+++ b/memory_model/src/guest_memory.rs
@@ -126,7 +126,7 @@ impl GuestMemory {
     pub fn checked_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {
         if let Some(addr) = base.checked_add(offset) {
             for region in self.regions.iter() {
-                if addr >= region.guest_base && addr < region_end(region) {
+                if addr >= region.guest_base && addr <= region_end(region) {
                     return Some(addr);
                 }
             }


### PR DESCRIPTION
When reading an object from a `MemoryRegion`, we would normally make an out of bound
check, partially based on the expression: "obj.addr + obj.len < region_end(region)".

This expression will be resolved to `false` for every obj which sits at the end of a region,
blocking reading the object. The fix consists in changing the expression
like follows: "obj.addr + obj.len <= region_end(region)".

Signed-off-by: iulianbarbu <iul@amazon.com>

## Reason for This PR

#1296 

## Description of Changes

**M**           *memory_model/src/guest_memory.rs*
**M**           *tests/integration_tests/build/test_coverage.py*

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
