### PR TITLE
Add 'InstanceForceStop' action to forcefully stop all VCPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Support for booting with an initial RAM disk image. This image can be
   specified through the new `initrd_path` field of the `/boot-source` API
   request.
+- New API action: InstanceForceStop, used to forcefully stop a running
+  instance. See [the docs](docs/api_requests/actions.md#instanceforcestop) for
+  details.
 
 ### Fixed
 

--- a/docs/api_requests/actions.md
+++ b/docs/api_requests/actions.md
@@ -118,3 +118,22 @@ curl --unix-socket /tmp/firecracker.socket -i \
              \"action_type\": \"SendCtrlAltDel\"
     }"
 ```
+
+## InstanceForceStop
+
+This action will forcefully exit the microVM by stopping all VCPUs. Note that
+this is an unclean shutdown; the guest will not have a chance to respond to
+this action, and no guarantees are made about the order or synchronization of
+stopping VCPUs.
+
+### InstanceForceStop Example
+
+```bash
+curl --unix-socket /tmp/firecracker.socket -i \
+    -X PUT "http://localhost/actions" \
+    -H  "accept: application/json" \
+    -H  "Content-Type: application/json" \
+    -d "{
+             \"action_type\": \"InstanceForceStop\"
+    }"
+```

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -84,6 +84,8 @@ pub enum VmmAction {
     /// Update a network interface, after microVM start. Currently, the only updatable properties
     /// are the RX and TX rate limiters.
     UpdateNetworkInterface(NetworkInterfaceUpdateConfig),
+    /// Forcefully stops the microVM.
+    ForceStopMicroVm,
 }
 
 /// The enum represents the response sent by the VMM in case of success. The response is either

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -50,7 +50,10 @@ fn validate_payload(action_body: &ActionBody) -> Result<(), Error> {
                 )),
             }
         }
-        ActionType::FlushMetrics | ActionType::InstanceStart | ActionType::SendCtrlAltDel | ActionType::InstanceForceStop => {
+        ActionType::FlushMetrics
+        | ActionType::InstanceStart
+        | ActionType::SendCtrlAltDel
+        | ActionType::InstanceForceStop => {
             // Neither FlushMetrics nor InstanceStart should have a payload.
             if action_body.payload.is_some() {
                 return Err(Error::Generic(
@@ -91,7 +94,7 @@ pub fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
 
             #[cfg(target_arch = "x86_64")]
             Ok(ParsedRequest::Sync(VmmAction::SendCtrlAltDel))
-        },
+        }
         ActionType::InstanceForceStop => Ok(ParsedRequest::Sync(VmmAction::ForceStopMicroVm)),
     }
 }

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -16,6 +16,7 @@ enum ActionType {
     FlushMetrics,
     InstanceStart,
     SendCtrlAltDel,
+    InstanceForceStop,
 }
 
 // The model of the json body from a sync request. We use Serde to transform each associated
@@ -49,7 +50,7 @@ fn validate_payload(action_body: &ActionBody) -> Result<(), Error> {
                 )),
             }
         }
-        ActionType::FlushMetrics | ActionType::InstanceStart | ActionType::SendCtrlAltDel => {
+        ActionType::FlushMetrics | ActionType::InstanceStart | ActionType::SendCtrlAltDel | ActionType::InstanceForceStop => {
             // Neither FlushMetrics nor InstanceStart should have a payload.
             if action_body.payload.is_some() {
                 return Err(Error::Generic(
@@ -90,7 +91,8 @@ pub fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
 
             #[cfg(target_arch = "x86_64")]
             Ok(ParsedRequest::Sync(VmmAction::SendCtrlAltDel))
-        }
+        },
+        ActionType::InstanceForceStop => Ok(ParsedRequest::Sync(VmmAction::ForceStopMicroVm)),
     }
 }
 

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -456,6 +456,7 @@ definitions:
         - FlushMetrics
         - InstanceStart
         - SendCtrlAltDel
+        - InstanceForceStop
       payload:
         type: string
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -385,6 +385,9 @@ fn vmm_control_event(
                 UpdateNetworkInterface(netif_update) => vmm
                     .update_net_device(netif_update)
                     .map(|_| api_server::VmmData::Empty),
+                ForceStopMicroVm => vmm
+                    .force_stop()
+                    .map(|_| api_server::VmmData::Empty),
             };
             // Run the requested action and send back the result.
             to_api

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -385,9 +385,7 @@ fn vmm_control_event(
                 UpdateNetworkInterface(netif_update) => vmm
                     .update_net_device(netif_update)
                     .map(|_| api_server::VmmData::Empty),
-                ForceStopMicroVm => vmm
-                    .force_stop()
-                    .map(|_| api_server::VmmData::Empty),
+                ForceStopMicroVm => vmm.force_stop().map(|_| api_server::VmmData::Empty),
             };
             // Run the requested action and send back the result.
             to_api

--- a/src/vmm/src/error.rs
+++ b/src/vmm/src/error.rs
@@ -529,7 +529,6 @@ impl std::convert::From<ForceStopMicrovmError> for VmmActionError {
     }
 }
 
-
 impl VmmActionError {
     /// Returns the error type.
     pub fn kind(&self) -> &ErrorKind {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -98,7 +98,9 @@ use vmm_config::net::{
 use vmm_config::vsock::{VsockDeviceConfig, VsockError};
 use vstate::{KvmContext, Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
 
-pub use error::{ErrorKind, ForceStopMicrovmError, LoadInitrdError, StartMicrovmError, VmmActionError};
+pub use error::{
+    ErrorKind, ForceStopMicrovmError, LoadInitrdError, StartMicrovmError, VmmActionError,
+};
 
 const WRITE_METRICS_PERIOD_SECONDS: u64 = 60;
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -673,8 +673,7 @@ def test_send_ctrl_alt_del(test_microvm_with_atkbd):
 
 
 def test_instance_force_stop(test_microvm_with_api):
-    """Test shutting down the microVM forcefully.
-    """
+    """Test shutting down the microVM forcefully."""
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 


### PR DESCRIPTION
## Reason for This PR

In the case that the guest kernel is either non-cooperative (i.e. does not shut down when Ctrl-Alt-Delete is sent), or hangs and does not respond, it's convenient to be able to forcefully stop a microVM.

## Description of Changes

Building off the work done in #1414, I simply wired through use of `VcpuEvent::Exit`.

Feedback is appreciated - this is my first time contributing to Firecracker!

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
