### PR TITLE
vmm: remove unused Vmm InstanceStates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Vsock API call: `PUT /vsocks/{id}` changed to `PUT /vsock` and no longer
   appear to support multiple vsock devices. Any subsequent calls to this API endpoint
   will override the previous vsock device configuration.
+- Removed unused 'Halting' and 'Halted' instance states.
 
 ### Fixed
 

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -477,8 +477,6 @@ definitions:
           - Uninitialized
           - Starting
           - Running
-          - Halting
-          - Halted
       vmm_version:
         description: MicroVM hypervisor build version.
         type: string

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2904,12 +2904,6 @@ mod tests {
         let vmm = create_vmm_object(InstanceState::Starting);
         assert_eq!(vmm.is_instance_initialized(), true);
 
-        let vmm = create_vmm_object(InstanceState::Halting);
-        assert_eq!(vmm.is_instance_initialized(), true);
-
-        let vmm = create_vmm_object(InstanceState::Halted);
-        assert_eq!(vmm.is_instance_initialized(), true);
-
         let vmm = create_vmm_object(InstanceState::Running);
         assert_eq!(vmm.is_instance_initialized(), true);
     }

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -14,7 +14,6 @@ use vstate;
 /// The microvm state. When Firecracker starts, the instance state is Uninitialized.
 /// Once start_microvm method is called, the state goes from Uninitialized to Starting.
 /// The state is changed to Running before ending the start_microvm method.
-/// Halting and Halted are currently unsupported.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum InstanceState {
     /// Microvm is not initialized.
@@ -23,10 +22,6 @@ pub enum InstanceState {
     Starting,
     /// Microvm is running.
     Running,
-    /// Microvm received a halt instruction.
-    Halting,
-    /// Microvm is halted.
-    Halted,
 }
 
 /// The strongly typed that contains general information about the microVM.


### PR DESCRIPTION
## Description of Changes

Instance states `Halting` and `Halted` were unused/unsupported. Removed them.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
