### PR TITLE
Ratelimiter API: Correctly return error for invalid fields in PUT/PATCH requests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 - Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
   prevent potential unwrap on None panics.
 - Raise interrupt for TX queue used descriptors - Github issue #1436
-- Fixed a bug that causes 100% cpu load when the net device rx is throttled 
+- Fixed a bug that causes 100% cpu load when the net device rx is throttled
   by the ratelimiter - Github issue #1439
+- Invalid fields in rate limiter related API requests are now failing with
+  a proper error message.
 
 ## [0.19.0]
 

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -145,4 +145,27 @@ mod tests {
         assert!(parse_put_net(&Body::new(body), Some(&"bar")).is_err());
         assert!(parse_patch_net(&Body::new(body), Some(&"bar")).is_err());
     }
+
+    #[test]
+    fn test_network_interface_body_error_handling() {
+        // Serde error for invalid field (bytes instead of bandwidth).
+        let body = r#"
+        {
+            "iface_id": "foo",
+            "rx_rate_limiter": {
+                "bytes": {
+                    "size": 62500,
+                    "refill_time": 1000
+                }
+            },
+            "tx_rate_limiter": {
+                "bytes": {
+                    "size": 62500,
+                    "refill_time": 1000
+                }
+            }
+        }"#;
+
+        assert!(parse_patch_net(&Body::new(body), Some(&"foo")).is_err());
+    }
 }

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -56,6 +56,7 @@ impl TokenBucketConfig {
 /// A public-facing, stateless structure, holding all the data we need to create a RateLimiter
 /// (live) object.
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimiterConfig {
     /// Data used to initialize the RateLimiter::bandwidth bucket.
     pub bandwidth: Option<TokenBucketConfig>,


### PR DESCRIPTION
## Reason for This PR

Invalid fields in PATCH requests should be failing properly with an error message, not silently. See #1437 for more information.

## Description of Changes

Added serde macro to the RateLimiterConfig.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
