### PR TITLE
Add block/net device benchmark tests.

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,145 @@
+# Firecracker performance benchmarking
+
+## Overview
+
+Performance benchmarking is available for the following emulated devices:
+- [net device](../tests/integration_tests/performance/test_net_performance.py) - using iperf3
+- [block device](../tests/integration_tests/performance/test_blk_performance.py) - using fio
+  
+The benchmarks are part of the integration testing but are not run by the normal
+CI pipeline due to the long duration and isolation requirements.
+
+## Manually running the benchmarks
+
+Spawn a shell in the development container:
+```bash
+    sudo tools/devtool shell -p -r
+```
+The *-r* switch will create a ramdisk in /mnt/ramdisk that will be mounted
+in the container as /srv. This is required for the block device test to not be
+affected by the I/O latency of a normal disk. 
+If you want to asses the block performance on top of a host disk device remove
+the *-r* flag.
+
+### Network device benchmark
+Run the network performance test:
+```bash
+    cd tests
+    pytest -E benchmark integration_tests/performance/test_net_performance.py
+```
+
+Some results will be shown as soon as each test case is completed and after
+completion of all test cases the results will be written to **test_net_performance.json**.
+
+```bash
+    cat test_net_performance.json
+```
+
+```json
+[
+    {
+        "test": "tcp-h2g-100",
+        "tput": 93.17,
+        "retransmits": 0
+    },
+    {
+        "test": "tcp-g2h-100",
+        "tput": 94.6,
+        "retransmits": 0
+    },
+  
+    {
+        "test": "udp-h2g-100",
+        "tput": 95.39,
+        "lost": 0,
+        "pps": 1526.27,
+        "jitter": 0.05
+    },
+    {
+        "test": "udp-g2h-100",
+        "tput": 94.45,
+        "lost": 0,
+        "pps": 1511.26,
+        "jitter": 0.02
+    },
+]
+```
+
+For TCP tests the metrics collected are throughtput(Mbps) and retransmits. For UDP: throughtput(Mbps),
+lost packets(lost), packets per second(pps) and jitter.
+
+### Block device benchmark
+Run the block performance test:
+```bash
+    cd tests
+    pytest -E benchmark integration_tests/performance/test_blk_performance.py
+```
+
+The output JSON will be in this format:
+
+```json
+[
+    {
+        "test": "65536-randread",
+        "read_iops_min": 54630,
+        "read_iops_mean": 76745,
+        "read_iops_max": 99391,
+        "read_bw_min": 3414.38,
+        "read_bw_mean": 4796.63,
+        "read_bw_max": 6211.95,
+        "write_iops_min": 0,
+        "write_iops_mean": 0,
+        "write_iops_max": 0,
+        "write_bw_min": 0.0,
+        "write_bw_mean": 0.0,
+        "write_bw_max": 0.0
+    },
+    {
+        "test": "4096-randread",
+        "read_iops_min": 58848,
+        "read_iops_mean": 63385,
+        "read_iops_max": 67142,
+        "read_bw_min": 229.88,
+        "read_bw_mean": 247.6,
+        "read_bw_max": 262.27,
+        "write_iops_min": 0,
+        "write_iops_mean": 0,
+        "write_iops_max": 0,
+        "write_bw_min": 0.0,
+        "write_bw_mean": 0.0,
+        "write_bw_max": 0.0
+    },
+```
+
+Collected metrics:
+- test name is formatted as blocksize-mode, where mode is the fio test mode
+- read_iops(min, mean, max) - read operations per second
+- read_bw(min, mean, max) - read bandwidth in MBytes per second
+- write_iops(min, mean, max) - write operations per second
+- write_bw(min, mean, max) - write bandwidth in MBytes per second
+
+More test modes and metrics are available in fio and they can be enabled by adding
+them in the test:
+
+```python
+# Block device size in MB.
+BLOCK_DEVICE_SIZE = 2048
+# Iteration duration in seconds.
+ITERATION_DURATION = 120
+
+FIO_BLOCK_SIZES = [65536, 4096, 1024, 512]
+FIO_TEST_MODES = ["randread", "randrw", "read", "readwrite"]
+
+FIO_RESULT_OPS = ["read", "write"]
+FIO_RESULT_METRICS = ["iops", "bw"]
+FIO_RESULT_VALUES = ["min", "mean", "max"]
+```
+
+
+## Known issues
+
+There are a couple of issues you should expect when running the benchmark:
+- result variance for multiple runs on the same hardware
+- high result variance when running performance tests along with 
+other intensive workloads
+  

--- a/tests/integration_tests/performance/test_blk_performance.py
+++ b/tests/integration_tests/performance/test_blk_performance.py
@@ -1,0 +1,107 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Performance benchmark for block device emulation."""
+import json
+import os
+import pytest
+
+import host_tools.drive as drive_tools
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+# Block device size in MB.
+BLOCK_DEVICE_SIZE = 2048
+# Iteration duration in seconds.
+ITERATION_DURATION = 120
+
+FIO_BLOCK_SIZES = [65536, 4096, 1024, 512]
+FIO_TEST_MODES = ["randread", "randrw", "read", "readwrite"]
+
+FIO_RESULT_OPS = ["read", "write"]
+FIO_RESULT_METRICS = ["iops", "bw"]
+FIO_RESULT_VALUES = ["min", "mean", "max"]
+
+
+def parse_fio_result(json_result, mode, bs):
+    """Parse fio json result and collect metrics."""
+    job = json_result["jobs"][0]
+
+    result = {
+        "test": "{}-{}".format(bs, mode),
+    }
+
+    for op in FIO_RESULT_OPS:
+        for metric in FIO_RESULT_METRICS:
+            for value in FIO_RESULT_VALUES:
+                result_name = "{}_{}_{}".format(op, metric, value)
+                result_metric = "{}_{}".format(metric, value)
+                result_value = int(job[op][result_metric])
+                if metric == "bw":
+                    # Bandwidth in MB/s
+                    result[result_name] = round(result_value/1024, 2)
+                else:
+                    result[result_name] = result_value
+    return result
+
+
+def run_fio(ssh_connection, mode, bs):
+    """Run a fio test in the specified mode with block size bs."""
+    # Clear host page cache first.
+    os.system("sync; echo 1 > /proc/sys/vm/drop_caches")
+
+    cmd = ("fio --name={mode}-{bs} --rw={mode} --bs={bs} --filename=/dev/vdb "
+           "--time_based  --size={block_size}M --direct=1 --ioengine=libaio "
+           "--iodepth=32 --numjobs=1  --randrepeat=0 --runtime={duration} "
+           "--output-format=json").format(
+           mode=mode, bs=bs, block_size=BLOCK_DEVICE_SIZE,
+           duration=ITERATION_DURATION)
+
+    # print(cmd)
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+
+    assert stderr.read().decode("utf-8") == ""
+
+    fio_result = json.loads(stdout.read().decode("utf-8"))
+    result = parse_fio_result(fio_result, mode, bs)
+
+    print(json.dumps(result, indent=4))
+    return result
+
+
+@pytest.mark.timeout(3600)
+@pytest.mark.env("benchmark")
+def test_block_device_performance(test_microvm_with_ssh, network_config):
+    """Execute block device emulation benchmarking scenarios."""
+    microvm = test_microvm_with_ssh
+    microvm.spawn()
+    microvm.basic_config(mem_size_mib=1024)
+
+    # Add a secondary block device for benchmark tests.
+    fs = drive_tools.FilesystemFile(
+        os.path.join(microvm.fsfiles, 'scratch'),
+        BLOCK_DEVICE_SIZE
+    )
+
+    response = microvm.drive.put(
+        drive_id='scratch',
+        path_on_host=microvm.create_jailed_resource(fs.path),
+        is_root_device=False,
+        is_read_only=False
+    )
+    assert microvm.api_session.is_status_no_content(response.status_code)
+
+    _tap, _, _ = microvm.ssh_network_config(network_config, '1')
+
+    microvm.start()
+    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+    results = []
+    for mode in FIO_TEST_MODES:
+        for bs in FIO_BLOCK_SIZES:
+            results.append(run_fio(ssh_connection, mode, bs))
+
+    print("Results: ")
+    print(json.dumps(results, indent=4))
+
+    with open('test_blk_performance.json', 'w') as outfile:
+        json.dump(results, outfile, indent=4)
+
+    # TODO: Compare values with a the baseline and fail test if required.

--- a/tests/integration_tests/performance/test_net_performance.py
+++ b/tests/integration_tests/performance/test_net_performance.py
@@ -1,0 +1,159 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Performance benchmark for network device emulation."""
+import json
+import os
+import time
+from subprocess import run
+import pytest
+
+import host_tools.logging as log_tools
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+IPERF = "iperf3"
+ITERATION_DURATION = 60
+SOCKET_BUFFER_SIZE = 10
+
+# BW in Mbits.
+BANDWIDTHS = {
+    "udp": [100, 5000, 10000],
+    "tcp": [100, 5000, 10000, 0]
+}
+
+# From server to client and reversed.
+MODES = ["h2g", "g2h"]
+# Corresponding MODES for iperf options.
+MODES_OPTIONS = {
+    "h2g": "-R",
+    "g2h": "",
+}
+
+# From server to client and reversed.
+PROTOCOL = ["udp", "tcp"]
+# Corresponding MODES for iperf options.
+PROTOCOL_OPTIONS = {
+    "tcp": "",
+    "udp": "-u",
+}
+
+
+def spawn_host_iperf(netns_cmd_prefix):
+    """Start iperf in server mode after killing any leftover iperf daemon."""
+    # pylint: disable=subprocess-run-check
+    iperf_cmd = 'pkill {}\n'.format(IPERF)
+
+    # Don't check the result of this command because it can fail if no iperf
+    # is running.
+    run(iperf_cmd, shell=True)
+
+    iperf_cmd = '{} {} -sD\n'.format(
+        netns_cmd_prefix, IPERF)
+
+    run(iperf_cmd, shell=True, check=True)
+
+    # Wait for the iperf daemon to start.
+    time.sleep(2)
+
+
+def spawn_guest_iperf(microvm, iperf_cmd):
+    """Run iperf in guest and return result json."""
+    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+    _, stdout, stderr = ssh_connection.execute_command(iperf_cmd)
+    assert stderr.read().decode('utf-8') == ''
+
+    out = stdout.read().decode('utf-8')
+    return json.loads(out)
+
+
+def parse_iperf_udp_result(result, mode, bw):
+    """Parse iperf udp test output and return result json."""
+    totals = result["end"]["sum"]
+    total_bytes = int(totals["bytes"])
+    total_packets = int(totals["packets"])
+    lost_packets = int(totals["lost_packets"])
+    duration = float(totals["seconds"])
+    jitter = round(float(totals["jitter_ms"]), 2)
+    tput = round((total_bytes*8) / (1024*1024*duration), 2)
+    pps = round(total_packets / duration, 2)
+
+    return {
+        "test": "udp-{}-{}".format(mode, bw),
+        "tput": tput,
+        "lost": lost_packets,
+        "pps": pps,
+        "jitter": jitter,
+    }
+
+
+def parse_iperf_tcp_result(result, mode, bw):
+    """Parse iperf tcp test output and return result json."""
+    total_sent = result["end"]["sum_sent"]
+    total_received = result["end"]["sum_received"]
+    duration = float(total_received["seconds"])
+    total_bytes_received = int(total_received["bytes"])
+    retransmits = int(total_sent["retransmits"])
+
+    # Measuring TPUT from rx-ing side.
+    tput = round((total_bytes_received*8) / (1024*1024*duration), 2)
+
+    return {
+        "test": "tcp-{}-{}".format(mode, bw),
+        "tput": tput,
+        "retransmits": retransmits,
+    }
+
+
+@pytest.mark.timeout(3600)
+@pytest.mark.env("benchmark")
+def test_block_device_performance(test_microvm_with_ssh, network_config):
+    """Execute net device emulation benchmarking scenarios."""
+    microvm = test_microvm_with_ssh
+    microvm.spawn()
+    microvm.basic_config(mem_size_mib=1024)
+
+    # Configure logging.
+    log_fifo_path = os.path.join(microvm.path, 'log_fifo')
+    metrics_fifo_path = os.path.join(microvm.path, 'metrics_fifo')
+    log_fifo = log_tools.Fifo(log_fifo_path)
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+    response = microvm.logger.put(
+        log_fifo=microvm.create_jailed_resource(log_fifo.path),
+        metrics_fifo=microvm.create_jailed_resource(metrics_fifo.path)
+    )
+    assert microvm.api_session.is_status_no_content(response.status_code)
+
+    spawn_host_iperf(microvm.jailer.netns_cmd_prefix())
+
+    _tap, host_ip, _ = microvm.ssh_network_config(network_config, '1')
+
+    microvm.start()
+
+    results = []
+
+    for protocol in PROTOCOL_OPTIONS:
+        for bw in BANDWIDTHS[protocol]:
+            for mode in MODES:
+                cmd = '{} -c {} -t{} -f MBytes -J -b {}M {} {} -w {}M'.format(
+                    IPERF,
+                    host_ip,
+                    ITERATION_DURATION,
+                    bw,
+                    MODES_OPTIONS[mode],
+                    PROTOCOL_OPTIONS[protocol],
+                    SOCKET_BUFFER_SIZE
+                )
+
+                iperf_out = spawn_guest_iperf(microvm, cmd)
+                result = None
+                if protocol == "udp":
+                    result = parse_iperf_udp_result(iperf_out, mode, bw)
+                else:
+                    result = parse_iperf_tcp_result(iperf_out, mode, bw)
+
+                results.append(result)
+                print(result)
+
+    with open('test_net_performance.json', 'w') as outfile:
+        json.dump(results, outfile, indent=4)
+
+    # TODO: Compare values with a the baseline and fail test if required.

--- a/tools/devtool
+++ b/tools/devtool
@@ -553,12 +553,14 @@ cmd_shell() {
 
     # By default, we run the container as the current user.
     privileged=false
+    ram_disk=false
 
     # Parse any command line args.
     while [ $# -gt 0 ]; do
         case "$1" in
             "-h"|"--help")          { cmd_help; exit 1; } ;;
             "-p"|"--privileged")    { privileged=true;  } ;;
+            "-r"|"--ramdisk")       { ram_disk=true;  } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
             ;;
@@ -569,6 +571,16 @@ cmd_shell() {
     # Make sure we have what we need to continue.
     ensure_devctr
     ensure_build_dir
+
+    extra_args=""
+    
+    # The ramdisk is used in performance tests.
+    if [[ $ram_disk = true ]]; then
+        umount /mnt/ramdisk
+        mkdir -p /mnt/ramdisk && mount -t tmpfs -o size=4096m tmpfs /mnt/ramdisk
+        mkdir -p /mnt/ramdisk/tmp
+        extra_args="--volume /mnt/ramdisk/srv:/srv"
+    fi
 
     if [[ $privileged = true ]]; then
         # If requested, spin up a privileged container.
@@ -581,6 +593,7 @@ cmd_shell() {
             --privileged \
             --security-opt seccomp=unconfined \
             --workdir "$CTR_FC_ROOT_DIR" \
+            ${extra_args} \
             -- \
             bash
         ret=$?
@@ -605,6 +618,7 @@ cmd_shell() {
             --device=/dev/kvm:/dev/kvm \
             --workdir "$CTR_FC_ROOT_DIR" \
             --env PS1="$(whoami)@\h:\w\$ " \
+            ${extra_args} \
             -- \
             bash --norc
         ret=$?


### PR DESCRIPTION
Signed-off-by: Andrei Sandu <sandreim@amazon.com>

## Reason for This PR

Benchmark test for net and block devices: #1097 .

## Description of Changes

- devtool: add -r option to map a ramdisk as /srv
- add env pytest marker to skip/run benchmark tests
- iperf3 based benchmark for net device
- fio based benchmark for block device
- add initial benchmarking docs

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue and the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
