### PR TITLE
Remove `--seccomp-level` argument from jailer parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Fixed #1469 - Broken GitHub location for Firecracker release binary.
 
+### Changed
+  
+- Removed redundant `--seccomp-level` jailer parameter since it can be
+  simply forwarded to the Firecracker executable using "end of command
+  options" convention.
+
 ## [0.20.0]
 
 ### Added

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -13,7 +13,6 @@ jailer --id <id> \
        [--chroot-base-dir <chroot_base>]
        [--netns <netns>]
        [--daemonize]
-       [--seccomp-level <level>]
        [--...extra arguments for Firecracker]
 ```
 
@@ -32,21 +31,21 @@ jailer --id <id> \
   jailer will use this to join the associated network namespace.
 - When present, the `--daemonize` flag causes the jailer to cal `setsid()` and
   redirect all three standard I/O file descriptors to `/dev/null`.
-- `--seccomp-level` specifies whether seccomp filters should be installed and
-  how restrictive they should be. Possible values are:
-  - 0 : disabled.
-  - 1 : basic filtering. This prohibits syscalls not whitelisted by
-    Firecracker.
-  - 2 (default): advanced filtering. This adds further checks on some of the
-    parameters of the allowed syscalls.
 - The jailer adheres to the "end of command options" convention, meaning
   all parameters specified after `--` are forwarded to Firecracker. For
   example, this can be paired with the `--config-file` Firecracker argument to
   specify a configuration file when starting Firecracker via the jailer (the
   file path and the resources referenced within must be valid relative to a
-  jailed Firecracker). Please note the jailer already passes the following
-  parameters to the Firecracker process: `--api-sock`, `--seccomp-level` and
-  `--id`.
+  jailed Firecracker). Another argument that can be passed in this way is
+  `--seccomp-level`, which specifies whether seccomp filters should be installed
+  and how restrictive they should be. Possible values are:
+  - 0 : disabled.
+  - 1 : basic filtering. This prohibits syscalls not whitelisted by
+    Firecracker.
+  - 2 (default): advanced filtering. This adds further checks on some of the
+    parameters of the allowed syscalls.
+  Please note the jailer already passes the following parameters to the
+  Firecracker process: `--api-sock` and `--id`.
 
 ## Jailer Operation
 
@@ -87,12 +86,10 @@ After starting, the Jailer goes through the following operations:
   `STDOUT`, and `STDERR` to `/dev/null`.
 - Drop privileges via setting the provided `uid` and `gid`.
 - Exec into `<exec_file_name> --id=<id> --api-sock=/api.socket
-  --seccomp-level=<level> --start-time-us=<opaque>
-  --start-time-cpu-us=<opaque>` (and also forward any extra arguments provided
-  to the jailer after `--`, as mentioned in the **Jailer Usage** section),
-  where:
+  --start-time-us=<opaque> --start-time-cpu-us=<opaque>` (and also forward
+  any extra arguments provided to the jailer after `--`, as mentioned in
+  the **Jailer Usage** section), where:
   - `id`: (`string`) - The `id` argument provided to jailer.
-  - `level`: (`number`) - the `--seccomp-level` argument provided to jailer.
   - `opaque`: (`number`) time calculated by the jailer that it spent doing
      its work.
 
@@ -192,7 +189,6 @@ Finally, the jailer switches the `uid` to `123`, and `gid` to `100`, and execs
 ./firecracker \
   --id="551e7604-e35c-42b3-b825-416853441234" \
   --api-sock=/api.socket \
-  --seccomp-level=2 \
   --start-time-us=<opaque> \
   --start-time-cpu-us=<opaque>
 ```

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -24,10 +24,6 @@ To set up the jailer correctly, you'll need to:
   their individually owned resources in the unlikely case where any one of the
   jails is broken out of.
 
-- Use Jailer's ``--seccomp-level 2`` flag to enable seccomp filter. The Jailer
-  will apply a restrictive filter on what ``syscall`` and associated call
-  parameters can issued by Firecracker.
-
 Additional details of Jailer features can be found in the
 [Jailer documentation](jailer.md).
 

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -49,7 +49,6 @@ pub struct Env {
     gid: u32,
     netns: Option<String>,
     daemonize: bool,
-    seccomp_level: u32,
     start_time_us: u64,
     start_time_cpu_us: u64,
     extra_args: Vec<String>,
@@ -110,13 +109,6 @@ impl Env {
 
         let daemonize = args.is_present("daemonize");
 
-        // The value of the argument can be safely unwrapped, because a default value was specified.
-        // It can be parsed into an unsigned integer since its possible values were specified and
-        // they are all unsigned integers.
-        let seccomp_level = get_value(&args, "seccomp-level")?
-            .parse::<u32>()
-            .map_err(Error::SeccompLevel)?;
-
         let extra_args = args
             .values_of("extra-args")
             .into_iter()
@@ -133,7 +125,6 @@ impl Env {
             gid,
             netns,
             daemonize,
-            seccomp_level,
             start_time_us,
             start_time_cpu_us,
             extra_args,
@@ -306,7 +297,6 @@ impl Env {
         Err(Error::Exec(
             Command::new(chroot_exec_file)
                 .arg(format!("--id={}", self.id))
-                .arg(format!("--seccomp-level={}", self.seccomp_level))
                 .arg(format!("--start-time-us={}", self.start_time_us))
                 .arg(format!("--start-time-cpu-us={}", self.start_time_cpu_us))
                 .arg(format!("--api-sock=/{}", socket_file_name))

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -29,7 +29,6 @@ class JailerContext:
     chroot_base = None
     netns = None
     daemonize = None
-    seccomp_level = None
 
     def __init__(
             self,
@@ -41,7 +40,6 @@ class JailerContext:
             chroot_base=JAILER_DEFAULT_CHROOT,
             netns=None,
             daemonize=True,
-            seccomp_level=2
     ):
         """Set up jailer fields.
 
@@ -57,7 +55,6 @@ class JailerContext:
         self.chroot_base = chroot_base
         self.netns = netns if netns is not None else jailer_id
         self.daemonize = daemonize
-        self.seccomp_level = seccomp_level
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -91,10 +88,6 @@ class JailerContext:
             jailer_param_list.extend(['--netns', str(self.netns_file_path())])
         if self.daemonize:
             jailer_param_list.append('--daemonize')
-        if self.seccomp_level is not None:
-            jailer_param_list.extend(
-                ['--seccomp-level', str(self.seccomp_level)]
-            )
         if config_file is not None:
             jailer_param_list.extend(['--'])
             jailer_param_list.extend(['--config-file', str(config_file)])


### PR DESCRIPTION
## Reason for This PR

`--seccomp-level` command line argument, if passed to jailer process, was only sent further to Firecracker. This was a leftover from when the jailer was setting the seccomp filters.

## Description of Changes

Remove `--secomp-level` from jailer parameters; now this argument should be specified after `--` (end of command options) in order to be forwarded to Firecracker process.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] No new `unsafe` code has been added.
