### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ development container) as follows:
 git clone https://github.com/firecracker-microvm/firecracker
 cd firecracker
 tools/devtool build
-toolchain="$(uname -m)-unkown-linux-musl"
+toolchain="$(uname -m)-unknown-linux-musl"
 ```
 
 The Firecracker binary will be placed at


### PR DESCRIPTION


## Reason for This PR

There's a typo in the README: `unkown` instead of  `unknown`

## Description of Changes

typo fixed in the README

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
