### PR TITLE
vcpu: add support for kicking out of KVM_RUN

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -914,6 +914,8 @@ impl Vmm {
             "The number of vCPU fds is corrupted!"
         );
 
+        Vcpu::register_kick_signal_handler();
+
         self.vcpus_handles.reserve(vcpu_count as usize);
 
         let vcpus_thread_barrier = Arc::new(Barrier::new((vcpu_count + 1) as usize));


### PR DESCRIPTION
## Reason for This PR

Fixes #1392 

## Description of Changes

Kicking the `Vcpu` out of `KVM_RUN` is done by making use of the kvm `immediate_exit` flag.

The vcpu is signaled and the `immediate_exit` flag is set in the signal handler. This leads to race-free interruption of KVM_RUN.

In order to access the `immediate_exit` flag for a particular vcpu from a global context such as the signal handler, we use the TLS of that vcpu thread to gain access to the vcpu's data.

This commit tries to keep the flow as safe as possible, and in that spirit, the following vcpu methods are defined:
- `init_thread_local_data(&mut self)` - associates the `self` vcpu to the current thread.
- `reset_thread_local_data(&mut self)` - deassociates the `self` vcpu from the current thread.
- `Vcpu::run_on_thread_local_vcpu<F>(fn: F)` - runs `fn` passing it a reference to the vcpu in TLS of local thread. This model enforces a limited lifetime (lifetime of `fn`) for the unsafe vcpu reference.
- `Vcpu::register_vcpu_kick_signal_handler()` - Registers a signal handler that sets kvm `immediate_exit` using `run_on_thread_local_vcpu()` in order to kick the vcpu running on the current thread.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
