### PR TITLE
vmm: move `KvmContext` to vstate file

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,8 +56,6 @@ use std::sync::{Arc, Barrier, Mutex, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use kvm_bindings::KVM_API_VERSION;
-use kvm_ioctls::{Cap, Kvm};
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 
 #[cfg(target_arch = "aarch64")]
@@ -100,7 +98,7 @@ use vmm_config::net::{
     NetworkInterfaceUpdateConfig,
 };
 use vmm_config::vsock::{VsockDeviceConfig, VsockError};
-use vstate::{Vcpu, Vm};
+use vstate::{KvmContext, Vcpu, Vm};
 
 pub use error::{ErrorKind, StartMicrovmError, VmmActionError};
 
@@ -132,51 +130,6 @@ pub enum EventLoopExitReason {
     Break,
     /// The control action file descriptor has data available for reading.
     ControlAction,
-}
-
-/// Describes a KVM context that gets attached to the micro vm instance.
-/// It gives access to the functionality of the KVM wrapper as long as every required
-/// KVM capability is present on the host.
-pub struct KvmContext {
-    kvm: Kvm,
-    max_memslots: usize,
-}
-
-impl KvmContext {
-    fn with_kvm(kvm: Kvm) -> Result<Self> {
-        use Cap::*;
-
-        // Check that KVM has the correct version.
-        if kvm.get_api_version() != KVM_API_VERSION as i32 {
-            return Err(Error::KvmApiVersion(kvm.get_api_version()));
-        }
-
-        // A list of KVM capabilities we want to check.
-        #[cfg(target_arch = "x86_64")]
-        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, SetTssAddr];
-
-        #[cfg(target_arch = "aarch64")]
-        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, ArmPsci02];
-
-        // Check that all desired capabilities aer supported.
-        for capability in capabilities.iter() {
-            if !kvm.check_extension(*capability) {
-                return Err(Error::KvmCap(*capability));
-            }
-        }
-
-        let max_memslots = kvm.get_nr_memslots();
-        Ok(KvmContext { kvm, max_memslots })
-    }
-
-    fn fd(&self) -> &Kvm {
-        &self.kvm
-    }
-
-    /// Get the maximum number of memory slots reported by this KVM context.
-    pub fn max_memslots(&self) -> usize {
-        self.max_memslots
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -463,7 +416,6 @@ impl Vmm {
         control_fd: &dyn AsRawFd,
         seccomp_level: u32,
     ) -> Result<Self> {
-        let kvm = Kvm::new().expect("Error creating the Kvm object");
         let mut epoll_context = EpollContext::new()?;
         // If this fails, it's fatal; using expect() to crash.
         epoll_context
@@ -486,7 +438,8 @@ impl Vmm {
             NetworkInterfaceConfigs::new(),
             None,
         );
-        let kvm = KvmContext::with_kvm(kvm)?;
+
+        let kvm = KvmContext::new().map_err(Error::KvmContext)?;
         let vm = Vm::new(kvm.fd()).map_err(Error::Vm)?;
 
         Ok(Vmm {
@@ -1810,13 +1763,6 @@ mod tests {
         }
     }
 
-    impl KvmContext {
-        pub fn new() -> Result<Self> {
-            let kvm = Kvm::new().map_err(Error::Kvm)?;
-            Self::with_kvm(kvm)
-        }
-    }
-
     struct DummyEpollHandler {
         evt: Option<DeviceEventT>,
     }
@@ -2306,24 +2252,6 @@ mod tests {
             *ep.dispatch_table[idx].as_ref().unwrap(),
             EpollDispatch::Exit
         );
-    }
-
-    #[test]
-    fn test_kvm_context() {
-        use std::os::unix::fs::MetadataExt;
-        use std::os::unix::io::FromRawFd;
-
-        let c = KvmContext::new().unwrap();
-
-        assert!(c.max_memslots >= 32);
-
-        let kvm = Kvm::new().unwrap();
-        let f = unsafe { File::from_raw_fd(kvm.as_raw_fd()) };
-        let m1 = f.metadata().unwrap();
-        let m2 = File::open("/dev/kvm").unwrap().metadata().unwrap();
-
-        assert_eq!(m1.dev(), m2.dev());
-        assert_eq!(m1.ino(), m2.ino());
     }
 
     #[test]

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -9,14 +9,14 @@ use std::io;
 use std::result;
 use std::sync::{Arc, Barrier};
 
-use super::{KvmContext, TimestampUs};
+use super::TimestampUs;
 use arch;
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3, filter_cpuid, t2, VmSpec};
 use default_syscalls;
-use kvm_bindings::kvm_userspace_memory_region;
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{kvm_pit_config, KVM_PIT_SPEAKER_DUMMY};
+use kvm_bindings::{kvm_userspace_memory_region, KVM_API_VERSION};
 use kvm_ioctls::*;
 use logger::{LogOption, Metric, LOGGER, METRICS};
 use memory_model::{GuestAddress, GuestMemory, GuestMemoryError};
@@ -43,6 +43,10 @@ pub enum Error {
     GuestMemory(GuestMemoryError),
     /// Hyperthreading flag is not initialized.
     HTNotInitialized,
+    /// The host kernel reports an invalid KVM API version.
+    KvmApiVersion(i32),
+    /// Cannot initialize the KVM context due to missing capabilities.
+    KvmCap(kvm_ioctls::Cap),
     /// vCPU count is not initialized.
     VcpuCountNotInitialized,
     /// Cannot open the VM file descriptor.
@@ -94,6 +98,52 @@ pub enum Error {
     VcpuArmInit(io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
+
+/// Describes a KVM context that gets attached to the microVM.
+/// It gives access to the functionality of the KVM wrapper as
+/// long as every required KVM capability is present on the host.
+pub struct KvmContext {
+    kvm: Kvm,
+    max_memslots: usize,
+}
+
+impl KvmContext {
+    pub fn new() -> Result<Self> {
+        use kvm_ioctls::Cap::*;
+        let kvm = Kvm::new().expect("Error creating the Kvm object");
+
+        // Check that KVM has the correct version.
+        if kvm.get_api_version() != KVM_API_VERSION as i32 {
+            return Err(Error::KvmApiVersion(kvm.get_api_version()));
+        }
+
+        // A list of KVM capabilities we want to check.
+        #[cfg(target_arch = "x86_64")]
+        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, SetTssAddr];
+
+        #[cfg(target_arch = "aarch64")]
+        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, ArmPsci02];
+
+        // Check that all desired capabilities are supported.
+        for capability in capabilities.iter() {
+            if !kvm.check_extension(*capability) {
+                return Err(Error::KvmCap(*capability));
+            }
+        }
+
+        let max_memslots = kvm.get_nr_memslots();
+        Ok(KvmContext { kvm, max_memslots })
+    }
+
+    pub fn fd(&self) -> &Kvm {
+        &self.kvm
+    }
+
+    /// Get the maximum number of memory slots reported by this KVM context.
+    fn max_memslots(&self) -> usize {
+        self.max_memslots
+    }
+}
 
 /// A wrapper around creating and using a VM.
 pub struct Vm {
@@ -481,6 +531,8 @@ impl Vcpu {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+
     use super::super::devices;
     use super::*;
 
@@ -653,5 +705,23 @@ mod tests {
             seccomp::SECCOMP_LEVEL_ADVANCED + 10,
             EventFd::new().unwrap(),
         );
+    }
+
+    #[test]
+    fn test_kvm_context() {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::{AsRawFd, FromRawFd};
+
+        let c = KvmContext::new().unwrap();
+
+        assert!(c.max_memslots >= 32);
+
+        let kvm = Kvm::new().unwrap();
+        let f = unsafe { File::from_raw_fd(kvm.as_raw_fd()) };
+        let m1 = f.metadata().unwrap();
+        let m2 = File::open("/dev/kvm").unwrap().metadata().unwrap();
+
+        assert_eq!(m1.dev(), m2.dev());
+        assert_eq!(m1.ino(), m2.ino());
     }
 }


### PR DESCRIPTION
## Reason for This PR

KvmContext is actually coupled to the
functonality defined in vstate since it
all handles kvm interaction. Move it there and
make the appropriate changes.


## Description of Changes

The commit says it all.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
