### PR TITLE
Add support to control Vcpu

### DIFF
--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -8,6 +8,7 @@ pub use vmm_sys_util::{errno, eventfd, ioctl, signal, terminal};
 
 pub mod net;
 pub mod rand;
+pub mod sm;
 pub mod structs;
 pub mod syscall;
 pub mod time;

--- a/src/utils/src/sm.rs
+++ b/src/utils/src/sm.rs
@@ -1,0 +1,153 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::Deref;
+
+/// Simple abstraction of a state machine.
+///
+/// `StateMachine<T>` is a wrapper over `T` that also encodes state information for `T`.
+///
+/// Each state for `T` is represented by a `StateFn<T>` which is a function that acts as
+/// the state handler for that particular state of `T`.
+///
+/// `StateFn<T>` returns exactly one other `StateMachine<T>` thus each state gets clearly
+/// defined transitions to other states.
+pub struct StateMachine<T> {
+    function: StateFn<T>,
+    end_state: bool,
+}
+
+/// Type representing a state handler of a `StateMachine<T>` machine. Each state handler
+/// is a function from `T` that handles a specific state of `T`.
+type StateFn<T> = fn(&mut T) -> StateMachine<T>;
+
+impl<T> StateMachine<T> {
+    /// Creates a new state wrapper.
+    ///
+    /// # Arguments
+    ///
+    /// `function` - the state handler for this state.
+    /// `end_state` - whether this state is final.
+    ///
+    pub fn new(function: StateFn<T>, end_state: bool) -> StateMachine<T> {
+        StateMachine {
+            function,
+            end_state,
+        }
+    }
+
+    /// Creates a new state wrapper that has further possible transitions.
+    ///
+    /// # Arguments
+    ///
+    /// `function` - the state handler for this state.
+    ///
+    pub fn next(function: StateFn<T>) -> StateMachine<T> {
+        StateMachine::new(function, false)
+    }
+
+    /// Creates a new state wrapper that has no further transitions. The state machine
+    /// will finish after running this handler.
+    ///
+    /// # Arguments
+    ///
+    /// `function` - the state handler for this last state.
+    ///
+    pub fn finish(function: StateFn<T>) -> StateMachine<T> {
+        StateMachine::new(function, true)
+    }
+
+    /// Runs a state machine for `T` starting from the provided state.
+    ///
+    /// # Arguments
+    ///
+    /// `machine` - a mutable reference to the object running through the various states.
+    /// `starting_state_fn` - a `fn(&mut T) -> StateMachine<T>` that should be the handler for
+    ///                       the initial state.
+    ///
+    pub fn run(machine: &mut T, starting_state_fn: StateFn<T>) {
+        // Start off in the `starting_state` state.
+        let mut sf = StateMachine::new(starting_state_fn, false);
+        // While current state is not a final/end state, keep churning.
+        while !sf.end_state {
+            // Run the current state handler, and get the next one.
+            sf = sf(machine);
+        }
+    }
+}
+
+// Implement Deref of `StateMachine<T>` so that we can directly call its underlying state handler.
+impl<T> Deref for StateMachine<T> {
+    type Target = StateFn<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.function
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // DummyMachine with states `s1`, `s2` and `s3`.
+    struct DummyMachine {
+        private_data_s1: bool,
+        private_data_s2: bool,
+        private_data_s3: bool,
+    }
+
+    impl DummyMachine {
+        fn new() -> Self {
+            DummyMachine {
+                private_data_s1: false,
+                private_data_s2: false,
+                private_data_s3: false,
+            }
+        }
+
+        // DummyMachine functions here.
+
+        // Simple state-machine: start->s1->s2->s3->done.
+        fn run(&mut self) {
+            // Verify the machine has not run yet.
+            assert!(!self.private_data_s1);
+            assert!(!self.private_data_s2);
+            assert!(!self.private_data_s3);
+
+            // Run the state-machine.
+            StateMachine::run(self, Self::s1);
+
+            // Verify the machine went through all states.
+            assert!(self.private_data_s1);
+            assert!(self.private_data_s2);
+            assert!(self.private_data_s3);
+        }
+
+        fn s1(&mut self) -> StateMachine<Self> {
+            // Verify private data mutates along with the states.
+            assert!(!self.private_data_s1);
+            self.private_data_s1 = true;
+            StateMachine::next(Self::s2)
+        }
+
+        fn s2(&mut self) -> StateMachine<Self> {
+            // Verify private data mutates along with the states.
+            assert!(!self.private_data_s2);
+            self.private_data_s2 = true;
+            StateMachine::next(Self::s3)
+        }
+
+        fn s3(&mut self) -> StateMachine<Self> {
+            // Verify private data mutates along with the states.
+            assert!(!self.private_data_s3);
+            self.private_data_s3 = true;
+            // The machine ends here, adding `s1` as next state to validate this.
+            StateMachine::finish(Self::s1)
+        }
+    }
+
+    #[test]
+    fn test_sm() {
+        let mut machine = DummyMachine::new();
+        machine.run();
+    }
+}

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -87,6 +87,19 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             ),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_stat),
+            allow_syscall_if(
+                libc::SYS_tkill,
+                or![and![Cond::new(
+                    1,
+                    ArgLen::DWORD,
+                    Eq,
+                    utils::signal::validate_signal_num(
+                        super::super::vstate::VCPU_RTSIG_OFFSET,
+                        true
+                    )
+                    .map_err(|_| Error::InvalidArgumentNumber)? as u64,
+                )?]],
+            ),
             allow_syscall(libc::SYS_timerfd_create),
             allow_syscall(libc::SYS_timerfd_settime),
             allow_syscall(libc::SYS_write),

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.2
+COVERAGE_TARGET_PCT = 85.3
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1391
Fixes #1393

## Description of Changes

Implemented a control interface through which the Vmm (or another controller component) can communicate in a request/response model with each Vcpu.
    
`Vcpu` exposes a `start_threaded()` function which will run the vcpu emulation on its own thread. The function returns a `VcpuHandle` which exposes a control interface to be able to send requests/events and receive responses from the owned vcpu thread.
    
Using the above, the control thread can now send commands/events to the vcpu threads.
Implemented support for `Pause`, `Resume` and `Exit` events. These effectively pause, resume, or respectively stop the microVM by pausing, unpausing or stopping the vcpu threads.
    
The vcpus are kicked out of KVM_RUN when the VMM thread needs to send them events.

**Note:** this builds on top of pending PR https://github.com/firecracker-microvm/firecracker/pull/1410

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
