### PR TITLE
[RFC] Polly: the I/O EventManager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "memory_model 0.1.0",
  "net_gen 0.1.0",
  "net_util 0.1.0",
+ "polly 0.0.1",
  "rate_limiter 0.1.0",
  "sys_util 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -243,6 +244,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
 version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -310,6 +316,16 @@ dependencies = [
  "net_gen 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys_util 0.1.0",
+]
+
+[[package]]
+name = "polly"
+version = "0.0.1"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys_util 0.1.0",
 ]
 
@@ -545,6 +561,7 @@ dependencies = [
  "memory_model 0.1.0",
  "mmds 0.1.0",
  "net_util 0.1.0",
+ "polly 0.0.1",
  "rate_limiter 0.1.0",
  "seccomp 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,6 +621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
 "checksum kvm-ioctls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43e647ed90b0f5214eb938601fc2e7aad2fc624fde62f13c0c2e672407b8ce7b"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)" = "74dfca3d9957906e8d1e6a0b641dc9a59848e793f1da2165889fd4f62d10d79c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -18,6 +18,7 @@ net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }
 sys_util = { path = "../sys_util" }
 virtio_gen = { path = "../virtio_gen" }
+polly = { path = "../polly" }
 
 [dev-dependencies]
 tempfile = ">=3.0.2"

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -16,6 +16,7 @@ extern crate logger;
 extern crate memory_model;
 extern crate net_gen;
 extern crate net_util;
+extern crate polly;
 extern crate rate_limiter;
 extern crate sys_util;
 extern crate virtio_gen;

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -11,11 +11,11 @@ use std::convert::From;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::linux::fs::MetadataExt;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use logger::{Metric, METRICS};
 use memory_model::{DataInit, GuestAddress, GuestMemory, GuestMemoryError};
@@ -23,9 +23,12 @@ use rate_limiter::{RateLimiter, TokenType};
 use sys_util::EventFd;
 use virtio_gen::virtio_blk::*;
 
+use polly::event_manager::*;
+use polly::pollable::*;
+
 use super::{
-    ActivateError, ActivateResult, DescriptorChain, EpollConfigConstructor, Queue, VirtioDevice,
-    TYPE_BLOCK, VIRTIO_MMIO_INT_VRING,
+    ActivateError, ActivateResult, DescriptorChain, Queue, VirtioDevice, TYPE_BLOCK,
+    VIRTIO_MMIO_INT_VRING,
 };
 use crate::{DeviceEventT, EpollHandler, Error as DeviceError};
 
@@ -300,27 +303,81 @@ impl Request {
     }
 }
 
-/// Handler that drives the execution of the Block devices
-pub struct BlockEpollHandler {
-    queues: Vec<Queue>,
-    mem: GuestMemory,
+/// Virtio device for exposing block level read/write operations on a host file.
+pub struct Block {
     disk_image: File,
     disk_nsectors: u64,
-    interrupt_status: Arc<AtomicUsize>,
-    interrupt_evt: EventFd,
-    queue_evt: EventFd,
+    avail_features: u64,
+    acked_features: u64,
+    config_space: Vec<u8>,
     rate_limiter: RateLimiter,
+    queues: Option<Vec<Queue>>,
+    mem: Option<GuestMemory>,
+    interrupt_status: Option<Arc<AtomicUsize>>,
+    interrupt_evt: Option<EventFd>,
+    queue_evt: Option<EventFd>,
     disk_image_id: Vec<u8>,
 }
 
-impl BlockEpollHandler {
-    fn process_queue(&mut self, queue_index: usize) -> bool {
-        let queue = &mut self.queues[queue_index];
-        let mut used_any = false;
+pub fn build_config_space(disk_size: u64) -> Vec<u8> {
+    // We only support disk size, which uses the first two words of the configuration space.
+    // If the image is not a multiple of the sector size, the tail bits are not exposed.
+    // The config space is little endian.
+    let mut config = Vec::with_capacity(CONFIG_SPACE_SIZE);
+    let num_sectors = disk_size >> SECTOR_SHIFT;
+    for i in 0..8 {
+        config.push((num_sectors >> (8 * i)) as u8);
+    }
+    config
+}
 
-        while let Some(head) = queue.pop(&self.mem) {
+impl Block {
+    /// Create a new virtio block device that operates on the given file.
+    ///
+    /// The given file must be seekable and sizable.
+    pub fn new(
+        mut disk_image: File,
+        is_disk_read_only: bool,
+        rate_limiter: RateLimiter,
+    ) -> io::Result<Block> {
+        let disk_size = disk_image.seek(SeekFrom::End(0))? as u64;
+        if disk_size % SECTOR_SIZE != 0 {
+            warn!(
+                "Disk size {} is not a multiple of sector size {}; \
+                 the remainder will not be visible to the guest.",
+                disk_size, SECTOR_SIZE
+            );
+        }
+
+        let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_BLK_F_FLUSH);
+
+        if is_disk_read_only {
+            avail_features |= 1u64 << VIRTIO_BLK_F_RO;
+        };
+
+        Ok(Block {
+            disk_image_id: build_disk_image_id(&disk_image),
+            disk_image: disk_image,
+            disk_nsectors: disk_size / SECTOR_SIZE,
+            avail_features,
+            acked_features: 0u64,
+            config_space: build_config_space(disk_size),
+            rate_limiter,
+            interrupt_status: None,
+            interrupt_evt: None,
+            queue_evt: None,
+            queues: None,
+            mem: None,
+        })
+    }
+
+    fn process_queue(&mut self, queue_index: usize) -> bool {
+        let queues = &mut self.queues.as_mut().unwrap();
+        let queue = &mut queues[queue_index];
+        let mut used_any = false;
+        while let Some(head) = queue.pop(self.mem.as_ref().unwrap()) {
             let len;
-            match Request::parse(&head, &self.mem) {
+            match Request::parse(&head, &self.mem.as_ref().unwrap()) {
                 Ok(request) => {
                     // If limiter.consume() fails it means there is no more TokenType::Ops
                     // budget and rate limiting is in effect.
@@ -351,7 +408,7 @@ impl BlockEpollHandler {
                     let status = match request.execute(
                         &mut self.disk_image,
                         self.disk_nsectors,
-                        &self.mem,
+                        &self.mem.as_ref().unwrap(),
                         &self.disk_image_id,
                     ) {
                         Ok(l) => {
@@ -368,6 +425,8 @@ impl BlockEpollHandler {
                     // We use unwrap because the request parsing process already checked that the
                     // status_addr was valid.
                     self.mem
+                        .as_ref()
+                        .unwrap()
                         .write_obj_at_addr(status, request.status_addr)
                         .unwrap();
                 }
@@ -377,7 +436,7 @@ impl BlockEpollHandler {
                     len = 0;
                 }
             }
-            queue.add_used(&self.mem, head.index, len);
+            queue.add_used(&self.mem.as_ref().unwrap(), head.index, len);
             used_any = true;
         }
 
@@ -386,12 +445,17 @@ impl BlockEpollHandler {
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
         self.interrupt_status
+            .as_ref()
+            .unwrap()
             .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
-        self.interrupt_evt.write(1).map_err(|e| {
+
+        self.interrupt_evt.as_ref().unwrap().write(1).map_err(|e| {
             error!("Failed to signal used queue: {:?}", e);
+            println!("Failed to signal used queue: {:?}", e);
             METRICS.block.event_fails.inc();
             DeviceError::FailedSignalingUsedQueue(e)
-        })
+        });
+        Ok(())
     }
 
     /// Update the backing file for the Block device
@@ -408,126 +472,36 @@ impl BlockEpollHandler {
     }
 }
 
-impl EpollHandler for BlockEpollHandler {
-    fn handle_event(
-        &mut self,
-        device_event: DeviceEventT,
-        _evset: epoll::Events,
-    ) -> result::Result<(), DeviceError> {
-        match device_event {
-            QUEUE_AVAIL_EVENT => {
-                METRICS.block.queue_event_count.inc();
-                if let Err(e) = self.queue_evt.read() {
-                    error!("Failed to get queue event: {:?}", e);
-                    METRICS.block.event_fails.inc();
-                    Err(DeviceError::FailedReadingQueue {
-                        event_type: "queue event",
-                        underlying: e,
-                    })
-                } else if !self.rate_limiter.is_blocked() && self.process_queue(0) {
-                    self.signal_used_queue()
-                } else {
-                    // While limiter is blocked, don't process any more requests.
-                    Ok(())
-                }
+impl EventHandler for Block {
+    fn handle_read(&mut self, source: Pollable) -> Option<Vec<PollableOp>> {
+        let queue_fd = self.queue_evt.as_ref().unwrap().as_raw_fd();
+        let rate_limiter_fd = self.rate_limiter.as_raw_fd();
+        if source.as_raw_fd() == queue_fd {
+            METRICS.block.queue_event_count.inc();
+            if let Err(e) = self.queue_evt.as_ref().unwrap().read() {
+                error!("Failed to get queue event: {:?}", e);
+                METRICS.block.event_fails.inc();
+            // Err(DeviceError::FailedReadingQueue {
+            //     event_type: "queue event",
+            //     underlying: e,
+            // })
+            } else if !self.rate_limiter.is_blocked() && self.process_queue(0) {
+                self.signal_used_queue();
             }
-            RATE_LIMITER_EVENT => {
-                METRICS.block.rate_limiter_event_count.inc();
-                // Upon rate limiter event, call the rate limiter handler
-                // and restart processing the queue.
-                if self.rate_limiter.event_handler().is_ok() && self.process_queue(0) {
-                    self.signal_used_queue()
-                } else {
-                    Ok(())
-                }
+        } else if source.as_raw_fd() == rate_limiter_fd {
+            METRICS.block.rate_limiter_event_count.inc();
+            // Upon rate limiter event, call the rate limiter handler
+            // and restart processing the queue.
+            if self.rate_limiter.event_handler().is_ok() && self.process_queue(0) {
+                self.signal_used_queue();
             }
-            unknown => Err(DeviceError::UnknownEvent {
-                device: "block",
-                event: unknown,
-            }),
-        }
-    }
-}
-
-pub struct EpollConfig {
-    q_avail_token: u64,
-    rate_limiter_token: u64,
-    epoll_raw_fd: RawFd,
-    sender: mpsc::Sender<Box<dyn EpollHandler>>,
-}
-
-impl EpollConfigConstructor for EpollConfig {
-    fn new(
-        first_token: u64,
-        epoll_raw_fd: RawFd,
-        sender: mpsc::Sender<Box<dyn EpollHandler>>,
-    ) -> Self {
-        EpollConfig {
-            q_avail_token: first_token + u64::from(QUEUE_AVAIL_EVENT),
-            rate_limiter_token: first_token + u64::from(RATE_LIMITER_EVENT),
-            epoll_raw_fd,
-            sender,
-        }
-    }
-}
-
-/// Virtio device for exposing block level read/write operations on a host file.
-pub struct Block {
-    disk_image: Option<File>,
-    disk_nsectors: u64,
-    avail_features: u64,
-    acked_features: u64,
-    config_space: Vec<u8>,
-    epoll_config: EpollConfig,
-    rate_limiter: Option<RateLimiter>,
-}
-
-pub fn build_config_space(disk_size: u64) -> Vec<u8> {
-    // We only support disk size, which uses the first two words of the configuration space.
-    // If the image is not a multiple of the sector size, the tail bits are not exposed.
-    // The config space is little endian.
-    let mut config = Vec::with_capacity(CONFIG_SPACE_SIZE);
-    let num_sectors = disk_size >> SECTOR_SHIFT;
-    for i in 0..8 {
-        config.push((num_sectors >> (8 * i)) as u8);
-    }
-    config
-}
-
-impl Block {
-    /// Create a new virtio block device that operates on the given file.
-    ///
-    /// The given file must be seekable and sizable.
-    pub fn new(
-        mut disk_image: File,
-        is_disk_read_only: bool,
-        epoll_config: EpollConfig,
-        rate_limiter: Option<RateLimiter>,
-    ) -> io::Result<Block> {
-        let disk_size = disk_image.seek(SeekFrom::End(0))? as u64;
-        if disk_size % SECTOR_SIZE != 0 {
-            warn!(
-                "Disk size {} is not a multiple of sector size {}; \
-                 the remainder will not be visible to the guest.",
-                disk_size, SECTOR_SIZE
-            );
         }
 
-        let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_BLK_F_FLUSH);
+        None
+    }
 
-        if is_disk_read_only {
-            avail_features |= 1u64 << VIRTIO_BLK_F_RO;
-        };
-
-        Ok(Block {
-            disk_image: Some(disk_image),
-            disk_nsectors: disk_size / SECTOR_SIZE,
-            avail_features,
-            acked_features: 0u64,
-            config_space: build_config_space(disk_size),
-            epoll_config,
-            rate_limiter,
-        })
+    fn init(&self) -> Option<Vec<PollableOp>> {
+        None
     }
 }
 
@@ -595,60 +569,25 @@ impl VirtioDevice for Block {
             METRICS.block.activate_fails.inc();
             return Err(ActivateError::BadActivate);
         }
+        let queue_evt = queue_evts.remove(0);
+        let queue_evt_raw_fd = queue_evt.as_raw_fd();
 
-        if let Some(disk_image) = self.disk_image.take() {
-            let queue_evt = queue_evts.remove(0);
-            let queue_evt_raw_fd = queue_evt.as_raw_fd();
+        self.mem = Some(mem);
+        self.queues = Some(queues);
+        self.queue_evt = Some(queue_evt);
+        self.interrupt_status = Some(status);
+        self.interrupt_evt = Some(interrupt_evt);
 
-            let disk_image_id = build_disk_image_id(&disk_image);
-            let handler = BlockEpollHandler {
-                queues,
-                mem,
-                disk_image,
-                disk_nsectors: self.disk_nsectors,
-                interrupt_status: status,
-                interrupt_evt,
-                queue_evt,
-                rate_limiter: self.rate_limiter.take().unwrap_or_default(),
-                disk_image_id,
-            };
-            let rate_limiter_rawfd = handler.rate_limiter.as_raw_fd();
+        let ops = vec![
+            PollableOpBuilder::new(unsafe { Pollable::from_raw_fd(queue_evt_raw_fd) })
+                .readable()
+                .register(),
+            PollableOpBuilder::new(Pollable::from(&self.rate_limiter))
+                .readable()
+                .register(),
+        ];
 
-            // The channel should be open at this point.
-            self.epoll_config
-                .sender
-                .send(Box::new(handler))
-                .expect("Failed to send through the channel");
-
-            //TODO: barrier needed here by any chance?
-            epoll::ctl(
-                self.epoll_config.epoll_raw_fd,
-                epoll::ControlOptions::EPOLL_CTL_ADD,
-                queue_evt_raw_fd,
-                epoll::Event::new(epoll::Events::EPOLLIN, self.epoll_config.q_avail_token),
-            )
-            .map_err(|e| {
-                METRICS.block.activate_fails.inc();
-                ActivateError::EpollCtl(e)
-            })?;
-
-            if rate_limiter_rawfd != -1 {
-                epoll::ctl(
-                    self.epoll_config.epoll_raw_fd,
-                    epoll::ControlOptions::EPOLL_CTL_ADD,
-                    rate_limiter_rawfd,
-                    epoll::Event::new(epoll::Events::EPOLLIN, self.epoll_config.rate_limiter_token),
-                )
-                .map_err(|e| {
-                    METRICS.block.activate_fails.inc();
-                    ActivateError::EpollCtl(e)
-                })?;
-            }
-
-            return Ok(());
-        }
-        METRICS.block.activate_fails.inc();
-        Err(ActivateError::BadActivate)
+        return Ok(Some(ops));
     }
 }
 

--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -25,6 +25,8 @@ pub use self::queue::*;
 pub use self::vsock::*;
 
 use super::EpollHandler;
+use polly::event_manager::WrappedHandler;
+use polly::pollable::PollableOp;
 
 /// When the driver initializes the device, it lets the device know about the
 /// completed stages using the Device Status Field.
@@ -63,7 +65,7 @@ pub enum ActivateError {
     BadActivate,
 }
 
-pub type ActivateResult = std::result::Result<(), ActivateError>;
+pub type ActivateResult = std::result::Result<Option<Vec<PollableOp>>, ActivateError>;
 
 pub trait EpollConfigConstructor {
     fn new(

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -24,6 +24,8 @@ use logger::{Metric, METRICS};
 use memory_model::{GuestAddress, GuestMemory};
 use net_gen;
 use net_util::{Tap, TapError};
+use polly::event_manager;
+use polly::pollable;
 use rate_limiter::{RateLimiter, TokenBucket, TokenType};
 use sys_util::EventFd;
 use virtio_gen::virtio_net::*;
@@ -681,6 +683,12 @@ pub struct Net {
     allow_mmds_requests: bool,
 }
 
+impl event_manager::EventHandler for Net {
+    fn init(&self) -> Option<Vec<pollable::PollableOp>> {
+        None
+    }
+}
+
 impl Net {
     /// Create a new virtio network device with the given TAP interface.
     pub fn new_with_tap(
@@ -909,7 +917,7 @@ impl VirtioDevice for Net {
                 .map_err(ActivateError::EpollCtl)?;
             }
 
-            return Ok(());
+            return Ok(None);
         }
         METRICS.net.activate_fails.inc();
         Err(ActivateError::BadActivate)

--- a/devices/src/virtio/vsock/device.rs
+++ b/devices/src/virtio/vsock/device.rs
@@ -36,7 +36,8 @@ use super::super::{ActivateError, ActivateResult, Queue as VirtQueue, VirtioDevi
 use super::epoll_handler::VsockEpollHandler;
 use super::VsockBackend;
 use super::{defs, defs::uapi, EpollConfig};
-
+use polly::event_manager;
+use polly::pollable;
 /// The virtio features supported by our vsock device:
 /// - VIRTIO_F_VERSION_1: the device conforms to at least version 1.0 of the VirtIO spec.
 /// - VIRTIO_F_IN_ORDER: the device returns used buffers in the same order that the driver makes
@@ -50,6 +51,15 @@ pub struct Vsock<B: VsockBackend> {
     avail_features: u64,
     acked_features: u64,
     epoll_config: EpollConfig,
+}
+
+impl<B> event_manager::EventHandler for Vsock<B>
+where
+    B: VsockBackend + 'static,
+{
+    fn init(&self) -> Option<Vec<pollable::PollableOp>> {
+        None
+    }
 }
 
 impl<B> Vsock<B>
@@ -198,7 +208,7 @@ where
         )
         .map_err(ActivateError::EpollCtl)?;
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/polly/Cargo.toml
+++ b/polly/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "polly"
+version = "0.0.1"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+
+[dependencies]
+libc = "0.1.12"
+epoll = "4.0.1"
+bitflags = "1.2.0"
+sys_util = { path="../sys_util" }

--- a/polly/src/event_manager.rs
+++ b/polly/src/event_manager.rs
@@ -270,8 +270,7 @@ impl EventManager {
         Ok(())
     }
 
-    /// Process requests via the event channel.
-    fn process_api_channel(&mut self) -> Result<()> {
+    pub fn process_api_channel(&mut self) -> Result<()> {
         loop {
             let _events = self.api_channel_tx.read_event();
             match self.api_channel_rx.try_recv() {

--- a/polly/src/event_manager.rs
+++ b/polly/src/event_manager.rs
@@ -1,0 +1,508 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use epoll::Events;
+use pollable::{EventRegistrationData, EventSet, Pollable, PollableOp, PollableOpBuilder};
+use std::collections::HashMap;
+use std::fmt::Formatter;
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use sys_util::EventFd;
+
+const EVENT_BUFFER_SIZE: usize = 128;
+const DEFAULT_EPOLL_TIMEOUT: i32 = 250;
+
+pub type Result<T> = std::result::Result<T, Error>;
+pub type WrappedHandler = Arc<Mutex<dyn EventHandler>>;
+
+pub enum Error {
+    /// Cannot create epoll fd.
+    EpollCreate,
+    /// Polling i/o error.
+    Poll(io::Error),
+    /// The specified pollable already registered.
+    AlreadyExists,
+    /// The specified pollable is not registered.
+    NotFound(Pollable),
+    /// Error while writing the api channel eventfd.
+    ApiChannelFd(io::Error),
+    /// Error while sending data on the api channel.
+    ApiChannelTx,
+    /// Api channel disconnected.
+    ApiChannelDisconnect,
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use self::Error::*;
+
+        match self {
+            EpollCreate => write!(f, "Unable to create epoll fd."),
+            Poll(err) => write!(f, "Error during epoll call: {}", err),
+            AlreadyExists => write!(f, "A handler for the specified pollable already exists"),
+            ApiChannelFd(err) => write!(f, "Error while writing Api channel event fd: {}", err),
+            ApiChannelTx => write!(f, "Error while sending on the Api channel"),
+            ApiChannelDisconnect => write!(f, "Error while reading the Api channel: disconnected"),
+            NotFound(pollable) => write!(
+                f,
+                "A handler for the specified pollable {} was not found",
+                pollable.as_raw_fd()
+            ),
+        }
+    }
+}
+
+struct EventHandlerData {
+    data: EventRegistrationData,
+    handler: WrappedHandler,
+}
+
+impl EventHandlerData {
+    fn new(data: EventRegistrationData, handler: WrappedHandler) -> EventHandlerData {
+        EventHandlerData {
+            data: data,
+            handler: handler,
+        }
+    }
+}
+
+/// A trait to express the ability to respond to I/O event readiness
+/// using callbacks.
+pub trait EventHandler: Send {
+    /// Handle a read event (EPOLLIN).
+    fn handle_read(&mut self, _source: Pollable) -> Option<Vec<PollableOp>> {
+        None
+    }
+    /// Handle a write event (EPOLLOUT).
+    fn handle_write(&mut self, _source: Pollable) -> Option<Vec<PollableOp>> {
+        None
+    }
+    /// Handle a close event (EPOLLRDHUP).
+    fn handle_close(&mut self, _source: Pollable) -> Option<Vec<PollableOp>> {
+        None
+    }
+    /// Handle an error event (EPOLLERR).assert_ne!
+    fn handle_error(&mut self, _source: Pollable) -> Option<Vec<PollableOp>> {
+        None
+    }
+
+    /// Initial registration of pollable objects.
+    /// Use the PollableOpBuilder to build the vector of PollableOps.
+    fn init(&self) -> Option<Vec<PollableOp>>;
+}
+
+/// Wraps a HashMap of fd to EventHandlerData.
+struct HandlerMap {
+    handlers: HashMap<i32, EventHandlerData>,
+}
+
+impl HandlerMap {
+    pub fn new() -> HandlerMap {
+        HandlerMap {
+            handlers: HashMap::new(),
+        }
+    }
+
+    // Returns a copy of EventHandlerData instead of mut ref.
+    pub fn get(&mut self, id: &i32) -> Option<EventHandlerData> {
+        match self.handlers.get(id) {
+            Some(handler) => Some(EventHandlerData::new(
+                (handler.data.0.clone(), handler.data.1),
+                handler.handler.clone(),
+            )),
+            None => None,
+        }
+    }
+}
+
+impl Deref for HandlerMap {
+    type Target = HashMap<i32, EventHandlerData>;
+    fn deref(&self) -> &Self::Target {
+        &self.handlers
+    }
+}
+
+impl DerefMut for HandlerMap {
+    fn deref_mut(&mut self) -> &mut HashMap<i32, EventHandlerData> {
+        &mut self.handlers
+    }
+}
+
+// The tx side of a generic API channel.
+// Sending a T message over this channel will also write the eventFd.
+// The rx side of the channel polls the eventfd for incoming messages.
+pub struct GenericApiChannel<T> {
+    channel: Sender<T>,
+    fd: EventFd,
+}
+
+impl<T> GenericApiChannel<T> {
+    pub fn new(channel: Sender<T>) -> GenericApiChannel<T> {
+        GenericApiChannel {
+            channel: channel,
+            fd: EventFd::new().unwrap(),
+        }
+    }
+
+    /// Send a message of type T and notify rx side by writing
+    /// the eventfd.
+    pub fn send(&mut self, msg: T) -> Result<()> {
+        self.fd.write(1).map_err(Error::ApiChannelFd)?;
+        self.channel.send(msg).map_err(|_| Error::ApiChannelTx)
+    }
+
+    /// Reads evenfd event count.
+    pub fn read_event(&mut self) -> u64 {
+        self.fd.read().unwrap_or(0)
+    }
+}
+
+impl<T> Clone for GenericApiChannel<T> {
+    fn clone(&self) -> Self {
+        GenericApiChannel {
+            channel: self.channel.clone(),
+            fd: self.fd.try_clone().unwrap(),
+        }
+    }
+}
+
+impl<T> AsRawFd for GenericApiChannel<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+pub type ApiChannelMessage = (WrappedHandler, Vec<PollableOp>);
+pub type ApiChannel = GenericApiChannel<ApiChannelMessage>;
+
+pub struct EventManager {
+    fd: Pollable,
+    handlers: HandlerMap,
+    events: Vec<epoll::Event>,
+    api_channel_rx: Receiver<ApiChannelMessage>,
+    api_channel_tx: ApiChannel,
+}
+
+impl AsRawFd for EventManager {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl EventManager {
+    /// Create a new EventManager.
+    pub fn new() -> Result<EventManager> {
+        let epoll_fd =
+            unsafe { Pollable::from_raw_fd(epoll::create(true).map_err(|_| Error::EpollCreate)?) };
+        let (tx, rx) = channel();
+
+        Ok(EventManager {
+            fd: epoll_fd,
+            handlers: HandlerMap::new(),
+            events: vec![epoll::Event::new(epoll::Events::empty(), 0); EVENT_BUFFER_SIZE],
+            api_channel_rx: rx,
+            api_channel_tx: ApiChannel::new(tx),
+        })
+    }
+
+    #[inline(always)]
+    pub fn get_api_channel(&self) -> ApiChannel {
+        self.api_channel_tx.clone()
+    }
+
+    // Convert from event type to epoll event mask.
+    #[inline(always)]
+    fn event_type_to_epoll_mask(event_types: EventSet) -> epoll::Events {
+        let mut epoll_event_mask = epoll::Events::empty();
+
+        if event_types.readable() {
+            epoll_event_mask |= epoll::Events::EPOLLIN;
+        }
+
+        if event_types.writeable() {
+            epoll_event_mask |= epoll::Events::EPOLLOUT;
+        }
+
+        if event_types.closed() {
+            epoll_event_mask |= epoll::Events::EPOLLRDHUP;
+        }
+
+        epoll_event_mask
+    }
+
+    // Register a new eventhandler for the pollable and mask specified
+    // in event_data.
+    fn register_handler(
+        &mut self,
+        event_data: EventRegistrationData,
+        wrapped_handler: WrappedHandler,
+    ) -> Result<()> {
+        let (pollable, event_type) = event_data;
+
+        if let Some(_) = self.handlers.get(&pollable.as_raw_fd()) {
+            println!("Pollable {} already registered", pollable.clone());
+            return Err(Error::AlreadyExists);
+        };
+
+        epoll::ctl(
+            self.fd.as_raw_fd(),
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            pollable.as_raw_fd(),
+            epoll::Event::new(
+                EventManager::event_type_to_epoll_mask(event_type),
+                // Use the fd for event source identification in handlers.
+                pollable.as_raw_fd() as u64,
+            ),
+        )
+        .map_err(|_| Error::Poll(io::Error::last_os_error()))?;
+
+        self.handlers.insert(
+            pollable.as_raw_fd(),
+            EventHandlerData::new((pollable.clone(), event_type), wrapped_handler.clone()),
+        );
+        Ok(())
+    }
+
+    /// Process requests via the event channel.
+    fn process_api_channel(&mut self) -> Result<()> {
+        loop {
+            let _events = self.api_channel_tx.read_event();
+            match self.api_channel_rx.try_recv() {
+                Ok((wrapped_handler, ops)) => Ok(self.run_pollable_ops(wrapped_handler, ops)?),
+                // We expect to try reading until TryRecvError::Empty.
+                Err(err) => match err {
+                    TryRecvError::Empty => return Ok(()),
+                    TryRecvError::Disconnected => Err(Error::ApiChannelDisconnect),
+                },
+            }?
+        }
+    }
+
+    /// Update an event handler pollables and event sets.
+    /// Use the PollableOpBuilder to build the vector of PollableOps.
+    pub fn update(
+        &mut self,
+        wrapped_handler: WrappedHandler,
+        pollable_ops: Vec<PollableOp>,
+    ) -> Result<()> {
+        self.run_pollable_ops(wrapped_handler, pollable_ops)
+    }
+
+    fn run_pollable_ops(
+        &mut self,
+        wrapped_handler: WrappedHandler,
+        pollable_ops: Vec<PollableOp>,
+    ) -> Result<()> {
+        for op in pollable_ops {
+            match op {
+                PollableOp::Register(data) => {
+                    self.register_handler(data, wrapped_handler.clone())?
+                }
+                PollableOp::Unregister(data) => self.unregister(data.0)?,
+                PollableOp::Update(data) => self.update_event(data)?,
+            }
+        }
+        Ok(())
+    }
+
+    /// Register a new event handler.
+    /// handler.init() will specify the pollable and event set.
+    ///
+    pub fn register<T: EventHandler + 'static>(&mut self, handler: T) -> Result<Arc<Mutex<T>>> {
+        let pollable_ops = handler.init();
+        let wrapped_type = Arc::new(Mutex::new(handler));
+        let wrapped_handler: Arc<Mutex<dyn EventHandler>> = wrapped_type.clone();
+
+        if let Some(ops) = pollable_ops {
+            self.run_pollable_ops(wrapped_handler, ops)?;
+        }
+
+        Ok(wrapped_type)
+    }
+
+    fn update_event(&mut self, event: EventRegistrationData) -> Result<()> {
+        if let Some(_) = self.handlers.get(&event.0.as_raw_fd()) {
+            epoll::ctl(
+                self.fd.as_raw_fd(),
+                epoll::ControlOptions::EPOLL_CTL_MOD,
+                event.0.as_raw_fd(),
+                epoll::Event::new(
+                    EventManager::event_type_to_epoll_mask(event.1),
+                    event.0.as_raw_fd() as u64,
+                ),
+            )
+            .map_err(|_| Error::Poll(io::Error::last_os_error()))?;
+        } else {
+            return Err(Error::NotFound(event.0));
+        }
+
+        Ok(())
+    }
+
+    /// Unregister a the event handler for the specified pollable.
+    ///
+    pub fn unregister(&mut self, pollable: Pollable) -> Result<()> {
+        match self.handlers.remove(&pollable.as_raw_fd()) {
+            Some(_) => {
+                epoll::ctl(
+                    self.fd.as_raw_fd(),
+                    epoll::ControlOptions::EPOLL_CTL_DEL,
+                    pollable.as_raw_fd(),
+                    epoll::Event::new(epoll::Events::empty(), 0),
+                )
+                .map_err(|_| Error::Poll(io::Error::last_os_error()))?;
+            }
+            None => {
+                return Err(Error::NotFound(pollable));
+            }
+        }
+        Ok(())
+    }
+
+    // Dispatch an epoll eventset for a handler.
+    #[inline(always)]
+    fn dispatch_event(
+        &mut self,
+        source: Pollable,
+        evset: epoll::Events,
+        wrapped_handler: WrappedHandler,
+    ) -> Result<()> {
+        let mut all_ops = Vec::new();
+
+        // If an error occurs on a fd then only dispatch the error callback,
+        // ignoring other flags.
+        if evset.contains(epoll::Events::EPOLLERR) {
+            if let Some(mut ops) = wrapped_handler
+                .lock()
+                .expect("Handler lock is poisoned")
+                .handle_error(source.clone())
+            {
+                all_ops.append(&mut ops);
+            }
+        } else {
+            // We expect EventHandler implementors to be prepared to
+            // handle multiple events for a pollable in this order:
+            // READ, WRITE, CLOSE.
+            if evset.contains(epoll::Events::EPOLLIN) {
+                if let Some(mut ops) = wrapped_handler
+                    .lock()
+                    .expect("Handler lock is poisoned")
+                    .handle_read(source.clone())
+                {
+                    all_ops.append(&mut ops);
+                }
+            }
+            if evset.contains(epoll::Events::EPOLLOUT) {
+                if let Some(mut ops) = wrapped_handler
+                    .lock()
+                    .expect("Handler lock is poisoned")
+                    .handle_write(source.clone())
+                {
+                    all_ops.append(&mut ops);
+                }
+            }
+            if evset.contains(epoll::Events::EPOLLRDHUP) {
+                if let Some(mut ops) = wrapped_handler
+                    .lock()
+                    .expect("Handler lock is poisoned")
+                    .handle_close(source.clone())
+                {
+                    all_ops.append(&mut ops);
+                }
+            }
+        }
+
+        self.run_pollable_ops(wrapped_handler.clone(), all_ops)?;
+        Ok(())
+    }
+
+    // Process/dispatch buffered epoll events.
+    fn process_events(&mut self, event_count: usize) -> Result<()> {
+        for idx in 0..event_count {
+            let event = self.events[idx];
+            let event_mask = event.events;
+            let event_data = event.data;
+            let evset = match Events::from_bits(event_mask) {
+                Some(evset) => evset,
+                None => {
+                    println!("epoll: ignoring unknown event set: 0x{:x}", event_mask);
+                    continue;
+                }
+            };
+
+            if let Some(event_handler_data) = self.handlers.get(&(event_data as i32)) {
+                match self.dispatch_event(
+                    event_handler_data.data.0.clone(),
+                    evset,
+                    event_handler_data.handler,
+                ) {
+                    Ok(()) => continue,
+                    Err(_) => {
+                        // We might get errors related to pollableops.
+                        // Need to decide what to do with them.
+                        // Options:
+                        // 1. Break loop and throw them to the caller
+                        // 2. Invoke a TBD evenhandler error callback.
+                    }
+                }
+            } else {
+                // There is no handler registered for this eventset/pollable.
+            }
+        }
+
+        Ok(())
+    }
+
+    // Wait for events, then dispatch to registered event handlers.
+    pub fn run(&mut self) -> Result<usize> {
+        self.run_timeout(-1)
+    }
+
+    // Wait for events or a timeout, then dispatch to registered event handlers.
+    pub fn run_timeout(&mut self, milliseconds: i32) -> Result<usize> {
+        let event_count = epoll::wait(self.fd.as_raw_fd(), milliseconds, &mut self.events[..])
+            .map_err(|_| Error::Poll(io::Error::last_os_error()))?;
+        self.process_events(event_count)?;
+
+        self.process_api_channel()?;
+
+        Ok(event_count)
+    }
+}
+
+// Cascaded epoll support.
+impl EventHandler for EventManager {
+    fn handle_read(&mut self, _source: Pollable) -> Option<Vec<PollableOp>> {
+        match self.run_timeout(DEFAULT_EPOLL_TIMEOUT) {
+            Ok(_) => None,
+            Err(_) => None,
+        }
+    }
+
+    // Returns the epoll fd to the parent EventManager.
+    fn init(&self) -> Option<Vec<PollableOp>> {
+        Some(vec![PollableOpBuilder::new(Pollable::from(self))
+            .readable()
+            .register()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_event_type_to_epoll_mask() {
+        let mask = EventSet::READ | EventSet::WRITE | EventSet::CLOSE;
+        let epoll_mask =
+            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT | epoll::Events::EPOLLRDHUP;
+
+        assert_eq!(EventManager::event_type_to_epoll_mask(mask), epoll_mask);
+    }
+}

--- a/polly/src/lib.rs
+++ b/polly/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+extern crate epoll;
+extern crate libc;
+extern crate sys_util;
+#[macro_use]
+extern crate bitflags;
+
+pub mod event_manager;
+pub mod pollable;

--- a/polly/src/pollable.rs
+++ b/polly/src/pollable.rs
@@ -1,0 +1,197 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::fmt::Formatter;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+
+#[derive(Default, Clone, PartialEq, Debug)]
+pub struct Pollable {
+    // Event manager will use this in callbacks so the EventHandler implementation can
+    // multiplex the handling for multiple registered fds.
+    fd: RawFd,
+}
+
+/// Wrapper for file descriptorsl
+impl Pollable {
+    pub fn from<T: AsRawFd>(rawfd: &T) -> Pollable {
+        Pollable {
+            fd: rawfd.as_raw_fd(),
+        }
+    }
+}
+
+impl FromRawFd for Pollable {
+    unsafe fn from_raw_fd(fd: RawFd) -> Pollable {
+        Pollable { fd }
+    }
+}
+
+impl AsRawFd for Pollable {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+pub type EventRegistrationData = (Pollable, EventSet);
+
+#[derive(PartialEq)]
+pub enum PollableOp {
+    /// Register a new handler for a pollable and eventset.
+    Register(EventRegistrationData),
+    /// Unregister a handler for a pollable.
+    Unregister(EventRegistrationData),
+    /// Update eventset for a specified pollable.
+    Update(EventRegistrationData),
+}
+
+impl std::fmt::Debug for PollableOp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use self::PollableOp::*;
+
+        match self {
+            Register(data) => write!(f, "Register {:?}", data),
+            Unregister(data) => write!(f, "Unregister {:?}", data),
+            Update(data) => write!(f, "Update {:?}", data),
+        }
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    pub struct EventSet: u8 {
+        const NONE = 0b00000000;
+        const READ = 0b00000001;
+        const WRITE = 0b00000010;
+        const CLOSE = 0b00000100;
+    }
+}
+
+impl EventSet {
+    /// Read event.
+    pub fn readable(&self) -> bool {
+        self.contains(EventSet::READ)
+    }
+    /// Write event.
+    pub fn writeable(&self) -> bool {
+        self.contains(EventSet::WRITE)
+    }
+    // Close event.
+    pub fn closed(&self) -> bool {
+        self.contains(EventSet::CLOSE)
+    }
+}
+
+impl std::fmt::Display for Pollable {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.fd)
+    }
+}
+
+pub struct PollableOpBuilder {
+    fd: Pollable,
+    event_mask: EventSet,
+}
+
+impl PollableOpBuilder {
+    /// Constructs a new PollableOp builder for the specified Pollable.
+    pub fn new(fd: Pollable) -> PollableOpBuilder {
+        PollableOpBuilder {
+            fd: fd,
+            event_mask: EventSet::NONE,
+        }
+    }
+
+    /// Caller is interested in Pollable read events.
+    pub fn readable<'a>(&'a mut self) -> &'a mut PollableOpBuilder {
+        self.event_mask |= EventSet::READ;
+        self
+    }
+
+    /// Caller is interested in Pollable write events.
+    pub fn writeable<'a>(&'a mut self) -> &'a mut PollableOpBuilder {
+        self.event_mask |= EventSet::WRITE;
+        self
+    }
+
+    /// Caller is interested in Pollable close events.
+    pub fn closeable<'a>(&'a mut self) -> &'a mut PollableOpBuilder {
+        self.event_mask |= EventSet::CLOSE;
+        self
+    }
+
+    /// Create a Register PollableOp.
+    pub fn register(&self) -> PollableOp {
+        PollableOp::Register((self.fd.clone(), self.event_mask))
+    }
+
+    /// Create an Unregister PollableOp.
+    pub fn unregister(&self) -> PollableOp {
+        PollableOp::Unregister((self.fd.clone(), self.event_mask))
+    }
+
+    /// Create an Update PollableOp.
+    pub fn update(&self) -> PollableOp {
+        PollableOp::Update((self.fd.clone(), self.event_mask))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    #[test]
+    fn test_pollable() {
+        let mut pollable = Pollable::from(&io::stdin());
+        assert_eq!(pollable.as_raw_fd(), io::stdin().as_raw_fd());
+        pollable = unsafe { Pollable::from_raw_fd(io::stdin().as_raw_fd()) };
+        assert_eq!(pollable.as_raw_fd(), io::stdin().as_raw_fd());
+    }
+
+    #[test]
+    fn test_pollable_op_builder() {
+        let pollable = Pollable::from(&io::stdin());
+        let mut op_register = PollableOpBuilder::new(pollable.clone())
+            .readable()
+            .writeable()
+            .closeable()
+            .register();
+        assert_eq!(
+            format!("{:?}", op_register),
+            "Register (Pollable { fd: 0 }, READ | WRITE | CLOSE)"
+        );
+
+        match op_register {
+            PollableOp::Register(data) => {
+                assert_eq!(data.0, pollable.clone());
+                assert_eq!(data.1, EventSet::READ | EventSet::WRITE | EventSet::CLOSE);
+            }
+            _ => panic!("Expected Register op"),
+        }
+
+        op_register = PollableOpBuilder::new(pollable.clone())
+            .closeable()
+            .unregister();
+
+        match op_register {
+            PollableOp::Unregister(data) => {
+                assert_eq!(data.0, pollable.clone());
+                assert_eq!(data.1, EventSet::CLOSE);
+            }
+            _ => panic!("Expected Unregister op"),
+        }
+
+        op_register = PollableOpBuilder::new(pollable.clone()).readable().update();
+
+        match op_register {
+            PollableOp::Update(data) => {
+                assert_eq!(data.0, pollable.clone());
+                assert_eq!(data.1, EventSet::READ);
+            }
+            _ => panic!("Expected Update op"),
+        }
+    }
+}

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -25,6 +25,7 @@ net_util = { path = "../net_util"}
 rate_limiter = { path = "../rate_limiter" }
 seccomp = { path = "../seccomp" }
 sys_util = { path = "../sys_util" }
+polly = { path = "../polly" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1244,10 +1244,10 @@ impl Vmm {
 
             match self.epoll_context.dispatch_table[event.data as usize] {
                 Some(EpollDispatch::PollyEvent) => {
-                    self.event_manager.run_timeout(1).unwrap();
+                    self.event_manager.run().unwrap();
                 }
                 Some(EpollDispatch::PollyChannel) => {
-                    self.event_manager.run_timeout(1).unwrap();
+                    self.event_manager.process_api_channel();
                 }
                 Some(EpollDispatch::Exit) => {
                     match self.exit_evt {


### PR DESCRIPTION
Signed-off-by: Andrei Sandu <sandreim@amazon.com>

## Reason for This PR

Discuss about an I/O EventManager implementation. Please comment on this PR.

## Description of Changes

_This code is prototype level quality, it is not supposed to be merged and it is missing docs and testing._

Added the "polly" crate and used it to rework the Block
device and remove BlockEpollHandler. Changed VMM run_event_loop()
to drive the cascaded EventManager under vm.epoll_context.

The EventManager supports 3 interfaces:
- external by API (register/update/unregister)
- internal callback API (callbacks returning PollableOps)
- channel via ApiChannel (sending PollableOps) allows device
registration from vcpu threads.

Commit summary:
- Implements an observer pattern
- Implements Pollable, PollableOps
- Implements EventManager and EventHandler trait.
- Implements ApiChannel
- Implements helper PollableOpBuilder
- VMM integration changes
- Some block device refactoring as EventHandler
- Disabled update_drive_handler() as I was lazy to
  change more code which was out of scope of this commit

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.


