### PR TITLE
Added support for chunking in micro_http

### DIFF
--- a/src/micro_http/src/lib.rs
+++ b/src/micro_http/src/lib.rs
@@ -7,8 +7,7 @@
 //! HTTP/1.1 has a mandatory header **Host**, but as this crate is only used
 //! for parsing API requests, this header (if present) is ignored.
 //!
-//! This HTTP implementation is stateless thus it does not support chunking or
-//! compression.
+//! This HTTP implementation is stateless thus it does not support compression.
 //!
 //! ## Supported Headers
 //! The **micro_http** crate has support for parsing the following **Request**


### PR DESCRIPTION
## Description of Changes

Added chunking capabilities to `micro_http::HttpConnection` and, transitively to `micro_http::HttpServer` and the API server.

If a client wants to send a big request, say an MMDS request of 100 MiB, they would most likely do it with the chunked transfer encoding. Furthermore, the HTTP [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.3) states that all servers must support the chunked transfer encoding.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [ ] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [ ] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
