### PR TITLE
jailer: enforce directory check for the chroot

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -81,6 +81,10 @@ impl Env {
         let mut chroot_dir = canonicalize(chroot_base)
             .map_err(|e| Error::Canonicalize(PathBuf::from(chroot_base), e))?;
 
+        if !chroot_dir.is_dir() {
+            return Err(Error::NotADirectory(chroot_dir));
+        }
+
         chroot_dir.push(
             exec_file_path
                 .file_name()

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -54,6 +54,7 @@ pub enum Error {
     MountBind(io::Error),
     MountPropagationSlave(io::Error),
     NotAFile(PathBuf),
+    NotADirectory(PathBuf),
     NumaNode(String),
     OpenDevNull(io::Error),
     OsStringParsing(PathBuf, OsString),
@@ -164,6 +165,11 @@ impl fmt::Display for Error {
                 f,
                 "{}",
                 format!("{:?} is not a file", path).replace("\"", "")
+            ),
+            NotADirectory(ref path) => write!(
+                f,
+                "{}",
+                format!("{:?} is not a directory", path).replace("\"", "")
             ),
             NumaNode(ref node) => write!(f, "Invalid numa node: {}", node),
             OpenDevNull(ref err) => write!(f, "Failed to open /dev/null: {}", err),
@@ -545,6 +551,10 @@ mod tests {
         assert_eq!(
             format!("{}", Error::NotAFile(file_path.clone())),
             "/foo/bar is not a file",
+        );
+        assert_eq!(
+            format!("{}", Error::NotADirectory(file_path.clone())),
+            "/foo/bar is not a directory",
         );
         assert_eq!(
             format!("{}", Error::NumaNode(id.to_string())),


### PR DESCRIPTION
Signed-off-by: karthik nedunchezhiyan <karthik1705.n@gmail.com>

## Reason for This PR

directory check for the chroot_dir missed in the jailer.

## Description of Changes

added directory check for the chroot_dir in jailer.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
