### PR TITLE
Fix CVE-2019-18960

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed a logical error in bounds checking performed on vsock virtio
+  descriptors (CVE-2019-18960).
 - Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
 - The backtrace are printed on `panic`, no longer causing a seccomp fault.
 - Fixed #1375 - Change logger options type from Value to Vec<LogOption> to

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -108,7 +108,7 @@ impl<'a> DescriptorChain<'a> {
     fn is_valid(&self) -> bool {
         !(self
             .mem
-            .checked_offset(self.addr, self.len as usize)
+            .checked_range_offset(self.addr, self.len as usize)
             .is_none()
             || (self.has_next() && self.next >= self.queue_size))
     }

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -115,7 +115,7 @@ impl VsockPacket {
         let mut pkt = Self {
             hdr: head
                 .mem
-                .get_host_address(head.addr)
+                .get_host_address(head.addr, VSOCK_PKT_HDR_SIZE)
                 .map_err(VsockError::GuestMemory)? as *mut u8,
             buf: None,
             buf_size: 0,
@@ -150,7 +150,7 @@ impl VsockPacket {
         pkt.buf = Some(
             buf_desc
                 .mem
-                .get_host_address(buf_desc.addr)
+                .get_host_address(buf_desc.addr, pkt.buf_size)
                 .map_err(VsockError::GuestMemory)? as *mut u8,
         );
 
@@ -178,19 +178,20 @@ impl VsockPacket {
             return Err(VsockError::BufDescMissing);
         }
         let buf_desc = head.next_descriptor().ok_or(VsockError::BufDescMissing)?;
+        let buf_size = buf_desc.len as usize;
 
         Ok(Self {
             hdr: head
                 .mem
-                .get_host_address(head.addr)
+                .get_host_address(head.addr, VSOCK_PKT_HDR_SIZE)
                 .map_err(VsockError::GuestMemory)? as *mut u8,
             buf: Some(
                 buf_desc
                     .mem
-                    .get_host_address(buf_desc.addr)
+                    .get_host_address(buf_desc.addr, buf_size)
                     .map_err(VsockError::GuestMemory)? as *mut u8,
             ),
-            buf_size: buf_desc.len as usize,
+            buf_size,
         })
     }
 
@@ -372,7 +373,9 @@ mod tests {
 
     fn set_pkt_len(len: u32, guest_desc: &GuestQDesc, mem: &GuestMemory) {
         let hdr_gpa = guest_desc.addr.get();
-        let hdr_ptr = mem.get_host_address(GuestAddress(hdr_gpa)).unwrap() as *mut u8;
+        let hdr_ptr = mem
+            .get_host_address(GuestAddress(hdr_gpa), VSOCK_PKT_HDR_SIZE)
+            .unwrap() as *mut u8;
         let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
 
         LittleEndian::write_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);

--- a/src/memory_model/src/guest_memory.rs
+++ b/src/memory_model/src/guest_memory.rs
@@ -124,11 +124,32 @@ impl GuestMemory {
         false
     }
 
-    /// Returns the address plus the offset if it is in range.
+    /// Returns the address plus the offset if the result falls within a valid memory region. The
+    /// resulting address and base address may belong to different memory regions, and the base
+    /// might not even exist in a valid region.
     pub fn checked_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {
         if let Some(addr) = base.checked_add(offset as u64) {
             for region in self.regions.iter() {
                 if addr >= region.guest_base && addr < region_end(region) {
+                    return Some(addr);
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the address plus the offset if base and the result belong to the same memory
+    /// region (Firecracker currently does not use adjacent memory regions, so distinct regions
+    /// always have a gap in-between).
+    pub fn checked_range_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {
+        if let Some(addr) = base.checked_add(offset as u64) {
+            for region in self.regions.iter() {
+                let region_end = region_end(region);
+                if base >= region.guest_base
+                    && base < region_end
+                    && addr >= region.guest_base
+                    && addr < region_end
+                {
                     return Some(addr);
                 }
             }
@@ -374,10 +395,14 @@ impl GuestMemory {
     /// Converts a GuestAddress into a pointer in the address space of this
     /// process. This should only be necessary for giving addresses to the
     /// kernel, as with vhost ioctls. Normal reads/writes to guest memory should
-    /// be done through `write_from_memory`, `read_obj_from_addr`, etc.
+    /// be done through `write_from_memory`, `read_obj_from_addr`, etc. This method
+    /// also checks whether the provided GuestAddress and size define a valid range
+    /// in the guest memory region, which is helpful to ensure the operation that
+    /// uses the result does not access memory outside the guest memory mappings.
     ///
     /// # Arguments
     /// * `guest_addr` - Guest address to convert.
+    /// * `size` - The size of the range to validate starting at `guest_addr`.
     ///
     /// # Examples
     ///
@@ -386,13 +411,13 @@ impl GuestMemory {
     /// fn test_host_addr() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
     ///     let mut gm = GuestMemory::new(&vec![(start_addr, 0x500)]).map_err(|_| ())?;
-    ///     let addr = gm.get_host_address(GuestAddress(0x1200)).unwrap();
+    ///     let addr = gm.get_host_address(GuestAddress(0x1200), 1).unwrap();
     ///     println!("Host address is {:p}", addr);
     ///     Ok(())
     /// }
     /// ```
-    pub fn get_host_address(&self, guest_addr: GuestAddress) -> Result<*const u8> {
-        self.do_in_region(guest_addr, 1, |mapping, offset| {
+    pub fn get_host_address(&self, guest_addr: GuestAddress, size: usize) -> Result<*const u8> {
+        self.do_in_region(guest_addr, size, |mapping, offset| {
             // This is safe; `do_in_region` already checks that offset is in
             // bounds.
             Ok(unsafe { mapping.as_ptr().add(offset) } as *const u8)
@@ -503,9 +528,48 @@ mod tests {
         let end_addr = GuestAddress(0xc00);
         assert!(!guest_mem.address_in_range(end_addr));
         assert_eq!(guest_mem.end_addr(), end_addr);
-        assert!(guest_mem.checked_offset(start_addr1, 0x900).is_some());
+
+        // Begins and ends within first region.
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0x300),
+            Some(GuestAddress(0x300))
+        );
+        assert_eq!(
+            guest_mem.checked_range_offset(start_addr1, 0x300),
+            Some(GuestAddress(0x300))
+        );
+
+        // Begins in the first region, and ends in the second, crossing the gap.
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0x900),
+            Some(GuestAddress(0x900))
+        );
+        assert!(guest_mem.checked_range_offset(start_addr1, 0x900).is_none());
+
+        // Goes past the end of the first region, into the gap.
         assert!(guest_mem.checked_offset(start_addr1, 0x700).is_none());
+        assert!(guest_mem.checked_range_offset(start_addr1, 0x700).is_none());
+
+        // Starts in the second region, and goes past the end of it.
         assert!(guest_mem.checked_offset(start_addr2, 0xc00).is_none());
+        assert!(guest_mem.checked_range_offset(start_addr2, 0xc00).is_none());
+
+        // Exists entirely within the gap.
+        assert!(guest_mem
+            .checked_offset(GuestAddress(0x500), 0x100)
+            .is_none());
+        assert!(guest_mem
+            .checked_range_offset(GuestAddress(0x500), 0x100)
+            .is_none());
+
+        // Starts inside the gap, crosses into the second region.
+        assert_eq!(
+            guest_mem.checked_offset(GuestAddress(0x500), 0x400),
+            Some(GuestAddress(0x900))
+        );
+        assert!(guest_mem
+            .checked_range_offset(GuestAddress(0x500), 0x400)
+            .is_none());
     }
 
     #[test]
@@ -631,17 +695,41 @@ mod tests {
         let start_addr2 = GuestAddress(0x100);
         let mem = GuestMemory::new(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
 
+        assert!(mem.get_host_address(start_addr1, 0x100).is_ok());
+        // Error because we go past the end of the first region.
+        assert!(mem.get_host_address(start_addr1, 0x101).is_err());
+
+        assert!(mem
+            .get_host_address(start_addr2.checked_add(0x100).unwrap(), 0x300)
+            .is_ok());
+
+        // Error because we go past the end of the second region.
+        assert!(mem
+            .get_host_address(start_addr2.checked_add(0x100).unwrap(), 0x301)
+            .is_err());
+
+        // Error because we start in the gap between regions.
+        assert!(mem
+            .get_host_address(start_addr2.checked_sub(1).unwrap(), 0x100)
+            .is_err());
+
+        // Error because we start in the first region, but when also adding the size we end
+        // up in the second region.
+        assert!(mem
+            .get_host_address(start_addr1, (start_addr2.0 + 1) as usize)
+            .is_err());
+
         // Verify the host addresses match what we expect from the mappings.
         let addr1_base = get_mapping(&mem, start_addr1).unwrap();
         let addr2_base = get_mapping(&mem, start_addr2).unwrap();
-        let host_addr1 = mem.get_host_address(start_addr1).unwrap();
-        let host_addr2 = mem.get_host_address(start_addr2).unwrap();
+        let host_addr1 = mem.get_host_address(start_addr1, 1).unwrap();
+        let host_addr2 = mem.get_host_address(start_addr2, 1).unwrap();
         assert_eq!(host_addr1, addr1_base);
         assert_eq!(host_addr2, addr2_base);
 
         // Check that a bad address returns an error.
         let bad_addr = GuestAddress(0x12_3456);
-        assert!(mem.get_host_address(bad_addr).is_err());
+        assert!(mem.get_host_address(bad_addr, 1).is_err());
     }
 
     #[test]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.1
+COVERAGE_TARGET_PCT = 85.2
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixed a logical error in bounds checking performed on vsock virtio descriptors. (CVE-2019-18960)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
