### PR TITLE
Allow installing custom Seccomp Filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "micro_http",
  "mmds",
  "rate_limiter",
+ "seccomp",
  "serde",
  "serde_derive",
  "serde_json",

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -13,6 +13,7 @@ libc = ">=0.2.39"
 logger = { path = "../logger" }
 micro_http = { path = "../micro_http" }
 mmds = { path = "../mmds" }
+seccomp = { path = "../seccomp" }
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
 

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -3,7 +3,7 @@
 
 use seccomp::{
     Error, SeccompAction, SeccompCmpArgLen as ArgLen, SeccompCmpOp::Eq, SeccompCondition as Cond,
-    SeccompRule, SECCOMP_LEVEL_ADVANCED, SECCOMP_LEVEL_BASIC, SECCOMP_LEVEL_NONE,
+    SeccompRule,
 };
 
 #[macro_use]
@@ -11,19 +11,6 @@ mod macros;
 mod filters;
 
 pub use self::filters::default_filter;
-
-/// Applies the configured level of seccomp filtering to the current thread.
-pub fn set_seccomp_level(seccomp_level: u32) -> Result<(), Error> {
-    // Load seccomp filters before executing guest code.
-    // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
-    // altogether is the desired behaviour.
-    match seccomp_level {
-        SECCOMP_LEVEL_ADVANCED => default_filter()?.apply(),
-        SECCOMP_LEVEL_BASIC => default_filter()?.allow_all().apply(),
-        SECCOMP_LEVEL_NONE => Ok(()),
-        _ => Err(Error::InvalidLevel),
-    }
-}
 
 // See include/uapi/asm-generic/fcntl.h in the kernel code.
 const FCNTL_FD_CLOEXEC: u64 = 1;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -417,7 +417,6 @@ mod tests {
         Vmm::new(
             shared_info,
             &EventFd::new(libc::EFD_NONBLOCK).expect("cannot create eventFD"),
-            0,
         )
         .expect("Cannot Create VMM")
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.1
+COVERAGE_TARGET_PCT = 85.0
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Vmm only has a few predefined seccomp filters, however, in practice it might be useful to allow filters to be defined more dynamically. This PR allows the filters to be fully customized when creating the Vmm structure.

https://github.com/firecracker-microvm/firecracker/issues/1366

## Description of Changes

This commit aims to move the creation of seccomp filters closer to the CLI/API server and allows them to be defined before instantiating the Vmm.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
