### PR TITLE
Removed tempfile dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,19 +83,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+checksum = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 
 [[package]]
 name = "cfg-if"
@@ -141,7 +132,6 @@ dependencies = [
  "memory_model",
  "net_gen",
  "rate_limiter",
- "tempfile",
  "utils",
  "virtio_gen",
 ]
@@ -180,20 +170,8 @@ dependencies = [
  "logger",
  "mmds",
  "seccomp",
- "tempfile",
  "utils",
  "vmm",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -209,7 +187,6 @@ dependencies = [
  "clap",
  "libc",
  "regex",
- "tempfile",
  "utils",
 ]
 
@@ -249,9 +226,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "log"
@@ -272,7 +249,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tempfile",
  "utils",
 ]
 
@@ -287,7 +263,6 @@ name = "memory_model"
 version = "0.1.0"
 dependencies = [
  "libc",
- "tempfile",
  "utils",
 ]
 
@@ -312,12 +287,6 @@ name = "net_gen"
 version = "0.1.0"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,47 +305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
-dependencies = [
- "getrandom",
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
-dependencies = [
- "c2-chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rate_limiter"
 version = "0.1.0"
 dependencies = [
@@ -385,12 +313,6 @@ dependencies = [
  "timerfd",
  "utils",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
@@ -409,15 +331,6 @@ name = "regex-syntax"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -457,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043"
+checksum = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 dependencies = [
  "itoa",
  "ryu",
@@ -468,27 +381,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+checksum = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-dependencies = [
- "cfg-if",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -520,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
@@ -567,44 +466,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tempfile",
  "timerfd",
  "utils",
 ]
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebb6ba7ba5653b69bfd3fab8c8c363945c0d3f616a6a1592e12122c3be4724e"
+checksum = "f86cb7552cfb77270aefe112931d8fe6899ae09d4de5c2685a1db5372ed3ab27"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-
-[[package]]
-name = "winapi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -16,7 +16,3 @@ utils = { path = "../utils" }
 net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }
 virtio_gen = { path = "../virtio_gen" }
-
-[dev-dependencies]
-utils = { path = "../utils" }
-tempfile = ">=3.0.2"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -14,6 +14,3 @@ logger = { path = "../logger" }
 mmds = { path = "../mmds" }
 seccomp = { path = "../seccomp" }
 vmm = { path = "../vmm" }
-
-[dev-dependencies]
-tempfile = ">=3.0.2"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -9,6 +9,3 @@ libc = ">=0.2.39"
 regex = ">=1.0.0"
 
 utils = { path = "../utils" }
-
-[dev-dependencies]
-tempfile = ">=3.0.2"

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -14,4 +14,4 @@ serde_json = ">=1.0.9"
 utils = { path = "../utils" }
 
 [dev-dependencies]
-tempfile = ">=3.0.2"
+libc = ">=0.2.39"

--- a/src/memory_model/Cargo.toml
+++ b/src/memory_model/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { path = "../utils" }
 
 [dev-dependencies]
-tempfile = ">=3.0.2"
+utils = { path = "../utils" }

--- a/src/memory_model/src/mmap.rs
+++ b/src/memory_model/src/mmap.rs
@@ -307,13 +307,14 @@ impl Drop for MemoryMapping {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
+    extern crate utils;
 
-    use self::tempfile::tempfile;
-    use super::*;
-    use std::fs::File;
+    use std::fs::{File, OpenOptions};
     use std::mem;
     use std::path::Path;
+
+    use self::utils::tempfile::TempFile;
+    use super::*;
 
     #[test]
     fn basic_map() {
@@ -383,7 +384,11 @@ mod tests {
             .read_to_memory(1, &mut file, mem::size_of::<u32>())
             .is_ok());
 
-        let mut f = tempfile().unwrap();
+        let temp_f = TempFile::new().unwrap();
+        let mut f = OpenOptions::new()
+            .read(true)
+            .open(temp_f.as_path())
+            .unwrap();
         assert!(mem_map
             .read_to_memory(1, &mut f, mem::size_of::<u32>())
             .is_err());

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -4,10 +4,11 @@
 #[macro_use]
 extern crate vmm_sys_util;
 
-pub use vmm_sys_util::{errno, eventfd, ioctl, signal, terminal};
+pub use vmm_sys_util::{errno, eventfd, ioctl, tempdir, tempfile, terminal};
 
 pub mod net;
 pub mod rand;
+pub mod signal;
 pub mod sm;
 pub mod structs;
 pub mod syscall;

--- a/src/utils/src/rand.rs
+++ b/src/utils/src/rand.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::time;

--- a/src/utils/src/signal.rs
+++ b/src/utils/src/signal.rs
@@ -1,0 +1,18 @@
+extern crate libc;
+extern crate vmm_sys_util;
+
+use libc::c_int;
+pub use vmm_sys_util::signal::*;
+
+extern "C" {
+    fn __libc_current_sigrtmin() -> c_int;
+    fn __libc_current_sigrtmax() -> c_int;
+}
+
+pub fn sigrtmin() -> c_int {
+    unsafe { __libc_current_sigrtmin() }
+}
+
+pub fn sigrtmax() -> c_int {
+    unsafe { __libc_current_sigrtmax() }
+}

--- a/src/utils/src/structs.rs
+++ b/src/utils/src/structs.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;

--- a/src/utils/src/validators.rs
+++ b/src/utils/src/validators.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Misc data format validations, shared by multiple Firecracker components.

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -28,4 +28,4 @@ seccomp = { path = "../seccomp" }
 cpuid = { path = "../cpuid" }
 
 [dev-dependencies]
-tempfile = ">=3.0.2"
+libc = ">=0.2.39"

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -1,10 +1,14 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate libc;
+extern crate utils;
+
 use seccomp::{
     allow_syscall, allow_syscall_if, Error, SeccompAction, SeccompCmpArgLen as ArgLen,
     SeccompCmpOp::Eq, SeccompCondition as Cond, SeccompFilter, SeccompRule,
 };
+use utils::signal::sigrtmin;
 
 /// The default filter containing the white listed syscall rules required by `Firecracker` to
 /// function.
@@ -93,11 +97,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     1,
                     ArgLen::DWORD,
                     Eq,
-                    utils::signal::validate_signal_num(
-                        super::super::vstate::VCPU_RTSIG_OFFSET,
-                        true
-                    )
-                    .map_err(|_| Error::InvalidArgumentNumber)? as u64,
+                    (sigrtmin() + super::super::vstate::VCPU_RTSIG_OFFSET) as u64
                 )?]],
             ),
             allow_syscall(libc::SYS_timerfd_create),

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -1,9 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate logger;
-extern crate utils;
-
 use libc::{_exit, c_int, c_void, siginfo_t, SIGBUS, SIGSEGV, SIGSYS};
 
 use logger::{Metric, LOGGER, METRICS};
@@ -105,30 +102,9 @@ pub fn register_signal_handlers() -> utils::errno::Result<()> {
     // register a signal handler which will be called in the current thread and will interrupt
     // whatever work is done on the current thread, so we have to keep in mind that the registered
     // signal handler must only do async-signal-safe operations.
-    unsafe {
-        register_signal_handler(
-            SIGSYS,
-            utils::signal::SignalHandler::Siginfo(sigsys_handler),
-            false,
-            libc::SA_SIGINFO,
-        )?;
-    }
-    unsafe {
-        register_signal_handler(
-            SIGBUS,
-            utils::signal::SignalHandler::Siginfo(sigbus_sigsegv_handler),
-            false,
-            libc::SA_SIGINFO,
-        )?;
-    }
-    unsafe {
-        register_signal_handler(
-            SIGSEGV,
-            utils::signal::SignalHandler::Siginfo(sigbus_sigsegv_handler),
-            false,
-            libc::SA_SIGINFO,
-        )?;
-    }
+    register_signal_handler(SIGSYS, sigsys_handler)?;
+    register_signal_handler(SIGBUS, sigbus_sigsegv_handler)?;
+    register_signal_handler(SIGSEGV, sigbus_sigsegv_handler)?;
 
     Ok(())
 }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -228,10 +228,9 @@ impl BlockDeviceConfigs {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
 
-    use self::tempfile::NamedTempFile;
     use super::*;
+    use utils::tempfile::TempFile;
 
     // This implementation is used only in tests.
     // We cannot directly derive clone because RateLimiter does not implement clone.
@@ -257,8 +256,8 @@ mod tests {
 
     #[test]
     fn test_add_non_root_block_device() {
-        let dummy_file = NamedTempFile::new().unwrap();
-        let dummy_path = dummy_file.path().to_path_buf();
+        let dummy_file = TempFile::new().unwrap();
+        let dummy_path = dummy_file.as_path().to_path_buf();
         let dummy_id = String::from("1");
         let dummy_block_device = BlockDeviceConfig {
             path_on_host: dummy_path.clone(),
@@ -289,8 +288,8 @@ mod tests {
 
     #[test]
     fn test_add_one_root_block_device() {
-        let dummy_file = NamedTempFile::new().unwrap();
-        let dummy_path = dummy_file.path().to_path_buf();
+        let dummy_file = TempFile::new().unwrap();
+        let dummy_path = dummy_file.as_path().to_path_buf();
 
         let dummy_block_device = BlockDeviceConfig {
             path_on_host: dummy_path,
@@ -315,8 +314,8 @@ mod tests {
 
     #[test]
     fn test_add_two_root_block_devices_configs() {
-        let dummy_file_1 = NamedTempFile::new().unwrap();
-        let dummy_path_1 = dummy_file_1.path().to_path_buf();
+        let dummy_file_1 = TempFile::new().unwrap();
+        let dummy_path_1 = dummy_file_1.as_path().to_path_buf();
         let root_block_device_1 = BlockDeviceConfig {
             path_on_host: dummy_path_1,
             is_root_device: true,
@@ -326,8 +325,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = NamedTempFile::new().unwrap();
-        let dummy_path_2 = dummy_file_2.path().to_path_buf();
+        let dummy_file_2 = TempFile::new().unwrap();
+        let dummy_path_2 = dummy_file_2.as_path().to_path_buf();
         let root_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
             is_root_device: true,
@@ -350,8 +349,8 @@ mod tests {
     #[test]
     // Test BlockDevicesConfigs::add when you first add the root device and then the other devices.
     fn test_add_root_block_device_first() {
-        let dummy_file_1 = NamedTempFile::new().unwrap();
-        let dummy_path_1 = dummy_file_1.path().to_path_buf();
+        let dummy_file_1 = TempFile::new().unwrap();
+        let dummy_path_1 = dummy_file_1.as_path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1,
             is_root_device: true,
@@ -361,8 +360,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = NamedTempFile::new().unwrap();
-        let dummy_path_2 = dummy_file_2.path().to_path_buf();
+        let dummy_file_2 = TempFile::new().unwrap();
+        let dummy_path_2 = dummy_file_2.as_path().to_path_buf();
         let dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
             is_root_device: false,
@@ -372,8 +371,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_3 = NamedTempFile::new().unwrap();
-        let dummy_path_3 = dummy_file_3.path().to_path_buf();
+        let dummy_file_3 = TempFile::new().unwrap();
+        let dummy_path_3 = dummy_file_3.as_path().to_path_buf();
         let dummy_block_device_3 = BlockDeviceConfig {
             path_on_host: dummy_path_3,
             is_root_device: false,
@@ -407,8 +406,8 @@ mod tests {
     #[test]
     // Test BlockDevicesConfigs::add when you add other devices first and then the root device.
     fn test_root_block_device_add_last() {
-        let dummy_file_1 = NamedTempFile::new().unwrap();
-        let dummy_path_1 = dummy_file_1.path().to_path_buf();
+        let dummy_file_1 = TempFile::new().unwrap();
+        let dummy_path_1 = dummy_file_1.as_path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1.clone(),
             is_root_device: true,
@@ -418,8 +417,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = NamedTempFile::new().unwrap();
-        let dummy_path_2 = dummy_file_2.path().to_path_buf();
+        let dummy_file_2 = TempFile::new().unwrap();
+        let dummy_path_2 = dummy_file_2.as_path().to_path_buf();
         let dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2,
             is_root_device: false,
@@ -429,8 +428,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_3 = NamedTempFile::new().unwrap();
-        let dummy_path_3 = dummy_file_3.path().to_path_buf();
+        let dummy_file_3 = TempFile::new().unwrap();
+        let dummy_path_3 = dummy_file_3.as_path().to_path_buf();
         let dummy_block_device_3 = BlockDeviceConfig {
             path_on_host: dummy_path_3,
             is_root_device: false,
@@ -465,8 +464,8 @@ mod tests {
 
     #[test]
     fn test_update() {
-        let dummy_file_1 = NamedTempFile::new().unwrap();
-        let dummy_path_1 = dummy_file_1.path().to_path_buf();
+        let dummy_file_1 = TempFile::new().unwrap();
+        let dummy_path_1 = dummy_file_1.as_path().to_path_buf();
         let root_block_device = BlockDeviceConfig {
             path_on_host: dummy_path_1.clone(),
             is_root_device: true,
@@ -476,8 +475,8 @@ mod tests {
             rate_limiter: None,
         };
 
-        let dummy_file_2 = NamedTempFile::new().unwrap();
-        let dummy_path_2 = dummy_file_2.path().to_path_buf();
+        let dummy_file_2 = TempFile::new().unwrap();
+        let dummy_path_2 = dummy_file_2.as_path().to_path_buf();
         let mut dummy_block_device_2 = BlockDeviceConfig {
             path_on_host: dummy_path_2.clone(),
             is_root_device: false,

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -127,15 +127,15 @@ impl Display for LoggerConfigError {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-    use self::tempfile::NamedTempFile;
+
     use super::*;
+    use utils::tempfile::TempFile;
 
     #[test]
     fn test_log_writer() {
         let log_file_temp =
-            NamedTempFile::new().expect("Failed to create temporary output logging file.");
-        let good_file = String::from(log_file_temp.path().to_path_buf().to_str().unwrap());
+            TempFile::new().expect("Failed to create temporary output logging file.");
+        let good_file = String::from(log_file_temp.as_path().to_path_buf().to_str().unwrap());
         let res = LoggerWriter::new(&good_file);
         assert!(res.is_ok());
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.3
+COVERAGE_TARGET_PCT = 85.2
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Signed-off-by: Iulian Barbu <iul@amazon.com>

## Reason for This PR

Fixes #1125 

## Description of Changes

Some of Firecracker crates have dev-dependency on `tempfile` crate from crates.io. This crate has other dependencies on its own that are brought into Firecracker as well.

Removed `tempfile` crate dev-dependency and used instead `vmm-sys-util` `tempfile module`, which basically replaces `tempfile` crate with a simpler implementation for temporary files & temporary directories, without additional dependencies.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
