### PR TITLE
Fixed #1469: Broken link to firecracker binaries in getting started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed #1469 - Broken GitHub location for Firecracker release binary.
+
 ## [0.20.0]
 
 ### Added

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,13 +73,13 @@ latest=$(basename $(curl -fsSLI -o /dev/null -w  %{url_effective}  https://githu
 ```
 
 ```
-curl -LOJ https://github.com/firecracker-microvm/firecracker/releases/download/${latest}/firecracker-${latest}
+curl -LOJ https://github.com/firecracker-microvm/firecracker/releases/download/${latest}/firecracker-${latest}-$(uname -m)
 ```
 
 Rename the binary to "firecracker":
 
 ```
-mv firecracker-${latest} firecracker
+mv firecracker-${latest}-$(uname -m) firecracker
 ```
 
 Make the binary executable:


### PR DESCRIPTION
## Reason for This PR

#1469 
- Fixes issue were downloading broken links would later throw `Command Not Found` exceptions while running firecracker binary

## Description of Changes

- Updated binary links in [Getting Started](https://github.com/firecracker-microvm/firecracker/blob/master/docs/getting-started.md#getting-the-firecracker-binary) documentation to include system architecture via `uname -m`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] No code has been touched.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] No new `unsafe` code has been added.
