### PR TITLE
Raise interrupt for used descriptors on tx queue and use edged triggered epoll.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - The backtrace are printed on `panic`, no longer causing a seccomp fault.
 - Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
   prevent potential unwrap on None panics.
+- Raise interrupt for TX queue used descriptors - Github issue #1436
+- Fixed a bug that causes 100% cpu load when the net device rx is throttled 
+  by the ratelimiter - Github issue #1439
 
 ## [0.19.0]
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.2
+COVERAGE_TARGET_PCT = 85.1
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1439, #1436 .

## Description of Changes

- Raise interrupt after TX queue is processed. 
- Use edged triggered epoll for the tap fd.

This change will degrade performance as it increases the interrupt rate. It will also improve emulation thread cpu usage.

I've run some benchmarks on a m5d.metal host running a microvm with 2vCPUs and 2GB of RAM.

Without this PR:
- Guest RX, throughput: 13194.73 Mbps, retransmits: 106
- Guest TX, throughput: 18468.89 Mbps, retransmits: 0

With this PR:
- Guest RX, throughput: 12484.86 Mbps, retransmits: 102 **-6%**
- Guest TX, throughput: 17103.22 Mbps, retransmits: 0 **-8%**


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] No new `unsafe` code has been added.

