### PR TITLE
Update to kvm-bindings v0.2 and kvm-ioctls v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,9 @@ name = "kvm-bindings"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d381156ad52005b4655a9421401f02b80f9f049e653496e3ea6639a83fc12453"
+dependencies = [
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "kvm-ioctls"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e647ed90b0f5214eb938601fc2e7aad2fc624fde62f13c0c2e672407b8ce7b"
+checksum = "ac8a59db3c7098cc87f140eb7a4317decda01dd42e7979b1d4d789bd6f6c599a"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-kvm-bindings = ">=0.1"
+kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.3"
 libc = ">=0.2.39"
 

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.3"
+kvm-ioctls = ">=0.4"
 libc = ">=0.2.39"
 
 arch_gen = { path = "../arch_gen" }

--- a/src/arch/src/aarch64/gic.rs
+++ b/src/arch/src/aarch64/gic.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{boxed::Box, io, result};
+use std::{boxed::Box, result};
 
 use kvm_ioctls::{DeviceFd, VmFd};
 
@@ -12,9 +12,9 @@ use super::gicv3::GICv3;
 #[derive(Debug)]
 pub enum Error {
     /// Error while calling KVM ioctl for setting up the global interrupt controller.
-    CreateGIC(io::Error),
+    CreateGIC(kvm_ioctls::Error),
     /// Error while setting device attributes for the GIC.
-    SetDeviceAttribute(io::Error),
+    SetDeviceAttribute(kvm_ioctls::Error),
 }
 type Result<T> = result::Result<T, Error>;
 

--- a/src/arch/src/aarch64/gicv2.rs
+++ b/src/arch/src/aarch64/gicv2.rs
@@ -3,7 +3,7 @@
 
 use std::{boxed::Box, result};
 
-use kvm_ioctls::{DeviceFd, VmFd};
+use kvm_ioctls::DeviceFd;
 
 use super::gic::{Error, GICDevice};
 

--- a/src/arch/src/aarch64/gicv3.rs
+++ b/src/arch/src/aarch64/gicv3.rs
@@ -3,7 +3,7 @@
 
 use std::{boxed::Box, result};
 
-use kvm_ioctls::{DeviceFd, VmFd};
+use kvm_ioctls::DeviceFd;
 
 use super::gic::{Error, GICDevice};
 

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::{io, mem, result};
+use std::{mem, result};
 
 use super::get_fdt_addr;
 use kvm_bindings::{
@@ -23,9 +23,9 @@ use memory_model::GuestMemory;
 #[derive(Debug)]
 pub enum Error {
     /// Failed to set core register (PC, PSTATE or general purpose ones).
-    SetCoreRegister(io::Error),
+    SetCoreRegister(kvm_ioctls::Error),
     /// Failed to get a system register.
-    GetSysRegister(io::Error),
+    GetSysRegister(kvm_ioctls::Error),
 }
 type Result<T> = result::Result<T, Error>;
 
@@ -167,7 +167,7 @@ mod tests {
         let mem = GuestMemory::new(&regions).expect("Cannot initialize memory");
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {
-            Error::SetCoreRegister(ref e) => assert_eq!(e.raw_os_error(), Some(libc::ENOEXEC)),
+            Error::SetCoreRegister(ref e) => assert_eq!(e.errno(), libc::ENOEXEC),
             _ => panic!("Expected to receive Error::SetCoreRegister"),
         }
         let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();

--- a/src/arch/src/x86_64/interrupts.rs
+++ b/src/arch/src/x86_64/interrupts.rs
@@ -5,8 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::{io, result};
-
 use kvm_bindings::kvm_lapic_state;
 use kvm_ioctls::VcpuFd;
 
@@ -14,11 +12,11 @@ use kvm_ioctls::VcpuFd;
 #[derive(Debug)]
 pub enum Error {
     /// Failure in retrieving the LAPIC configuration.
-    GetLapic(io::Error),
+    GetLapic(kvm_ioctls::Error),
     /// Failure in modifying the LAPIC configuration.
-    SetLapic(io::Error),
+    SetLapic(kvm_ioctls::Error),
 }
-type Result<T> = result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 // Defines poached from apicdef.h kernel header.
 const APIC_LVT0: usize = 0x350;

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-kvm-bindings = ">=0.1"
+kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.3"
-vmm-sys-util = ">=0.2.0"
+vmm-sys-util = ">=0.2.1"

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.3"
+kvm-ioctls = ">=0.4"
 vmm-sys-util = ">=0.2.1"

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -14,7 +14,7 @@ extern crate kvm_bindings;
 extern crate kvm_ioctls;
 extern crate vmm_sys_util;
 
-use kvm_ioctls::CpuId;
+use kvm_bindings::CpuId;
 
 mod common;
 use common::*;
@@ -44,13 +44,15 @@ mod brand_string;
 /// # Example
 /// ```
 /// extern crate cpuid;
+/// extern crate kvm_bindings;
 /// extern crate kvm_ioctls;
 ///
 /// use cpuid::{filter_cpuid, VmSpec};
-/// use kvm_ioctls::{CpuId, Kvm, MAX_KVM_CPUID_ENTRIES};
+/// use kvm_bindings::{CpuId, KVM_MAX_CPUID_ENTRIES};
+/// use kvm_ioctls::Kvm;
 ///
 /// let kvm = Kvm::new().unwrap();
-/// let mut kvm_cpuid: CpuId = kvm.get_supported_cpuid(MAX_KVM_CPUID_ENTRIES).unwrap();
+/// let mut kvm_cpuid: CpuId = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
 ///
 /// let vm_spec = VmSpec::new(0, 1, true).unwrap();
 ///

--- a/src/cpuid/src/template/c3.rs
+++ b/src/cpuid/src/template/c3.rs
@@ -3,8 +3,7 @@
 
 use bit_helper::BitHelper;
 use cpu_leaf::*;
-use kvm_bindings::kvm_cpuid_entry2;
-use kvm_ioctls::CpuId;
+use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 use transformer::*;
 
 fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) -> Result<(), Error> {

--- a/src/cpuid/src/template/t2.rs
+++ b/src/cpuid/src/template/t2.rs
@@ -3,8 +3,7 @@
 
 use bit_helper::BitHelper;
 use cpu_leaf::*;
-use kvm_bindings::kvm_cpuid_entry2;
-use kvm_ioctls::CpuId;
+use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 use transformer::*;
 
 fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) -> Result<(), Error> {

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -3,8 +3,7 @@
 
 use super::*;
 
-use kvm_bindings::KVM_CPUID_FLAG_SIGNIFCANT_INDEX;
-use kvm_ioctls::CpuId;
+use kvm_bindings::{CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX};
 
 use bit_helper::BitHelper;
 use cpu_leaf::*;

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -5,8 +5,7 @@ use super::*;
 use bit_helper::BitHelper;
 use common::get_cpuid;
 
-use kvm_bindings::kvm_cpuid_entry2;
-use kvm_ioctls::CpuId;
+use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 use transformer::Error::FamError;
 
 // constants for setting the fields of kvm_cpuid2 structures
@@ -295,7 +294,7 @@ mod test {
     fn test_use_host_cpuid_function_err() {
         let topoext_fn = get_topoext_fn();
         // check that it returns Err when there are too many entriesentry.function == topoext_fn
-        let mut cpuid = CpuId::new(kvm_ioctls::MAX_KVM_CPUID_ENTRIES);
+        let mut cpuid = CpuId::new(kvm_bindings::KVM_MAX_CPUID_ENTRIES);
         match use_host_cpuid_function(&mut cpuid, topoext_fn, true) {
             Err(Error::FamError(vmm_sys_util::fam::Error::SizeLimitExceeded)) => {}
             _ => panic!("Wrong behavior"),

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -5,8 +5,7 @@ pub mod amd;
 pub mod common;
 pub mod intel;
 
-pub use kvm_bindings::kvm_cpuid_entry2;
-use kvm_ioctls::CpuId;
+pub use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 
 use brand_string::BrandString;
 use brand_string::Reg as BsReg;

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -209,7 +209,6 @@ mod tests {
         // Read and write to the LR register.
         let v = utils::time::get_time(utils::time::ClockType::Real);
         LittleEndian::write_u32(&mut data, (v / utils::time::NANOS_PER_SECOND) as u32);
-        let tick_offset_before = rtc.tick_offset;
         let previous_now_before = rtc.previous_now;
         rtc.write(RTCLR, &mut data);
 

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -15,7 +15,7 @@ use std::mem;
 
 use super::cmdline::Error as CmdlineError;
 use memory_model::{Address, GuestAddress, GuestMemory};
-use utils::structs::{read_struct, read_struct_slice};
+use utils::structs::read_struct;
 
 #[allow(non_camel_case_types)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -118,7 +118,7 @@ where
         .map_err(|_| Error::SeekProgramHeader)?;
     let phdrs: Vec<elf::Elf64_Phdr> = unsafe {
         // Reading the structs is safe for a slice of POD structs.
-        read_struct_slice(kernel_image, ehdr.e_phnum as usize)
+        utils::structs::read_struct_slice(kernel_image, ehdr.e_phnum as usize)
             .map_err(|_| Error::ReadKernelDataStruct("Failed to read ELF program header"))?
     };
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-vmm-sys-util = ">=0.2.0"
+vmm-sys-util = ">=0.2.1"
 libc = ">=0.2.39"
 serde = ">=1.0.27"
 net_gen = { path = "../net_gen" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.3.0"
+kvm-ioctls = ">=0.4"
 libc = ">=0.2.39"
 epoll = ">=4.0.1"
 serde = ">=1.0.27"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-kvm-bindings = ">=0.1"
+kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.3.0"
 libc = ">=0.2.39"
 epoll = ">=4.0.1"

--- a/src/vmm/src/error.rs
+++ b/src/vmm/src/error.rs
@@ -765,7 +765,7 @@ mod tests {
         );
         assert_eq!(
             error_kind(StartMicrovmError::VcpuConfigure(
-                vstate::Error::SetSupportedCpusFailed(io::Error::from_raw_os_error(0))
+                vstate::Error::SetSupportedCpusFailed(utils::errno::Error::new(0))
             )),
             ErrorKind::Internal
         );

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -812,9 +812,11 @@ impl Vmm {
             ($evt: ident, $index: expr) => {{
                 self.vm
                     .fd()
-                    .register_irqfd(self.pio_device_manager.$evt.as_raw_fd(), $index)
+                    .register_irqfd(&self.pio_device_manager.$evt, $index)
                     .map_err(|e| {
-                        StartMicrovmError::LegacyIOBus(device_manager::legacy::Error::EventFd(e))
+                        StartMicrovmError::LegacyIOBus(device_manager::legacy::Error::EventFd(
+                            io::Error::from_raw_os_error(e.errno()),
+                        ))
                     })?;
             }};
         }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -78,8 +78,6 @@ use logger::error::LoggerError;
 use logger::LogOption;
 use logger::{AppInfo, Level, Metric, LOGGER, METRICS};
 use memory_model::{GuestAddress, GuestMemory};
-#[cfg(target_arch = "aarch64")]
-use serde_json::Value;
 use utils::eventfd::EventFd;
 use utils::net::TapError;
 use utils::terminal::Terminal;
@@ -767,7 +765,7 @@ impl Vmm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_serial_device(&self) -> Option<&Arc<Mutex<RawIOHandler>>> {
+    fn get_serial_device(&self) -> Option<&Arc<Mutex<dyn RawIOHandler>>> {
         self.mmio_device_manager
             .as_ref()
             .unwrap()
@@ -2885,7 +2883,6 @@ mod tests {
         vmm.setup_interrupt_controller()
             .expect("Failed to setup interrupt controller");
         assert!(vmm.attach_legacy_devices().is_ok());
-        let kernel_config = vmm.kernel_config.as_mut();
 
         let dev_man = vmm.mmio_device_manager.as_ref().unwrap();
         // On aarch64, we are using first region of the memory

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -11,8 +11,6 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
-use logger::LogOption;
-
 type Result<T> = std::result::Result<T, std::io::Error>;
 
 /// Structure `LoggerWriter` used for writing to a FIFO.
@@ -96,14 +94,15 @@ pub struct LoggerConfig {
     /// Additional logging options.
     #[cfg(target_arch = "x86_64")]
     #[serde(default = "default_log_options")]
-    pub options: Vec<LogOption>,
+    pub options: Vec<logger::LogOption>,
 }
 
 fn default_level() -> LoggerLevel {
     LoggerLevel::Warning
 }
 
-fn default_log_options() -> Vec<LogOption> {
+#[cfg(target_arch = "x86_64")]
+fn default_log_options() -> Vec<logger::LogOption> {
     vec![]
 }
 

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -556,7 +556,6 @@ mod tests {
 
     use super::super::devices;
     use super::*;
-    use vmm_config::machine_config::VmConfig;
 
     // Auxiliary function being used throughout the tests.
     fn setup_vcpu() -> (Vm, Vcpu) {
@@ -700,7 +699,6 @@ mod tests {
         // Try it for when vcpu id is 0.
         let mut vcpu = Vcpu::new_aarch64(0, vm.fd(), super::super::TimestampUs::default()).unwrap();
 
-        let vm_config = VmConfig::default();
         assert!(vcpu
             .configure_aarch64(vm.fd(), vm_mem, GuestAddress(0))
             .is_ok());


### PR DESCRIPTION
## Reason for This PR

Fixes #1385 
Fixes #1386 

## Description of Changes

No reason to pin certain versions of the rust-vmm crates in our TOMLs.
We control the exact versions we build from using the Cargo.lock.
Unpinned version numbers for `kvm-bindings`, `kvm-ioctls` and `vmm-sys-util`.

Also updated the minimum version of `vmm-sys-util` to v0.2.1 to include the FAM wrappers safe clone fix.

Updated `kvm-ioctl` errors to work with `kvm_ioctl::Error` instead of `io::Error` directly.
    
Changed to use `CpuId` from `kvm-bindings` instead of `kvm-ioctls`.
    
Updated the usages of the `kvm-ioctls` that changed their interface.
    
Replaced MSRs `unsafe` code with the safe FAM wrapper over `kvm_msrs`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`  
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided. 
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
