### PR TITLE
[WIP] Fix off-by-one error resulted from memory methods checked_offset & checked_range_offset incorrect usage

### DIFF
--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -326,7 +326,7 @@ fn create_cpu_nodes(fdt: &mut Vec<u8>, vcpu_mpidr: &Vec<u64>) -> Result<()> {
 }
 
 fn create_memory_node(fdt: &mut Vec<u8>, guest_mem: &GuestMemory) -> Result<()> {
-    let mem_size = guest_mem.end_addr().raw_value() - super::layout::DRAM_MEM_START;
+    let mem_size = guest_mem.last_addr().raw_value() - super::layout::DRAM_MEM_START + 1;
     // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L960
     // for an explanation of this.
     let mem_reg_prop = generate_prop64(&[super::layout::DRAM_MEM_START as u64, mem_size as u64]);

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -99,11 +99,12 @@ fn get_fdt_addr(mem: &GuestMemory) -> u64 {
     // we return the start of the DRAM so that
     // we allow the code to try and load the FDT.
 
-    if let Some(offset) = mem.end_addr().checked_sub(layout::FDT_MAX_SIZE as u64) {
-        if mem.address_in_range(offset) {
-            return offset.raw_value();
+    if let Some(addr) = mem.last_addr().checked_sub(layout::FDT_MAX_SIZE as u64 - 1) {
+        if mem.address_in_range(addr) {
+            return actual_addr.raw_value();
         }
     }
+
     layout::DRAM_MEM_START
 }
 

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -14,8 +14,6 @@ mod mptable;
 /// Logic for configuring x86_64 registers.
 pub mod regs;
 
-use std::mem;
-
 use arch_gen::x86::bootparam::{boot_params, E820_RAM};
 use memory_model::{Address, ByteValued, Bytes, GuestAddress, GuestMemory};
 use InitrdConfig;
@@ -131,7 +129,7 @@ pub fn configure_system(
 
     add_e820_entry(&mut params.0, 0, EBDA_START, E820_RAM)?;
 
-    let mem_end = guest_mem.end_addr();
+    let mem_end = guest_mem.last_addr();
     if mem_end < end_32bit_gap_start {
         add_e820_entry(
             &mut params.0,
@@ -163,9 +161,6 @@ pub fn configure_system(
     }
 
     let zero_page_addr = GuestAddress(layout::ZERO_PAGE_START);
-    guest_mem
-        .checked_offset(zero_page_addr, mem::size_of::<boot_params>())
-        .ok_or(Error::ZeroPagePastRamEnd)?;
     guest_mem
         .write_obj(params, zero_page_addr)
         .map_err(|_| Error::ZeroPageSetup)?;

--- a/src/devices/src/virtio/block.rs
+++ b/src/devices/src/virtio/block.rs
@@ -218,9 +218,11 @@ impl Request {
             if data_desc.is_write_only() && req.request_type == RequestType::Out {
                 return Err(Error::UnexpectedWriteOnlyDescriptor);
             }
+
             if !data_desc.is_write_only() && req.request_type == RequestType::In {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }
+
             if !data_desc.is_write_only() && req.request_type == RequestType::GetDeviceID {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -245,9 +245,10 @@ pub fn load_cmdline(
     }
 
     let end = guest_addr
-        .checked_add(raw_cmdline.len() as u64)
+        .checked_add(raw_cmdline.len() as u64 - 1)
         .ok_or(CmdlineError::CommandLineOverflow)?; // Extra for null termination.
-    if end > guest_mem.end_addr() {
+
+    if end > guest_mem.last_addr() {
         return Err(CmdlineError::CommandLineOverflow);
     }
 

--- a/src/memory_model/src/guest_memory.rs
+++ b/src/memory_model/src/guest_memory.rs
@@ -33,6 +33,7 @@ pub enum Error {
     /// No memory regions were provided for initializing the guest memory.
     NoMemoryRegions,
 }
+
 type Result<T> = result::Result<T, Error>;
 
 /// Tracks a mapping of anonymous memory in the current process and the corresponding base address
@@ -47,13 +48,12 @@ impl MemoryRegion {
     pub fn size(&self) -> usize {
         self.mapping.size()
     }
-}
 
-fn region_end(region: &MemoryRegion) -> GuestAddress {
-    // unchecked_add is safe as the region bounds were checked when it was created.
-    region
-        .guest_base
-        .unchecked_add(region.mapping.size() as u64)
+    fn last_addr(&self) -> GuestAddress {
+        // unchecked_add is safe as the region bounds were checked when it was created.
+        self.guest_base
+            .unchecked_add((self.mapping.size() - 1) as u64)
+    }
 }
 
 /// Tracks all memory regions allocated for the guest in the current process.
@@ -100,24 +100,24 @@ impl GuestMemory {
     ///
     /// ```
     /// use memory_model::{Address, GuestAddress, GuestMemory, MemoryMapping};
-    /// fn test_end_addr() -> Result<(), ()> {
+    /// fn test_last_addr() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
     ///     let mut gm = GuestMemory::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
-    ///     assert_eq!(start_addr.checked_add(0x400), Some(gm.end_addr()));
+    ///     assert_eq!(start_addr.checked_add(0x3ff), Some(gm.last_addr()));
     ///     Ok(())
     /// }
     /// ```
-    pub fn end_addr(&self) -> GuestAddress {
+    pub fn last_addr(&self) -> GuestAddress {
         self.regions
             .iter()
             .max_by_key(|region| region.guest_base)
-            .map_or(GuestAddress(0), |region| region_end(region))
+            .map_or(GuestAddress(0), |region| region.last_addr())
     }
 
     /// Returns true if the given address is within the memory range available to the guest.
     pub fn address_in_range(&self, addr: GuestAddress) -> bool {
         for region in self.regions.iter() {
-            if addr >= region.guest_base && addr < region_end(region) {
+            if addr >= region.guest_base && addr <= region.last_addr() {
                 return true;
             }
         }
@@ -128,13 +128,11 @@ impl GuestMemory {
     /// resulting address and base address may belong to different memory regions, and the base
     /// might not even exist in a valid region.
     pub fn checked_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {
-        if let Some(addr) = base.checked_add(offset as u64) {
-            for region in self.regions.iter() {
-                if addr >= region.guest_base && addr < region_end(region) {
-                    return Some(addr);
-                }
-            }
+        let addr = base.checked_add(offset as u64)?;
+        if self.address_in_range(addr) {
+            return Some(addr);
         }
+
         None
     }
 
@@ -144,11 +142,11 @@ impl GuestMemory {
     pub fn checked_range_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {
         if let Some(addr) = base.checked_add(offset as u64) {
             for region in self.regions.iter() {
-                let region_end = region_end(region);
+                let last_addr = region.last_addr();
                 if base >= region.guest_base
-                    && base < region_end
+                    && base <= last_addr
                     && addr >= region.guest_base
-                    && addr < region_end
+                    && addr <= last_addr
                 {
                     return Some(addr);
                 }
@@ -280,7 +278,7 @@ impl GuestMemory {
         F: FnOnce(&MemoryMapping, usize) -> Result<T>,
     {
         for region in self.regions.iter() {
-            if guest_addr >= region.guest_base && guest_addr < region_end(region) {
+            if guest_addr >= region.guest_base && guest_addr <= region.last_addr() {
                 // it's safe to use unchecked_offset_from because
                 // guest_addr >= region.guest_base
                 // it's safe to convert the result to usize since region.size() is usize
@@ -300,7 +298,7 @@ impl GuestMemory {
         F: FnOnce(&MemoryMapping, usize) -> Result<()>,
     {
         for region in self.regions.iter() {
-            if guest_addr >= region.guest_base && guest_addr < region_end(region) {
+            if guest_addr >= region.guest_base && guest_addr <= region.last_addr() {
                 return cb(
                     &region.mapping,
                     // it's safe to use unchecked_offset_from because
@@ -504,9 +502,10 @@ mod tests {
         assert!(guest_mem.address_in_range(GuestAddress(0x200)));
         assert!(!guest_mem.address_in_range(GuestAddress(0x600)));
         assert!(guest_mem.address_in_range(GuestAddress(0xa00)));
-        let end_addr = GuestAddress(0xc00);
-        assert!(!guest_mem.address_in_range(end_addr));
-        assert_eq!(guest_mem.end_addr(), end_addr);
+
+        let last_addr = GuestAddress(0xc00);
+        assert!(!guest_mem.address_in_range(last_addr));
+        assert_eq!(guest_mem.last_addr(), last_addr.checked_sub(1).unwrap());
 
         // Begins and ends within first region.
         assert_eq!(
@@ -667,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn guest_to_host() {
+    fn test_guest_to_host() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x100);
         let mem = GuestMemory::new(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.9
+COVERAGE_TARGET_PCT = 85.0
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
This PR get rid of some discovered incorrect usages of `checked_offset` and `checked_range_offset` from memory_model crate. It also renames memory model
functions like `region_end` and `end_addr` which with their naming bring ambiguity
in how their usage should be.

Signed-off-by: Iulian Barbu <iul@amazon.com>

## Reason for This PR

#1296 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
