### PR TITLE
MMDS: custom IP address support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   all parameters specified after `--` are forwarded verbatim to Firecracker.
 - Added `KVM_PTP` support to the recommended guest kernel config.
 - Added entry in FAQ.md for Firecracker Guest timekeeping.
+- The MMDS IP address is now configurable via the optional `mmds_ip` field,
+  available through `PUT /network-interfaces/`.
 
 ### Changed
 

--- a/api_server/src/http_service.rs
+++ b/api_server/src/http_service.rs
@@ -1244,6 +1244,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
 
         assert!(netif

--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -49,6 +49,7 @@ use vmm::VmmActionError;
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.).
 #[derive(PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum VmmAction {
     /// Configure the boot source of the microVM using as input the `ConfigureBootSource`. This
     /// action can only be called before the microVM has booted.

--- a/api_server/src/request/net.rs
+++ b/api_server/src/request/net.rs
@@ -76,6 +76,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         }
     }
 
@@ -119,6 +120,7 @@ mod tests {
             rx_rate_limiter: Some(RateLimiterConfig::default()),
             tx_rate_limiter: Some(RateLimiterConfig::default()),
             allow_mmds_requests: true,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
 
         // This is the json encoding of the netif variable.

--- a/api_server/swagger/firecracker.yaml
+++ b/api_server/swagger/firecracker.yaml
@@ -559,9 +559,14 @@ definitions:
         description:
           If this field is set, the device model will reply to HTTP GET
           requests sent to the MMDS address via this interface. In this case,
-          both ARP requests for 169.254.169.254 and TCP segments heading to the
+          both ARP requests for `mmds_ip` and TCP segments heading to the
           same address are intercepted by the device model, and do not reach
           the associated TAP device.
+      mmds_ip:
+        type: string
+        description:
+          This is the IPv4 address that the guest can use to contact the MMDS.
+          If this field is missing, its value will default to "169.254.169.254".
       rx_rate_limiter:
         $ref: "#/definitions/RateLimiter"
       tx_rate_limiter:

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -2,13 +2,17 @@
 
 The Firecracker microVM Metadata Service (MMDS) is a mutable data store which
 implements a simplified data path, made possible by the unique setting found in
-Firecracker. The MMDS consists of three major logical components: the backend,
-the data store, and the minimalist HTTP/TCP/IPv4 stack (named *Dumbo*). They
-all exist within the Firecracker process, and outside the KVM boundary; the
-first is a part of the API server, the data store is a global entity for a
-single microVM, and the last is a part of the device model.
-When the API server is disabled by passing `--no-api` parameter to Firecracker, 
-MMDS is no longer available. 
+Firecracker. Software running inside the microVM can query the MMDS via HTTP
+GET requests directed at a special IPv4 address. By default, this address is
+169.254.169.254, but its value can be specified as part of the microVM network
+interface configuration. The MMDS consists of three major logical components:
+the backend, the data store, and the minimalist HTTP/TCP/IPv4 stack (named
+*Dumbo*). They all exist within the Firecracker process, and outside the KVM
+boundary; the first is a part of the API server, the data store is a global
+entity for a single microVM, and the last is a part of the device model.
+
+*Note*: When the API server is disabled by passing `--no-api` parameter to
+Firecracker, MMDS is no longer available. 
 
 ## The MMDS backend
 

--- a/dumbo/src/ns.rs
+++ b/dumbo/src/ns.rs
@@ -21,7 +21,6 @@ use tcp::handler::{self, RecvEvent, TcpIPv4Handler, WriteEvent};
 use tcp::NextSegmentStatus;
 
 const DEFAULT_MAC_ADDR: &str = "06:01:23:45:67:01";
-const DEFAULT_IPV4_ADDR: [u8; 4] = [169, 254, 169, 254];
 const DEFAULT_TCP_PORT: u16 = 80;
 const DEFAULT_MAX_CONNECTIONS: usize = 30;
 const DEFAULT_MAX_PENDING_RESETS: usize = 100;
@@ -86,10 +85,9 @@ impl MmdsNetworkStack {
         }
     }
 
-    pub fn new_with_defaults() -> Self {
+    pub fn new_with_ipv4_addr(ipv4_addr: Ipv4Addr) -> Self {
         // The unwrap is safe if parse_str() is implemented properly.
         let mac_addr = MacAddr::parse_str(DEFAULT_MAC_ADDR).unwrap();
-        let ipv4_addr = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
 
         // The unwrap()s are safe because the given literals are greater than 0.
         Self::new(
@@ -363,9 +361,10 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_ns() {
-        let mut ns = MmdsNetworkStack::new_with_defaults();
+        const IPV4_ADDR: [u8; 4] = [169, 254, 169, 254];
+
+        let mut ns = MmdsNetworkStack::new_with_ipv4_addr(Ipv4Addr::from(IPV4_ADDR));
         assert_eq!(ns.mac_addr, MacAddr::parse_str(DEFAULT_MAC_ADDR).unwrap());
-        assert_eq!(ns.ipv4_addr, Ipv4Addr::from(DEFAULT_IPV4_ADDR));
 
         let mut buf = [0u8; 2000];
         let mut bad_buf = [0u8; 1];

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -417,8 +417,9 @@ class Microvm:
             network_config,
             iface_id,
             allow_mmds_requests=False,
+            mmds_ip=None,
             tx_rate_limiter=None,
-            rx_rate_limiter=None
+            rx_rate_limiter=None,
     ):
         """Create a host tap device and a guest network interface.
 
@@ -430,6 +431,7 @@ class Microvm:
         :param allow_mmds_requests: specifies whether requests sent from
         the guest on this interface towards the MMDS address are
         intercepted and processed by the device model.
+        :param mmds_ip: the IP address at which the guest can reach the MMDS
         :param tx_rate_limiter: limit the tx rate
         :param rx_rate_limiter: limit the rx rate
         :return: an instance of the tap which needs to be kept around until
@@ -453,6 +455,7 @@ class Microvm:
             host_dev_name=tapname,
             guest_mac=guest_mac,
             allow_mmds_requests=allow_mmds_requests,
+            mmds_ip=mmds_ip,
             tx_rate_limiter=tx_rate_limiter,
             rx_rate_limiter=rx_rate_limiter
         )

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -362,6 +362,7 @@ class Network:
             host_dev_name=None,
             guest_mac=None,
             allow_mmds_requests=None,
+            mmds_ip=None,
             rx_rate_limiter=None,
             tx_rate_limiter=None
     ):
@@ -376,6 +377,8 @@ class Network:
             datax['guest_mac'] = guest_mac
         if allow_mmds_requests is not None:
             datax['allow_mmds_requests'] = allow_mmds_requests
+        if mmds_ip is not None:
+            datax['mmds_ip'] = mmds_ip
         if tx_rate_limiter is not None:
             datax['tx_rate_limiter'] = tx_rate_limiter
         if rx_rate_limiter is not None:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -285,7 +285,8 @@ impl std::convert::From<NetworkInterfaceError> for VmmActionError {
             GuestMacAddressInUse(_)
             | HostDeviceNameInUse(_)
             | DeviceIdNotFound
-            | UpdateNotAllowedPostBoot => ErrorKind::User,
+            | UpdateNotAllowedPostBoot
+            | InvalidMmdsIp => ErrorKind::User,
             // Internal errors.
             EpollHandlerNotFound(_) | RateLimiterUpdateFailed(_) => ErrorKind::Internal,
             OpenTap(ref te) => match te {
@@ -942,6 +943,7 @@ impl Vmm {
                             rx_rate_limiter,
                             tx_rate_limiter,
                             allow_mmds_requests,
+                            cfg.mmds_ipv4_addr(),
                         )
                         .map_err(CreateNetDevice)?,
                     );
@@ -2272,6 +2274,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
         assert!(vmm.insert_net_device(network_interface).is_ok());
 
@@ -2284,6 +2287,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
         assert!(vmm.insert_net_device(network_interface).is_ok());
 
@@ -2295,6 +2299,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
         assert!(vmm.insert_net_device(network_interface).is_err());
 
@@ -2307,6 +2312,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
         assert!(vmm.insert_net_device(network_interface).is_err());
     }
@@ -2336,6 +2342,7 @@ mod tests {
             }),
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         })
         .unwrap();
 
@@ -2772,6 +2779,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
 
         assert!(vmm.insert_net_device(network_interface).is_ok());
@@ -3167,6 +3175,7 @@ mod tests {
             rx_rate_limiter: None,
             tx_rate_limiter: None,
             allow_mmds_requests: false,
+            mmds_ip: NetworkInterfaceConfig::default_mmds_ip(),
         };
 
         assert!(vmm.insert_net_device(network_interface).is_ok());


### PR DESCRIPTION
## Reason for This PR

Issue #1228 

## Description of Changes

This PR adds support for a configurable MMDS IP address. Previously, the MMDS IP was hardcoded to `169.254.169.254`. Following this PR, the user can choose the MMDS IP when configuring the microvm network interfaces (via `PUT /network-interfaces/<id>`). To that end, the `NetworkInterfaceConfig` struct now holds a new field named `mmds_ip`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] This PR closes #1228 
- [ ] The description of changes is clear and encompassing.
- [ ] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Code-level documentation for touched code is included in this PR.
- [ ] The API changes are reflected in `firecracker/swagger.yaml`.
- [ ] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
