### PR TITLE
api_server: improve termination message

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -162,7 +162,7 @@ impl ApiServer {
         start_time_cpu_us: Option<u64>,
         seccomp_filter: SeccompFilter,
     ) -> Result<()> {
-        let mut server = HttpServer::new(path).unwrap();
+        let mut server = HttpServer::new(path).expect("Error creating the HTTP server");
 
         if let Some(start_time) = start_time_us {
             let delta_us =


### PR DESCRIPTION
Turn unwrap into expect for a more friendly and
very frequently encountered exit message.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

Failing to create a new HTTP server object (most frequently due to the fact that the api socket is already in use), would throw a message error of the kind:
```
Firecracker panicked at 'called `Result::unwrap()` on an `Err` value: IOError(Os { code: 98, kind: AddrInUse, message: "Address in use" })', src/libcore/result.rs:1165:5
```
With this change the message looks like this:
```
Firecracker panicked at 'Error creating the HTTP Server: IOError(Os { code: 98, kind: AddrInUse, message: "Address in use" })', src/libcore/result.rs:1165:5
```
Furthermore, this is more in the direction of what #593 tries to accomplish.

## Description of Changes

Use `expect("pretty message")` instead of `unwrap()`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
