### PR TITLE
[memory_model] rename DataInit to ByteValued

### DIFF
--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -17,18 +17,18 @@ pub mod regs;
 use std::mem;
 
 use arch_gen::x86::bootparam::{boot_params, E820_RAM};
-use memory_model::{Address, DataInit, GuestAddress, GuestMemory};
+use memory_model::{Address, ByteValued, GuestAddress, GuestMemory};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
-// trait (in this case `DataInit`) where:
+// trait (in this case `ByteValued`) where:
 // *    the type that is implementing the trait is foreign or
 // *    all of the parameters being passed to the trait (if there are any) are also foreign
 // is prohibited.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct BootParamsWrapper(boot_params);
 
 // It is safe to initialize BootParamsWrap which is a wrapper over `boot_params` (a series of ints).
-unsafe impl DataInit for BootParamsWrapper {}
+unsafe impl ByteValued for BootParamsWrapper {}
 
 /// Errors thrown while configuring x86_64 system.
 #[derive(Debug, PartialEq)]

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -13,36 +13,36 @@ use std::slice;
 use libc::c_char;
 
 use arch_gen::x86::mpspec;
-use memory_model::{Address, DataInit, GuestAddress, GuestMemory};
+use memory_model::{Address, ByteValued, GuestAddress, GuestMemory};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
-// trait (in this case `DataInit`) where:
+// trait (in this case `ByteValued`) where:
 // *    the type that is implementing the trait is foreign or
 // *    all of the parameters being passed to the trait (if there are any) are also foreign
 // is prohibited.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcBusWrapper(mpspec::mpc_bus);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcCpuWrapper(mpspec::mpc_cpu);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcIntsrcWrapper(mpspec::mpc_intsrc);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcIoapicWrapper(mpspec::mpc_ioapic);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcTableWrapper(mpspec::mpc_table);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpcLintsrcWrapper(mpspec::mpc_lintsrc);
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct MpfIntelWrapper(mpspec::mpf_intel);
 
 // These `mpspec` wrapper types are only data, reading them from data is a safe initialization.
-unsafe impl DataInit for MpcBusWrapper {}
-unsafe impl DataInit for MpcCpuWrapper {}
-unsafe impl DataInit for MpcIntsrcWrapper {}
-unsafe impl DataInit for MpcIoapicWrapper {}
-unsafe impl DataInit for MpcTableWrapper {}
-unsafe impl DataInit for MpcLintsrcWrapper {}
-unsafe impl DataInit for MpfIntelWrapper {}
+unsafe impl ByteValued for MpcBusWrapper {}
+unsafe impl ByteValued for MpcCpuWrapper {}
+unsafe impl ByteValued for MpcIntsrcWrapper {}
+unsafe impl ByteValued for MpcIoapicWrapper {}
+unsafe impl ByteValued for MpcTableWrapper {}
+unsafe impl ByteValued for MpcLintsrcWrapper {}
+unsafe impl ByteValued for MpfIntelWrapper {}
 
 // MPTABLE, describing VCPUS.
 const MPTABLE_START: u64 = 0x9fc00;

--- a/src/devices/src/virtio/block.rs
+++ b/src/devices/src/virtio/block.rs
@@ -18,7 +18,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 
 use logger::{Metric, METRICS};
-use memory_model::{DataInit, GuestAddress, GuestMemory, GuestMemoryError};
+use memory_model::{ByteValued, GuestAddress, GuestMemory, GuestMemoryError};
 use rate_limiter::{RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::*;
@@ -155,7 +155,7 @@ struct Request {
 ///
 /// The header simplifies reading the request from memory as all request follow
 /// the same memory layout.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
 struct RequestHeader {
     request_type: u32,
@@ -164,7 +164,7 @@ struct RequestHeader {
 }
 
 // Safe because RequestHeader only contains plain data.
-unsafe impl DataInit for RequestHeader {}
+unsafe impl ByteValued for RequestHeader {}
 
 impl RequestHeader {
     /// Reads the request header from GuestMemory starting at `addr`.

--- a/src/memory_model/src/bytes.rs
+++ b/src/memory_model/src/bytes.rs
@@ -1,0 +1,50 @@
+// Portions Copyright 2019 Red Hat, Inc.
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+//! Define the ByteValued trait to mark that it is safe to instantiate the struct with random data.
+
+/// Types for which it is safe to initialize from raw data.
+///
+/// A type `T` is `ByteValued` if and only if it can be initialized by reading its contents from a
+/// byte array.  This is generally true for all plain-old-data structs.  It is notably not true for
+/// any type that includes a reference.
+///
+/// Implementing this trait guarantees that it is safe to instantiate the struct with random data.
+pub unsafe trait ByteValued: Copy + Default + Send + Sync {}
+
+// All intrinsic types and arrays of intrinsic types are ByteValued. They are just numbers.
+macro_rules! byte_valued_array {
+    ($T:ty, $($N:expr)+) => {
+        $(
+            unsafe impl ByteValued for [$T; $N] {}
+        )+
+    }
+}
+macro_rules! byte_valued_type {
+    ($T:ty) => {
+        unsafe impl ByteValued for $T {}
+        byte_valued_array! {
+            $T,
+            0  1  2  3  4  5  6  7  8  9
+            10 11 12 13 14 15 16 17 18 19
+            20 21 22 23 24 25 26 27 28 29
+            30 31 32
+        }
+    };
+}
+byte_valued_type!(u8);
+byte_valued_type!(u16);
+byte_valued_type!(u32);
+byte_valued_type!(u64);
+byte_valued_type!(usize);
+byte_valued_type!(i8);
+byte_valued_type!(i16);
+byte_valued_type!(i32);
+byte_valued_type!(i64);
+byte_valued_type!(isize);

--- a/src/memory_model/src/guest_memory.rs
+++ b/src/memory_model/src/guest_memory.rs
@@ -13,7 +13,7 @@ use std::{mem, result};
 
 use guest_address::{Address, GuestAddress};
 use mmap::{self, MemoryMapping};
-use DataInit;
+use ByteValued;
 
 /// Errors associated with handling guest memory regions.
 #[derive(Debug)]
@@ -276,7 +276,7 @@ impl GuestMemory {
     ///     Ok(num1 + num2)
     /// }
     /// ```
-    pub fn read_obj_from_addr<T: DataInit>(&self, guest_addr: GuestAddress) -> Result<T> {
+    pub fn read_obj_from_addr<T: ByteValued>(&self, guest_addr: GuestAddress) -> Result<T> {
         self.do_in_region(guest_addr, mem::size_of::<T>(), |mapping, offset| {
             mapping
                 .read_obj(offset)
@@ -302,7 +302,7 @@ impl GuestMemory {
     ///         .map_err(|_| ())
     /// }
     /// ```
-    pub fn write_obj_at_addr<T: DataInit>(&self, val: T, guest_addr: GuestAddress) -> Result<()> {
+    pub fn write_obj_at_addr<T: ByteValued>(&self, val: T, guest_addr: GuestAddress) -> Result<()> {
         self.do_in_region(guest_addr, mem::size_of::<T>(), move |mapping, offset| {
             mapping
                 .write_obj(val, offset)

--- a/src/memory_model/src/lib.rs
+++ b/src/memory_model/src/lib.rs
@@ -11,50 +11,12 @@
 
 extern crate libc;
 
-/// Types for which it is safe to initialize from raw data.
-///
-/// A type `T` is `DataInit` if and only if it can be initialized by reading its contents from a
-/// byte array.  This is generally true for all plain-old-data structs.  It is notably not true for
-/// any type that includes a reference.
-///
-/// Implementing this trait guarantees that it is safe to instantiate the struct with random data.
-pub unsafe trait DataInit: Copy + Send + Sync {}
-
-// All intrinsic types and arrays of intrinsic types are DataInit. They are just numbers.
-macro_rules! array_data_init {
-    ($T:ty, $($N:expr)+) => {
-        $(
-            unsafe impl DataInit for [$T; $N] {}
-        )+
-    }
-}
-macro_rules! data_init_type {
-    ($T:ty) => {
-        unsafe impl DataInit for $T {}
-        array_data_init! {
-            $T,
-            0  1  2  3  4  5  6  7  8  9
-            10 11 12 13 14 15 16 17 18 19
-            20 21 22 23 24 25 26 27 28 29
-            30 31 32
-        }
-    };
-}
-data_init_type!(u8);
-data_init_type!(u16);
-data_init_type!(u32);
-data_init_type!(u64);
-data_init_type!(usize);
-data_init_type!(i8);
-data_init_type!(i16);
-data_init_type!(i32);
-data_init_type!(i64);
-data_init_type!(isize);
-
+mod bytes;
 mod guest_address;
 mod guest_memory;
 mod mmap;
 
+pub use bytes::ByteValued;
 pub use guest_address::Address;
 pub use guest_address::GuestAddress;
 pub use guest_memory::Error as GuestMemoryError;

--- a/src/memory_model/src/mmap.rs
+++ b/src/memory_model/src/mmap.rs
@@ -14,7 +14,7 @@ use std::ptr::null_mut;
 
 use libc;
 
-use DataInit;
+use ByteValued;
 
 /// Errors associated with memory mapping.
 #[derive(Debug)]
@@ -154,7 +154,7 @@ impl MemoryMapping {
     /// let res = mem_map.write_obj(55u64, 16);
     /// assert!(res.is_ok());
     /// ```
-    pub fn write_obj<T: DataInit>(&self, val: T, offset: usize) -> Result<()> {
+    pub fn write_obj<T: ByteValued>(&self, val: T, offset: usize) -> Result<()> {
         unsafe {
             // Guest memory can't strictly be modeled as a slice because it is
             // volatile.  Writing to it with what compiles down to a memcpy
@@ -184,7 +184,7 @@ impl MemoryMapping {
     /// let num: u64 = mem_map.read_obj(32).unwrap();
     /// assert_eq!(55, num);
     /// ```
-    pub fn read_obj<T: DataInit>(&self, offset: usize) -> Result<T> {
+    pub fn read_obj<T: ByteValued>(&self, offset: usize) -> Result<T> {
         let (end, fail) = offset.overflowing_add(std::mem::size_of::<T>());
         if fail || end > self.size() {
             return Err(Error::InvalidAddress);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.2
+COVERAGE_TARGET_PCT = 85.1
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Signed-off-by: Serban Iorga <seriorga@amazon.com>

## Reason for This PR

#1396 

## Description of Changes

Rename DataInit trait to ByteValued. We need this in order to align with `rust-vmm/vm-memory`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
