### PR TITLE
tests: fix broken parameter propagation

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -49,8 +49,6 @@ class Microvm:
         microvm_id,
         monitor_memory=True,
         bin_cloner_path=None,
-        config_file=None,
-        no_api=False,
     ):
         """Set up microVM attributes, paths, and data structures."""
         # Unique identifier for this machine.
@@ -98,13 +96,6 @@ class Microvm:
         self.network = None
         self.machine_cfg = None
         self.vsock = None
-
-        # Optional file that contains a json for configuring microvm from
-        # command line parameter.
-        self.config_file = config_file
-
-        # Parameter set when user wants to disable API thread.
-        self.no_api = no_api
 
         # The ssh config dictionary is populated with information about how
         # to connect to a microVM that has ssh capability. The path of the
@@ -284,8 +275,7 @@ class Microvm:
         self.network = Network(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
 
-        jailer_param_list = self._jailer.construct_param_list(self.config_file,
-                                                              self.no_api)
+        jailer_param_list = self._jailer.construct_param_list()
 
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell. Going
@@ -361,7 +351,7 @@ class Microvm:
         # We expect the jailer to start within 80 ms. However, we wait for
         # 1 sec since we are rechecking the existence of the socket 5 times
         # and leave 0.2 delay between them.
-        if not self.no_api:
+        if 'no-api' not in self._jailer.extra_args:
             self._wait_create()
 
     @retry(delay=0.2, tries=5)

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -33,7 +33,8 @@ def _configure_vm_from_json(test_microvm, vm_config_file):
             for line in f1:
                 f2.write(line)
     test_microvm.create_jailed_resource(vm_config_path, create_jail=True)
-    test_microvm.config_file = os.path.basename(vm_config_file)
+    test_microvm.jailer.extra_args = {'config-file': os.path.basename(
+        vm_config_file)}
 
 
 @pytest.mark.parametrize(
@@ -67,7 +68,8 @@ def test_config_start_no_api(test_microvm_with_ssh, vm_config_file):
     test_microvm.create_jailed_resource(metrics_fifo.path, create_jail=True)
 
     _configure_vm_from_json(test_microvm, vm_config_file)
-    test_microvm.no_api = True
+    test_microvm.jailer.extra_args.update({'no-api': None})
+
     test_microvm.spawn()
 
     # Get Firecracker PID so we can check the names of threads.


### PR DESCRIPTION
## Reason for This PR

The `--` (extra-args) feature for propagating
jailer parameters to firecracker gets appended
only when config-file is specified.
Fixed this by implementing a forward looking approach
that enables us to even exercise our new implementation
of the arg parser.
## Description of Changes

The approach implemented mirrors the codebase. Added the extra-args parameter to the jailer (just like in the [codebase](https://github.com/firecracker-microvm/firecracker/blob/master/src/jailer/src/main.rs#L272)) that can be tweaked from inside the integration tests in any means possible for the sake of exercising valid as well as non-valid scenarios.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] No code has been touched.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
