### PR TITLE
micro_http fixes and enhancements

### DIFF
--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -16,6 +16,8 @@ pub enum Header {
     Expect,
     /// Header `Transfer-Encoding`.
     TransferEncoding,
+    /// Header `Server`.
+    Server,
 }
 
 impl Header {
@@ -25,6 +27,7 @@ impl Header {
             Header::ContentType => b"Content-Type",
             Header::Expect => b"Expect",
             Header::TransferEncoding => b"Transfer-Encoding",
+            Header::Server => b"Server",
         }
     }
 
@@ -35,6 +38,7 @@ impl Header {
                 "Content-Type" => Ok(Header::ContentType),
                 "Expect" => Ok(Header::Expect),
                 "Transfer-Encoding" => Ok(Header::TransferEncoding),
+                "Server" => Ok(Header::Server),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -130,6 +134,7 @@ impl Headers {
                             }
                             _ => Err(RequestError::InvalidHeader),
                         },
+                        Header::Server => Ok(()),
                     }
                 } else {
                     Err(RequestError::UnsupportedHeader)

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -102,8 +102,8 @@ impl Headers {
                         Header::ContentLength => {
                             let try_numeric: Result<i32, std::num::ParseIntError> =
                                 std::str::FromStr::from_str(entry[1].trim());
-                            if try_numeric.is_ok() {
-                                self.content_length = try_numeric.unwrap();
+                            if let Ok(content_length) = try_numeric {
+                                self.content_length = content_length;
                                 Ok(())
                             } else {
                                 Err(RequestError::InvalidHeader)

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -82,4 +82,4 @@ pub use request::{Request, RequestError};
 pub use response::{Response, StatusCode};
 
 pub use common::headers::Headers;
-pub use common::{Body, Version};
+pub use common::{Body, Method, Version};


### PR DESCRIPTION
## Reason for This PR

As we're starting to use the `micro_http` crate from the cloud-hypervisor project, we have a few very minor fixes/improvements. This is an upstream submission tentative.

## Description of Changes

* Export the `Method` enum
* Clippy fix
* Allow for setting the HTTP response header `Server` field as there might be other consumer of the micro_http crate than Firecracker.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
