### PR TITLE
FAQ: Document 'Resource busy' error in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -241,3 +241,10 @@ If the microVM was not configured in terms of memory size through an API request
 the host needs to meet the minimum requirement in terms of free memory size,
 namely 128 MB of free memory which the microVM defaults to.
 
+### Firecracker fails to start and returns "Resource busy" error
+
+If another hypervisor like VMware or VirtualBox is running on the host and locks `/dev/kvm`,
+Firecracker process will fail to start with "Resource busy" error.
+
+This issue can be resolved by terminating the other hypervisor running on the host,
+and allowing Firecracker to start.


### PR DESCRIPTION
## Reason for This PR

Fixes: #1109

## Description of Changes

Document 'Resource busy' error cause and possible remedial in
FAQ documentation.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
