### PR TITLE
Renamed `region_end` to `last_addr` in guest memory

### DIFF
--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -326,7 +326,7 @@ fn create_cpu_nodes(fdt: &mut Vec<u8>, vcpu_mpidr: &Vec<u64>) -> Result<()> {
 }
 
 fn create_memory_node(fdt: &mut Vec<u8>, guest_mem: &GuestMemoryMmap) -> Result<()> {
-    let mem_size = guest_mem.end_addr().raw_value() - super::layout::DRAM_MEM_START;
+    let mem_size = guest_mem.last_addr().raw_value() - super::layout::DRAM_MEM_START + 1;
     // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L960
     // for an explanation of this.
     let mem_reg_prop = generate_prop64(&[super::layout::DRAM_MEM_START as u64, mem_size as u64]);

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -99,11 +99,12 @@ fn get_fdt_addr(mem: &GuestMemoryMmap) -> u64 {
     // we return the start of the DRAM so that
     // we allow the code to try and load the FDT.
 
-    if let Some(offset) = mem.end_addr().checked_sub(layout::FDT_MAX_SIZE as u64) {
-        if mem.address_in_range(offset) {
-            return offset.raw_value();
+    if let Some(addr) = mem.last_addr().checked_sub(layout::FDT_MAX_SIZE as u64 - 1) {
+        if mem.address_in_range(addr) {
+            return addr.raw_value();
         }
     }
+
     layout::DRAM_MEM_START
 }
 

--- a/src/devices/src/virtio/block.rs
+++ b/src/devices/src/virtio/block.rs
@@ -219,9 +219,11 @@ impl Request {
             if data_desc.is_write_only() && req.request_type == RequestType::Out {
                 return Err(Error::UnexpectedWriteOnlyDescriptor);
             }
+
             if !data_desc.is_write_only() && req.request_type == RequestType::In {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }
+
             if !data_desc.is_write_only() && req.request_type == RequestType::GetDeviceID {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -244,10 +244,11 @@ pub fn load_cmdline(
         return Ok(());
     }
 
-    let end = guest_addr
-        .checked_add(raw_cmdline.len() as u64)
+    let cmdline_last_addr = guest_addr
+        .checked_add(raw_cmdline.len() as u64 - 1)
         .ok_or(CmdlineError::CommandLineOverflow)?; // Extra for null termination.
-    if end > guest_mem.end_addr() {
+
+    if cmdline_last_addr > guest_mem.last_addr() {
         return Err(CmdlineError::CommandLineOverflow);
     }
 


### PR DESCRIPTION
`region_end` from `guest_memory.rs` is an orphan function which returns the end of a memory region exclusive. This behavior might be misleading for usage, and it also presents a possibility to overflow:

**BEFORE:** region_end = region.guest_base + region.mapping.size().
**NOW:** region_end -> last_addr = region.guest_base + region.mapping.size() - 1. 

Signed-off-by: Iulian Barbu <iul@amazon.com>

Linked to #1527.

## Reason for This PR

Disambiguate the `region_end` function, applied on `MemoryRegion` , changing it to a method,
bound to `MemoryRegion` struct.

## Description of Changes

* Renamed GuestMemory `region_end` to `last_addr`.
* Modified the behaviour of the function.
**BEFORE**: The function returned the last address of
a region exclusive.
**NOW**: The function returns the last address of a region
inclusive.
* Changed the function from being orphan to being bound
to the MemoryRegion struct.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] Changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.