### PR TITLE
vmm: remove superfluous vcpu count

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1004,7 +1004,6 @@ impl Vmm {
         Ok(entry_addr)
     }
 
-    #[allow(unused_variables)]
     fn configure_system(&self, vcpus: &[Vcpu]) -> std::result::Result<(), StartMicrovmError> {
         use StartMicrovmError::*;
 
@@ -1015,16 +1014,12 @@ impl Vmm {
 
         let kernel_config = self.kernel_config.as_ref().ok_or(MissingKernelConfig)?;
 
-        // The vcpu_count has a default value. We shouldn't have gotten to this point without
-        // having set the vcpu count.
-        let vcpu_count = self.vm_config.vcpu_count.ok_or(VcpusNotConfigured)?;
-
         #[cfg(target_arch = "x86_64")]
         arch::x86_64::configure_system(
             vm_memory,
             GuestAddress(arch::x86_64::layout::CMDLINE_START),
             kernel_config.cmdline.len() + 1,
-            vcpu_count,
+            vcpus.len() as u8,
         )
         .map_err(ConfigureSystem)?;
 


### PR DESCRIPTION
## Reason for This PR

Remove superfluous vcpu count variable.

## Description of Changes

We can use the length of the vcpus variable
to get the count of vcpus. This way we also
discarding unused variables for x86_64.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
