### PR TITLE
API: log failed api requests

### DIFF
--- a/api_server/src/lib.rs
+++ b/api_server/src/lib.rs
@@ -225,7 +225,10 @@ impl ApiServer {
             Ok(ParsedRequest::GetMMDS) => self.get_mmds(),
             Ok(ParsedRequest::PatchMMDS(value)) => self.patch_mmds(value),
             Ok(ParsedRequest::PutMMDS(value)) => self.put_mmds(value),
-            Err(e) => e.into(),
+            Err(e) => {
+                error!("{}", e);
+                e.into()
+            }
         }
     }
 

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -205,7 +205,7 @@ def test_api_requests_logs(test_microvm_with_api):
     # We are not interested in the actual body. Just check that the log
     # message also has the string "body" in it.
     expected_log_strings.append(
-        "The API server received a synchronous Patch request "
+        "The API server received a Patch request "
         "on \"/machine-config\" with body"
     )
 
@@ -217,7 +217,7 @@ def test_api_requests_logs(test_microvm_with_api):
     )
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Put request "
+        "The API server received a Put request "
         "on \"/machine-config\" with body"
     )
 
@@ -226,7 +226,7 @@ def test_api_requests_logs(test_microvm_with_api):
     response = microvm.machine_cfg.get()
     assert microvm.api_session.is_status_ok(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Get request "
+        "The API server received a Get request "
         "on \"/machine-config\"."
     )
 
@@ -241,19 +241,19 @@ def test_api_requests_logs(test_microvm_with_api):
     response = microvm.mmds.put(json=dummy_json)
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Put request on \"/mmds\"."
+        "The API server received a Put request on \"/mmds\"."
     )
 
     response = microvm.mmds.patch(json=dummy_json)
     assert microvm.api_session.is_status_no_content(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Patch request on \"/mmds\"."
+        "The API server received a Patch request on \"/mmds\"."
     )
 
     response = microvm.mmds.get()
     assert microvm.api_session.is_status_ok(response.status_code)
     expected_log_strings.append(
-        "The API server received a synchronous Get request on \"/mmds\"."
+        "The API server received a Get request on \"/mmds\"."
     )
 
     # Check that the fault message return by the client is also logged in the


### PR DESCRIPTION
## Reason for This PR

Fixes #1383 

## Description of Changes

Failing API requests would report their error message in the HTTP response, but not also log it.
Add the mechanism to also log the detailed error.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
