### PR TITLE
Firecracker release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,32 @@
 # Changelog
 
-## [Unreleased]
+## [0.20.0]
+
+### Added
+
+- Added support for GICv2.
 
 ### Fixed
 
-- Fixed a logical error in bounds checking performed on vsock virtio
-  descriptors (CVE-2019-18960).
+- Fixed CVE-2019-18960 - Fixed a logical error in bounds checking performed 
+  on vsock virtio descriptors.
 - Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
-- The backtrace are printed on `panic`, no longer causing a seccomp fault.
+- Fixed #1088 - The backtrace are printed on `panic`, no longer causing a 
+  seccomp fault.
 - Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
   prevent potential unwrap on None panics.
-- Raise interrupt for TX queue used descriptors - Github issue #1436
-- Fixed a bug that causes 100% cpu load when the net device rx is throttled
-  by the ratelimiter - Github issue #1439
-- Invalid fields in rate limiter related API requests are now failing with
-  a proper error message.
+- Fixed #1436 - Raise interrupt for TX queue used descriptors
+- Fixed #1439 - Prevent achieving 100% cpu load when the net device rx is 
+  throttled by the ratelimiter
+- Fixed #1437 - Invalid fields in rate limiter related API requests are 
+  now failing with a proper error message.
+- Fixed #1316 - correctly determine the size of a virtio device backed 
+  by a block device.
+- Fixed #1383 - Log failed api requests.
+
+### Changed
+
+- Decreased release binary size by 10%.
 
 ## [0.19.0]
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -28,10 +28,13 @@ Contributors to the Firecracker repository:
 * Alexandru Agache <aagch@amazon.com>
 * Alexandru Branciog <branciog@amazon.com>
 * Andreea Florescu <fandree@amazon.com>
+* Andrei Casu-Pop <cpo@amazon.com>
 * Andrei Cipu <acipu@amazon.com>
 * Andrei Sandu <sandreim@amazon.com>
 * Arun Gupta <arun.gupta@gmail.com>
 * Atsushi Ishibashi <atsushi.ishibashi@finatext.com>
+* Aussie Schnore <aussiev123@yahoo.com>
+* Babis Chalios <babis.chalios@gmail.com>
 * Bogdan Ionita <bci@amazon.com>
 * chaos matrix <mythsphoenix@outlook.com>
 * Chinmay Kousik <chinmaykousik1@gmail.com>
@@ -52,6 +55,7 @@ Contributors to the Firecracker repository:
 * german gomez <germangb42@gmail.com>
 * Greg Dunn <gregdunn@amazon.com>
 * Gábor Lipták <gliptak@gmail.com>
+* hacker65536 <s.hacker65536@gmail.com>
 * hatf0 <harrison@0xcc.pw>
 * Henri Yandell <hyandell@users.noreply.github.com>
 * Hermes <hermes.espinola@gmail.com>
@@ -62,14 +66,17 @@ Contributors to the Firecracker repository:
 * Javier Romero <xavinux@gmail.com>
 * Josh Abraham <sinisterpatrician@gmail.com>
 * Julian Stecklina <js@alien8.de>
+* KarthikVelayutham <karthik.velayutham@gmail.com>
 * Kazuyoshi Kato <katokazu@amazon.com>
 * Laura Loghin <lauralg@amazon.com>
+* lifupan <lifupan@gmail.com>
 * Liu Jiang <gerry@linux.alibaba.com>
 * Lloyd <lloydmeta@gmail.com>
 * lloydmeta <lloydmeta@gmail.com>
 * maciejhirsz <maciej.hirsz@gmail.com>
 * Manohar Castelino <manohar.r.castelino@intel.com>
 * Marc Brooker <mbrooker@amazon.com>
+* Marco Vedovati <mvedovati@suse.com>
 * Masatoshi Higuchi <matt9ucci@gmail.com>
 * Massimiliano Torromeo <massimiliano.torromeo@gmail.com>
 * Matt Wilson <msw@amazon.com>
@@ -79,6 +86,7 @@ Contributors to the Firecracker repository:
 * Noah Meyerhans <nmeyerha@amazon.com>
 * Peng Tao <bergwolf@gmail.com>
 * Penny Zheng <penny.zheng@arm.com>
+* Peter Hrvola <peter.hrvola@hotmail.com>
 * Petre Eftime <epetre@amazon.com>
 * Radu Matei Lăcraru <ral@amazon.com>
 * Radu Weiss <raduweis@amazon.com>
@@ -92,6 +100,7 @@ Contributors to the Firecracker repository:
 * Sean Lavine <freewil@users.noreply.github.com>
 * Sebastien Boeuf <sebastien.boeuf@intel.com>
 * Serban Iorga <seriorga@amazon.com>
+* shakram02 <ahmedhamdyau@gmail.com>
 * Shen Jiale <shenjiale@baidu.com>
 * Sripracha <ramsri@amazon.com>
 * Tamio-Vesa Nakajima <tamiove@amazon.com>
@@ -100,7 +109,10 @@ Contributors to the Firecracker repository:
 * Tyler Anton <tyler@debian.anton>
 * Urvil Patel <patelurvil38@gmail.com>
 * Weixiao Huang <hwx.simle@gmail.com>
+* Wesley Norris <repnop@outlook.com>
 * xibz <impactbchang@gmail.com>
 * xiekeyang <keyang.xie@gmail.com>
 * YLyu <lyuyuan92@gmail.com>
 * Yuval Kohavi <yuval.kohavi@gmail.com>
+* Zi Shen Lim <zlim.lnx@gmail.com>
+* Дамјан Георгиевски <gdamjan@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "api_server",
  "backtrace",
@@ -182,7 +182,7 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "jailer"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "libc",
@@ -353,15 +353,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86cb7552cfb77270aefe112931d8fe6899ae09d4de5c2685a1db5372ed3ab27"
+checksum = "f4588e216e77682850f4ae35ec855c2517f93d671a2578d2a32d20bf8a73de38"
 dependencies = [
  "libc",
 ]

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
                The API is accessible through HTTP calls on specific URLs
                carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.19.0
+  version: 0.20.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]


### PR DESCRIPTION
## Reason for This PR

Firecracker release v0.20.0

## Description of Changes

```
### Added

- Added support for GICv2.

### Fixed

- Fixed a logical error in bounds checking performed on vsock virtio
  descriptors (CVE-2019-18960).
- Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
- The backtrace are printed on `panic`, no longer causing a seccomp fault.
- Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
  prevent potential unwrap on None panics.
- Raise interrupt for TX queue used descriptors - Github issue #1436
- Fixed a bug that causes 100% cpu load when the net device rx is throttled
  by the ratelimiter - Github issue #1439
- Invalid fields in rate limiter related API requests are now failing with
  a proper error message.
- Fixed #1316 - fix the size of a virtio device, backed by a block device.
- Log failed api requests.

### Changed

- Decreased release binary size by 10%.
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
