### PR TITLE
tests: leftover aarch64 hardcoded syscall

### DIFF
--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -4,21 +4,21 @@
 name = "demo_seccomp"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "seccomp 0.1.0",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.48"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seccomp"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"

--- a/tests/integration_tests/security/demo_seccomp/Cargo.toml
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-libc = ">0.2.39"
+libc = ">=0.2.39"
 
 seccomp = { path = "../../../../src/seccomp" }
 

--- a/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
@@ -5,9 +5,6 @@ extern crate seccomp;
 
 use seccomp::{allow_syscall, SyscallRuleSet};
 
-#[cfg(target_arch = "aarch64")]
-const SYS_mmap: ::std::os::raw::c_long = 222;
-
 /// Returns a list of rules that allow syscalls required for running a rust program.
 pub fn rust_required_rules() -> Vec<SyscallRuleSet> {
     vec![
@@ -23,12 +20,7 @@ pub fn jailer_required_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_rt_sigaction),
         allow_syscall(libc::SYS_execve),
-        #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_mmap),
-        #[cfg(target_arch = "aarch64")]
-        // See this issue for why we are doing it this way on arch64:
-        // https://github.com/rust-lang/libc/issues/1348.
-        allow_syscall(SYS_mmap),
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_arch_prctl),
         allow_syscall(libc::SYS_set_tid_address),


### PR DESCRIPTION
## Reason for This PR

This is a leftover of PR #1333 which removed hardcoded
syscall numbers only in development code and forgot
to update demo_seccomp module inside the integration tests.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Description of Changes

* ran cargo update on demo_seccomp
* removed hardcoded stuff

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] No code has been touched.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
