### PR TITLE
Migrate Metrics and the Serial device to EventManager (polly)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "utils",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "polly",
  "seccomp",
  "tempfile",
+ "timerfd",
  "utils",
  "vmm",
 ]
@@ -580,7 +581,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
- "timerfd",
  "utils",
 ]
 

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -14,9 +14,9 @@ logger = { path = "../logger" }
 memory_model = { path = "../memory_model" }
 utils = { path = "../utils" }
 net_gen = { path = "../net_gen" }
+polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 virtio_gen = { path = "../virtio_gen" }
-polly = { path = "../polly" }
 
 [dev-dependencies]
 utils = { path = "../utils" }

--- a/src/devices/src/bus.rs
+++ b/src/devices/src/bus.rs
@@ -32,18 +32,6 @@ pub trait BusDevice: AsAny + Send {
     }
 }
 
-/// Trait for devices that handle raw non-blocking I/O requests.
-pub trait RawIOHandler {
-    /// Send raw input to this emulated device.
-    fn raw_input(&mut self, _data: &[u8]) -> io::Result<()> {
-        Ok(())
-    }
-    /// Receive raw output from this emulated device.
-    fn raw_output(&mut self, _data: &mut [u8]) -> io::Result<()> {
-        Ok(())
-    }
-}
-
 #[derive(Debug)]
 pub enum Error {
     /// The insertion failed because the new device overlapped with an old device.

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -14,4 +14,5 @@ pub use self::i8042::Error as I8042DeviceError;
 pub use self::i8042::I8042Device;
 #[cfg(target_arch = "aarch64")]
 pub use self::rtc_pl031::RTC;
+pub use self::serial::ReadableFd;
 pub use self::serial::Serial;

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -14,7 +14,7 @@ use polly::event_manager::EventHandler;
 use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
 use utils::eventfd::EventFd;
 
-use crate::bus::{BusDevice, RawIOHandler};
+use crate::bus::BusDevice;
 
 const LOOP_SIZE: usize = 0x40;
 
@@ -239,9 +239,7 @@ impl Serial {
             _ => 0,
         }
     }
-}
 
-impl RawIOHandler for Serial {
     fn raw_input(&mut self, data: &[u8]) -> io::Result<()> {
         if !self.is_loop() {
             self.in_buffer.extend(data);
@@ -355,7 +353,6 @@ mod tests {
     fn serial_input() {
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let serial_out = SharedBuffer::new();
-        let mut buffer: Vec<u8> = Vec::with_capacity(16);
 
         let mut serial =
             Serial::new_out(intr_evt.try_clone().unwrap(), Box::new(serial_out.clone()));
@@ -365,7 +362,6 @@ mod tests {
         assert!(intr_evt.write(1).is_ok());
         serial.write(u64::from(IER), &[IER_RECV_BIT]);
         serial.raw_input(&[b'a', b'b', b'c']).unwrap();
-        serial.raw_output(buffer.as_mut_slice()).unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);
 

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -26,7 +26,7 @@ mod bus;
 pub mod legacy;
 pub mod virtio;
 
-pub use self::bus::{Bus, BusDevice, Error as BusError, RawIOHandler};
+pub use self::bus::{Bus, BusDevice, Error as BusError};
 use virtio::AsAny;
 
 pub type DeviceEventT = u16;

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -7,14 +7,15 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 backtrace = {version = ">=0.3.35", features = ["libunwind", "libbacktrace", "std"], default-features = false}
 clap = { version = ">=2.27.1", default-features = false}
 libc = ">=0.2.39"
+timerfd = ">=1.0"
 
 api_server = { path = "../api_server" }
 utils = { path = "../utils" }
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
+polly = { path = "../polly" }
 seccomp = { path = "../seccomp" }
 vmm = { path = "../vmm" }
-polly = { path = "../polly"}
 
 [dev-dependencies]
 tempfile = ">=3.0.2"

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -231,7 +231,10 @@ pub fn run_with_api(
     };
 
     // Start the metrics.
-    firecracker_metrics.lock().expect("Unlock failed.").start();
+    firecracker_metrics
+        .lock()
+        .expect("Metrics lock poisoned.")
+        .start(super::metrics::WRITE_METRICS_PERIOD_MS);
 
     // Update the api shared instance info.
     api_shared_info.write().unwrap().started = true;

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -195,14 +195,20 @@ pub fn run_with_api(
 
     // The driving epoll engine.
     let mut epoll_context = vmm::EpollContext::new().expect("Cannot create the epoll context.");
+    // The event manager to replace EpollContext.
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");
-
+    // Cascade EventManager in EpollContext.
     epoll_context
         .add_epollin_event(&event_manager, EpollDispatch::PollyEvent)
         .expect("Cannot cascade EventManager from epoll_context");
 
+    // Create the firecracker metrics object responsible for periodically printing metrics.
+    let firecracker_metrics = event_manager
+        .register(super::metrics::PeriodicMetrics::new())
+        .expect("Cannot register the metrics event to the event manager.");
+
     epoll_context
-        .add_epollin_event(&api_event_fd, vmm::EpollDispatch::VmmActionRequest)
+        .add_epollin_event(&api_event_fd, EpollDispatch::VmmActionRequest)
         .expect("Cannot add vmm control_fd to epoll.");
 
     let api_handler = ApiServerAdapter::new(api_event_fd, from_api, to_api);
@@ -223,6 +229,9 @@ pub fn run_with_api(
             firecracker_version,
         ),
     };
+
+    // Start the metrics.
+    firecracker_metrics.lock().expect("Unlock failed.").start();
 
     // Update the api shared instance info.
     api_shared_info.write().unwrap().started = true;

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
 use api_server::{ApiRequest, ApiResponse, ApiServer};
@@ -203,8 +203,9 @@ pub fn run_with_api(
         .expect("Cannot cascade EventManager from epoll_context");
 
     // Create the firecracker metrics object responsible for periodically printing metrics.
-    let firecracker_metrics = event_manager
-        .register(super::metrics::PeriodicMetrics::new())
+    let firecracker_metrics = Arc::new(Mutex::new(super::metrics::PeriodicMetrics::new()));
+    event_manager
+        .register(firecracker_metrics.clone())
         .expect("Cannot register the metrics event to the event manager.");
 
     epoll_context

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -232,6 +232,11 @@ fn run_without_api(seccomp_level: u32, config_json: Option<String>) {
         .add_epollin_event(&event_manager, vmm::EpollDispatch::PollyEvent)
         .expect("Cannot cascade EventManager from epoll_context");
 
+    // Create the firecracker metrics object responsible for periodically printing metrics.
+    let firecracker_metrics = event_manager
+        .register(metrics::PeriodicMetrics::new())
+        .expect("Cannot register the metrics event to the event manager.");
+
     let (vm_resources, vmm) = build_microvm_from_json(
         seccomp_level,
         &mut epoll_context,
@@ -240,6 +245,12 @@ fn run_without_api(seccomp_level: u32, config_json: Option<String>) {
         // Safe to unwrap since no-api requires this to be set.
         config_json.unwrap(),
     );
+
+    // Start the metrics.
+    firecracker_metrics
+        .lock()
+        .expect("Metrics lock poisoned.")
+        .start(metrics::WRITE_METRICS_PERIOD_MS);
 
     let mut controller = VmmController::new(epoll_context, event_manager, vm_resources, vmm);
     let exit_code = loop {

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -26,6 +26,7 @@ use std::io;
 use std::panic;
 use std::path::PathBuf;
 use std::process;
+use std::sync::{Arc, Mutex};
 
 use logger::{Metric, LOGGER, METRICS};
 use polly::event_manager::EventManager;
@@ -233,8 +234,9 @@ fn run_without_api(seccomp_level: u32, config_json: Option<String>) {
         .expect("Cannot cascade EventManager from epoll_context");
 
     // Create the firecracker metrics object responsible for periodically printing metrics.
-    let firecracker_metrics = event_manager
-        .register(metrics::PeriodicMetrics::new())
+    let firecracker_metrics = Arc::new(Mutex::new(metrics::PeriodicMetrics::new()));
+    event_manager
+        .register(firecracker_metrics.clone())
         .expect("Cannot register the metrics event to the event manager.");
 
     let (vm_resources, vmm) = build_microvm_from_json(

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -81,6 +81,8 @@ impl EventHandler for PeriodicMetrics {
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use polly::event_manager::EventManager;
     use utils::eventfd::EventFd;
@@ -116,8 +118,9 @@ pub mod tests {
         // No flush happened.
         assert_eq!(metrics.flush_counter, 0);
 
-        let metrics = event_manager
-            .register(metrics)
+        let metrics = Arc::new(Mutex::new(metrics));
+        event_manager
+            .register(metrics.clone())
             .expect("Cannot register the metrics event to the event manager.");
 
         let flush_period_ms = 50;

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -1,0 +1,71 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::io::AsRawFd;
+use std::time::Duration;
+
+use logger::{Metric, LOGGER, METRICS};
+use polly::event_manager::EventHandler;
+use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
+use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
+
+const WRITE_METRICS_PERIOD_SECONDS: u64 = 60;
+
+pub struct PeriodicMetrics {
+    write_metrics_event_fd: TimerFd,
+}
+
+impl PeriodicMetrics {
+    pub fn new() -> Self {
+        let write_metrics_event_fd = TimerFd::new_custom(ClockId::Monotonic, true, true)
+            .expect("Cannot create the metrics timer fd.");
+        PeriodicMetrics {
+            write_metrics_event_fd,
+        }
+    }
+
+    pub fn start(&mut self) {
+        // Arm the log write timer.
+        let timer_state = TimerState::Periodic {
+            current: Duration::from_secs(WRITE_METRICS_PERIOD_SECONDS),
+            interval: Duration::from_secs(WRITE_METRICS_PERIOD_SECONDS),
+        };
+        self.write_metrics_event_fd
+            .set_state(timer_state, SetTimeFlags::Default);
+
+        // Log the metrics straight away to check the process startup time.
+        Self::log_metrics();
+    }
+
+    fn log_metrics() {
+        // Please note that, if LOGGER has no output file configured yet, it will write to
+        // stdout, so logging will interfere with console output.
+        if let Err(e) = LOGGER.log_metrics() {
+            METRICS.logger.missed_metrics_count.inc();
+            error!("Failed to log metrics: {}", e);
+        }
+    }
+}
+
+impl EventHandler for PeriodicMetrics {
+    /// Handle a read event (EPOLLIN).
+    fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
+        if source == self.write_metrics_event_fd.as_raw_fd() {
+            self.write_metrics_event_fd.read();
+            Self::log_metrics();
+        } else {
+            error!("Spurious METRICS event!");
+        }
+        vec![]
+    }
+
+    /// Initial registration of pollable objects.
+    /// Use the PollableOpBuilder to build the vector of PollableOps.
+    fn init(&self) -> Vec<PollableOp> {
+        vec![
+            PollableOpBuilder::new(self.write_metrics_event_fd.as_raw_fd())
+                .readable()
+                .register(),
+        ]
+    }
+}

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -9,41 +9,50 @@ use polly::event_manager::EventHandler;
 use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 
-const WRITE_METRICS_PERIOD_SECONDS: u64 = 60;
+/// Metrics reporting period.
+pub const WRITE_METRICS_PERIOD_MS: u64 = 60000;
 
+/// Object to drive periodic reporting of metrics.
 pub struct PeriodicMetrics {
     write_metrics_event_fd: TimerFd,
+    flush_counter: u64,
 }
 
 impl PeriodicMetrics {
+    /// PeriodicMetrics constructor. Can panic on `TimerFd` creation failure.
     pub fn new() -> Self {
         let write_metrics_event_fd = TimerFd::new_custom(ClockId::Monotonic, true, true)
             .expect("Cannot create the metrics timer fd.");
         PeriodicMetrics {
             write_metrics_event_fd,
+            flush_counter: 0,
         }
     }
 
-    pub fn start(&mut self) {
+    /// Start the periodic metrics engine which will flush metrics every `interval_ms` millisecs.
+    pub fn start(&mut self, interval_ms: u64) {
         // Arm the log write timer.
         let timer_state = TimerState::Periodic {
-            current: Duration::from_secs(WRITE_METRICS_PERIOD_SECONDS),
-            interval: Duration::from_secs(WRITE_METRICS_PERIOD_SECONDS),
+            current: Duration::from_millis(interval_ms),
+            interval: Duration::from_millis(interval_ms),
         };
         self.write_metrics_event_fd
             .set_state(timer_state, SetTimeFlags::Default);
 
         // Log the metrics straight away to check the process startup time.
-        Self::log_metrics();
+        self.log_metrics();
     }
 
-    fn log_metrics() {
+    fn log_metrics(&mut self) {
         // Please note that, if LOGGER has no output file configured yet, it will write to
         // stdout, so logging will interfere with console output.
         if let Err(e) = LOGGER.log_metrics() {
             METRICS.logger.missed_metrics_count.inc();
             error!("Failed to log metrics: {}", e);
         }
+
+        // Only used in tests, but has virtually no cost in production.
+        self.flush_counter += 1;
     }
 }
 
@@ -52,7 +61,7 @@ impl EventHandler for PeriodicMetrics {
     fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
         if source == self.write_metrics_event_fd.as_raw_fd() {
             self.write_metrics_event_fd.read();
-            Self::log_metrics();
+            self.log_metrics();
         } else {
             error!("Spurious METRICS event!");
         }
@@ -67,5 +76,63 @@ impl EventHandler for PeriodicMetrics {
                 .readable()
                 .register(),
         ]
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use polly::event_manager::EventManager;
+    use utils::eventfd::EventFd;
+
+    #[test]
+    fn test_event_handler_init() {
+        let metrics = PeriodicMetrics::new();
+        let pollable_ops = metrics.init();
+        assert_eq!(pollable_ops.len(), 1);
+        match pollable_ops[0] {
+            PollableOp::Register(reg_data) => {
+                let (pollable, event_set) = reg_data;
+                assert_eq!(pollable, metrics.write_metrics_event_fd.as_raw_fd());
+                assert!(event_set.is_readable());
+                assert!(!event_set.is_writeable());
+                assert!(!event_set.is_closed());
+            }
+            _ => panic!("Unexpected pollable op."),
+        }
+    }
+
+    #[test]
+    fn test_periodic_metrics() {
+        let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+        let mut metrics = PeriodicMetrics::new();
+
+        assert_eq!(metrics.flush_counter, 0);
+        // Test invalid read event.
+        let unrelated_object = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        let updated_pollable_ops = metrics.handle_read(unrelated_object.as_raw_fd());
+        // No events update is done.
+        assert!(updated_pollable_ops.is_empty());
+        // No flush happened.
+        assert_eq!(metrics.flush_counter, 0);
+
+        let metrics = event_manager
+            .register(metrics)
+            .expect("Cannot register the metrics event to the event manager.");
+
+        let flush_period_ms = 50;
+        metrics
+            .lock()
+            .expect("Unlock failed.")
+            .start(flush_period_ms);
+        // .start() does an initial flush.
+        assert_eq!(metrics.lock().expect("Unlock failed.").flush_counter, 1);
+
+        // Wait for at most 1.5x period.
+        event_manager
+            .run_timeout((flush_period_ms + flush_period_ms / 2) as i32)
+            .expect("Metrics event timeout or error.");
+        // Verify there was another flush.
+        assert_eq!(metrics.lock().expect("Unlock failed.").flush_counter, 2);
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,6 @@ epoll = ">=4.0.1"
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-timerfd = ">=1.0"
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -29,3 +29,4 @@ cpuid = { path = "../cpuid" }
 
 [dev-dependencies]
 tempfile = ">=3.0.2"
+vmm-sys-util = ">=0.2.1"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -5,6 +5,8 @@
 
 use std::fmt::{Display, Formatter};
 use std::fs::OpenOptions;
+use std::io;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
 
 use super::{EpollContext, Vmm};
@@ -14,10 +16,12 @@ use device_manager;
 #[cfg(target_arch = "x86_64")]
 use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
+use devices::legacy::Serial;
 use devices::virtio::vsock::{TYPE_VSOCK, VSOCK_EVENTS_COUNT};
 use devices::virtio::{MmioTransport, NET_EVENTS_COUNT, TYPE_NET};
 use memory_model::{GuestAddress, GuestMemory, GuestMemoryError};
 use polly::event_manager::{Error as EventManagerError, EventManager};
+use utils::eventfd::EventFd;
 use utils::time::TimestampUs;
 use vmm_config;
 use vmm_config::boot_source::BootConfig;
@@ -31,11 +35,11 @@ use vstate::{KvmContext, Vcpu, VcpuConfig, Vm};
 pub enum StartMicrovmError {
     /// Unable to seek the block device backing file due to invalid permissions or
     /// the file was deleted/corrupted.
-    CreateBlockDevice(std::io::Error),
+    CreateBlockDevice(io::Error),
     /// Internal errors are due to resource exhaustion.
     CreateNetDevice(devices::virtio::net::Error),
     /// Failed to create a `RateLimiter` object.
-    CreateRateLimiter(std::io::Error),
+    CreateRateLimiter(io::Error),
     /// Failed to create the backend for the vsock device.
     CreateVsockBackend(devices::virtio::vsock::VsockUnixBackendError),
     /// Failed to create the vsock device.
@@ -57,7 +61,7 @@ pub enum StartMicrovmError {
     /// The net device configuration is missing the tap device.
     NetDeviceNotConfigured,
     /// Cannot open the block device backing file.
-    OpenBlockDevice(std::io::Error),
+    OpenBlockDevice(io::Error),
     /// Cannot initialize a MMIO Block Device or add a device to the MMIO Bus.
     RegisterBlockDevice(device_manager::mmio::Error),
     /// Cannot register an EventHandler.
@@ -192,6 +196,34 @@ pub fn build_microvm(
     let mut kernel_cmdline = boot_config.cmdline.clone();
     let mut vm = setup_kvm_vm(&guest_memory)?;
 
+    // On x86_64 always create a serial device,
+    // while on aarch64 only create it if 'console=' is specified in the boot args.
+    let serial_device = if cfg!(target_arch = "x86_64")
+        || (cfg!(target_arch = "aarch64") && kernel_cmdline.as_str().contains("console="))
+    {
+        // Wrapper over io::Stdin that implements `ReadableFd`.
+        struct SerialStdin(io::Stdin);
+        impl io::Read for SerialStdin {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                self.0.read(buf)
+            }
+        }
+        impl AsRawFd for SerialStdin {
+            fn as_raw_fd(&self) -> RawFd {
+                self.0.as_raw_fd()
+            }
+        }
+        impl devices::legacy::ReadableFd for SerialStdin {};
+        let stdin_handle = SerialStdin(io::stdin());
+        Some(setup_serial_device(
+            event_manager,
+            Box::new(stdin_handle),
+            Box::new(io::stdout()),
+        )?)
+    } else {
+        None
+    };
+
     // Instantiate the MMIO device manager.
     // 'mmio_base' address has to be an address which is protected by the kernel
     // and is architectural specific.
@@ -202,7 +234,8 @@ pub fn build_microvm(
     );
 
     #[cfg(target_arch = "x86_64")]
-    let mut pio_device_manager = PortIODeviceManager::new()
+    // Safe to unwrap 'serial_device' as it's always 'Some' on x86_64.
+    let mut pio_device_manager = PortIODeviceManager::new(serial_device.unwrap())
         .map_err(Error::CreateLegacyDevice)
         .map_err(StartMicrovmError::Internal)?;
 
@@ -235,11 +268,16 @@ pub fn build_microvm(
             .map_err(StartMicrovmError::Internal)?;
 
         setup_interrupt_controller(&mut vm, vcpu_config.vcpu_count)?;
-        attach_legacy_devices(&vm, &mut mmio_device_manager, &mut kernel_cmdline)?;
+        attach_legacy_devices(
+            &vm,
+            &mut mmio_device_manager,
+            &mut kernel_cmdline,
+            serial_device,
+        )?;
     }
 
     let mut vmm = Vmm {
-        stdin_handle: std::io::stdin(),
+        stdin_handle: io::stdin(),
         guest_memory,
         kernel_cmdline,
         vcpus_handles: Vec::new(),
@@ -325,23 +363,49 @@ pub(crate) fn setup_kvm_vm(
     Ok(vm)
 }
 
+/// Sets up the irqchip for a x86_64 microVM.
 #[cfg(target_arch = "x86_64")]
-pub(crate) fn setup_interrupt_controller(
-    vm: &mut Vm,
-) -> std::result::Result<(), StartMicrovmError> {
+pub fn setup_interrupt_controller(vm: &mut Vm) -> std::result::Result<(), StartMicrovmError> {
     vm.setup_irqchip()
         .map_err(Error::Vm)
         .map_err(StartMicrovmError::Internal)
 }
 
+/// Sets up the irqchip for a aarch64 microVM.
 #[cfg(target_arch = "aarch64")]
-pub(crate) fn setup_interrupt_controller(
+pub fn setup_interrupt_controller(
     vm: &mut Vm,
     vcpu_count: u8,
 ) -> std::result::Result<(), StartMicrovmError> {
     vm.setup_irqchip(vcpu_count)
         .map_err(Error::Vm)
         .map_err(StartMicrovmError::Internal)
+}
+
+/// Sets up the serial device.
+pub fn setup_serial_device(
+    event_manager: &mut EventManager,
+    input: Box<dyn devices::legacy::ReadableFd + Send>,
+    out: Box<dyn io::Write + Send>,
+) -> std::result::Result<Arc<Mutex<Serial>>, StartMicrovmError> {
+    let interrupt_evt = EventFd::new(libc::EFD_NONBLOCK)
+        .map_err(Error::EventFd)
+        .map_err(StartMicrovmError::Internal)?;
+    let serial = Arc::new(Mutex::new(devices::legacy::Serial::new_in_out(
+        interrupt_evt,
+        input,
+        out,
+    )));
+    if let Err(e) = event_manager.register_protected(serial.clone()) {
+        // TODO: We just log this message, and immediately return Ok, instead of returning the
+        // actual error because this operation always fails with EPERM when adding a fd which
+        // has been redirected to /dev/null via dup2 (this may happen inside the jailer).
+        // Find a better solution to this (and think about the state of the serial device
+        // while we're at it). This also led to commenting out parts of the
+        // enable_disable_stdin_test() unit test function.
+        warn!("Could not add serial input event to epoll: {:?}", e);
+    }
+    Ok(serial)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -360,7 +424,7 @@ fn attach_legacy_devices(
                 .register_irqfd(&pio_device_manager.$evt, $index)
                 .map_err(|e| {
                     Error::LegacyIOBus(device_manager::legacy::Error::EventFd(
-                        std::io::Error::from_raw_os_error(e.errno()),
+                        io::Error::from_raw_os_error(e.errno()),
                     ))
                 })
                 .map_err(StartMicrovmError::Internal)?;
@@ -378,10 +442,11 @@ fn attach_legacy_devices(
     vm: &Vm,
     mmio_device_manager: &mut MMIODeviceManager,
     kernel_cmdline: &mut kernel::cmdline::Cmdline,
+    serial: Option<Arc<Mutex<Serial>>>,
 ) -> std::result::Result<(), StartMicrovmError> {
-    if kernel_cmdline.as_str().contains("console=") {
+    if let Some(serial) = serial {
         mmio_device_manager
-            .register_mmio_serial(vm.fd(), kernel_cmdline)
+            .register_mmio_serial(vm.fd(), kernel_cmdline, serial)
             .map_err(Error::RegisterMMIODevice)
             .map_err(StartMicrovmError::Internal)?;
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -391,12 +391,8 @@ pub fn setup_serial_device(
     let interrupt_evt = EventFd::new(libc::EFD_NONBLOCK)
         .map_err(Error::EventFd)
         .map_err(StartMicrovmError::Internal)?;
-    let serial = Arc::new(Mutex::new(devices::legacy::Serial::new_in_out(
-        interrupt_evt,
-        input,
-        out,
-    )));
-    if let Err(e) = event_manager.register_protected(serial.clone()) {
+    let serial = Arc::new(Mutex::new(Serial::new_in_out(interrupt_evt, input, out)));
+    if let Err(e) = event_manager.register(serial.clone()) {
         // TODO: We just log this message, and immediately return Ok, instead of returning the
         // actual error because this operation always fails with EPERM when adding a fd which
         // has been redirected to /dev/null via dup2 (this may happen inside the jailer).
@@ -610,16 +606,17 @@ fn attach_block_devices(
             .transpose()
             .map_err(CreateRateLimiter)?;
 
-        let block_device = event_manager
-            .register(
-                devices::virtio::Block::new(
-                    vmm.guest_memory.clone(),
-                    block_file,
-                    drive_config.is_read_only,
-                    rate_limiter.unwrap_or_default(),
-                )
-                .map_err(CreateBlockDevice)?,
+        let block_device = Arc::new(Mutex::new(
+            devices::virtio::Block::new(
+                vmm.guest_memory.clone(),
+                block_file,
+                drive_config.is_read_only,
+                rate_limiter.unwrap_or_default(),
             )
+            .map_err(CreateBlockDevice)?,
+        ));
+        event_manager
+            .register(block_device.clone())
             .map_err(StartMicrovmError::RegisterEvent)?;
 
         attach_block_device(

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -169,6 +169,20 @@ impl Display for StartMicrovmError {
     }
 }
 
+// Wrapper over io::Stdin that implements `ReadableFd`.
+struct SerialStdin(io::Stdin);
+impl io::Read for SerialStdin {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+impl AsRawFd for SerialStdin {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+impl devices::legacy::ReadableFd for SerialStdin {}
+
 /// Builds and starts a microVM based on the current Firecracker VmResources configuration.
 ///
 /// This is the default build recipe, one could build other microVM flavors by using the
@@ -201,23 +215,9 @@ pub fn build_microvm(
     let serial_device = if cfg!(target_arch = "x86_64")
         || (cfg!(target_arch = "aarch64") && kernel_cmdline.as_str().contains("console="))
     {
-        // Wrapper over io::Stdin that implements `ReadableFd`.
-        struct SerialStdin(io::Stdin);
-        impl io::Read for SerialStdin {
-            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-                self.0.read(buf)
-            }
-        }
-        impl AsRawFd for SerialStdin {
-            fn as_raw_fd(&self) -> RawFd {
-                self.0.as_raw_fd()
-            }
-        }
-        impl devices::legacy::ReadableFd for SerialStdin {};
-        let stdin_handle = SerialStdin(io::stdin());
         Some(setup_serial_device(
             event_manager,
-            Box::new(stdin_handle),
+            Box::new(SerialStdin(io::stdin())),
             Box::new(io::stdout()),
         )?)
     } else {
@@ -719,4 +719,49 @@ fn attach_vsock_device(
     .map_err(RegisterVsockDevice)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+pub mod tests {
+    extern crate vmm_sys_util;
+    use self::vmm_sys_util::tempfile::TempFile;
+
+    use std::fs::File;
+
+    use super::*;
+    use polly::event_manager::EventManager;
+
+    #[test]
+    fn test_stdin_wrapper() {
+        let wrapper = SerialStdin(io::stdin());
+        assert_eq!(wrapper.as_raw_fd(), io::stdin().as_raw_fd())
+    }
+
+    #[test]
+    fn test_setup_serial_device() {
+        // Wrapper over TempFile that implements `ReadableFd`.
+        struct SerialInput(File);
+        impl io::Read for SerialInput {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                self.0.read(buf)
+            }
+        }
+        impl AsRawFd for SerialInput {
+            fn as_raw_fd(&self) -> RawFd {
+                self.0.as_raw_fd()
+            }
+        }
+        impl devices::legacy::ReadableFd for SerialInput {};
+
+        let read_tempfile = TempFile::new("/tmp/serial_read_").unwrap();
+        let read_file = File::open(read_tempfile.as_path()).unwrap();
+        let read_handle = SerialInput(read_file);
+        let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+        setup_serial_device(
+            &mut event_manager,
+            Box::new(read_handle),
+            Box::new(io::stdout()),
+        )
+        .unwrap();
+    }
 }

--- a/src/vmm/src/controller.rs
+++ b/src/vmm/src/controller.rs
@@ -12,6 +12,7 @@ use super::Result;
 use arch::DeviceType;
 use device_manager::mmio::MMIO_CFG_SPACE_OFF;
 use devices::virtio::{self, TYPE_BLOCK, TYPE_NET};
+use logger::LOGGER;
 use polly::event_manager::EventManager;
 use resources::VmResources;
 use rpc_interface::VmmActionError;
@@ -41,8 +42,14 @@ impl VmmController {
     /// simply exposes functionality like getting the dirty pages, and then we'll have the
     /// metrics flushing logic entirely on the outside.
     pub fn flush_metrics(&mut self) -> ActionResult {
-        self.vmm
-            .write_metrics()
+        // The dirty pages are only available on x86_64.
+        #[cfg(target_arch = "x86_64")]
+        self.vmm.log_dirty_pages();
+        // FIXME: we're losing the bool saying whether metrics were actually written.
+        LOGGER
+            .log_metrics()
+            .map(|_| ())
+            .map_err(super::Error::Logger)
             .map_err(VmmActionError::InternalVmm)
     }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -20,7 +20,7 @@ use devices;
 use devices::virtio::block::Block;
 use devices::virtio::TYPE_BLOCK;
 
-use devices::{BusDevice, RawIOHandler};
+use devices::BusDevice;
 use kernel::cmdline as kernel_cmdline;
 use kvm_ioctls::{IoEventAddress, VmFd};
 #[cfg(target_arch = "aarch64")]
@@ -86,7 +86,6 @@ pub struct MMIODeviceManager {
     irq: u32,
     last_irq: u32,
     id_to_dev_info: HashMap<(DeviceType, String), MMIODeviceInfo>,
-    raw_io_handlers: HashMap<(DeviceType, String), Arc<Mutex<dyn RawIOHandler>>>,
     block_devices: HashMap<String, Arc<Mutex<Block>>>,
 }
 
@@ -102,7 +101,6 @@ impl MMIODeviceManager {
             last_irq: irq_interval.1,
             bus: devices::Bus::new(),
             id_to_dev_info: HashMap::new(),
-            raw_io_handlers: HashMap::new(),
             block_devices: HashMap::new(),
         }
     }
@@ -285,17 +283,9 @@ impl MMIODeviceManager {
         vm.register_irqfd(&serial.lock().unwrap().interrupt_evt(), self.irq)
             .map_err(Error::RegisterIrqFd)?;
 
-        let raw_io_device = serial.clone();
-
         self.bus
             .insert(serial, self.mmio_base, MMIO_LEN)
             .map_err(|err| Error::BusError(err))?;
-
-        // Register the RawIOHandler trait.
-        self.raw_io_handlers.insert(
-            (DeviceType::Serial, DeviceType::Serial.to_string()),
-            raw_io_device,
-        );
 
         cmdline
             .insert("earlycon", &format!("uart,mmio,0x{:08x}", self.mmio_base))
@@ -371,16 +361,6 @@ impl MMIODeviceManager {
             }
         }
         None
-    }
-
-    // Used only on 'aarch64', but needed by unit tests on all platforms.
-    #[allow(dead_code)]
-    pub fn get_raw_io_device(
-        &self,
-        device_type: DeviceType,
-    ) -> Option<&Arc<Mutex<dyn RawIOHandler>>> {
-        self.raw_io_handlers
-            .get(&(device_type, device_type.to_string()))
     }
 
     pub fn get_block_device(&self, device_id: &str) -> Option<&Arc<Mutex<Block>>> {
@@ -528,8 +508,6 @@ mod tests {
             Ok(())
         }
     }
-
-    impl devices::RawIOHandler for DummyDevice {}
 
     #[test]
     fn test_register_virtio_device() {
@@ -731,26 +709,5 @@ mod tests {
         assert!(device_manager
             .get_device(DeviceType::Virtio(type_id), &id)
             .is_none());
-    }
-
-    #[test]
-    fn test_raw_io_device() {
-        let mut device_manager =
-            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
-        let dummy_device = Arc::new(Mutex::new(DummyDevice::new()));
-
-        device_manager.raw_io_handlers.insert(
-            (
-                arch::DeviceType::Virtio(1337),
-                arch::DeviceType::Virtio(1337).to_string(),
-            ),
-            dummy_device,
-        );
-
-        let mut raw_io_device = device_manager.get_raw_io_device(arch::DeviceType::Virtio(1337));
-        assert!(raw_io_device.is_some());
-
-        raw_io_device = device_manager.get_raw_io_device(arch::DeviceType::Virtio(7331));
-        assert!(raw_io_device.is_none());
     }
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -64,7 +64,7 @@ use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceInfo;
 use device_manager::mmio::MMIODeviceManager;
 use devices::virtio::EpollConfigConstructor;
-use devices::{BusDevice, DeviceEventT, EpollHandler, RawIOHandler};
+use devices::{BusDevice, DeviceEventT, EpollHandler};
 use kernel::cmdline::Cmdline as KernelCmdline;
 use logger::error::LoggerError;
 #[cfg(target_arch = "x86_64")]
@@ -108,8 +108,6 @@ pub enum EventLoopExitReason {
 pub enum EpollDispatch {
     /// This dispatch type is now obsolete.
     Exit,
-    /// Stdin event.
-    Stdin,
     /// Cascaded polly event.
     PollyEvent,
     /// Event has to be dispatch to an EpollHandler.
@@ -137,7 +135,6 @@ impl MaybeHandler {
 // and duping of file descriptors. This issue will be solved when we also implement device removal.
 pub struct EpollContext {
     epoll_raw_fd: RawFd,
-    stdin_index: u64,
     // FIXME: find a different design as this does not scale. This Vec can only grow.
     dispatch_table: Vec<Option<EpollDispatch>>,
     device_handlers: Vec<MaybeHandler>,
@@ -159,16 +156,13 @@ impl EpollContext {
 
         // Initial capacity needs to be large enough to hold:
         // * 1 exit event
-        // * 1 stdin event
         // * 2 queue events for virtio block
         // * 4 for virtio net
         // The total is 8 elements; allowing spare capacity to avoid reallocations.
         let mut dispatch_table = Vec::with_capacity(20);
-        let stdin_index = dispatch_table.len() as u64;
         dispatch_table.push(None);
         Ok(EpollContext {
             epoll_raw_fd,
-            stdin_index,
             dispatch_table,
             device_handlers: Vec::with_capacity(6),
             device_id_to_handler_id: HashMap::new(),
@@ -176,40 +170,6 @@ impl EpollContext {
             num_events: 0,
             event_index: 0,
         })
-    }
-
-    /// Registers an EPOLLIN event associated with the stdin file descriptor.
-    pub fn enable_stdin_event(&mut self) {
-        if let Err(e) = epoll::ctl(
-            self.epoll_raw_fd,
-            epoll::ControlOptions::EPOLL_CTL_ADD,
-            libc::STDIN_FILENO,
-            epoll::Event::new(epoll::Events::EPOLLIN, self.stdin_index),
-        ) {
-            // TODO: We just log this message, and immediately return Ok, instead of returning the
-            // actual error because this operation always fails with EPERM when adding a fd which
-            // has been redirected to /dev/null via dup2 (this may happen inside the jailer).
-            // Find a better solution to this (and think about the state of the serial device
-            // while we're at it). This also led to commenting out parts of the
-            // enable_disable_stdin_test() unit test function.
-            warn!("Could not add stdin event to epoll. {}", e);
-        } else {
-            self.dispatch_table[self.stdin_index as usize] = Some(EpollDispatch::Stdin);
-        }
-    }
-
-    /// Removes the stdin event from the event set.
-    pub fn disable_stdin_event(&mut self) {
-        // Ignore failure to remove from epoll. The only reason for failure is
-        // that stdin has closed or changed in which case we won't get
-        // any more events on the original event_fd anyway.
-        let _ = epoll::ctl(
-            self.epoll_raw_fd,
-            epoll::ControlOptions::EPOLL_CTL_DEL,
-            libc::STDIN_FILENO,
-            epoll::Event::new(epoll::Events::EPOLLIN, self.stdin_index),
-        );
-        self.dispatch_table[self.stdin_index as usize] = None;
     }
 
     /// Given a file descriptor `fd`, and an EpollDispatch token `token`,
@@ -487,17 +447,6 @@ impl Vmm {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
-    fn get_serial_device(&self) -> Option<Arc<Mutex<dyn RawIOHandler>>> {
-        Some(self.pio_device_manager.stdio_serial.clone())
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn get_serial_device(&self) -> Option<&Arc<Mutex<dyn RawIOHandler>>> {
-        self.mmio_device_manager
-            .get_raw_io_device(DeviceType::Serial)
-    }
-
     #[cfg(target_arch = "aarch64")]
     fn get_mmio_device_info(&self) -> Option<&HashMap<(DeviceType, String), MMIODeviceInfo>> {
         Some(self.mmio_device_manager.get_device_info())
@@ -608,8 +557,6 @@ impl Vmm {
             self.exit_evt = Some(exit_poll_evt_fd);
         }
 
-        epoll_context.enable_stdin_event();
-
         Ok(())
     }
 
@@ -659,23 +606,6 @@ impl Vmm {
         }
     }
 
-    fn handle_stdin_event(&self, buffer: &[u8]) -> Result<()> {
-        match self.get_serial_device() {
-            Some(serial) => {
-                // Use expect() to panic if another thread panicked
-                // while holding the lock.
-                serial
-                    .lock()
-                    .expect("Failed to process stdin event due to poisoned lock")
-                    .raw_input(buffer)
-                    .map_err(Error::Serial)?;
-            }
-            None => warn!("Unable to handle stdin event: no serial device available"),
-        }
-
-        Ok(())
-    }
-
     /// Wait on VMM events and dispatch them to the appropriate handler. Returns to the caller
     /// when a control action occurs.
     pub fn run_event_loop(
@@ -703,23 +633,6 @@ impl Vmm {
                         None => warn!("leftover exit-evt in epollcontext!"),
                     }
                     self.stop(i32::from(FC_EXIT_CODE_OK));
-                }
-                Some(EpollDispatch::Stdin) => {
-                    let mut out = [0u8; 64];
-                    let stdin_lock = self.stdin_handle.lock();
-                    match stdin_lock.read_raw(&mut out[..]) {
-                        Ok(0) => {
-                            // Zero-length read indicates EOF. Remove from pollables.
-                            epoll_context.disable_stdin_event();
-                        }
-                        Err(e) => {
-                            warn!("error while reading stdin: {:?}", e);
-                            epoll_context.disable_stdin_event();
-                        }
-                        Ok(count) => {
-                            self.handle_stdin_event(&out[..count])?;
-                        }
-                    }
                 }
                 Some(EpollDispatch::DeviceHandler(device_idx, device_token)) => {
                     METRICS.vmm.device_events.inc();

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 74.3
+COVERAGE_TARGET_PCT = 74.7
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Another step in migrating Firecracker to the new `polly` event manager.

Fixes #1522 
Fixes #1523 

## Description of Changes

### Metrics

Both `LOGGER` and `METRICS` are Firecracker specific, not `Vmm` specific, and thus should not be tied to the `Vmm`.
Logger has already been taken out of `Vmm`, now take the metrics periodic logging logic out of the `Vmm` as well.

A `PeriodicMetrics` object is defined in the firecracker crate, which uses `EventManager` to drive periodic reporting of `METRICS`.

### Serial

The serial device no longer has to be injected with input from some external component. It can now be created with any input object that is `dyn std::io::Read + std::os::unix::io::AsRawFd`.
Because the serial now implements the `EventHandler` trait, it can internally handle all input.

Removed the `EpollDispatch::Stdin` previously handled by the `Vmm`.

The builder can now build a `Serial` device with any input and/or output sources.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.