### PR TITLE
seccomp: code and docs adjustments

### DIFF
--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -377,21 +377,21 @@ pub enum SeccompCmpOp {
     Ne,
 }
 
-/// Seccomp argument length.
+/// Seccomp argument value length.
 #[derive(Clone, Debug)]
 pub enum SeccompCmpArgLen {
-    /// Argument length is 4 bytes.
+    /// Argument value length is 4 bytes.
     DWORD,
-    /// Argument length is 8 bytes.
+    /// Argument value length is 8 bytes.
     QWORD,
 }
 
 /// Condition that syscall must match in order to satisfy a rule.
 #[derive(Clone, Debug)]
 pub struct SeccompCondition {
-    /// Number of the argument value that is to be compared.
+    /// Index of the argument that is to be compared.
     arg_number: u8,
-    /// Length of the argument that is to be compared.
+    /// Length of the argument value that is to be compared.
     arg_len: SeccompCmpArgLen,
     /// Comparison to perform.
     operator: SeccompCmpOp,
@@ -487,6 +487,7 @@ impl SeccompCondition {
     /// # Arguments
     ///
     /// * `arg_number` - The index of the argument in the system call.
+    /// * `arg_len` - The length of the argument value. See `SeccompCmpArgLen`.
     /// * `operator` - The comparison operator. See `SeccompCmpOp`.
     /// * `value` - The value against which the argument will be compared with `operator`.
     ///

--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -1016,10 +1016,8 @@ impl SeccompFilter {
         // Pre-collect the keys to avoid the double borrow.
         let syscalls: Vec<i64> = self.rules.keys().cloned().collect();
         for syscall in syscalls {
-            self.rules.insert(
-                syscall,
-                vec![SeccompRule::new(vec![], SeccompAction::Allow)],
-            );
+            let ruleset: SyscallRuleSet = allow_syscall(syscall);
+            self.rules.insert(ruleset.0, ruleset.1);
         }
         self
     }
@@ -1137,17 +1135,17 @@ fn EXAMINE_SYSCALL() -> Vec<sock_filter> {
 pub enum SeccompError {
     /// Error while trying to generate a BPF program.
     SeccompFilter(Error),
-    /// Failed to parse to `u32`.
+    /// Failed to parse to `u8`.
     Parse(std::num::ParseIntError),
-    /// Seccomp level is an `u32` value, other than 0, 1 or 2.
-    Level(u32),
+    /// Seccomp level is an `u8` value, other than 0, 1 or 2.
+    Level(u8),
 }
 
 impl Display for SeccompError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
             SeccompError::SeccompFilter(ref err) => write!(f, "Seccomp error: {}", err),
-            SeccompError::Parse(ref err) => write!(f, "Could not parse to 'u32': {}", err),
+            SeccompError::Parse(ref err) => write!(f, "Could not parse to 'u8': {}", err),
             SeccompError::Level(arg) => write!(
                 f,
                 "'{}' isn't a valid value for 'seccomp-level'. Must be 0, 1 or 2.",
@@ -1158,7 +1156,7 @@ impl Display for SeccompError {
 }
 
 /// Possible values for seccomp level.
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Debug, PartialEq)]
 pub enum SeccompLevel {
     /// Seccomp filtering disabled.
@@ -1173,7 +1171,7 @@ impl SeccompLevel {
     /// Converts from a seccomp level value of type String to the corresponding SeccompLevel variant
     /// or returns an error if the parsing failed.
     pub fn from_string(seccomp_value: String) -> std::result::Result<Self, SeccompError> {
-        match seccomp_value.parse::<u32>() {
+        match seccomp_value.parse::<u8>() {
             Ok(0) => Ok(SeccompLevel::None),
             Ok(1) => Ok(SeccompLevel::Basic),
             Ok(2) => Ok(SeccompLevel::Advanced),
@@ -2054,7 +2052,7 @@ mod tests {
                 "{}",
                 SeccompLevel::from_string("foo".to_string()).unwrap_err()
             ),
-            "Could not parse to 'u32': invalid digit found in string"
+            "Could not parse to 'u8': invalid digit found in string"
         );
         assert_eq!(
             SeccompLevel::from_string("0".to_string()).unwrap(),


### PR DESCRIPTION
## Description of Changes

This PR includes:

- Changed level representation of seccomp from u32 to u8.
- Some code and docs adjustments.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
