### PR TITLE
RFC: Implement a handshake for VSock

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.3
+COVERAGE_TARGET_PCT = 85.2
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
This RFC implements a *WebSocket-like upgrading* for [host-initiated vsock connection][fc-vsock]

## Background

Currently the *[host-initiated vsock connection][fc-vsock]* is initiated with a straight-fowward `CONNECT <port_num>\n;` command:

```
2. Guest: create an AF_VSOCK socket and listen() on <port_num>;
3. Host: connect() to AF_UNIX at uds_path.
4. Host: send() "CONNECT <port_num>\n".
5. Guest: accept() the new connection.
```

This works like a charm if the sequence is correct. However, sometimes we don't know whether the guest listener has been deployed when we send the command in *STEP 4*. As a result, the connection connected in *step 3* will be closed silently.

## The issue we facing

In practice, we don't know the exact time we have set up the VSock connection successfully because there is no message talking about that. We have to write a [dailer][kata-hvsock-dailer] to check the message feedback from guest. 

```go
eot := make([]byte, 1)
if _, _, err = unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil {
	conn.Close()
	return nil, err
}
```

This dailer expects the server in guest send message out once it `accept`s the connection. However, for some servers like [ttRPC][ttrpc], they won't send anything to the client. This makes trouble to the client dailer, which has to

- wait a period and assume it is connected if connection has not been closed; or
- wait a period before the `CONNECT` and assume the server has been deployed.

### Why not use guest-initiated vsock

We prefer host-initiated link because

- For security consideration, we don't allow guest initiate a vsock connection;
- Host-initiated vsock connection are used in other cases (qemu+grpc, qemu+ttrpc, fc+grpc).

## The proposed handshake

What we proposed is a simple handshake interaction like WebSocket:

- A new command called `Upgrade <port_num>\n` on step *4*;
- *4.5a* hybrid vsock response `101\n` (*Switching Protocol*) if connected
- *4.5b* hybrid vsock response `504\n` (*Service Unavailable*) if guest has not listened on the port.

```
+---------------+                    +----------------+
|               |                    |                |
|               |  Upgrade 3         |                |
|               +------------------->+                |    no server available
|               |                    |                +-------------->
|               |  503               |                |
|               +<-------------------+                |
|               |                    |                |
|               |                    |                |                     +-------------+
|               |   (wait and retry) |                |                     |             |
|               |                    |                |                     |             |
|               |                    |                |                     | listen      |
|               |  Upgrade 3         |                |                     | here        |
|               +------------------->+                |    conn accepted    |             |
|               |                    |                +-------------------->+             |
|               |  101               |                |                     |             |
|               +<-------------------+                |                     |             |
|               |                    |                |                     |             |
|               |   (success)        |                |                     |             |
+---------------+                    +----------------+                     +-------------+
   client in                           hybrid vsock                           server in
     host                                                                       guest

```

Then the dailer may retry/fail based on the explicit reponse.

[fc-vsock]: https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md#host-initiated-connections
[kata-hvsock-dailer]: https://github.com/kata-containers/agent/blob/master/protocols/client/client.go#L420
[ttrpc]: https://github.com/containerd/ttrpc