### PR TITLE
jailer: replace 'keys().len()' with 'len()' to get the size of HashMap

### DIFF
--- a/jailer/src/cgroup.rs
+++ b/jailer/src/cgroup.rs
@@ -158,9 +158,9 @@ impl Cgroup {
             }
         }
 
-        let keys_len = found_controllers.keys().len();
+        let found_controllers_len = found_controllers.len();
 
-        if keys_len < CONTROLLERS.len() {
+        if found_controllers_len < CONTROLLERS.len() {
             // We return an error about the first one we didn't find.
             for controller in CONTROLLERS.iter() {
                 if !found_controllers.contains_key(controller) {
@@ -173,10 +173,10 @@ impl Cgroup {
         }
 
         // This is just a sanity check.
-        assert_eq!(keys_len, CONTROLLERS.len());
+        assert_eq!(found_controllers_len, CONTROLLERS.len());
 
         // We now both create the cgroup subfolders, and fill the tasks_files vector.
-        let mut tasks_files = Vec::with_capacity(keys_len);
+        let mut tasks_files = Vec::with_capacity(found_controllers_len);
 
         for (controller, mut path_buf) in found_controllers.drain() {
             path_buf.push(exec_file_name);


### PR DESCRIPTION
Signed-off-by: chaos matrix <mythsphoenix@outlook.com>

## Reason for This PR
```
It might be better replace 'keys().len()' with 'len()' to get the number of elements in HashMap,
even there's no clear performance impact.
```
## Description of Changes
```
replace 'keys().len()' with 'len()' to get the size of HashMap
```
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
