### PR TITLE
Whitelist SYS_mremap to allow the backtrace to be built and printed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
+- The backtrace are printed on `panic`, no longer causing a seccomp fault.
 
 ## [0.19.0]
 

--- a/vmm/src/default_syscalls/filters.rs
+++ b/vmm/src/default_syscalls/filters.rs
@@ -32,8 +32,6 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                 ]],
             ),
             allow_syscall(libc::SYS_fstat),
-            #[cfg(target_arch = "aarch64")]
-            allow_syscall(libc::SYS_newfstatat),
             allow_syscall_if(
                 libc::SYS_futex,
                 or![
@@ -68,7 +66,10 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                 )?],],
             ),
             allow_syscall(libc::SYS_mmap),
+            allow_syscall(libc::SYS_mremap),
             allow_syscall(libc::SYS_munmap),
+            #[cfg(target_arch = "aarch64")]
+            allow_syscall(libc::SYS_newfstatat),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_open),
             allow_syscall(libc::SYS_openat),


### PR DESCRIPTION
## Reason for This PR

#1088 - `SYS_mremap` is called by `libbacktrace` when building the stack trace and was causing a seccomp fault, terminating Firecracker by `SIGSYS` before it got the chance to log the trace.
Note that Firecracker still dies by `SIGSYS` if a panic occurs because of its `panic=abort` configuration. `musl` aborts the process by literally raising `SIGABRT`, and blocks all signals while doing so. To block signals it uses `rt_sigprocmask`, which is blacklisted => seccomp fault. This is in the end okay as the process was going to die anyway and, with this fix, at least we have the stack trace.

## Description of Changes

Whitelisted `SYS_mremap`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] No new `unsafe` code has been added.