### PR TITLE
tests: eliminate some redundant steps in our CI

### DIFF
--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -63,8 +63,8 @@ def get_firecracker_binaries(root_path, features=''):
     Returns the location of the firecracker related binaries eventually after
     building them in case they do not exist at the specified root_path.
     """
-    extra_args = '--release --target {} >/dev/null 2>&1'
-    extra_args = extra_args.format(DEFAULT_BUILD_TARGET)
+    extra_args = \
+        '--release --target {} >/dev/null 2>&1'.format(DEFAULT_BUILD_TARGET)
     extra_env = 'TARGET_CC=musl-gcc'
 
     if features == '':

--- a/tests/integration_tests/build/test_build.py
+++ b/tests/integration_tests/build/test_build.py
@@ -12,42 +12,29 @@ import host_tools.cargo_build as host  # pylint:disable=import-error
 
 MACHINE = platform.machine()
 FEATURES = [""]
-BUILD_TYPES = ["debug", "release"]
-
 TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
            "{}-unknown-linux-musl".format(MACHINE)]
 
 
 @pytest.mark.parametrize(
-    "features, build_type, target",
-    itertools.product(FEATURES, BUILD_TYPES, TARGETS)
+    "features, target",
+    itertools.product(FEATURES, TARGETS)
 )
-@pytest.mark.timeout(400)
-def test_build(test_session_root_path, features, build_type, target):
+@pytest.mark.timeout(500)
+def test_build(test_session_root_path, features, target):
     """
     Test different builds.
 
     This will generate build tests using the cartesian product of all
-    features, build types (release/debug) and build targets (musl/gnu).
+    features and build targets (musl/gnu).
     """
     extra_env = ''
-    extra_args = "--target {} ".format(target)
-
-    if build_type == "release":
-        extra_args += "--release "
+    extra_args = "--target {} --release ".format(target)
 
     if "musl" in target:
         extra_env += "TARGET_CC=musl-gcc"
 
-    # The relative path of the binaries is computed using the build_type
-    # (either release or debug) and if any features are provided also using
-    # the features names.
-    # For example, a default release build with no features will end up in
-    # the relative directory "release".
-    rel_path = os.path.join(
-        host.CARGO_BUILD_REL_PATH,
-        build_type
-    )
+    rel_path = host.CARGO_RELEASE_REL_PATH
     if features:
         rel_path += "-{}".format(features)
         extra_args += "--features {} ".format(features)

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -31,6 +31,11 @@ def test_unittests(test_session_root_path, target):
     if "musl" in target:
         extra_env += "TARGET_CC=musl-gcc"
 
+        if MACHINE == "x86_64":
+            pytest.skip("On x86_64 with musl target unit tests"
+                        " are already run as part of testing"
+                        " code-coverage.")
+
     if MACHINE == "x86_64":
         extra_args += "--all-features "
 


### PR DESCRIPTION
Remove test for building with `debug` profile, only test building `release`.

Skip running unit tests on X86_64 with `musl` target where the unit tests are also run as part of testing code coverage.

This shaves off around 4-5 minutes from a full test run on x86_64.

Fixes #1308 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
