### PR TITLE
strict instance id

### DIFF
--- a/fc_util/Cargo.toml
+++ b/fc_util/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 libc = ">=0.2.39"
+regex = "1"

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -33,6 +33,5 @@ def test_empty_jailer_id(test_microvm_with_ssh):
         # we can set an empty ID.
         assert False
     except Exception as err:
-        expected_err = "Jailer error: Invalid instance ID: invalid len (0);" \
-                       "  the length must be between 1 and 64"
+        expected_err = "Invalid instance ID: invalid input"
         assert expected_err in str(err)


### PR DESCRIPTION
Currently instance id has little limitation. Here introduces some Regex to
limit it more strict.

It allows only alphanumeric and `-`, starting with alphanumeric and max
length of 64.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

## Reason for This PR

Limit instance id strictly;

Remove previous error enum items for this has more causes to fail and should depend on regexp.

This seems less strong, but it can bring more flexible improvement via fixing the regex pattern.

## Description of Changes

The commit says it all.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
