### PR TITLE
docs: update swagger path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Firecracker's overall architecture is described in
 
 Firecracker consists of a single micro Virtual Machine Manager process that
 exposes an API endpoint to the host once started. The API is
-[specified in OpenAPI format](api_server/swagger/firecracker.yaml). Read more
+[specified in OpenAPI format](src/api_server/swagger/firecracker.yaml). Read more
 about it in the [API docs](docs/api_requests).
 
 The **API endpoint** can be used to:

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -18,7 +18,7 @@ enough RAM, etc.), customers can rely on the following:
    they are logged³ by the Firecracker process.
 1. **API Stability:** The API socket is always available and the API conforms
    to the in-tree
-   [Open API specification](api_server/swagger/firecracker.yaml). API failures
+   [Open API specification](src/api_server/swagger/firecracker.yaml). API failures
    are logged in the Firecracker log.
 1. **Overhead:** For a Firecracker virtual machine manager running a microVM
    with `1 CPUs and 128 MiB of RAM`, and a guest OS with the Firecracker-tuned

--- a/docs/api_requests/actions.md
+++ b/docs/api_requests/actions.md
@@ -4,7 +4,7 @@ Firecracker microVMs can execute actions that can be triggered via `PUT`
 requests on the `/actions` resource.
 
 Details about the required fields can be found in the
-[swagger definition](../../api_server/swagger/firecracker.yaml).
+[swagger definition](../../src/api_server/swagger/firecracker.yaml).
 
 ## BlockDeviceRescan
 

--- a/docs/api_requests/logger.md
+++ b/docs/api_requests/logger.md
@@ -21,7 +21,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
 ```
 
 Details about the required and optional fields can be found in the
-[swagger definition](../../api_server/swagger/firecracker.yaml).
+[swagger definition](../../src/api_server/swagger/firecracker.yaml).
 
 The `logs.fifo` file stores the human readable logs (i.e errors,
 warnings etc) while the `metrics.fifo` file stores the metrics

--- a/docs/api_requests/patch-network-interface.md
+++ b/docs/api_requests/patch-network-interface.md
@@ -58,7 +58,7 @@ Accept: application/json
 ```
 
 The full specification of the data structures available for this call can be
-found in our [OpenAPI spec](../../api_server/swagger/firecracker.yaml).
+found in our [OpenAPI spec](../../src/api_server/swagger/firecracker.yaml).
 
 **Note**: The data provided for the update is merged with the existing data.
 In the above example, the RX rate limit is updated, but the TX rate limit


### PR DESCRIPTION
## Reason for This PR

Path to swagger definition is broken by commit b6f46364eacf ("build: workspace cleanup").

## Description of Changes

Update to new path since commit b6f46364eacf ("build: workspace cleanup").

git grep -l -e api_server/swagger --and --not -e src/api_server/swagger \
| xargs sed -i 's:api_server/swagger:src/api_server/swagger:'

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] ~~Either this PR is linked to an issue, or,~~ the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] ~~Either no docs need to be updated as part of this PR, or,~~ the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, ~~or, code-level documentation for touched
      code is included in this PR.~~
- [x] Either no API changes are included in this PR, ~~or, the API changes are
      reflected in `firecracker/swagger.yaml`.~~
- [x] Either the changes in this PR have no user impact, ~~or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.~~
- [x] Either no new `unsafe` code has been added, ~~or, the newly added `unsafe`
      code is unavoidable and properly documented.~~
