### PR TITLE
Added option to store data in MMDS at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "logger",
  "mmds",
  "seccomp",
+ "serde_json",
  "tempfile",
  "utils",
  "vmm",

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 backtrace = {version = ">=0.3.35", features = ["libunwind", "libbacktrace", "std"], default-features = false}
 clap = { version = ">=2.27.1", default-features = false}
 libc = ">=0.2.39"
+serde_json = ">=1.0.9"
 
 api_server = { path = "../api_server" }
 utils = { path = "../utils" }

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -63,7 +63,7 @@ class JailerContext:
         """Cleanup this jailer context."""
         self.cleanup()
 
-    def construct_param_list(self, config_file, no_api):
+    def construct_param_list(self, config_file, no_api, metadata):
         """Create the list of parameters we want the jailer to start with.
 
         We want to be able to vary any parameter even the required ones as we
@@ -95,9 +95,11 @@ class JailerContext:
             jailer_param_list.extend(
                 ['--seccomp-level', str(self.seccomp_level)]
             )
+        jailer_param_list.extend(['--'])
         if config_file is not None:
-            jailer_param_list.extend(['--'])
             jailer_param_list.extend(['--config-file', str(config_file)])
+        if metadata is not None:
+            jailer_param_list.extend(['--metadata', str(metadata)])
         if no_api:
             jailer_param_list.append('--no-api')
         return jailer_param_list

--- a/tests/framework/metadata.json
+++ b/tests/framework/metadata.json
@@ -1,0 +1,3 @@
+{
+  "command-line": "json"
+}

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -48,6 +48,7 @@ class Microvm:
         bin_cloner_path=None,
         config_file=None,
         no_api=False,
+        metadata=None,
     ):
         """Set up microVM attributes, paths, and data structures."""
         # Unique identifier for this machine.
@@ -103,6 +104,8 @@ class Microvm:
 
         # Parameter set when user wants to disable API thread.
         self.no_api = no_api
+
+        self.metadata = metadata
 
         # The ssh config dictionary is populated with information about how
         # to connect to a microVM that has ssh capability. The path of the
@@ -272,7 +275,7 @@ class Microvm:
         self.vsock = Vsock(self._api_socket, self._api_session)
 
         jailer_param_list = self._jailer.construct_param_list(self.config_file,
-                                                              self.no_api)
+                                                              self.no_api, self.metadata)
 
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell. Going


### PR DESCRIPTION
## Reason for This PR

Fixes: #1292 

## Description of Changes

Firecracker can now start with data in MMDS from a JSON file provided in command line arguments.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue. 
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
