### PR TITLE
fix: change logger options from Value to Vec<LogOption>     

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
 - The backtrace are printed on `panic`, no longer causing a seccomp fault.
+- Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
+  prevent potential unwrap on None panics.
 
 ## [0.19.0]
 

--- a/api_server/src/request/logger.rs
+++ b/api_server/src/request/logger.rs
@@ -19,9 +19,6 @@ pub fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cfg(target_arch = "x86_64")]
-    use serde_json::Value;
     use vmm::vmm_config::logger::LoggerLevel;
 
     #[test]
@@ -43,7 +40,7 @@ mod tests {
             show_level: false,
             show_log_origin: false,
             #[cfg(target_arch = "x86_64")]
-            options: Value::Array(vec![]),
+            options: vec![],
         };
         match parse_put_logger(&Body::new(body)) {
             Ok(ParsedRequest::Sync(VmmAction::ConfigureLogger(desc))) => {

--- a/vmm/src/vmm_config/logger.rs
+++ b/vmm/src/vmm_config/logger.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the logger.
-extern crate serde_json;
 
 use libc::O_NONBLOCK;
 use std::fmt::{Display, Formatter};
@@ -12,7 +11,7 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
-use self::serde_json::Value;
+use logger::LogOption;
 
 type Result<T> = std::result::Result<T, std::io::Error>;
 
@@ -97,15 +96,15 @@ pub struct LoggerConfig {
     /// Additional logging options.
     #[cfg(target_arch = "x86_64")]
     #[serde(default = "default_log_options")]
-    pub options: Value,
+    pub options: Vec<LogOption>,
 }
 
 fn default_level() -> LoggerLevel {
     LoggerLevel::Warning
 }
 
-fn default_log_options() -> Value {
-    Value::Array(vec![])
+fn default_log_options() -> Vec<LogOption> {
+    vec![]
 }
 
 /// Errors associated with actions on the `LoggerConfig`.


### PR DESCRIPTION
Change logger options type from Value to Vec<LogOption> for
strictly type checking, which would prevent potential unwrap
on None panics.

Signed-off-by: lifupan <lifupan@gmail.com>

## Reason for This PR

Fix: #1375 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
