### PR TITLE
rate limiters: convert Configs with *Into traits

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -43,6 +43,7 @@ pub mod vmm_config;
 mod vstate;
 
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::{Read, Seek, SeekFrom};
@@ -532,7 +533,7 @@ impl Vmm {
             );
             let rate_limiter = drive_config
                 .rate_limiter
-                .map(vmm_config::RateLimiterConfig::into_rate_limiter)
+                .map(vmm_config::RateLimiterConfig::try_into)
                 .transpose()
                 .map_err(CreateRateLimiter)?;
 
@@ -580,13 +581,13 @@ impl Vmm {
 
             let rx_rate_limiter = cfg
                 .rx_rate_limiter
-                .map(vmm_config::RateLimiterConfig::into_rate_limiter)
+                .map(vmm_config::RateLimiterConfig::try_into)
                 .transpose()
                 .map_err(CreateRateLimiter)?;
 
             let tx_rate_limiter = cfg
                 .tx_rate_limiter
-                .map(vmm_config::RateLimiterConfig::into_rate_limiter)
+                .map(vmm_config::RateLimiterConfig::try_into)
                 .transpose()
                 .map_err(CreateRateLimiter)?;
 
@@ -1501,10 +1502,7 @@ impl Vmm {
                 ($rate_limiter: ident, $metric: ident) => {{
                     new_cfg
                         .$rate_limiter
-                        .map(|rl| {
-                            rl.$metric
-                                .map(vmm_config::TokenBucketConfig::into_token_bucket)
-                        })
+                        .map(|rl| rl.$metric.map(vmm_config::TokenBucketConfig::into))
                         .unwrap_or(None)
                 }};
             }


### PR DESCRIPTION
## Reason for This PR

Minor cleanup that makes rate limiter-related struct conversion slightly more idiomatic, by use of `Into` and `TryInto` traits

## Description of Changes

The `into_rate_limiter` and `into_token_bucker` converter functions were replaced with implementations of the `Into` and `TryInto` traits.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
