### PR TITLE
cgroup: removed superfluous code

### DIFF
--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -217,9 +217,7 @@ impl Cgroup {
 
             // And now add "tasks" to get the path of the corresponding tasks file.
             path_buf.push("tasks");
-            if !tasks_files.contains(&path_buf) {
-                tasks_files.push(path_buf);
-            }
+            tasks_files.push(path_buf);
         }
 
         Ok(Cgroup { tasks_files })


### PR DESCRIPTION
removed some superfluous code.

## Description of Changes

Removed a superfluous check inside the jailer's cgroup management regarding setup of controllers.

Checking that the tasks_files does not already contain some value is redundant since the code before it makes sure that every value in `found_controllers` is unique and contains no less and no more than the controllers defined in the 
```const CONTROLLERS: [&str; 3] = [CONTROLLER_CPU, CONTROLLER_CPUSET, CONTROLLER_PIDS];```
variable.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR (neither is applicable to this PR).
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
