### PR TITLE
Disable unsupported `SendCtrlAltDel` API action on aarch64

### DIFF
--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -82,6 +82,7 @@ pub enum VmmAction {
     StartMicroVm,
     /// Send CTRL+ALT+DEL to the microVM, using the i8042 keyboard function. If an AT-keyboard
     /// driver is listening on the guest end, this can be used to shut down the microVM gracefully.
+    #[cfg(target_arch = "x86_64")]
     SendCtrlAltDel,
     /// Update the path of an existing block device. The data associated with this variant
     /// represents the `drive_id` and the `path_on_host`.

--- a/api_server/src/request/actions.rs
+++ b/api_server/src/request/actions.rs
@@ -93,11 +93,18 @@ impl IntoParsedRequest for ActionBody {
                 ))
             }
             ActionType::SendCtrlAltDel => {
-                let (sync_sender, sync_receiver) = oneshot::channel();
-                Ok(ParsedRequest::Sync(
-                    VmmRequest::new(VmmAction::SendCtrlAltDel, sync_sender),
-                    sync_receiver,
-                ))
+                // SendCtrlAltDel not supported on aarch64.
+                #[cfg(target_arch = "aarch64")]
+                return Err("SendCtrlAltDel does not supported on aarch64.".to_string());
+
+                #[cfg(target_arch = "x86_64")]
+                {
+                    let (sync_sender, sync_receiver) = oneshot::channel();
+                    Ok(ParsedRequest::Sync(
+                        VmmRequest::new(VmmAction::SendCtrlAltDel, sync_sender),
+                        sync_receiver,
+                    ))
+                }
             }
         }
     }
@@ -211,6 +218,7 @@ mod tests {
                 .eq(&req));
         }
 
+        #[cfg(target_arch = "x86_64")]
         {
             let json = r#"{
                 "action_type": "SendCtrlAltDel"

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,7 @@ fn vmm_control_event(
                     .rescan_block_device(&drive_id)
                     .map(|_| api_server::VmmData::Empty),
                 StartMicroVm => vmm.start_microvm().map(|_| api_server::VmmData::Empty),
+                #[cfg(target_arch = "x86_64")]
                 SendCtrlAltDel => vmm.send_ctrl_alt_del().map(|_| api_server::VmmData::Empty),
                 SetVmConfiguration(machine_config_body) => vmm
                     .set_vm_configuration(machine_config_body)

--- a/vmm/src/device_manager/legacy.rs
+++ b/vmm/src/device_manager/legacy.rs
@@ -4,6 +4,8 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
+#![cfg(target_arch = "x86_64")]
+
 use std::fmt;
 use std::io::{self, stdout};
 use std::sync::{Arc, Mutex};

--- a/vmm/src/device_manager/mmio.rs
+++ b/vmm/src/device_manager/mmio.rs
@@ -434,7 +434,7 @@ mod tests {
         assert!(vmm.setup_interrupt_controller().is_ok());
 
         assert!(device_manager
-            .register_virtio_device(vmm.vm.get_fd(), dummy_box, &mut cmdline, 0, "dummy")
+            .register_virtio_device(vmm.vm.fd(), dummy_box, &mut cmdline, 0, "dummy")
             .is_ok());
     }
 
@@ -453,13 +453,7 @@ mod tests {
 
         for _i in arch::IRQ_BASE..=arch::IRQ_MAX {
             device_manager
-                .register_virtio_device(
-                    vmm.vm.get_fd(),
-                    dummy_box.clone(),
-                    &mut cmdline,
-                    0,
-                    "dummy1",
-                )
+                .register_virtio_device(vmm.vm.fd(), dummy_box.clone(), &mut cmdline, 0, "dummy1")
                 .unwrap();
         }
         assert_eq!(
@@ -467,7 +461,7 @@ mod tests {
                 "{}",
                 device_manager
                     .register_virtio_device(
-                        vmm.vm.get_fd(),
+                        vmm.vm.fd(),
                         dummy_box.clone(),
                         &mut cmdline,
                         0,
@@ -578,7 +572,7 @@ mod tests {
         let vmm = create_vmm_object();
 
         if device_manager
-            .register_virtio_device(vmm.vm.get_fd(), dummy_box, &mut cmdline, TYPE_BLOCK, "foo")
+            .register_virtio_device(vmm.vm.fd(), dummy_box, &mut cmdline, TYPE_BLOCK, "foo")
             .is_ok()
         {
             assert!(device_manager.update_drive("foo", 1_048_576).is_ok());
@@ -602,7 +596,7 @@ mod tests {
         let type_id = 0;
         let id = String::from("foo");
         if let Ok(addr) = device_manager.register_virtio_device(
-            vmm.vm.get_fd(),
+            vmm.vm.fd(),
             dummy_box,
             &mut cmdline,
             type_id,

--- a/vmm/src/vmm_config/instance_info.rs
+++ b/vmm/src/vmm_config/instance_info.rs
@@ -68,6 +68,7 @@ pub enum StartMicrovmError {
     /// Cannot load kernel due to invalid memory configuration or invalid kernel image.
     KernelLoader(kernel_loader::Error),
     /// Cannot add devices to the Legacy I/O Bus.
+    #[cfg(target_arch = "x86_64")]
     LegacyIOBus(device_manager::legacy::Error),
     /// Cannot load command line string.
     LoadCommandline(kernel::cmdline::Error),
@@ -163,6 +164,7 @@ impl Display for StartMicrovmError {
                     err_msg
                 )
             }
+            #[cfg(target_arch = "x86_64")]
             LegacyIOBus(ref err) => {
                 let mut err_msg = format!("{:?}", err);
                 err_msg = err_msg.replace("\"", "");

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -202,7 +202,7 @@ impl Vm {
 
     /// Gets a reference to the kvm file descriptor owned by this VM.
     ///
-    pub fn get_fd(&self) -> &VmFd {
+    pub fn fd(&self) -> &VmFd {
         &self.fd
     }
 }


### PR DESCRIPTION
## Reason for This PR

Fixes #1340 

## Description of Changes

Firecracker doesn't currently have `i8042` support on `aarch64`. Because of this, disable and provide a clear error message for the `SendCtrlAltDel` API request.
    
Also mark all the port-io code as `x86_64` specific.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
