### PR TITLE
jailer: remove hardcoded api socket location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Fixed
 
 - Fixed #1469 - Broken GitHub location for Firecracker release binary.
+- The jailer allows changing the default api socket path by using the extra
+  arguments passed to firecracker.
 
 ### Changed
   
@@ -18,6 +20,8 @@
   simply forwarded to the Firecracker executable using "end of command
   options" convention.
 - Decreased release binary size by ~15%.
+- Changed default API socket path to `/run/firecracker.socket`. This path
+  also applies when running with the jailer.
 
 ## [0.20.0]
 

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -44,8 +44,8 @@ jailer --id <id> \
     Firecracker.
   - 2 (default): advanced filtering. This adds further checks on some of the
     parameters of the allowed syscalls.
-  Please note the jailer already passes the following parameters to the
-  Firecracker process: `--api-sock` and `--id`.
+  Please note the jailer already passes `--id` parameter to the
+  Firecracker process.
 
 ## Jailer Operation
 
@@ -85,7 +85,7 @@ After starting, the Jailer goes through the following operations:
 - If `--daemonize` is specified, call `setsid()` and redirect `STDIN`,
   `STDOUT`, and `STDERR` to `/dev/null`.
 - Drop privileges via setting the provided `uid` and `gid`.
-- Exec into `<exec_file_name> --id=<id> --api-sock=/api.socket
+- Exec into `<exec_file_name> --id=<id>
   --start-time-us=<opaque> --start-time-cpu-us=<opaque>` (and also forward
   any extra arguments provided to the jailer after `--`, as mentioned in
   the **Jailer Usage** section), where:
@@ -115,9 +115,6 @@ as the path which contains them):
 
 - `/srv/jailer/firecracker/551e7604-e35c-42b3-b825-416853441234/root/firecracker`
   (copied from `/usr/bin/firecracker`)
-
-Firecracker will create its API socket at
-`/srv/jailer/firecracker/551e7604-e35c-42b3-b825-416853441234/root/api.socket`
 
 We are going to refer to
 `/srv/jailer/firecracker/551e7604-e35c-42b3-b825-416853441234/root`
@@ -188,14 +185,15 @@ Finally, the jailer switches the `uid` to `123`, and `gid` to `100`, and execs
 ```
 ./firecracker \
   --id="551e7604-e35c-42b3-b825-416853441234" \
-  --api-sock=/api.socket \
   --start-time-us=<opaque> \
   --start-time-cpu-us=<opaque>
 ```
 
-We can now use the socket at
-`/srv/jailer/firecracker/551e7604-e35c-42b3-b825-416853441234/root/api.socket`
+Now firecracker creates the socket at
+`/srv/jailer/firecracker/551e7604-e35c-42b3-b825-416853441234/root/<api-sock>`
 to interact with the VM.
+
+Note: default value for <api-sock> is `/run/firecracker.socket`
 
 ### Observations
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -36,7 +36,10 @@ use vmm::signal_handler::register_signal_handlers;
 use vmm::vmm_config::instance_info::{InstanceInfo, InstanceState};
 use vmm::{EventLoopExitReason, Vmm};
 
-const DEFAULT_API_SOCK_PATH: &str = "/tmp/firecracker.socket";
+// The reason we place default API socket under /run is that API socket is a
+// runtime file.
+// see https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html for more information.
+const DEFAULT_API_SOCK_PATH: &str = "/run/firecracker.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 const FIRECRACKER_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -167,7 +167,7 @@ impl Env {
             .map_err(|e| Error::ChangeFileOwner(e, std::str::from_utf8(dev_path_str).unwrap()))
     }
 
-    pub fn run(mut self, socket_file_name: &str) -> Result<()> {
+    pub fn run(mut self) -> Result<()> {
         // We need to create the equivalent of /dev/net inside the jail.
         self.chroot_dir.push("dev/net");
 
@@ -294,8 +294,6 @@ impl Env {
                 .args(&["--id", &self.id])
                 .args(&["--start-time-us", &self.start_time_us.to_string()])
                 .args(&["--start-time-cpu-us", &self.start_time_cpu_us.to_string()])
-                .arg("--api-sock")
-                .arg(format!("/{}", socket_file_name))
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -22,9 +22,7 @@ use env::Env;
 use utils::arg_parser::{App, ArgInfo, Error as ParsingError};
 use utils::validators;
 
-const SOCKET_FILE_NAME: &str = "api.socket";
 const JAILER_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #[derive(Debug)]
 pub enum Error {
     ArgumentParsing(ParsingError),
@@ -341,7 +339,7 @@ fn main() {
     .and_then(|env| {
         fs::create_dir_all(env.chroot_dir())
             .map_err(|e| Error::CreateDir(env.chroot_dir().to_owned(), e))?;
-        env.run(SOCKET_FILE_NAME)
+        env.run()
     })
     .unwrap_or_else(|err| panic!("Jailer error: {}", err));
 }

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -88,11 +88,15 @@ class JailerContext:
             jailer_param_list.extend(['--netns', str(self.netns_file_path())])
         if self.daemonize:
             jailer_param_list.append('--daemonize')
-        if config_file is not None:
+        # applying neccessory extra args if needed
+        if API_USOCKET_NAME is not None or no_api or config_file is not None:
             jailer_param_list.extend(['--'])
-            jailer_param_list.extend(['--config-file', str(config_file)])
-        if no_api:
-            jailer_param_list.append('--no-api')
+            if config_file is not None:
+                jailer_param_list.extend(['--config-file', str(config_file)])
+            if no_api:
+                jailer_param_list.append('--no-api')
+            if API_USOCKET_NAME is not None:
+                jailer_param_list.extend(['--api-sock', str(API_USOCKET_NAME)])
         return jailer_param_list
 
     def chroot_base_with_id(self):


### PR DESCRIPTION
Signed-off-by: karthik nedunchezhiyan <karthik1705.n@gmail.com>

## Reason for This PR

`--api-sock` value was constant in jailer and not allowed to modify by the user.

## Description of Changes

Removed constant `--api-sock` from the jailer. Now user can pass `--api-sock` value as an extra argument (after --) to the jailer.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
