### PR TITLE
use u64 as GuestAddress inner type

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -50,11 +50,11 @@
 // Taken from (http://infocenter.arm.com/help/topic/com.arm.doc.den0001c/DEN0001C_principles_of_arm_memory_maps.pdf).
 
 /// Start of RAM on 64 bit ARM.
-pub const DRAM_MEM_START: usize = 0x8000_0000; // 2 GB.
+pub const DRAM_MEM_START: u64 = 0x8000_0000; // 2 GB.
 /// The maximum addressable RAM address.
-pub const DRAM_MEM_END: usize = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
+pub const DRAM_MEM_END: u64 = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
 /// The maximum RAM size.
-pub const DRAM_MEM_MAX_SIZE: usize = DRAM_MEM_END - DRAM_MEM_START;
+pub const DRAM_MEM_MAX_SIZE: u64 = DRAM_MEM_END - DRAM_MEM_START;
 
 /// Kernel command line maximum size.
 /// As per `arch/arm64/include/uapi/asm/setup.h`.

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -53,6 +53,8 @@
 pub const DRAM_MEM_START: usize = 0x8000_0000; // 2 GB.
 /// The maximum addressable RAM address.
 pub const DRAM_MEM_END: usize = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
+/// The maximum RAM size.
+pub const DRAM_MEM_MAX_SIZE: usize = DRAM_MEM_END - DRAM_MEM_START;
 
 /// Kernel command line maximum size.
 /// As per `arch/arm64/include/uapi/asm/setup.h`.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -26,6 +26,9 @@ pub enum Error {
     SetupFDT(fdt::Error),
 }
 
+/// The start of the memory area reserved for MMIO devices.
+pub const MMIO_MEM_START: u64 = layout::MAPPED_IO_START;
+
 pub use self::fdt::DeviceInfoForFDT;
 use DeviceType;
 
@@ -61,11 +64,6 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
     )
     .map_err(Error::SetupFDT)?;
     Ok(())
-}
-
-/// Function that returns the address reserved for MMIO devices.
-pub fn get_reserved_mem_addr() -> u64 {
-    layout::MAPPED_IO_START
 }
 
 /// Returns the memory address where the kernel could be loaded.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -35,7 +35,7 @@ use DeviceType;
 /// Returns a Vec of the valid memory addresses for aarch64.
 /// See [`layout`](layout) module for a drawing of the specific memory model for this platform.
 pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
-    let dram_size = min(size, layout::DRAM_MEM_MAX_SIZE);
+    let dram_size = min(size as u64, layout::DRAM_MEM_MAX_SIZE) as usize;
     vec![(GuestAddress(layout::DRAM_MEM_START), dram_size)]
 }
 
@@ -67,17 +67,17 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
 }
 
 /// Returns the memory address where the kernel could be loaded.
-pub fn get_kernel_start() -> usize {
+pub fn get_kernel_start() -> u64 {
     layout::DRAM_MEM_START
 }
 
 // Auxiliary function to get the address where the device tree blob is loaded.
-fn get_fdt_addr(mem: &GuestMemory) -> usize {
+fn get_fdt_addr(mem: &GuestMemory) -> u64 {
     // If the memory allocated is smaller than the size allocated for the FDT,
     // we return the start of the DRAM so that
     // we allow the code to try and load the FDT.
 
-    if let Some(offset) = mem.end_addr().checked_sub(layout::FDT_MAX_SIZE) {
+    if let Some(offset) = mem.end_addr().checked_sub(layout::FDT_MAX_SIZE as u64) {
         if mem.address_in_range(offset) {
             return offset.raw_value();
         }
@@ -102,7 +102,7 @@ mod tests {
         let regions = arch_memory_regions(1usize << 41);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
-        assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1);
+        assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1 as u64);
     }
 
     #[test]

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -35,7 +35,7 @@ use DeviceType;
 /// Returns a Vec of the valid memory addresses for aarch64.
 /// See [`layout`](layout) module for a drawing of the specific memory model for this platform.
 pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
-    let dram_size = min(size, layout::DRAM_MEM_END);
+    let dram_size = min(size, layout::DRAM_MEM_MAX_SIZE);
     vec![(GuestAddress(layout::DRAM_MEM_START), dram_size)]
 }
 
@@ -102,7 +102,7 @@ mod tests {
         let regions = arch_memory_regions(1usize << 41);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
-        assert_eq!(super::layout::DRAM_MEM_END, regions[0].1);
+        assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1);
     }
 
     #[test]

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -122,7 +122,7 @@ arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);
 /// * `cpu_id` - Index of current vcpu.
 /// * `boot_ip` - Starting instruction pointer.
 /// * `mem` - Reserved DRAM for current VM.
-pub fn setup_regs(vcpu: &VcpuFd, cpu_id: u8, boot_ip: usize, mem: &GuestMemory) -> Result<()> {
+pub fn setup_regs(vcpu: &VcpuFd, cpu_id: u8, boot_ip: u64, mem: &GuestMemory) -> Result<()> {
     // Get the register index of the PSTATE (Processor State) register.
     vcpu.set_one_reg(arm64_core_reg!(pstate), PSTATE_FAULT_BITS_64)
         .map_err(Error::SetCoreRegister)?;
@@ -130,7 +130,7 @@ pub fn setup_regs(vcpu: &VcpuFd, cpu_id: u8, boot_ip: usize, mem: &GuestMemory) 
     // Other vCPUs are powered off initially awaiting PSCI wakeup.
     if cpu_id == 0 {
         // Setting the PC (Processor Counter) to the current program address (kernel address).
-        vcpu.set_one_reg(arm64_core_reg!(pc), boot_ip as u64)
+        vcpu.set_one_reg(arm64_core_reg!(pc), boot_ip)
             .map_err(Error::SetCoreRegister)?;
 
         // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -20,8 +20,8 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    arch_memory_regions, configure_system, get_kernel_start, get_reserved_mem_addr,
-    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error,
+    arch_memory_regions, configure_system, get_kernel_start, layout::CMDLINE_MAX_SIZE,
+    layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
 };
 
 /// Module for x86_64 related functionality.
@@ -30,8 +30,8 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, get_32bit_gap_start as get_reserved_mem_addr,
-    get_kernel_start, layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error,
+    arch_memory_regions, configure_system, get_kernel_start, layout::CMDLINE_MAX_SIZE,
+    layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
 };
 
 /// Type for returning public functions outcome.

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -8,15 +8,15 @@
 /// Magic addresses externally used to lay out x86_64 VMs.
 
 /// Initial stack for the boot CPU.
-pub const BOOT_STACK_POINTER: usize = 0x8ff0;
+pub const BOOT_STACK_POINTER: u64 = 0x8ff0;
 
 /// Kernel command line start address.
-pub const CMDLINE_START: usize = 0x20000;
+pub const CMDLINE_START: u64 = 0x20000;
 /// Kernel command line start address maximum size.
 pub const CMDLINE_MAX_SIZE: usize = 0x10000;
 
 /// Start of the high memory.
-pub const HIMEM_START: usize = 0x0010_0000; //1 MB.
+pub const HIMEM_START: u64 = 0x0010_0000; //1 MB.
 
 // Typically, on x86 systems 16 IRQs are used (0-15).
 /// First usable IRQ ID for virtio device interrupts on x86_64.
@@ -25,7 +25,7 @@ pub const IRQ_BASE: u32 = 5;
 pub const IRQ_MAX: u32 = 15;
 
 /// Address for the TSS setup.
-pub const KVM_TSS_ADDRESS: usize = 0xfffb_d000;
+pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;
 
 /// The 'zero page', a.k.a linux kernel bootparams.
-pub const ZERO_PAGE_START: usize = 0x7000;
+pub const ZERO_PAGE_START: u64 = 0x7000;

--- a/devices/src/virtio/block.rs
+++ b/devices/src/virtio/block.rs
@@ -1119,9 +1119,9 @@ mod tests {
         vq.avail.idx.set(1);
 
         // dtable[1] is the data descriptor
-        let data_addr = GuestAddress(vq.dtable[1].addr.get() as usize);
+        let data_addr = GuestAddress(vq.dtable[1].addr.get());
         // dtable[2] is the status descriptor
-        let status_addr = GuestAddress(vq.dtable[2].addr.get() as usize);
+        let status_addr = GuestAddress(vq.dtable[2].addr.get());
 
         {
             // let's start with a request that does not parse

--- a/devices/src/virtio/mmio.rs
+++ b/devices/src/virtio/mmio.rs
@@ -365,11 +365,11 @@ impl BusDevice for MmioDevice {
 
     fn write(&mut self, offset: u64, data: &[u8]) {
         fn hi(v: &mut GuestAddress, x: u32) {
-            *v = (*v & 0xffff_ffff) | (u64::from(x) << 32) as usize
+            *v = (*v & 0xffff_ffff) | (u64::from(x) << 32)
         }
 
         fn lo(v: &mut GuestAddress, x: u32) {
-            *v = (*v & !0xffff_ffff) | u64::from(x) as usize
+            *v = (*v & !0xffff_ffff) | u64::from(x)
         }
 
         match offset {

--- a/devices/src/virtio/net.rs
+++ b/devices/src/virtio/net.rs
@@ -1526,7 +1526,7 @@ mod tests {
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
-        assert!(daddr as usize > txq.end().0);
+        assert!(daddr > txq.end().0);
 
         // Some corner cases for rx_single_frame().
         {
@@ -1675,7 +1675,7 @@ mod tests {
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
-        assert!(daddr as usize > txq.end().0);
+        assert!(daddr > txq.end().0);
 
         // Test TX bandwidth rate limiting
         {
@@ -1783,7 +1783,7 @@ mod tests {
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
-        assert!(daddr as usize > txq.end().0);
+        assert!(daddr > txq.end().0);
 
         // Test TX ops rate limiting
         {

--- a/devices/src/virtio/vsock/packet.rs
+++ b/devices/src/virtio/vsock/packet.rs
@@ -371,7 +371,7 @@ mod tests {
     }
 
     fn set_pkt_len(len: u32, guest_desc: &GuestQDesc, mem: &GuestMemory) {
-        let hdr_gpa = guest_desc.addr.get() as usize;
+        let hdr_gpa = guest_desc.addr.get();
         let hdr_ptr = mem.get_host_address(GuestAddress(hdr_gpa)).unwrap() as *mut u8;
         let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
 

--- a/memory_model/src/guest_address.rs
+++ b/memory_model/src/guest_address.rs
@@ -72,10 +72,10 @@ pub trait Address:
 
 /// Represents an Address in the guest's memory.
 #[derive(Clone, Copy, Debug)]
-pub struct GuestAddress(pub usize);
+pub struct GuestAddress(pub u64);
 
 impl AddressValue for GuestAddress {
-    type V = usize;
+    type V = u64;
 }
 
 impl Address for GuestAddress {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -745,7 +745,7 @@ impl Vmm {
         // and is architectural specific.
         let device_manager = MMIODeviceManager::new(
             guest_mem,
-            &mut (arch::get_reserved_mem_addr() as u64),
+            &mut (arch::MMIO_MEM_START as u64),
             (arch::IRQ_BASE, arch::IRQ_MAX),
         );
         self.mmio_device_manager = Some(device_manager);
@@ -2874,7 +2874,7 @@ mod tests {
         let guest_mem = vmm.vm.memory().unwrap().clone();
         let device_manager = MMIODeviceManager::new(
             guest_mem,
-            &mut (arch::get_reserved_mem_addr() as u64),
+            &mut (arch::MMIO_MEM_START),
             (arch::IRQ_BASE, arch::IRQ_MAX),
         );
         vmm.mmio_device_manager = Some(device_manager);
@@ -2888,10 +2888,7 @@ mod tests {
         let dev_man = vmm.mmio_device_manager.as_ref().unwrap();
         // On aarch64, we are using first region of the memory
         // reserved for attaching MMIO devices for measuring boot time.
-        assert!(dev_man
-            .bus
-            .get_device(arch::get_reserved_mem_addr() as u64)
-            .is_none());
+        assert!(dev_man.bus.get_device(arch::MMIO_MEM_START).is_none());
         assert!(dev_man
             .get_device_info()
             .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
@@ -2912,7 +2909,7 @@ mod tests {
         let guest_mem = vmm.vm.memory().unwrap().clone();
         let device_manager = MMIODeviceManager::new(
             guest_mem,
-            &mut (arch::get_reserved_mem_addr() as u64),
+            &mut (arch::MMIO_MEM_START),
             (arch::IRQ_BASE, arch::IRQ_MAX),
         );
         vmm.mmio_device_manager = Some(device_manager);

--- a/vmm/src/vstate.rs
+++ b/vmm/src/vstate.rs
@@ -222,7 +222,7 @@ impl Vm {
 
         #[cfg(target_arch = "x86_64")]
         self.fd
-            .set_tss_address(GuestAddress(arch::x86_64::layout::KVM_TSS_ADDRESS).raw_value())
+            .set_tss_address(arch::x86_64::layout::KVM_TSS_ADDRESS as usize)
             .map_err(Error::VmSetup)?;
 
         Ok(())


### PR DESCRIPTION
## Reason for This PR

addresses #1397 

## Description of Changes

Use u64 as GuestAddress inner type. This is needed in order to make the switch to `rust-vmm/vm-memory` crate.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue. 
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
