### PR TITLE
Move SyscallReturnCode to utils/syscall.rs

### DIFF
--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -9,7 +9,7 @@ use std::ptr::null;
 use libc;
 
 use super::{to_cstring, Error, Result};
-use utils::SyscallReturnCode;
+use utils::syscall::SyscallReturnCode;
 
 const OLD_ROOT_DIR_NAME_NUL_TERMINATED: &[u8] = b"old_root\0";
 const ROOT_DIR_NUL_TERMINATED: &[u8] = b"/\0";

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -13,8 +13,8 @@ use libc;
 
 use cgroup::Cgroup;
 use chroot::chroot;
+use utils::syscall::SyscallReturnCode;
 use utils::validators;
-use utils::SyscallReturnCode;
 use {Error, Result};
 
 const STDIN_FILENO: libc::c_int = 0;

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,6 +1,6 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
+
 #[macro_use]
 extern crate vmm_sys_util;
 
@@ -9,23 +9,6 @@ pub use vmm_sys_util::{errno, eventfd, ioctl, signal, terminal};
 pub mod net;
 pub mod rand;
 pub mod structs;
+pub mod syscall;
 pub mod time;
 pub mod validators;
-
-/// Wrapper to interpret syscall exit codes and provide a rustacean `io::Result`
-pub struct SyscallReturnCode(pub std::os::raw::c_int);
-impl SyscallReturnCode {
-    /// Returns the last OS error if value is -1 or Ok(value) otherwise.
-    pub fn into_result(self) -> std::io::Result<std::os::raw::c_int> {
-        if self.0 == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(self.0)
-        }
-    }
-
-    /// Returns the last OS error if value is -1 or Ok(()) otherwise.
-    pub fn into_empty_result(self) -> std::io::Result<()> {
-        self.into_result().map(|_| ())
-    }
-}

--- a/src/utils/src/syscall.rs
+++ b/src/utils/src/syscall.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::raw::c_int;
+
+/// Wrapper to interpret syscall exit codes and provide a rustacean `io::Result`
+pub struct SyscallReturnCode(pub c_int);
+impl SyscallReturnCode {
+    /// Returns the last OS error if value is -1 or Ok(value) otherwise.
+    pub fn into_result(self) -> std::io::Result<c_int> {
+        if self.0 == -1 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(self.0)
+        }
+    }
+
+    /// Returns the last OS error if value is -1 or Ok(()) otherwise.
+    pub fn into_empty_result(self) -> std::io::Result<()> {
+        self.into_result().map(|_| ())
+    }
+}


### PR DESCRIPTION
Signed-off-by: Iulian Barbu <iul@amazon.com>

## Reason for This PR

Fixes #1422 

## Description of Changes

Moved `SyscallReturnCode` struct and logic pertaining to this
struct from utils/src/lib.rs to utils/src/syscall.rs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
