### PR TITLE
Extra `micro_http` documentation and connection error fix

### DIFF
--- a/micro_http/src/connection.rs
+++ b/micro_http/src/connection.rs
@@ -400,9 +400,9 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
-                                 Content-Length: 26\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Content-Length: 26\r\n\
                                  Transfer-Encoding: chunked\r\n\r\n",
             )
             .unwrap();
@@ -429,8 +429,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
                                  Transfer-Encoding: chunked\r\n",
             )
             .unwrap();
@@ -464,8 +464,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
                                  Transfer-Encoding: chunked\r\n",
             )
             .unwrap();
@@ -497,8 +497,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
                                  Transfer-Encoding: chunked\r\n",
             )
             .unwrap();
@@ -527,9 +527,9 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
-                                 Transfer-Encoding: chunked\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: chunked\r\n\
                                  Content-Length: 1400\r\n\r\n",
             )
             .unwrap();
@@ -600,8 +600,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Expect: 100-continue\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
                                  Transfer-Encoding: chunked\r\n\r\n",
             )
             .unwrap();
@@ -690,8 +690,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Transfer-Encoding: chunked\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Transfer-Encoding: chunked\r\n\
                                  Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
             )
             .unwrap();
@@ -728,8 +728,8 @@ mod tests {
         let mut conn = HttpConnection::new(receiver);
         sender
             .write_all(
-                b"PATCH http://localhost/home HTTP/1.1\r\n \
-                                 Transfer-Encoding: chunked\r\n \
+                b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Transfer-Encoding: chunked\r\n\
                                  Content-Len",
             )
             .unwrap();


### PR DESCRIPTION
## Description of Changes

- add extra `micro_http` documentation
- fix a case where errors in `try_read` now lead to dropping all requests that we have not yet yielded to the user and marking the connection as being closed

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
