### PR TITLE
Properly set 'reg' field for fdt cpu nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
+
 ## [0.19.0]
 
 ### Added

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -43,17 +43,18 @@ pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
 ///
 /// * `guest_mem` - The memory to be used by the guest.
 /// * `cmdline_cstring` - The kernel commandline.
-/// * `num_cpus` - Number of virtual CPUs of the system.
+/// * `vcpu_mpidr` - Array of MPIDR register values per vcpu.
+/// * `device_info` - A hashmap containing the attached devices for building FDT device nodes.
 pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
     guest_mem: &GuestMemory,
     cmdline_cstring: &CStr,
-    num_cpus: u8,
+    vcpu_mpidr: Vec<u64>,
     device_info: Option<&HashMap<(DeviceType, String), T>>,
     gic_device: &Box<dyn GICDevice>,
 ) -> super::Result<()> {
     fdt::create_fdt(
         guest_mem,
-        u32::from(num_cpus),
+        vcpu_mpidr,
         cmdline_cstring,
         device_info,
         gic_device,

--- a/tests/framework/state_machine.py
+++ b/tests/framework/state_machine.py
@@ -1,0 +1,58 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Defines a stream based string matcher and a generic state object."""
+
+
+# Too few public methods (1/2) (too-few-public-methods)
+# pylint: disable=R0903
+class MatchStaticString:
+    """Match a static string versus input."""
+
+    # Prevent state objects from being collected by pytest.
+    __test__ = False
+
+    def __init__(self, match_string):
+        """Initialize using specified match string."""
+        self._string = match_string
+        self._input = ""
+
+    def match(self, input_char) -> bool:
+        """
+        Check if `_input` matches the match `_string`.
+
+        Process one char at a time and build `_input` string.
+        Preserve built `_input` if partially matches `_string`.
+        Return True when `_input` is the same as `_string`.
+        """
+        self._input += str(input_char)
+        if self._input == self._string[:len(self._input)]:
+            if len(self._input) == len(self._string):
+                self._input = ""
+                return True
+            return False
+
+        self._input = self._input[1:]
+        return False
+
+
+class TestState(MatchStaticString):
+    """Generic test state object."""
+
+    # Prevent state objects from being collected by pytest.
+    __test__ = False
+
+    def __init__(self, match_string=''):
+        """Initialize state fields."""
+        MatchStaticString.__init__(self, match_string)
+        print('\n*** Current test state: ', str(self), end='')
+
+    def handle_input(self, microvm, input_char):
+        """Handle input event and return next state."""
+
+    def __repr__(self):
+        """Leverages the __str__ method to describe the TestState."""
+        return self.__str__()
+
+    def __str__(self):
+        """Return state name."""
+        return self.__class__.__name__

--- a/tests/integration_tests/functional/test_max_vcpus.py
+++ b/tests/integration_tests/functional/test_max_vcpus.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests scenario for microvms with max vcpus(32)."""
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+MAX_VCPUS = 32
+
+
+def test_max_vcpus(test_microvm_with_ssh, network_config):
+    """Test if all configured guest vcpus are online."""
+    microvm = test_microvm_with_ssh
+    microvm.spawn()
+
+    # Configure a microVM with 32 vCPUs.
+    microvm.basic_config(vcpu_count=MAX_VCPUS)
+    _tap, _, _ = microvm.ssh_network_config(network_config, '1')
+
+    microvm.start()
+
+    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+    cmd = "nproc"
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    assert stderr.read().decode("utf-8") == ""
+    assert int(stdout.read().decode("utf-8")) == MAX_VCPUS

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -4,61 +4,7 @@
 import os
 import time
 import select
-
-
-# Too few public methods (1/2) (too-few-public-methods)
-# pylint: disable=R0903
-class MatchStaticString:
-    """Match a static string versus input."""
-
-    # Prevent state objects from being collected by pytest.
-    __test__ = False
-
-    def __init__(self, match_string):
-        """Initialize using specified match string."""
-        self._string = match_string
-        self._input = ""
-
-    def match(self, input_char) -> bool:
-        """
-        Check if `_input` matches the match `_string`.
-
-        Process one char at a time and build `_input` string.
-        Preserve built `_input` if partially matches `_string`.
-        Return True when `_input` is the same as `_string`.
-        """
-        self._input += str(input_char)
-        if self._input == self._string[:len(self._input)]:
-            if len(self._input) == len(self._string):
-                self._input = ""
-                return True
-            return False
-
-        self._input = self._input[1:]
-        return False
-
-
-class TestState(MatchStaticString):
-    """Generic test state object."""
-
-    # Prevent state objects from being collected by pytest.
-    __test__ = False
-
-    def __init__(self, match_string=''):
-        """Initialize state fields."""
-        MatchStaticString.__init__(self, match_string)
-        print('\n*** Current test state: ', str(self), end='')
-
-    def handle_input(self, microvm, input_char):
-        """Handle input event and return next state."""
-
-    def __repr__(self):
-        """Leverages the __str__ method to describe the TestState."""
-        return self.__str__()
-
-    def __str__(self):
-        """Return state name."""
-        return self.__class__.__name__
+from framework.state_machine import TestState
 
 
 class WaitLogin(TestState):


### PR DESCRIPTION
Signed-off-by: Andrei Sandu <sandreim@amazon.com>

## Reason for This PR

Fixes #1283 - Can't start a VM in AARCH64 with vcpus number more than 16. 

## Description of Changes

Changes:
- added integration test for booting with max vcpus
- moved common state machine code to tests/framework

Changes relevant to ARM platform:
- implement read_mpdir() function
- implement arm64_sys_reg macro
- add vcpu array parameter to vmm.configure_system()
- add vcpu mpidr array parameter to create_fdt()
- use mpidr in fdt.rs/create_cpu_nodes

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
