### PR TITLE
tests: add env variable to keep test session

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -171,7 +171,7 @@ tools/devtool test
 ## FAQ
 
 `Q1:`
-*I have a shell script that runs my tests and I don't want to rewrite it.*  
+*I have a shell script that runs my tests and I don't want to rewrite it.*
 `A1:`
 Insofar as it makes sense, you should write it as a python test function.
 However, you can always call the script from a shim python test function. You
@@ -181,20 +181,20 @@ as part of your test.
 
 `Q2:`
 *I want to add more tests that I don't want to commit to the Firecracker
-repository.*  
+repository.*
 `A2:`
 Before a testrun or test session, just add your test directory under `tests/`.
 `pytest` will discover all tests in this tree.
 
 `Q3:`
-*I want to have my own test fixtures, and not commit them in the repo.*  
+*I want to have my own test fixtures, and not commit them in the repo.*
 `A3:`
 Add a `conftest.py` file in your test directory, and place your fixtures there.
 `pytest` will bring them into scope for all your tests.
 
 `Q4:`
 *I want to use more/other microvm test images, but I don't want to add them to
-the common s3 bucket.*  
+the common s3 bucket.*
 `A4:`
 There are two options to achieve this:
 
@@ -209,6 +209,29 @@ There are two options to achieve this:
    - Using that `MicrovmImageS3Fetcher` object, create a fixture
      similar to the `test_microvm_*` fixtures in in `conftest.py`, and pass that
      as an argument to your tests.
+
+`Q5:`
+*Is there a way to speed up integration tests execution time?*
+`A5:`
+You can speed up tests execution time with any of these:
+
+1. Run the tests from inside the container and set the environment variable
+   `KEEP_TEST_SESSION` to a non-empty value.
+
+   Each **Testrun** begins by building the firecracker and unit tests binaries,
+   and ends by deleting all the built artifacts.
+   If you run the tests [from inside the container](#running), you can prevent
+   the binaries from being deleted exporting the `KEEP_TEST_SESSION` variable.
+   This way, all the following **Testrun** will be significantly faster as they
+   will not need to rebuild everything.
+   If any Rust source file is changed, the build is done incrementally.
+
+2. Pass the `-k substring` option to Pytest to only run a subset of tests by
+   specifying a part of their name.
+
+3. Only run the tests contained in a file or directory, as specified in the
+   **Running** section.
+
 
 ## Implementation Goals
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,10 @@ If variable exists in `os.environ`, its value it will be used for the test
 session root and temporary directories.
 """
 
+ENV_KEEP_TEST_SESSION = 'KEEP_TEST_SESSION'
+""" Enviroment variable to override the deletion of the test session root
+directory at the end of the test."""
+
 DEFAULT_ROOT_TESTSESSION_PATH = '/tmp/firecracker_test_session/'
 """If ENV_TMPDIR_VAR is not set, this path will be used instead."""
 
@@ -178,13 +182,18 @@ def test_session_root_path():
     except KeyError:
         root_path = DEFAULT_ROOT_TESTSESSION_PATH
 
+    try:
+        delete_test_session = (len(os.environ[ENV_KEEP_TEST_SESSION]) == 0)
+    except KeyError:
+        delete_test_session = True
+
     if not os.path.exists(root_path):
         os.makedirs(root_path)
         created_test_session_root_path = True
 
     yield root_path
 
-    if created_test_session_root_path:
+    if delete_test_session and created_test_session_root_path:
         shutil.rmtree(root_path)
 
 


### PR DESCRIPTION

## Reason for This PR

Add the env variable KEEP_TEST_SESSION to keep the created test session
files tree at the end of a test. This allow re-launching tests on a
previous test session without rebuilding all binaries.
## Description of Changes

conftest.py and integration tests README.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
