### PR TITLE
tests: solved unit/coverage conflict

### DIFF
--- a/tests/framework/scheduler.py
+++ b/tests/framework/scheduler.py
@@ -115,7 +115,8 @@ class PytestScheduler(mpsing.MultiprocessSingleton):
                     "/functional/test_initrd.py",
                     "/functional/test_max_vcpus.py",
                     "/functional/test_rate_limiter.py",
-                    "/functional/test_signals.py"
+                    "/functional/test_signals.py",
+                    "/build/test_coverage.py"
                 ],
                 'items': []
             },


### PR DESCRIPTION
## Reason for This PR

CI could fail erroneously due to running multiple unit tests in parallel.

## Description of Changes

Marked the coverage integration test as concurrency-unsafe, so that it
doesn't get scheduled to run at the same time as test_unittests.

Currently the unit tests cannot be run in parallel, and computing the
coverage involves running all the unit tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] No docs need to be updated as part of this PR.
- [ ] Code-level documentation for touched code is included in this PR.
- [ ] No API changes are included in this PR.
- [ ] The changes in this PR have no user impact.
- [ ] No new `unsafe` code has been added.
