### PR TITLE
Byteorder remove from device and dumbo crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "byteorder"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-
-[[package]]
 name = "cc"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +108,6 @@ checksum = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 name = "devices"
 version = "0.1.0"
 dependencies = [
- "byteorder",
  "dumbo",
  "epoll",
  "libc",
@@ -131,7 +124,6 @@ name = "dumbo"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "byteorder",
  "logger",
  "mmds",
  "serde",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["The Chromium OS Authors"]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.4"
 libc = ">=0.2.39"
+utils = { path = "../utils" }
 
 arch_gen = { path = "../arch_gen" }
 vm-memory = { path = "../vm-memory" }

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -9,6 +9,7 @@ extern crate kvm_ioctls;
 extern crate libc;
 
 extern crate arch_gen;
+extern crate utils;
 extern crate vm_memory;
 
 use std::fmt;

--- a/src/arch/src/x86_64/interrupts.rs
+++ b/src/arch/src/x86_64/interrupts.rs
@@ -7,7 +7,7 @@
 
 use kvm_bindings::kvm_lapic_state;
 use kvm_ioctls::VcpuFd;
-
+use utils::byte_order;
 /// Errors thrown while configuring the LAPIC.
 #[derive(Debug)]
 pub enum Error {
@@ -27,23 +27,13 @@ const APIC_MODE_EXTINT: u32 = 0x7;
 fn get_klapic_reg(klapic: &kvm_lapic_state, reg_offset: usize) -> u32 {
     let range = reg_offset..reg_offset + 4;
     let reg = klapic.regs.get(range).expect("get_klapic_reg range");
-
-    let mut reg_bytes = [0u8; 4];
-    for (byte, read) in reg_bytes.iter_mut().zip(reg.iter().cloned()) {
-        *byte = read as u8;
-    }
-
-    u32::from_le_bytes(reg_bytes)
+    byte_order::read_le_i32(&reg[..]) as u32
 }
 
 fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
     let range = reg_offset..reg_offset + 4;
     let reg = klapic.regs.get_mut(range).expect("set_klapic_reg range");
-
-    let value = u32::to_le_bytes(value);
-    for (byte, read) in reg.iter_mut().zip(value.iter().cloned()) {
-        *byte = read as i8;
-    }
+    byte_order::write_le_i32(&mut reg[..], value as i32)
 }
 
 fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -5,10 +5,8 @@ authors = ["The Chromium OS Authors"]
 edition = "2018"
 
 [dependencies]
-byteorder = ">=1.2.1"
 epoll = ">=4.0.1"
 libc = ">=0.2.39"
-
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
 vm-memory = { path = "../vm-memory" }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 //! Emulates virtual and hardware devices.
-extern crate byteorder;
 extern crate epoll;
 extern crate libc;
 

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use super::super::DescriptorChain;
+use super::defs;
+use super::{Result, VsockError};
 /// `VsockPacket` provides a thin wrapper over the buffers exchanged via virtio queues.
 /// There are two components to a vsock packet, each using its own descriptor in a
 /// virtio queue:
@@ -14,11 +17,7 @@
 /// `VsockPacket` wraps these two buffers and provides direct access to the data stored
 /// in guest memory. This is done to avoid unnecessarily copying data from guest memory
 /// to temporary buffers, before passing it on to the vsock backend.
-use byteorder::{ByteOrder, LittleEndian};
-
-use super::super::DescriptorChain;
-use super::defs;
-use super::{Result, VsockError};
+use utils::byte_order;
 
 // The vsock packet header is defined by the C struct:
 //
@@ -240,74 +239,74 @@ impl VsockPacket {
     }
 
     pub fn src_cid(&self) -> u64 {
-        LittleEndian::read_u64(&self.hdr()[HDROFF_SRC_CID..])
+        byte_order::read_le_u64(&self.hdr()[HDROFF_SRC_CID..])
     }
 
     pub fn set_src_cid(&mut self, cid: u64) -> &mut Self {
-        LittleEndian::write_u64(&mut self.hdr_mut()[HDROFF_SRC_CID..], cid);
+        byte_order::write_le_u64(&mut self.hdr_mut()[HDROFF_SRC_CID..], cid);
         self
     }
 
     pub fn dst_cid(&self) -> u64 {
-        LittleEndian::read_u64(&self.hdr()[HDROFF_DST_CID..])
+        byte_order::read_le_u64(&self.hdr()[HDROFF_DST_CID..])
     }
 
     pub fn set_dst_cid(&mut self, cid: u64) -> &mut Self {
-        LittleEndian::write_u64(&mut self.hdr_mut()[HDROFF_DST_CID..], cid);
+        byte_order::write_le_u64(&mut self.hdr_mut()[HDROFF_DST_CID..], cid);
         self
     }
 
     pub fn src_port(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_SRC_PORT..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_SRC_PORT..])
     }
 
     pub fn set_src_port(&mut self, port: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_SRC_PORT..], port);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_SRC_PORT..], port);
         self
     }
 
     pub fn dst_port(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_DST_PORT..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_DST_PORT..])
     }
 
     pub fn set_dst_port(&mut self, port: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_DST_PORT..], port);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_DST_PORT..], port);
         self
     }
 
     pub fn len(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_LEN..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_LEN..])
     }
 
     pub fn set_len(&mut self, len: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_LEN..], len);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_LEN..], len);
         self
     }
 
     pub fn type_(&self) -> u16 {
-        LittleEndian::read_u16(&self.hdr()[HDROFF_TYPE..])
+        byte_order::read_le_u16(&self.hdr()[HDROFF_TYPE..])
     }
 
     pub fn set_type(&mut self, type_: u16) -> &mut Self {
-        LittleEndian::write_u16(&mut self.hdr_mut()[HDROFF_TYPE..], type_);
+        byte_order::write_le_u16(&mut self.hdr_mut()[HDROFF_TYPE..], type_);
         self
     }
 
     pub fn op(&self) -> u16 {
-        LittleEndian::read_u16(&self.hdr()[HDROFF_OP..])
+        byte_order::read_le_u16(&self.hdr()[HDROFF_OP..])
     }
 
     pub fn set_op(&mut self, op: u16) -> &mut Self {
-        LittleEndian::write_u16(&mut self.hdr_mut()[HDROFF_OP..], op);
+        byte_order::write_le_u16(&mut self.hdr_mut()[HDROFF_OP..], op);
         self
     }
 
     pub fn flags(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_FLAGS..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_FLAGS..])
     }
 
     pub fn set_flags(&mut self, flags: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_FLAGS..], flags);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_FLAGS..], flags);
         self
     }
 
@@ -317,20 +316,20 @@ impl VsockPacket {
     }
 
     pub fn buf_alloc(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_BUF_ALLOC..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_BUF_ALLOC..])
     }
 
     pub fn set_buf_alloc(&mut self, buf_alloc: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_BUF_ALLOC..], buf_alloc);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_BUF_ALLOC..], buf_alloc);
         self
     }
 
     pub fn fwd_cnt(&self) -> u32 {
-        LittleEndian::read_u32(&self.hdr()[HDROFF_FWD_CNT..])
+        byte_order::read_le_u32(&self.hdr()[HDROFF_FWD_CNT..])
     }
 
     pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) -> &mut Self {
-        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_FWD_CNT..], fwd_cnt);
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_FWD_CNT..], fwd_cnt);
         self
     }
 }
@@ -378,7 +377,7 @@ mod tests {
             .unwrap() as *mut u8;
         let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
 
-        LittleEndian::write_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);
+        byte_order::write_le_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);
     }
 
     #[test]
@@ -565,31 +564,31 @@ mod tests {
 
         assert_eq!(
             SRC_CID,
-            LittleEndian::read_u64(&pkt.hdr()[HDROFF_SRC_CID..])
+            byte_order::read_le_u64(&pkt.hdr()[HDROFF_SRC_CID..])
         );
         assert_eq!(
             DST_CID,
-            LittleEndian::read_u64(&pkt.hdr()[HDROFF_DST_CID..])
+            byte_order::read_le_u64(&pkt.hdr()[HDROFF_DST_CID..])
         );
         assert_eq!(
             SRC_PORT,
-            LittleEndian::read_u32(&pkt.hdr()[HDROFF_SRC_PORT..])
+            byte_order::read_le_u32(&pkt.hdr()[HDROFF_SRC_PORT..])
         );
         assert_eq!(
             DST_PORT,
-            LittleEndian::read_u32(&pkt.hdr()[HDROFF_DST_PORT..])
+            byte_order::read_le_u32(&pkt.hdr()[HDROFF_DST_PORT..])
         );
-        assert_eq!(LEN, LittleEndian::read_u32(&pkt.hdr()[HDROFF_LEN..]));
-        assert_eq!(TYPE, LittleEndian::read_u16(&pkt.hdr()[HDROFF_TYPE..]));
-        assert_eq!(OP, LittleEndian::read_u16(&pkt.hdr()[HDROFF_OP..]));
-        assert_eq!(FLAGS, LittleEndian::read_u32(&pkt.hdr()[HDROFF_FLAGS..]));
+        assert_eq!(LEN, byte_order::read_le_u32(&pkt.hdr()[HDROFF_LEN..]));
+        assert_eq!(TYPE, byte_order::read_le_u16(&pkt.hdr()[HDROFF_TYPE..]));
+        assert_eq!(OP, byte_order::read_le_u16(&pkt.hdr()[HDROFF_OP..]));
+        assert_eq!(FLAGS, byte_order::read_le_u32(&pkt.hdr()[HDROFF_FLAGS..]));
         assert_eq!(
             BUF_ALLOC,
-            LittleEndian::read_u32(&pkt.hdr()[HDROFF_BUF_ALLOC..])
+            byte_order::read_le_u32(&pkt.hdr()[HDROFF_BUF_ALLOC..])
         );
         assert_eq!(
             FWD_CNT,
-            LittleEndian::read_u32(&pkt.hdr()[HDROFF_FWD_CNT..])
+            byte_order::read_le_u32(&pkt.hdr()[HDROFF_FWD_CNT..])
         );
 
         assert_eq!(pkt.hdr_mut().len(), VSOCK_PKT_HDR_SIZE);

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 bitflags = ">=1.0.4"
-byteorder = ">=1.2.1"
 serde = ">=1.0.27"
 
 utils = { path = "../utils" }

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -7,7 +7,6 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate byteorder;
 
 extern crate logger;
 extern crate mmds;

--- a/src/utils/src/byte_order.rs
+++ b/src/utils/src/byte_order.rs
@@ -1,0 +1,109 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! generate_read_fn {
+    ($fn_name: ident, $data_type: ty, $byte_type: ty, $type_size: expr, $endian_type: ident) => {
+        pub fn $fn_name(input: &[$byte_type]) -> $data_type {
+            assert!($type_size == std::mem::size_of::<$data_type>());
+            let mut array = [0u8; $type_size];
+            for (byte, read) in array.iter_mut().zip(input.iter().cloned()) {
+                *byte = read as u8;
+            }
+            <$data_type>::$endian_type(array)
+        }
+    };
+}
+
+macro_rules! generate_write_fn {
+    ($fn_name: ident, $data_type: ty, $byte_type: ty, $endian_type: ident) => {
+        pub fn $fn_name(buf: &mut [$byte_type], n: $data_type) {
+            for (byte, read) in buf
+                .iter_mut()
+                .zip(<$data_type>::$endian_type(n).iter().cloned())
+            {
+                *byte = read as $byte_type;
+            }
+        }
+    };
+}
+
+generate_read_fn!(read_le_u16, u16, u8, 2, from_le_bytes);
+generate_read_fn!(read_le_u32, u32, u8, 4, from_le_bytes);
+generate_read_fn!(read_le_u64, u64, u8, 8, from_le_bytes);
+generate_read_fn!(read_le_i32, i32, i8, 4, from_le_bytes);
+
+generate_read_fn!(read_be_u16, u16, u8, 2, from_be_bytes);
+generate_read_fn!(read_be_u32, u32, u8, 4, from_be_bytes);
+
+generate_write_fn!(write_le_u16, u16, u8, to_le_bytes);
+generate_write_fn!(write_le_u32, u32, u8, to_le_bytes);
+generate_write_fn!(write_le_u64, u64, u8, to_le_bytes);
+generate_write_fn!(write_le_i32, i32, i8, to_le_bytes);
+
+generate_write_fn!(write_be_u16, u16, u8, to_be_bytes);
+generate_write_fn!(write_be_u32, u32, u8, to_be_bytes);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    macro_rules! byte_order_test_read_write {
+        ($test_name: ident, $write_fn_name: ident, $read_fn_name: ident, $is_be: expr, $data_type: ty) => {
+            #[test]
+            fn $test_name() {
+                #[allow(overflowing_literals)]
+                let test_cases = [
+                    (
+                        0x0123_4567_89AB_CDEF as u64,
+                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef],
+                    ),
+                    (
+                        0x0000_0000_0000_0000 as u64,
+                        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                    ),
+                    (
+                        0x1923_2345_ABF3_CCD4 as u64,
+                        [0x19, 0x23, 0x23, 0x45, 0xAB, 0xF3, 0xCC, 0xD4],
+                    ),
+                    (
+                        0x0FF0_0FF0_0FF0_0FF0 as u64,
+                        [0x0F, 0xF0, 0x0F, 0xF0, 0x0F, 0xF0, 0x0F, 0xF0],
+                    ),
+                    (
+                        0xFFFF_FFFF_FFFF_FFFF as u64,
+                        [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+                    ),
+                    (
+                        0x89AB_12D4_C2D2_09BB as u64,
+                        [0x89, 0xAB, 0x12, 0xD4, 0xC2, 0xD2, 0x09, 0xBB],
+                    ),
+                ];
+
+                let type_size = std::mem::size_of::<$data_type>();
+                for (test_val, v_arr) in &test_cases {
+                    let v = *test_val as $data_type;
+                    let cmp_iter: Box<dyn Iterator<Item = _>> = if $is_be {
+                        Box::new(v_arr[(8 - type_size)..].iter())
+                    } else {
+                        Box::new(v_arr.iter().rev())
+                    };
+                    // test write
+                    let mut write_arr = vec![Default::default(); type_size];
+                    $write_fn_name(&mut write_arr, v);
+                    for (cmp, cur) in cmp_iter.zip(write_arr.iter()) {
+                        assert_eq!(*cmp, *cur as u8)
+                    }
+                    // test read
+                    let read_val = $read_fn_name(&write_arr);
+                    assert_eq!(v, read_val);
+                }
+            }
+        };
+    }
+
+    byte_order_test_read_write!(test_le_u16, write_le_u16, read_le_u16, false, u16);
+    byte_order_test_read_write!(test_le_u32, write_le_u32, read_le_u32, false, u32);
+    byte_order_test_read_write!(test_le_u64, write_le_u64, read_le_u64, false, u64);
+    byte_order_test_read_write!(test_le_i32, write_le_i32, read_le_i32, false, i32);
+    byte_order_test_read_write!(test_be_u16, write_be_u16, read_be_u16, true, u16);
+    byte_order_test_read_write!(test_be_u32, write_be_u32, read_be_u32, true, u32);
+}

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -7,6 +7,7 @@ extern crate vmm_sys_util;
 pub use vmm_sys_util::{errno, eventfd, ioctl, tempdir, tempfile, terminal};
 
 pub mod arg_parser;
+pub mod byte_order;
 pub mod net;
 pub mod rand;
 pub mod signal;


### PR DESCRIPTION
## Reason for This PR

The `device` and `dumbo` crates only have a few uses of the `byteorder` crate and all of them can be trivially replaced with functions from the standard library.
Fixes #1365 

## Description of Changes

This PR removes the `byteorder` dependency of the `device` and `dumbo` crates and improves the code that was using it. This also involved updating the tests to ensure complete removal of dependency on the `byteorder` crate. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
