### PR TITLE
docs: initrd support is not released yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for booting with an initial RAM disk image. This image can be
+  specified through the new `initrd_path` field of the `/boot-source` API
+  request.
+
 ### Fixed
 
 - Fixed #1469 - Broken GitHub location for Firecracker release binary.
@@ -56,9 +62,6 @@
   all parameters specified after `--` are forwarded verbatim to Firecracker.
 - Added `KVM_PTP` support to the recommended guest kernel config.
 - Added entry in FAQ.md for Firecracker Guest timekeeping.
-- Support for booting with an initial RAM disk image. This image can be
-  specified through the new `initrd_path` field of the `/boot-source` API
-  request.
 
 ### Changed
 


### PR DESCRIPTION
## Reason for This PR

When https://github.com/firecracker-microvm/firecracker/pull/1246 was merged,
the changelog entry was added under 0.19.0. This seems like a mistake as 0.19.0
was already released.

## Description of Changes

Moves the changelog entry about initrd support into the "Unreleased" section.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR.
- [x] No code has been touched.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
