### PR TITLE
docs: fix inconsistent reference to rootfs.ext4

### DIFF
--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -60,7 +60,7 @@ To build an EXT4 image:
    on how much data you'll want to fit inside:
 
    ```bash
-   dd if=/dev/zero of=/rootfs.ext4 bs=1M count=50
+   dd if=/dev/zero of=rootfs.ext4 bs=1M count=50
    ```
 
 2. Create an empty file system on the file you created:


### PR DESCRIPTION
Steps 1 and 2 listed in the documentation should use the same path

Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

## Reason for This PR

The documentation that shows how a root filesystem is built references the root filesystem image once as "/rootfs.ext4" and another time as "rootfs.ext4". 
If one is to follow these steps, there would be a file not found error thrown.

## Description of Changes

Since it makes more sense to have the filesystem built in the current working directory, this PR removes the extra "/" which is prepended in the first step

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] The required doc changes are included in this PR.
- [x] No code has been touched.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
