### PR TITLE
Replace clap with our own args parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed redundant `--seccomp-level` jailer parameter since it can be
   simply forwarded to the Firecracker executable using "end of command
   options" convention.
+- Decreased release binary size by ~15%.
 
 ## [0.20.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,17 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "clap"
-version = "2.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-dependencies = [
- "bitflags",
- "textwrap",
- "unicode-width",
-]
-
-[[package]]
 name = "cpuid"
 version = "0.1.0"
 dependencies = [
@@ -166,7 +155,6 @@ version = "0.20.0"
 dependencies = [
  "api_server",
  "backtrace",
- "clap",
  "libc",
  "logger",
  "mmds",
@@ -185,7 +173,6 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 name = "jailer"
 version = "0.20.0"
 dependencies = [
- "clap",
  "libc",
  "regex",
  "utils",
@@ -384,15 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,12 +387,6 @@ checksum = "6c9a7822e546fa39d0b5ae14a93a33903975b62af6597288aea77f0580a6abbe"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 backtrace = {version = ">=0.3.35", features = ["libunwind", "libbacktrace", "std"], default-features = false}
-clap = { version = ">=2.27.1", default-features = false}
 libc = ">=0.2.39"
 
 api_server = { path = "../api_server" }
-utils = { path = "../utils" }
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
 seccomp = { path = "../seccomp" }
+utils = { path = "../utils" }
 vmm = { path = "../vmm" }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate backtrace;
-#[macro_use(crate_version, crate_authors)]
-extern crate clap;
-extern crate api_server;
 extern crate libc;
-extern crate utils;
+
+extern crate api_server;
 #[macro_use]
 extern crate logger;
 extern crate mmds;
 extern crate seccomp;
+extern crate utils;
 extern crate vmm;
 
 use backtrace::Backtrace;
-use clap::{App, Arg};
 
 use std::convert::TryInto;
 use std::fs;
@@ -30,6 +28,7 @@ use api_server::{ApiServer, Error, VmmRequest, VmmResponse};
 use logger::{Metric, LOGGER, METRICS};
 use mmds::MMDS;
 use seccomp::{BpfInstructionSlice, BpfProgram};
+use utils::arg_parser::{App, ArgInfo};
 use utils::eventfd::EventFd;
 use utils::terminal::Terminal;
 use utils::validators::validate_instance_id;
@@ -40,6 +39,7 @@ use vmm::{EventLoopExitReason, Vmm};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/firecracker.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
+const FIRECRACKER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Level of filtering that causes syscall numbers and parameters to be examined.
 const SECCOMP_LEVEL_ADVANCED: u32 = 2;
@@ -94,105 +94,110 @@ fn main() {
         }
     }));
 
-    let cmd_arguments = App::new("firecracker")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Launch a microvm.")
+    let mut app = App::new()
+        .name("Firecracker")
+        .version(FIRECRACKER_VERSION)
+        .header("Launch a microVM.")
         .arg(
-            Arg::with_name("api_sock")
-                .long("api-sock")
-                .help("Path to unix domain socket used by the API")
+            ArgInfo::new("api-sock")
                 .takes_value(true)
-                .default_value(DEFAULT_API_SOCK_PATH),
+                .default_value(DEFAULT_API_SOCK_PATH)
+                .help("Path to unix domain socket used by the API"),
         )
         .arg(
-            Arg::with_name("id")
-                .long("id")
-                .help("MicroVM unique identifier")
+            ArgInfo::new("id")
                 .takes_value(true)
                 .default_value(DEFAULT_INSTANCE_ID)
-                .validator(|s: String| -> Result<(), String> {
-                    validate_instance_id(&s).map_err(|e| format!("{}", e))
-                }),
+                .help("MicroVM unique identifier"),
         )
         .arg(
-            Arg::with_name("seccomp-level")
-                .long("seccomp-level")
-                .help(
-                    "Level of seccomp filtering.\n
-                            - Level 0: No filtering.\n
-                            - Level 1: Seccomp filtering by syscall number.\n
-                            - Level 2: Seccomp filtering by syscall number and argument values.\n
-                        ",
-                )
+            ArgInfo::new("seccomp-level")
                 .takes_value(true)
                 .default_value("2")
-                .possible_values(&["0", "1", "2"]),
+                .help(
+                    "Level of seccomp filtering that will be passed to executed path as \
+                    argument.\n
+                        - Level 0: No filtering.\n
+                        - Level 1: Seccomp filtering by syscall number.\n
+                        - Level 2: Seccomp filtering by syscall number and argument values.\n
+                    ",
+                ),
         )
         .arg(
-            Arg::with_name("start-time-us")
-                .long("start-time-us")
+            ArgInfo::new("start-time-us")
+                .takes_value(true),
+        )
+        .arg(
+            ArgInfo::new("start-time-cpu-us")
+                .takes_value(true),
+        )
+        .arg(
+            ArgInfo::new("config-file")
                 .takes_value(true)
-                .hidden(true),
+                .help("Path to a file that contains the microVM configuration in JSON format."),
         )
         .arg(
-            Arg::with_name("start-time-cpu-us")
-                .long("start-time-cpu-us")
-                .takes_value(true)
-                .hidden(true),
-        )
-        .arg(
-            Arg::with_name("config-file")
-                .long("config-file")
-                .help("Path to a file that contains the microVM configuration in JSON format.")
-                .takes_value(true)
-                .required(false),
-        )
-        .arg(
-            Arg::with_name("no-api")
-                .long("no-api")
-                .help("Optional parameter which allows starting and using a microVM without an active API socket.")
+            ArgInfo::new("no-api")
                 .takes_value(false)
-                .required(false)
                 .requires("config-file")
-        )
-        .get_matches();
+                .help("Optional parameter which allows starting and using a microVM without an active API socket.")
+        );
 
-    let bind_path = cmd_arguments
-        .value_of("api_sock")
+    let arguments = match app.parse_cmdline_args() {
+        Err(err) => {
+            error!(
+                "Arguments parsing error: {} \n\n\
+                 For more information try --help.",
+                err
+            );
+            process::exit(i32::from(vmm::FC_EXIT_CODE_ARG_PARSING));
+        }
+        _ => {
+            if let Some(help) = app.arguments().value_as_bool("help") {
+                if help {
+                    println!("{}", app.format_help());
+                    process::exit(i32::from(vmm::FC_EXIT_CODE_OK));
+                }
+            }
+            app.arguments()
+        }
+    };
+
+    let bind_path = arguments
+        .value_as_string("api-sock")
         .map(PathBuf::from)
         .expect("Missing argument: api_sock");
 
-    // It's safe to unwrap here because clap's been provided with a default value
-    let instance_id = cmd_arguments.value_of("id").unwrap().to_string();
+    // It's safe to unwrap here because the field's been provided with a default value.
+    let instance_id = arguments.value_as_string("id").unwrap();
+    validate_instance_id(instance_id.as_str()).expect("Invalid instance ID");
 
-    // It's safe to unwrap here because clap's been provided with a default value,
-    // and allowed values are guaranteed to parse to u32.
-    let seccomp_level = cmd_arguments.value_of("seccomp-level").unwrap();
+    // It's safe to unwrap here because the field's been provided with a default value.
+    let seccomp_level = arguments.value_as_string("seccomp-level").unwrap();
     let seccomp_filter =
-        get_seccomp_filter(seccomp_level).expect("Could not create seccomp filter");
+        get_seccomp_filter(seccomp_level.as_str()).expect("Could not create seccomp filter");
 
-    let start_time_us = cmd_arguments.value_of("start-time-us").map(|s| {
+    let start_time_us = arguments.value_as_string("start-time-us").map(|s| {
         s.parse::<u64>()
             .expect("'start-time-us' parameter expected to be of 'u64' type.")
     });
 
-    let start_time_cpu_us = cmd_arguments.value_of("start-time-cpu-us").map(|s| {
+    let start_time_cpu_us = arguments.value_as_string("start-time-cpu-us").map(|s| {
         s.parse::<u64>()
             .expect("'start-time-cpu_us' parameter expected to be of 'u64' type.")
     });
 
-    let vmm_config_json = cmd_arguments
-        .value_of("config-file")
+    let vmm_config_json = arguments
+        .value_as_string("config-file")
         .map(fs::read_to_string)
         .map(|x| x.expect("Unable to open or read from the configuration file"));
 
-    let no_api = cmd_arguments.is_present("no-api");
+    let no_api = arguments.value_as_bool("no-api").unwrap_or(false);
 
     let api_shared_info = Arc::new(RwLock::new(InstanceInfo {
         state: InstanceState::Uninitialized,
-        id: instance_id,
-        vmm_version: crate_version!().to_string(),
+        id: instance_id.clone(),
+        vmm_version: FIRECRACKER_VERSION.to_string(),
     }));
 
     let request_event_fd = EventFd::new(libc::EFD_NONBLOCK)
@@ -422,7 +427,6 @@ fn vmm_control_event(
     };
     Ok(())
 }
-
 #[cfg(test)]
 mod tests {
     use super::get_seccomp_filter;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -14,7 +14,6 @@ extern crate vmm;
 
 use backtrace::Backtrace;
 
-use std::convert::TryInto;
 use std::fs;
 use std::io;
 use std::panic;
@@ -27,12 +26,12 @@ use std::thread;
 use api_server::{ApiServer, Error, VmmRequest, VmmResponse};
 use logger::{Metric, LOGGER, METRICS};
 use mmds::MMDS;
-use seccomp::{BpfInstructionSlice, BpfProgram};
+use seccomp::{BpfInstructionSlice, BpfProgram, SeccompLevel};
 use utils::arg_parser::{App, ArgInfo};
 use utils::eventfd::EventFd;
 use utils::terminal::Terminal;
 use utils::validators::validate_instance_id;
-use vmm::default_syscalls::default_filter;
+use vmm::default_syscalls::get_seccomp_filter;
 use vmm::signal_handler::register_signal_handlers;
 use vmm::vmm_config::instance_info::{InstanceInfo, InstanceState};
 use vmm::{EventLoopExitReason, Vmm};
@@ -40,21 +39,6 @@ use vmm::{EventLoopExitReason, Vmm};
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/firecracker.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 const FIRECRACKER_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Level of filtering that causes syscall numbers and parameters to be examined.
-const SECCOMP_LEVEL_ADVANCED: u32 = 2;
-/// Level of filtering that causes only syscall numbers to be examined.
-const SECCOMP_LEVEL_BASIC: u32 = 1;
-/// Seccomp filtering disabled.
-const SECCOMP_LEVEL_NONE: u32 = 0;
-
-/// Possible errors that could be encountered while processing seccomp levels from CLI.
-#[derive(Debug)]
-enum SeccompFilterError {
-    Seccomp(seccomp::Error),
-    Parse(std::num::ParseIntError),
-    Level(String),
-}
 
 fn main() {
     LOGGER
@@ -174,8 +158,14 @@ fn main() {
 
     // It's safe to unwrap here because the field's been provided with a default value.
     let seccomp_level = arguments.value_as_string("seccomp-level").unwrap();
-    let seccomp_filter =
-        get_seccomp_filter(seccomp_level.as_str()).expect("Could not create seccomp filter");
+    let seccomp_filter = get_seccomp_filter(
+        SeccompLevel::from_string(seccomp_level).unwrap_or_else(|err| {
+            panic!("Invalid value for seccomp-level: {}", err);
+        }),
+    )
+    .unwrap_or_else(|err| {
+        panic!("Could not create seccomp filter: {}", err);
+    });
 
     let start_time_us = arguments.value_as_string("start-time-us").map(|s| {
         s.parse::<u64>()
@@ -257,25 +247,6 @@ fn main() {
         seccomp_filter,
         vmm_config_json,
     );
-}
-
-/// Parse seccomp level and generate a BPF program based on it.
-fn get_seccomp_filter(val: &str) -> Result<BpfProgram, SeccompFilterError> {
-    match val.parse::<u32>() {
-        Ok(SECCOMP_LEVEL_NONE) => Ok(vec![]),
-        Ok(SECCOMP_LEVEL_BASIC) => default_filter()
-            .and_then(|filter| Ok(filter.allow_all()))
-            .and_then(|filter| filter.try_into())
-            .map_err(SeccompFilterError::Seccomp),
-        Ok(SECCOMP_LEVEL_ADVANCED) => default_filter()
-            .and_then(|filter| filter.try_into())
-            .map_err(SeccompFilterError::Seccomp),
-        Ok(level) => Err(SeccompFilterError::Level(format!(
-            "Invalid value for seccomp level: {}",
-            level
-        ))),
-        Err(err) => Err(SeccompFilterError::Parse(err)),
-    }
 }
 
 /// Creates and starts a vmm.
@@ -426,32 +397,4 @@ fn vmm_control_event(
         }
     };
     Ok(())
-}
-#[cfg(test)]
-mod tests {
-    use super::get_seccomp_filter;
-    use super::SeccompFilterError;
-
-    #[test]
-    fn test_parse_seccomp_ok() {
-        assert!(get_seccomp_filter("0").is_ok());
-        assert!(get_seccomp_filter("1").is_ok());
-        assert!(get_seccomp_filter("2").is_ok());
-    }
-
-    #[test]
-    fn test_parse_seccomp_err_str() {
-        match get_seccomp_filter("whatever") {
-            Err(SeccompFilterError::Parse(_)) => (),
-            _ => panic!("Unexpected result"),
-        }
-    }
-
-    #[test]
-    fn test_parse_seccomp_err_u32() {
-        match get_seccomp_filter("3") {
-            Err(SeccompFilterError::Level(_)) => (),
-            _ => panic!("Unexpected result"),
-        }
-    }
 }

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.20.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-clap = { version = ">=2.27.1", default-features = false}
 libc = ">=0.2.39"
 regex = ">=1.0.0"
 

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use(crate_version, crate_authors)]
-extern crate clap;
 extern crate libc;
 extern crate regex;
 
@@ -17,17 +15,19 @@ use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::result;
 
-use clap::{App, AppSettings, Arg};
-
 use env::Env;
+use utils::arg_parser::{App, ArgInfo, Error as ParsingError};
 use utils::validators;
 
 const SOCKET_FILE_NAME: &str = "api.socket";
+const JAILER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug)]
 pub enum Error {
+    ArgumentParsing(ParsingError),
     Canonicalize(PathBuf, io::Error),
     CgroupInheritFromParent(PathBuf, String),
     CgroupLineNotFound(String, String),
@@ -47,7 +47,6 @@ pub enum Error {
     GetOldFdFlags(io::Error),
     Gid(String),
     InvalidInstanceId(validators::Error),
-    MissingArgument(&'static str),
     MissingParent(PathBuf),
     MkdirOldRoot(io::Error),
     MknodDev(io::Error, &'static str),
@@ -79,6 +78,7 @@ impl fmt::Display for Error {
         use self::Error::*;
 
         match *self {
+            ArgumentParsing(ref err) => write!(f, "Failed to parse arguments: {}", err),
             Canonicalize(ref path, ref io_err) => write!(
                 f,
                 "{}",
@@ -138,7 +138,6 @@ impl fmt::Display for Error {
             GetOldFdFlags(ref err) => write!(f, "Failed to get flags from fd: {}", err),
             Gid(ref gid) => write!(f, "Invalid gid: {}", gid),
             InvalidInstanceId(ref err) => write!(f, "Invalid instance ID: {}", err),
-            MissingArgument(ref arg) => write!(f, "Missing argument: {}", arg),
             MissingParent(ref path) => write!(
                 f,
                 "{}",
@@ -217,81 +216,62 @@ impl fmt::Display for Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
-pub fn clap_app<'a, 'b>() -> App<'a, 'b> {
-    // Initially, the uid and gid params had default values, but it turns out that it's quite
-    // easy to shoot yourself in the foot by not setting proper permissions when preparing the
-    // contents of the jail, so I think their values should be provided explicitly.
-    App::new("jailer")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Jail a microVM.")
-        .setting(AppSettings::TrailingVarArg)
+/// Create an App object which contains info about the application and populate it with the expected
+/// arguments and their characteristics.
+pub fn build_app() -> App<'static> {
+    App::new()
+        .name("Jailer")
+        .version(JAILER_VERSION)
+        .header("Jail a microVM.")
         .arg(
-            Arg::with_name("id")
-                .long("id")
-                .help("Jail ID")
+            ArgInfo::new("id")
                 .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("exec_file")
-                .long("exec-file")
-                .help("File path to exec into.")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("numa_node")
-                .long("node")
-                .help("NUMA node to assign this microVM to.")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("uid")
-                .long("uid")
-                .help("The user identifier the jailer switches to after exec.")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("gid")
-                .long("gid")
-                .help("The group identifier the jailer switches to after exec.")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("chroot_base")
-                .long("chroot-base-dir")
-                .help("The base folder where chroot jails are located.")
-                .required(false)
-                .default_value("/srv/jailer")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("netns")
-                .long("netns")
-                .help("Path to the network namespace this microVM should join.")
-                .required(false)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("daemonize")
-                .long("daemonize")
-                .help(
-                    "Daemonize the jailer before exec, by invoking setsid(), and redirecting \
-                     the standard I/O file descriptors to /dev/null.",
-                )
-                .required(false)
-                .takes_value(false),
-        )
-        .arg(
-            Arg::with_name("extra-args")
-                .help("Arguments that will be passed verbatim to the exec file.")
-                .required(false)
                 .takes_value(true)
-                .multiple(true),
+                .help("Jail ID"),
+        )
+        .arg(
+            ArgInfo::new("exec-file")
+                .required(true)
+                .takes_value(true)
+                .help("File path to exec into."),
+        )
+        .arg(
+            ArgInfo::new("node")
+                .required(true)
+                .takes_value(true)
+                .help("NUMA node to assign this microVM to."),
+        )
+        .arg(
+            ArgInfo::new("uid")
+                .required(true)
+                .takes_value(true)
+                .help("The user identifier the jailer switches to after exec."),
+        )
+        .arg(
+            ArgInfo::new("gid")
+                .required(true)
+                .takes_value(true)
+                .help("The group identifier the jailer switches to after exec."),
+        )
+        .arg(
+            ArgInfo::new("chroot-base-dir")
+                .takes_value(true)
+                .default_value("/srv/jailer")
+                .help("The base folder where chroot jails are located."),
+        )
+        .arg(
+            ArgInfo::new("netns")
+                .takes_value(true)
+                .help("Path to the network namespace this microVM should join."),
+        )
+        .arg(ArgInfo::new("daemonize").takes_value(false).help(
+            "Daemonize the jailer before exec, by invoking setsid(), and redirecting \
+             the standard I/O file descriptors to /dev/null.",
+        ))
+        .arg(
+            ArgInfo::new("extra-args")
+                .takes_value(true)
+                .help("Arguments that will be passed verbatim to the exec file."),
         )
 }
 
@@ -332,8 +312,29 @@ fn to_cstring<T: AsRef<Path>>(path: T) -> Result<CString> {
 fn main() {
     sanitize_process();
 
+    let mut app = build_app();
+
+    match app.parse_cmdline_args() {
+        Err(err) => {
+            println!(
+                "Arguments parsing error: {} \n\n\
+                 For more information try --help.",
+                err
+            );
+            process::exit(1);
+        }
+        _ => {
+            if let Some(help) = app.arguments().value_as_bool("help") {
+                if help {
+                    println!("{}", app.format_help());
+                    process::exit(0);
+                }
+            }
+        }
+    }
+
     Env::new(
-        clap_app().get_matches(),
+        app.arguments(),
         utils::time::get_time(utils::time::ClockType::Monotonic) / 1000,
         utils::time::get_time(utils::time::ClockType::ProcessCpu) / 1000,
     )
@@ -350,6 +351,8 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::os::unix::io::AsRawFd;
+
+    use utils::arg_parser;
 
     #[test]
     fn test_sanitize_process() {
@@ -384,9 +387,14 @@ mod tests {
         let proc_mounts = "/proc/mounts";
         let controller = "sysfs";
         let id = "foobar";
+        let err_args_parse = arg_parser::Error::UnexpectedArgument("foo".to_string());
         let err_regex = regex::Error::Syntax(id.to_string());
         let err2_str = "No such file or directory (os error 2)";
 
+        assert_eq!(
+            format!("{}", Error::ArgumentParsing(err_args_parse)),
+            "Failed to parse arguments: Found argument 'foo' which wasn't expected, or isn't valid in this context."
+        );
         assert_eq!(
             format!(
                 "{}",
@@ -499,10 +507,6 @@ mod tests {
                 Error::InvalidInstanceId(validators::Error::InvalidChar('a', 1))
             ),
             "Invalid instance ID: invalid char (a) at position 1",
-        );
-        assert_eq!(
-            format!("{}", Error::MissingArgument(id)),
-            "Missing argument: foobar",
         );
         assert_eq!(
             format!("{}", Error::MissingParent(file_path.clone())),

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -1,0 +1,748 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::env;
+use std::fmt;
+use std::result;
+
+pub type Result<T> = result::Result<T, Error>;
+
+const ARG_PREFIX: &str = "--";
+const ARG_SEPARATOR: &str = "--";
+const HELP_ARG: &str = "--help";
+
+/// Errors associated with parsing and validating arguments.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// The required argument was not provided.
+    MissingArgument(String),
+    /// A value for the argument was not provided.
+    MissingValue(String),
+    /// The provided argument was not expected.
+    UnexpectedArgument(String),
+    /// The argument was provided more than once.
+    DuplicateArgument(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match *self {
+            MissingArgument(ref arg) => write!(f, "Argument '{}' required, but not found.", arg),
+            MissingValue(ref arg) => write!(
+                f,
+                "The argument '{}' requires a value, but none was supplied.",
+                arg
+            ),
+            UnexpectedArgument(ref arg) => write!(
+                f,
+                "Found argument '{}' which wasn't expected, or isn't valid in this context.",
+                arg
+            ),
+            DuplicateArgument(ref arg) => {
+                write!(f, "The argument '{}' was provided more than once.", arg)
+            }
+        }
+    }
+}
+
+/// Keep information about the application.
+#[derive(Clone, Default)]
+pub struct App<'a> {
+    arguments: Arguments<'a>,
+    name: &'a str,
+    version: &'a str,
+    header: &'a str,
+}
+
+impl<'a> App<'a> {
+    /// Add an argument with its associated `ArgInfo` in `arguments`.
+    pub fn arg(mut self, arg_info: ArgInfo<'a>) -> Self {
+        self.arguments.insert_arg(arg_info);
+        self
+    }
+
+    /// Create a new App instance.
+    pub fn new() -> Self {
+        App::default()
+    }
+
+    /// Set the name of the running application.
+    pub fn name(mut self, name: &'a str) -> Self {
+        self.name = name;
+        self
+    }
+
+    /// Set the version of the running application.
+    pub fn version(mut self, version: &'a str) -> Self {
+        self.version = version;
+        self
+    }
+
+    /// Set general information about the running application.
+    pub fn header(mut self, header: &'a str) -> Self {
+        self.header = header;
+        self
+    }
+
+    /// Parse the command line arguments.
+    pub fn parse_cmdline_args(&mut self) -> Result<()> {
+        self.arguments.parse_from_cmdline()
+    }
+
+    /// Concatenate the `help` information of every possible argument
+    /// in a message that represents the correct command line usage
+    /// for the application.
+    pub fn format_help(&self) -> String {
+        let mut help_builder = vec![];
+
+        help_builder.push(format!("{} v{}.\n", self.name, self.version));
+
+        help_builder.push(format!("{}\n\n", self.header));
+
+        for arg in self.arguments.args.values() {
+            help_builder.push(format!("{}\n", arg.format_help()));
+        }
+
+        help_builder.concat()
+    }
+
+    /// Return a reference to `arguments` field.
+    pub fn arguments(&self) -> &Arguments {
+        &self.arguments
+    }
+}
+
+/// Stores the characteristics of the `name` command line argument.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArgInfo<'a> {
+    name: &'a str,
+    required: bool,
+    requires: Option<&'a str>,
+    takes_value: bool,
+    default_value: Option<Value>,
+    help: Option<&'a str>,
+    user_value: Option<Value>,
+}
+
+impl<'a> ArgInfo<'a> {
+    /// Create a new `ArgInfo` that keeps the necessary information for an argument.
+    pub fn new(name: &'a str) -> ArgInfo<'a> {
+        ArgInfo {
+            name,
+            required: false,
+            requires: None,
+            takes_value: false,
+            default_value: None,
+            help: None,
+            user_value: None,
+        }
+    }
+
+    /// Set if the argument *must* be provided by user.
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    /// Add `other_arg` as a required parameter when `self` is specified.
+    pub fn requires(mut self, other_arg: &'a str) -> Self {
+        self.requires = Some(other_arg);
+        self
+    }
+
+    /// If `takes_value` is true, then the user *must* provide a value for the
+    /// argument, otherwise that argument is a flag.
+    pub fn takes_value(mut self, takes_value: bool) -> Self {
+        self.takes_value = takes_value;
+        self
+    }
+
+    /// Keep a default value which will be used if the user didn't provide a value for
+    /// the argument.
+    pub fn default_value(mut self, default_value: &'a str) -> Self {
+        self.default_value = Some(Value::String(String::from(default_value)));
+        self
+    }
+
+    /// Set the information that will be displayed for the argument when user passes
+    /// `--help` flag.
+    pub fn help(mut self, help: &'a str) -> Self {
+        self.help = Some(help);
+        self
+    }
+
+    fn format_help(&self) -> String {
+        let mut help_builder = vec![];
+
+        help_builder.push(format!("--{}", self.name));
+
+        if self.takes_value {
+            help_builder.push(format!(" <{}>", self.name));
+        }
+
+        if let Some(help) = self.help {
+            help_builder.push(format!(": {}", help));
+        }
+        help_builder.concat()
+    }
+}
+
+/// Represents the value of an argument, which will be a `String` if
+/// the argument takes a value, or `bool` if it's a flag.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    Bool(bool),
+    String(String),
+}
+
+impl Value {
+    fn as_string(&self) -> Option<String> {
+        match self {
+            Value::String(s) => Some(s.to_string()),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+}
+
+/// Stores the arguments of the application.
+#[derive(Clone, Default)]
+pub struct Arguments<'a> {
+    // A Hash Map in which the key is an argument and the value is its associated `ArgInfo`.
+    args: HashMap<&'a str, ArgInfo<'a>>,
+    // The arguments specified after `--` (i.e. end of command options).
+    extra_args: Vec<String>,
+}
+
+impl<'a> Arguments<'a> {
+    /// Add an argument with its associated `ArgInfo` in `args`.
+    fn insert_arg(&mut self, arg_info: ArgInfo<'a>) {
+        self.args.insert(arg_info.name, arg_info);
+    }
+
+    /// Get the value for the argument specified by `arg_name`.
+    fn value_of(&self, arg_name: &'static str) -> Option<&Value> {
+        if let Some(arg_info) = self.args.get(arg_name) {
+            match &arg_info.user_value {
+                Some(val) => {
+                    return Some(val);
+                }
+                None => return arg_info.default_value.as_ref(),
+            }
+        }
+
+        None
+    }
+
+    /// Return the value of an argument if the argument exists and has the type
+    /// String. Otherwise return None.
+    pub fn value_as_string(&self, arg_name: &'static str) -> Option<String> {
+        if let Some(arg_value) = self.value_of(arg_name) {
+            return arg_value.as_string();
+        }
+
+        None
+    }
+
+    /// Return the value of an argument if the argument exists and has the type
+    /// bool. Otherwise return None.
+    pub fn value_as_bool(&self, arg_name: &'static str) -> Option<bool> {
+        if let Some(arg_value) = self.value_of(arg_name) {
+            return arg_value.as_bool();
+        }
+
+        None
+    }
+
+    /// Get the extra arguments (all arguments after `--`).
+    pub fn extra_args(&self) -> Vec<String> {
+        self.extra_args.clone()
+    }
+
+    // Split `args` in two slices: one with the actual arguments of the process and the other with
+    // the extra arguments, meaning all parameters specified after `--`.
+    fn split_args(args: &[String]) -> (&[String], &[String]) {
+        if let Some(index) = args.iter().position(|arg| arg == ARG_SEPARATOR) {
+            return (&args[..index], &args[index + 1..]);
+        }
+
+        (&args, &[])
+    }
+
+    /// Collect the command line arguments and the values provided for them.
+    pub fn parse_from_cmdline(&mut self) -> Result<()> {
+        let args: Vec<String> = env::args().collect();
+
+        self.parse(&args)
+    }
+
+    /// Clear split between the actual arguments of the process, the extra arguments if any
+    /// and the `--help` argument if present.
+    pub fn parse(&mut self, args: &[String]) -> Result<()> {
+        // Skipping the first element of `args` as it is the name of the binary.
+        let (args, extra_args) = Arguments::split_args(&args[1..]);
+        self.extra_args = extra_args.to_vec();
+
+        // If `--help` is provided as a parameter, we artificially skip the parsing of other
+        // command line arguments by adding just the help argument to the parsed list and
+        // returning.
+        if args.contains(&HELP_ARG.to_string()) {
+            let mut help_arg = ArgInfo::new("help");
+            help_arg.user_value = Some(Value::Bool(true));
+            self.insert_arg(help_arg);
+            return Ok(());
+        }
+
+        // Otherwise, we continue the parsing of the other arguments.
+        self.populate_args(args)
+    }
+
+    // Check if `required` and `requires` field rules are indeed followed by every argument.
+    fn validate_requirements(&self, args: &[String]) -> Result<()> {
+        for arg_info in self.args.values() {
+            // The arguments that are marked `required` must be provided by user.
+            if arg_info.required && arg_info.user_value.is_none() {
+                return Err(Error::MissingArgument(arg_info.name.to_string()));
+            }
+            // For the arguments that require a specific argument to be also present in the list
+            // of arguments provided by user, search for that argument.
+            if arg_info.user_value.is_some() {
+                if let Some(arg_name) = arg_info.requires {
+                    if !args.contains(&(format!("--{}", arg_name))) {
+                        return Err(Error::MissingArgument(arg_name.to_string()));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // Does a general validation of `arg` command line argument.
+    fn validate_arg(&self, arg: &str) -> Result<()> {
+        if !arg.starts_with(ARG_PREFIX) {
+            return Err(Error::UnexpectedArgument(arg.to_string()));
+        }
+        let arg_name = &arg[ARG_PREFIX.len()..];
+
+        // Check if the argument is an expected one and, if yes, check that it was not
+        // provided more than once.
+        if self
+            .args
+            .get(arg_name)
+            .ok_or_else(|| Error::UnexpectedArgument(arg_name.to_string()))?
+            .user_value
+            .is_some()
+        {
+            return Err(Error::DuplicateArgument(arg_name.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Validate the arguments provided by user and their values. Insert those
+    /// values in the `ArgInfo` instances of the corresponding arguments.
+    fn populate_args(&mut self, args: &[String]) -> Result<()> {
+        let mut iter = args.iter();
+
+        while let Some(arg) = iter.next() {
+            self.validate_arg(arg)?;
+
+            // If the `arg` argument is indeed an expected one, set the value provided by user
+            // if it's a valid one.
+            let arg_info = self
+                .args
+                .get_mut(&arg[ARG_PREFIX.len()..])
+                .ok_or_else(|| Error::UnexpectedArgument(arg[ARG_PREFIX.len()..].to_string()))?;
+
+            let arg_val = if arg_info.takes_value {
+                let val = iter
+                    .next()
+                    .filter(|v| !v.starts_with(ARG_PREFIX))
+                    .ok_or_else(|| Error::MissingValue(arg_info.name.to_string()))?
+                    .clone();
+                Value::String(val)
+            } else {
+                Value::Bool(true)
+            };
+
+            arg_info.user_value = Some(arg_val);
+        }
+
+        // Check the constraints for the `required` and `requires` fields of all arguments.
+        self.validate_requirements(&args)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arg_parser::Value;
+
+    fn build_app() -> App<'static> {
+        App::new()
+            .arg(
+                ArgInfo::new("exec-file")
+                    .required(true)
+                    .takes_value(true)
+                    .help("'exec-file' info."),
+            )
+            .arg(
+                ArgInfo::new("no-api")
+                    .requires("config-file")
+                    .takes_value(false)
+                    .help("'no-api' info."),
+            )
+            .arg(
+                ArgInfo::new("api-sock")
+                    .takes_value(true)
+                    .default_value("socket")
+                    .help("'api-sock' info."),
+            )
+            .arg(
+                ArgInfo::new("id")
+                    .takes_value(true)
+                    .default_value("instance")
+                    .help("'id' info."),
+            )
+            .arg(
+                ArgInfo::new("seccomp-level")
+                    .takes_value(true)
+                    .default_value("2")
+                    .help("'seccomp-level' info."),
+            )
+            .arg(
+                ArgInfo::new("config-file")
+                    .takes_value(true)
+                    .help("'config-file' info."),
+            )
+    }
+
+    #[test]
+    fn test_arg_help() {
+        // Checks help format for an argument.
+        let mut arg_info = ArgInfo::new("exec-file").required(true).takes_value(true);
+
+        assert_eq!(arg_info.format_help(), "--exec-file <exec-file>");
+
+        arg_info = ArgInfo::new("exec-file")
+            .required(true)
+            .takes_value(true)
+            .help("'exec-file' info.");
+
+        assert_eq!(
+            arg_info.format_help(),
+            "--exec-file <exec-file>: 'exec-file' info."
+        );
+
+        arg_info = ArgInfo::new("no-api")
+            .requires("config-file")
+            .takes_value(false);
+
+        assert_eq!(arg_info.format_help(), "--no-api");
+
+        arg_info = ArgInfo::new("no-api")
+            .requires("config-file")
+            .takes_value(false)
+            .help("'no-api' info.");
+
+        assert_eq!(arg_info.format_help(), "--no-api: 'no-api' info.");
+    }
+
+    #[test]
+    fn test_app_help() {
+        // Checks help information when user passes `--help` flag.
+        let app = App::new()
+            .name("name")
+            .version("0.x.0")
+            .header("App info")
+            .arg(
+                ArgInfo::new("exec-file")
+                    .required(true)
+                    .takes_value(true)
+                    .help("'exec-file' info."),
+            );
+        assert_eq!(
+            app.format_help(),
+            "name v0.x.0.\nApp info\n\n--exec-file <exec-file>: \'exec-file\' info.\n"
+        );
+    }
+
+    #[test]
+    fn test_value() {
+        //Test `as_string()` and `as_bool()` functions behaviour.
+        let mut value = Value::Bool(true);
+        assert!(Value::as_string(&value).is_none());
+        value = Value::String("arg".to_string());
+        assert_eq!(Value::as_string(&value).unwrap(), "arg".to_string());
+
+        value = Value::String("arg".to_string());
+        assert!(Value::as_bool(&value).is_none());
+        value = Value::Bool(true);
+        assert_eq!(Value::as_bool(&value).unwrap(), true);
+    }
+
+    #[test]
+    fn test_parse() {
+        let app = build_app();
+        let mut arguments = app.arguments().clone();
+
+        // Test different scenarios for the command line arguments provided by user.
+        let args = vec!["binary-name", "--exec-file", "foo", "--help"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        assert!(arguments.parse(&args).is_ok());
+        assert!(arguments.args.contains_key("help"));
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "--id",
+            "bar",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingValue("api-sock".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--api-sock",
+            "foobar",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::DuplicateArgument("api-sock".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec!["binary-name", "--api-sock", "foo"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingArgument("exec-file".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--invalid-arg",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::UnexpectedArgument("invalid-arg".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--id",
+            "foobar",
+            "--no-api",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingArgument("config-file".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--id",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingValue("id".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--config-file",
+            "bar",
+            "--no-api",
+            "foobar",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::UnexpectedArgument("foobar".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "foobar",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::UnexpectedArgument("foobar".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec!["binary-name", "foo"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::UnexpectedArgument("foo".to_string()))
+        );
+
+        let app = build_app();
+        arguments = app.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--id",
+            "foobar",
+            "--seccomp-level",
+            "0",
+            "--",
+            "--extra-flag",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert!(arguments.parse(&args).is_ok());
+        assert!(arguments.extra_args.contains(&"--extra-flag".to_string()));
+    }
+
+    #[test]
+    fn test_split() {
+        let mut args = vec!["--exec-file", "foo", "--", "--extra-arg-1", "--extra-arg-2"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+        let (left, right) = Arguments::split_args(&args);
+        assert_eq!(left.to_vec(), vec!["--exec-file", "foo"]);
+        assert_eq!(right.to_vec(), vec!["--extra-arg-1", "--extra-arg-2"]);
+
+        args = vec!["--exec-file", "foo", "--"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+        let (left, right) = Arguments::split_args(&args);
+        assert_eq!(left.to_vec(), vec!["--exec-file", "foo"]);
+        assert!(right.is_empty());
+
+        args = vec!["--exec-file", "foo"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+        let (left, right) = Arguments::split_args(&args);
+        assert_eq!(left.to_vec(), vec!["--exec-file", "foo"]);
+        assert!(right.is_empty());
+    }
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            format!("{}", Error::MissingArgument("foo".to_string())),
+            "Argument 'foo' required, but not found."
+        );
+        assert_eq!(
+            format!("{}", Error::MissingValue("foo".to_string())),
+            "The argument 'foo' requires a value, but none was supplied."
+        );
+        assert_eq!(
+            format!("{}", Error::UnexpectedArgument("foo".to_string())),
+            "Found argument 'foo' which wasn't expected, or isn't valid in this context."
+        );
+        assert_eq!(
+            format!("{}", Error::DuplicateArgument("foo".to_string())),
+            "The argument 'foo' was provided more than once."
+        );
+    }
+}

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -6,6 +6,7 @@ extern crate vmm_sys_util;
 
 pub use vmm_sys_util::{errno, eventfd, ioctl, tempdir, tempfile, terminal};
 
+pub mod arg_parser;
 pub mod net;
 pub mod rand;
 pub mod signal;

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -11,6 +11,7 @@ mod macros;
 mod filters;
 
 pub use self::filters::default_filter;
+pub use self::filters::get_seccomp_filter;
 
 // See include/uapi/asm-generic/fcntl.h in the kernel code.
 const FCNTL_FD_CLOEXEC: u64 = 1;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -119,6 +119,8 @@ pub const FC_EXIT_CODE_SIGSEGV: u8 = 150;
 pub const FC_EXIT_CODE_INVALID_JSON: u8 = 151;
 /// Bad configuration for microvm's resources, when using a single json.
 pub const FC_EXIT_CODE_BAD_CONFIGURATION: u8 = 152;
+/// Command line arguments parsing error.
+pub const FC_EXIT_CODE_ARG_PARSING: u8 = 153;
 
 /// Describes all possible reasons which may cause the event loop to return to the caller in
 /// the absence of errors.

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -11,16 +11,16 @@ import host_tools.cargo_build as host
 MACHINE = platform.machine()
 """ Platform definition used to select the correct size target"""
 
-FC_BINARY_SIZE_TARGET = 3137280 if MACHINE == "x86_64" else 3536544
+FC_BINARY_SIZE_TARGET = 2751144 if MACHINE == "x86_64" else 3132008
 """Firecracker target binary size in bytes"""
 
-FC_BINARY_SIZE_LIMIT = 3500000 if MACHINE == "x86_64" else 4000000
+FC_BINARY_SIZE_LIMIT = 3100000 if MACHINE == "x86_64" else 3500000
 """Firecracker maximum binary size in bytes"""
 
-JAILER_BINARY_SIZE_TARGET = 2985152 if MACHINE == "x86_64" else 3149128
+JAILER_BINARY_SIZE_TARGET = 2483592 if MACHINE == "x86_64" else 2714528
 """Jailer target binary size in bytes"""
 
-JAILER_BINARY_SIZE_LIMIT = 3500000
+JAILER_BINARY_SIZE_LIMIT = 3000000
 """Jailer maximum binary size in bytes"""
 
 BINARY_SIZE_TOLERANCE = 0.05


### PR DESCRIPTION
Signed-off-by: Laura Loghin <lauralg@amazon.com>

## Reason for This PR

Get rid of `clap` crate dependencies and reduce this way the binary size.

## Description of Changes

Implements command line arguments parsing and validating and replaces `clap` crate functionality.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.