### PR TITLE
comment refactor

### DIFF
--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -50,14 +50,15 @@ fn readln_special<T: AsRef<Path>>(file_path: &T) -> Result<String> {
     Ok(line)
 }
 
-// If we call inherit_from_parent_aux(.../A/B/C, file, condition), the following will happen:
-// 1) If .../A/B/C/file does not exist, or if .../A/B/file does not exist, return an error.
-// 2) If .../A/B/file is not empty, write the first line of .../A/B/file into .../A/B/C/file
-// and return.
-// 3) If ../A/B/file exists but it is empty, call inherit_from_parent_aux(.../A/B, file, false).
-// 4) If .../A/B/file is no longer empty, write the first line of .../A/B/file into
-// .../A/B/C/file, and return.
-// 5) Otherwise, return an error.
+// If we call inherit_from_parent_aux(.../A/B/C, file_name, true), the following will happen:
+// 1) If .../A/B/file_name is not empty, write the first line of .../A/B/file_name into .../A/B/C/file_name and return.
+// 2) If .../A/B/file_name is exist but empty then call inherit_from_parent_aux(.../A/B, file_name, false). 
+//    If still .../A/B/file_name is empty throw error or else write the first line of .../A/B/file_name into 
+//    .../A/B/C/file_name and return.
+
+// If we call inherit_from_parent_aux(.../A/B, file_name, false), the following will happen:
+// 1) If .../A/file_name is not empty, write the first line of .../A/file_name into .../A/B/file_name and return.
+// 2) If .../A/file_name is exist but empty then throw error.
 
 // How is this helpful? When creating cgroup folders for the jailer Firecracker instance, the jailer
 // will create a hierarchy that looks like <cgroup_base>/firecracker/<id>. Depending on each


### PR DESCRIPTION
## Reason for This PR

While reading the source code I found some comment in **_src/jailer/src/cgroup.rs_** is misleading so I decided to change that comment.

## Description of Changes

I have changed the comment in **_src/jailer/src/cgroup.rs_** file to match the working of the **_inherit_from_parent_aux_** function

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
