### PR TITLE
Tiny Updates to Virtio Impl

### DIFF
--- a/devices/src/virtio/mod.rs
+++ b/devices/src/virtio/mod.rs
@@ -26,12 +26,22 @@ pub use self::vsock::*;
 
 use super::EpollHandler;
 
-const DEVICE_INIT: u32 = 0x0;
-const DEVICE_ACKNOWLEDGE: u32 = 0x01;
-const DEVICE_DRIVER: u32 = 0x02;
-const DEVICE_DRIVER_OK: u32 = 0x04;
-const DEVICE_FEATURES_OK: u32 = 0x08;
-const DEVICE_FAILED: u32 = 0x80;
+/// When the driver initializes the device, it lets the device know about the
+/// completed stages using the Device Status Field.
+///
+/// These following consts are defined in the order in which the bits would
+/// typically be set by the driver. INIT -> ACKNOWLEDGE -> DRIVER and so on.
+///
+/// This module is a 1:1 mapping for the Device Status Field in the virtio 1.0
+/// specification, section 2.1.
+mod device_status {
+    pub const INIT: u32 = 0;
+    pub const ACKNOWLEDGE: u32 = 1;
+    pub const DRIVER: u32 = 2;
+    pub const FAILED: u32 = 128;
+    pub const FEATURES_OK: u32 = 8;
+    pub const DRIVER_OK: u32 = 4;
+}
 
 /// Types taken from linux/virtio_ids.h.
 /// Type 0 is not used by virtio. Use it as wildcard for non-virtio devices


### PR DESCRIPTION
## Reason for This PR

This PR contains some small updates to the virtio implementation that should make it easier to map the Firecracker code to the virtio spec.

## Description of Changes
- Group Device Status in a module so that we can have an associated namespace. Renamed the Device Status fields so that they map to the virtio spec.
- Renamed variables and function names where "driver" was used instead of "device"
- Virtio Block Device: added a RequestHeader used for simplifying the parsing of the Request.   

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
