### PR TITLE
Implement epoll wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,6 @@ name = "polly"
 version = "0.0.1"
 dependencies = [
  "bitflags",
- "epoll",
  "libc",
  "utils",
 ]

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -11,7 +11,6 @@ impl EventHandler for Block {
     fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
         let queue = self.queue_evt.as_raw_fd();
         let rate_limiter = self.rate_limiter.as_raw_fd();
-        let source = source.as_raw_fd();
 
         // Looks better than C style if/else if/else.
         match source {
@@ -26,10 +25,10 @@ impl EventHandler for Block {
     // Returns the rate_limiter and queue event fds.
     fn init(&self) -> Vec<PollableOp> {
         vec![
-            PollableOpBuilder::new(Pollable::from(&self.rate_limiter))
+            PollableOpBuilder::new(self.rate_limiter.as_raw_fd())
                 .readable()
                 .register(),
-            PollableOpBuilder::new(Pollable::from(&self.queue_evt))
+            PollableOpBuilder::new(self.queue_evt.as_raw_fd())
                 .readable()
                 .register(),
         ]

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -5,6 +5,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 libc = ">=0.2.39"
-epoll = "4.0.1"
 bitflags = "1.2.0"
 utils = { path="../utils" }

--- a/src/polly/src/epoll.rs
+++ b/src/polly/src/epoll.rs
@@ -1,0 +1,375 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::ops::Deref;
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use libc::{
+    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLEXCLUSIVE, EPOLLHUP,
+    EPOLLIN, EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC,
+    EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
+};
+
+use utils::syscall::SyscallReturnCode;
+
+/// Wrapper over EPOLL_CTL_* operations that can be performed on a file descriptor.
+#[repr(i32)]
+pub enum ControlOperation {
+    /// Add a file descriptor to the interest list.
+    Add = EPOLL_CTL_ADD,
+    /// Change the settings associated with a file descriptor that is
+    /// already in the interest list.
+    Modify = EPOLL_CTL_MOD,
+    /// Remove a file descriptor from the interest list.
+    Delete = EPOLL_CTL_DEL,
+}
+
+bitflags! {
+    /// The type of events we can monitor a file descriptor for.
+    pub struct EventType: u32 {
+        /// The associated file descriptor is available for read operations.
+        const IN = EPOLLIN as u32;
+        /// The associated file descriptor is available for write operations.
+        const OUT = EPOLLOUT as u32;
+        /// Error condition happened on the associated file descriptor.
+        const ERROR = EPOLLERR as u32;
+        /// This can be used to detect peer shutdown when using Edge Triggered monitoring.
+        const READ_HANG_UP = EPOLLRDHUP as u32;
+        /// Sets the Edge Triggered behavior for the associated file descriptor.
+        /// The default behavior is Level Triggered.
+        const EDGE_TRIGGERED = EPOLLET as u32;
+        /// Hang up happened on the associated file descriptor. Note that `epoll_wait`
+        /// will always wait for this event and it is not necessary to set it in events.
+        const HANG_UP = EPOLLHUP as u32;
+        /// There is an exceptional condition on that file descriptor. It is mostly used to
+        /// set high priority for some data.
+        const PRIORITY = EPOLLPRI as u32;
+        /// The event is considered as being "processed" from the time when it is returned
+        /// by a call to `epoll_wait` until the next call to `epoll_wait` on the same
+        /// epoll file descriptor, the closure of that file descriptor, the removal of the
+        /// event file descriptor via EPOLL_CTL_DEL, or the clearing of EPOLLWAKEUP
+        /// for the event file descriptor via EPOLL_CTL_MOD.
+        const WAKE_UP = EPOLLWAKEUP as u32;
+        /// Sets the one-shot behavior for the associated file descriptor.
+        const ONE_SHOT = EPOLLONESHOT as u32;
+        /// Sets an exclusive wake up mode for the epoll file descriptor that is being
+        /// attached to the associated file descriptor.
+        /// When a wake up event occurs and multiple epoll file descriptors are attached to
+        /// the same target file using this mode, one or more of the epoll file descriptors
+        /// will receive an event with `epoll_wait`. The default here is for all those file
+        /// descriptors to receive an event.
+        const EXCLUSIVE = EPOLLEXCLUSIVE as u32;
+    }
+}
+
+/// Wrapper over 'libc::epoll_event'.
+///
+// We are using `transparent` here to be super sure that this struct and its fields
+// have the same alignment as those from the `epoll_event` struct from C.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Event(epoll_event);
+
+impl Deref for Event {
+    type Target = epoll_event;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for Event {
+    fn default() -> Self {
+        Event(epoll_event {
+            events: 0u32,
+            u64: 0u64,
+        })
+    }
+}
+
+impl Event {
+    /// Create a new epoll_event instance with the following fields: `events`, which contains
+    /// an event mask and `data` which represents a user data variable. `data` field can be
+    /// a fd on which we want to monitor the events specified by `events`.
+    pub fn new(events: EventType, data: u64) -> Self {
+        Event(epoll_event {
+            events: events.bits(),
+            u64: data,
+        })
+    }
+
+    pub fn events(&self) -> u32 {
+        self.events
+    }
+
+    pub fn data(&self) -> u64 {
+        self.u64
+    }
+}
+
+/// Wrapper over epoll functionality.
+#[derive(Clone, Copy, Debug)]
+pub struct Epoll {
+    epoll_fd: RawFd,
+}
+
+impl Epoll {
+    /// Create a new epoll file descriptor.
+    pub fn new() -> io::Result<Self> {
+        let epoll_fd = SyscallReturnCode(unsafe { epoll_create1(EPOLL_CLOEXEC) }).into_result()?;
+        Ok(Epoll { epoll_fd })
+    }
+
+    /// Wrapper for `libc::epoll_ctl`.
+    ///
+    /// This can be used for adding, modifying or removing a file descriptor in the
+    /// interest list of the epoll instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `operation` refers to the action to be performed on the file descriptor.
+    /// * `fd` is the file descriptor on which we want to perform `operation`.
+    /// * `event` refers to the `epoll_event` instance that is linked to `fd`.
+    pub fn ctl(self, operation: ControlOperation, fd: RawFd, event: Event) -> io::Result<()> {
+        // We copy here `event` in order to obtain a mutable Event as this is a requirement
+        // from `epoll_ctl()` signature even if this syscall doesn't actually mutate the object.
+        let mut event_as_mut = event;
+
+        // Safe because we give a valid epoll file descriptor, a valid file descriptor to watch,
+        // as well as a valid epoll_event structure. We also check the return value.
+        SyscallReturnCode(unsafe {
+            epoll_ctl(
+                self.epoll_fd,
+                operation as i32,
+                fd,
+                &mut event_as_mut as *mut _ as *mut epoll_event,
+            )
+        })
+        .into_empty_result()
+    }
+
+    /// Wrapper for `libc::epoll_wait`.
+    /// Returns the number of file descriptors in the interest list that became ready
+    /// for I/O or `errno` if an error occurred.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_events` is the maximum number of events that we want to be returned in
+    /// `events` buffer.
+    /// * `timeout` specifies for how long the `epoll_wait` system call will block
+    /// (measured in milliseconds).
+    /// * `events` points to a memory area that will be used for storing the events
+    /// returned by `epoll_wait()` call.
+    pub fn wait(self, max_events: usize, timeout: i32, events: &mut [Event]) -> io::Result<usize> {
+        // Safe because we give a valid epoll file descriptor and an array of epoll_event structures
+        // that will be modified by the kernel to indicate information about the subset of file
+        // descriptors in the interest list. We also check the return value.
+        let events_count = SyscallReturnCode(unsafe {
+            epoll_wait(
+                self.epoll_fd,
+                events.as_mut_ptr() as *mut epoll_event,
+                max_events as i32,
+                timeout,
+            )
+        })
+        .into_result()? as usize;
+
+        Ok(events_count)
+    }
+}
+
+impl AsRawFd for Epoll {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll_fd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use utils::eventfd::EventFd;
+
+    #[test]
+    fn test_event_ops() {
+        let mut event = Event::default();
+        assert_eq!(event.events(), 0);
+        assert_eq!(event.data(), 0);
+
+        event = Event::new(EventType::IN, 2);
+        assert_eq!(event.events(), 1);
+        assert_eq!(event.data(), 2);
+    }
+
+    #[test]
+    fn test_epoll() {
+        const DEFAULT__TIMEOUT: i32 = 250;
+        const EVENT_BUFFER_SIZE: usize = 128;
+        const MAX_EVENTS: usize = 10;
+
+        let epoll = Epoll::new().unwrap();
+        assert_eq!(epoll.epoll_fd, epoll.as_raw_fd());
+
+        // Let's test different scenarios for `epoll_ctl()` and `epoll_wait()` functionality.
+
+        let event_fd_1 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        // For EPOLLOUT to be available it is enough only to be possible to write a value of
+        // at least 1 to the eventfd counter without blocking.
+        // If we write a value greater than 0 to this counter, the fd will be available for
+        // EPOLLIN events too.
+        event_fd_1.write(1).unwrap();
+
+        let mut event_1 = Event::new(
+            EventType::IN | EventType::OUT,
+            event_fd_1.as_raw_fd() as u64,
+        );
+
+        // For EPOLL_CTL_ADD behavior we will try to add some fds with different event masks into
+        // the interest list of epoll instance.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_ok());
+
+        // We can't add twice the same fd to epoll interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_err());
+
+        let event_fd_2 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        event_fd_2.write(1).unwrap();
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_2.as_raw_fd() as i32,
+                // For this fd, we want an Event instance that has `data` field set to other
+                // value than the value of the fd and `events` without EPOLLIN type set.
+                Event::new(EventType::OUT, 10)
+            )
+            .is_ok());
+
+        // For the following eventfd we won't write anything to its counter, so we expect EPOLLIN
+        // event to not be available for this fd, even if we say that we want to monitor this type
+        // of event via EPOLL_CTL_ADD operation.
+        let event_fd_3 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        let event_3 = Event::new(
+            EventType::OUT | EventType::IN,
+            event_fd_3.as_raw_fd() as u64,
+        );
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_3.as_raw_fd() as i32,
+                event_3
+            )
+            .is_ok());
+
+        // Let's check `epoll_wait()` behavior for our epoll instance.
+        let mut ready_events = vec![Event::default(); EVENT_BUFFER_SIZE];
+        let mut ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        // We expect to have 3 fds in the ready list of epoll instance.
+        assert_eq!(ev_count, 3);
+
+        // Let's check also the Event values that are now returned in the ready list.
+        assert_eq!(ready_events[0].data(), event_fd_1.as_raw_fd() as u64);
+        // For this fd, `data` field was populated with random data instead of the
+        // corresponding fd value.
+        assert_eq!(ready_events[1].data(), 10);
+        assert_eq!(ready_events[2].data(), event_fd_3.as_raw_fd() as u64);
+
+        // EPOLLIN and EPOLLOUT should be available for this fd.
+        assert_eq!(
+            ready_events[0].events(),
+            (EventType::IN | EventType::OUT).bits()
+        );
+        // Only EPOLLOUT is expected because we didn't want to monitor EPOLLIN on this fd.
+        assert_eq!(ready_events[1].events(), EventType::OUT.bits());
+        // Only EPOLLOUT too because eventfd counter value is 0 (we didn't write a value
+        // greater than 0 to it).
+        assert_eq!(ready_events[2].events(), EventType::OUT.bits());
+
+        // Now we're gonna modify the Event instance for a fd to test EPOLL_CTL_MOD
+        // behavior.
+        // We create here a new Event with some events, other than those previously set,
+        // that we want to monitor this time on event_fd_1.
+        event_1 = Event::new(EventType::OUT, 20);
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_ok());
+
+        let event_fd_4 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        // Can't modify a fd that wasn't added to epoll interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_4.as_raw_fd() as i32,
+                Event::default()
+            )
+            .is_err());
+
+        let _ = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        // Let's check that Event fields were indeed changed for the `event_fd_1` fd.
+        assert_eq!(ready_events[0].data(), 20);
+        // EPOLLOUT is now available for this fd as we've intended with EPOLL_CTL_MOD operation.
+        assert_eq!(ready_events[0].events(), EventType::OUT.bits());
+
+        // Now let's set for a fd to not have any events monitored.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_1.as_raw_fd() as i32,
+                Event::default()
+            )
+            .is_ok());
+
+        // In this particular case we expect to remain only with 2 fds in the ready list.
+        ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+        assert_eq!(ev_count, 2);
+
+        // Let's also delete a fd from the interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd_2.as_raw_fd() as i32,
+                Event::default()
+            )
+            .is_ok());
+
+        // We expect to have only one fd remained in the ready list (event_fd_3).
+        ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        assert_eq!(ev_count, 1);
+        assert_eq!(ready_events[0].data(), event_fd_3.as_raw_fd() as u64);
+        assert_eq!(ready_events[0].events(), EventType::OUT.bits());
+
+        // If we try to remove a fd from epoll interest list that wasn't added before it will fail.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd_4.as_raw_fd() as i32,
+                Event::default()
+            )
+            .is_err());
+    }
+}

--- a/src/polly/src/event_manager.rs
+++ b/src/polly/src/event_manager.rs
@@ -1,8 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use epoll;
-use pollable::{EventRegistrationData, Pollable, PollableOp, PollableOpBuilder};
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::io;
@@ -10,7 +8,11 @@ use std::ops::{Deref, DerefMut};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex};
+
 use utils::eventfd::EventFd;
+
+use epoll;
+use pollable::{EventRegistrationData, Pollable, PollableOp, PollableOpBuilder};
 
 const EVENT_BUFFER_SIZE: usize = 128;
 const DEFAULT_EPOLL_TIMEOUT: i32 = 250;
@@ -18,6 +20,7 @@ const DEFAULT_EPOLL_TIMEOUT: i32 = 250;
 pub type Result<T> = std::result::Result<T, Error>;
 pub type WrappedHandler = Arc<Mutex<dyn EventHandler>>;
 
+/// Errors associated with epoll events handling.
 pub enum Error {
     /// Cannot create epoll fd.
     EpollCreate(io::Error),
@@ -44,7 +47,7 @@ impl std::fmt::Debug for Error {
             Poll(err) => write!(f, "Error during epoll call: {}", err),
             AlreadyExists(pollable) => write!(
                 f,
-                "A handler for the specified pollable {} already exists",
+                "A handler for the specified pollable {} already exists.",
                 pollable
             ),
             ChannelFd(err) => write!(f, "Error while writing channel event fd: {}", err),
@@ -52,7 +55,7 @@ impl std::fmt::Debug for Error {
             ChannelClone(err) => write!(f, "Error while cloning tx channel: {}", err),
             NotFound(pollable) => write!(
                 f,
-                "A handler for the specified pollable {} was not found",
+                "A handler for the specified pollable {} was not found.",
                 pollable
             ),
         }
@@ -156,7 +159,7 @@ impl<T> GenericChannel<T> {
         self.channel.send(msg).map_err(|_| Error::ChannelDisconnect)
     }
 
-    /// Reads evenfd event count.
+    /// Reads eventfd event count.
     pub fn read_event(&mut self) -> u64 {
         self.fd.read().unwrap_or(0)
     }
@@ -180,10 +183,11 @@ impl<T> AsRawFd for GenericChannel<T> {
 pub type ChannelMessage = (WrappedHandler, Vec<PollableOp>);
 pub type Channel = GenericChannel<ChannelMessage>;
 
+/// Manages I/O notifications using epoll mechanism.
 pub struct EventManager {
     epoll: epoll::Epoll,
     handlers: HandlerMap,
-    events: Vec<epoll::Event>,
+    ready_events: Vec<epoll::Event>,
     channel_rx: Receiver<ChannelMessage>,
     channel_tx: Channel,
 }
@@ -203,7 +207,10 @@ impl EventManager {
         Ok(EventManager {
             epoll: epoll_fd,
             handlers: HandlerMap::new(),
-            events: vec![epoll::Event::default(); EVENT_BUFFER_SIZE],
+            // This buffer is used for storing the events returned by `epoll_wait()`.
+            // We preallocate memory for this buffer in order to not repeat this
+            // operation every time `run()` loop is executed.
+            ready_events: vec![epoll::Event::default(); EVENT_BUFFER_SIZE],
             channel_rx: rx,
             channel_tx: Channel::new(tx)?,
         })
@@ -214,7 +221,7 @@ impl EventManager {
         self.channel_tx.try_clone()
     }
 
-    // Register a new eventhandler for the pollable and mask specified
+    // Register a new event handler for the pollable and mask specified
     // in event_data.
     fn register_handler(
         &mut self,
@@ -223,24 +230,24 @@ impl EventManager {
     ) -> Result<()> {
         let (pollable, event_type) = event_data;
 
-        if self.handlers.get(pollable.as_raw_fd()).is_some() {
+        if self.handlers.get(pollable).is_some() {
             return Err(Error::AlreadyExists(pollable));
         };
 
         self.epoll
             .ctl(
                 epoll::ControlOperation::Add,
-                pollable.as_raw_fd(),
+                pollable,
                 epoll::Event::new(
                     event_type.into(),
                     // Use the fd for event source identification in handlers.
-                    pollable.as_raw_fd() as u64,
+                    pollable as u64,
                 ),
             )
             .map_err(Error::Poll)?;
 
         self.handlers.insert(
-            pollable.as_raw_fd(),
+            pollable,
             EventHandlerData::new((pollable, event_type), wrapped_handler.clone()),
         );
         Ok(())
@@ -300,12 +307,12 @@ impl EventManager {
     }
 
     fn update_event(&mut self, event: EventRegistrationData) -> Result<()> {
-        if let Some(handler_data) = self.handlers.get_mut(&event.0.as_raw_fd()) {
+        if let Some(handler_data) = self.handlers.get_mut(&event.0) {
             self.epoll
                 .ctl(
                     epoll::ControlOperation::Modify,
-                    event.0.as_raw_fd(),
-                    epoll::Event::new(event.1.into(), event.0.as_raw_fd() as u64),
+                    event.0,
+                    epoll::Event::new(event.1.into(), event.0 as u64),
                 )
                 .map_err(Error::Poll)?;
             handler_data.data = event;
@@ -316,15 +323,15 @@ impl EventManager {
         Ok(())
     }
 
-    /// Unregister a the event handler for the specified pollable.
+    /// Unregister the event handler for the specified pollable.
     ///
     pub fn unregister(&mut self, pollable: Pollable) -> Result<()> {
-        match self.handlers.remove(&pollable.as_raw_fd()) {
+        match self.handlers.remove(&pollable) {
             Some(_) => {
                 self.epoll
                     .ctl(
                         epoll::ControlOperation::Delete,
-                        pollable.as_raw_fd(),
+                        pollable,
                         epoll::Event::default(),
                     )
                     .map_err(Error::Poll)?;
@@ -336,7 +343,7 @@ impl EventManager {
         Ok(())
     }
 
-    // Dispatch an epoll eventset for a handler.
+    // Dispatch an epoll event set for a handler.
     #[inline(always)]
     fn dispatch_event(
         &mut self,
@@ -374,7 +381,7 @@ impl EventManager {
     // Process/dispatch buffered epoll events.
     fn process_events(&mut self, event_count: usize) -> Result<()> {
         for idx in 0..event_count {
-            let event = self.events[idx];
+            let event = self.ready_events[idx];
             let event_mask = event.events();
             let event_data = event.data();
             let evset = match epoll::EventType::from_bits(event_mask) {
@@ -395,14 +402,14 @@ impl EventManager {
                 ) {
                     continue;
                 } else {
-                    // We might get errors related to pollableops.
+                    // We might get errors related to PollableOps.
                     // Need to decide what to do with them.
                     // Options:
                     // 1. Break loop and throw them to the caller
-                    // 2. Invoke a TBD evenhandler error callback.
+                    // 2. Invoke a TBD event handler error callback.
                 }
             } else {
-                // There is no handler registered for this eventset/pollable.
+                // There is no handler registered for this event set/pollable.
             }
         }
 
@@ -418,7 +425,7 @@ impl EventManager {
     pub fn run_timeout(&mut self, milliseconds: i32) -> Result<usize> {
         let event_count = self
             .epoll
-            .wait(EVENT_BUFFER_SIZE, milliseconds, &mut self.events[..])
+            .wait(EVENT_BUFFER_SIZE, milliseconds, &mut self.ready_events[..])
             .map_err(Error::Poll)?;
         self.process_events(event_count)?;
 
@@ -439,7 +446,7 @@ impl EventHandler for EventManager {
 
     // Returns the epoll fd to the parent EventManager.
     fn init(&self) -> Vec<PollableOp> {
-        vec![PollableOpBuilder::new(Pollable::from(self))
+        vec![PollableOpBuilder::new(self.epoll.as_raw_fd())
             .readable()
             .register()]
     }
@@ -463,7 +470,7 @@ mod tests {
         pub fn new() -> Self {
             let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
             DummyEventConsumer {
-                pollable: Pollable::from(&event_fd),
+                pollable: event_fd.as_raw_fd(),
                 event_fd,
                 read: false,
                 write: false,
@@ -476,28 +483,28 @@ mod tests {
     impl EventHandler for DummyEventConsumer {
         /// Handle a read event (EPOLLIN).
         fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
-            if source.as_raw_fd() == self.event_fd.as_raw_fd() {
+            if source == self.event_fd.as_raw_fd() {
                 self.read = true;
             }
             vec![]
         }
         /// Handle a write event (EPOLLOUT).
         fn handle_write(&mut self, source: Pollable) -> Vec<PollableOp> {
-            if source.as_raw_fd() == self.event_fd.as_raw_fd() {
+            if source == self.event_fd.as_raw_fd() {
                 self.write = true;
             }
             vec![]
         }
         /// Handle a close event (EPOLLRDHUP).
         fn handle_close(&mut self, source: Pollable) -> Vec<PollableOp> {
-            if source.as_raw_fd() == self.event_fd.as_raw_fd() {
+            if source == self.event_fd.as_raw_fd() {
                 self.close = true;
             }
             vec![]
         }
         /// Handle an error event (EPOLLERR).assert_ne!
         fn handle_error(&mut self, source: Pollable) -> Vec<PollableOp> {
-            if source.as_raw_fd() == self.event_fd.as_raw_fd() {
+            if source == self.event_fd.as_raw_fd() {
                 self.error = true;
             }
             vec![]
@@ -530,7 +537,7 @@ mod tests {
         let dummy = DummyEventConsumer::new();
         let pollable = dummy.pollable;
         let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
-        let pollable2 = Pollable::from(&event_fd);
+        let pollable2 = event_fd.as_raw_fd();
 
         let handler = Arc::new(Mutex::new(dummy));
         let mut ops = vec![PollableOpBuilder::new(pollable).readable().register()];
@@ -559,12 +566,12 @@ mod tests {
 
         // Validate the handler is registered.
         let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
-        let pollable2 = Pollable::from(&event_fd);
+        let pollable2 = event_fd.as_raw_fd();
         ops = vec![PollableOpBuilder::new(pollable2).writeable().register()];
         channel.send((handler.clone(), ops)).unwrap();
 
         assert_eq!(em.process_ops().unwrap(), 1);
-        assert!(em.handlers.get(pollable.as_raw_fd()).is_some());
+        assert!(em.handlers.get(pollable).is_some());
     }
 
     #[test]
@@ -575,7 +582,7 @@ mod tests {
         let handler = em.register(DummyEventConsumer::new()).unwrap();
         let pollable = handler.lock().expect("Unlock failed.").pollable;
 
-        assert!(em.handlers.get(pollable.as_raw_fd()).is_some());
+        assert!(em.handlers.get(pollable).is_some());
     }
 
     #[test]
@@ -588,7 +595,7 @@ mod tests {
         let ops = handler.lock().expect("Unlock failed.").init();
         em.update(handler, ops).unwrap();
 
-        let handler_data = em.handlers.get(pollable.as_raw_fd());
+        let handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_some());
         let reg_data = handler_data.unwrap().data;
         assert_eq!(
@@ -607,7 +614,7 @@ mod tests {
         let ops = handler.lock().expect("Unlock failed.").init();
         em.update(handler.clone(), ops).unwrap();
 
-        let mut handler_data = em.handlers.get(pollable.as_raw_fd());
+        let mut handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_some());
 
         assert!(em
@@ -617,7 +624,7 @@ mod tests {
             )
             .is_ok());
 
-        handler_data = em.handlers.get(pollable.as_raw_fd());
+        handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_none());
     }
 
@@ -630,7 +637,7 @@ mod tests {
         let handler = em.register(DummyEventConsumer::new()).unwrap();
         let pollable = handler.lock().expect("Unlock failed.").pollable;
 
-        let mut handler_data = em.handlers.get(pollable.as_raw_fd());
+        let mut handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_some());
 
         channel
@@ -642,7 +649,7 @@ mod tests {
 
         assert_eq!(em.process_ops().unwrap(), 1);
 
-        handler_data = em.handlers.get(pollable.as_raw_fd());
+        handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_none());
     }
 
@@ -654,19 +661,19 @@ mod tests {
         let handler = Arc::new(Mutex::new(DummyEventConsumer::new()));
         let pollable = handler.lock().expect("Unlock failed").pollable;
 
-        let mut handler_data = em.handlers.get(pollable.as_raw_fd());
+        let mut handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_none());
 
         let err = em.unregister(pollable).unwrap_err();
         assert_eq!(
             format!("{:?}", err),
             format!(
-                "A handler for the specified pollable {} was not found",
+                "A handler for the specified pollable {} was not found.",
                 pollable
             )
         );
 
-        handler_data = em.handlers.get(pollable.as_raw_fd());
+        handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_none());
     }
 
@@ -688,7 +695,7 @@ mod tests {
             Err(err) => assert_eq!(
                 format!("{:?}", err),
                 format!(
-                    "A handler for the specified pollable {} already exists",
+                    "A handler for the specified pollable {} already exists.",
                     pollable
                 )
             ),
@@ -708,7 +715,7 @@ mod tests {
         // register via update
         em.update(handler.clone(), ops).unwrap();
 
-        let mut handler_data = em.handlers.get(pollable.as_raw_fd());
+        let mut handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_some());
 
         channel
@@ -720,7 +727,7 @@ mod tests {
 
         assert_eq!(em.process_ops().unwrap(), 1);
 
-        handler_data = em.handlers.get(pollable.as_raw_fd());
+        handler_data = em.handlers.get(pollable);
         assert!(handler_data.is_some());
         let reg_data = handler_data.unwrap().data;
         assert_eq!(reg_data, (pollable, EventSet::WRITE));

--- a/src/polly/src/lib.rs
+++ b/src/polly/src/lib.rs
@@ -1,10 +1,10 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-extern crate epoll;
 extern crate libc;
 extern crate utils;
 #[macro_use]
 extern crate bitflags;
 
+pub mod epoll;
 pub mod event_manager;
 pub mod pollable;

--- a/src/polly/src/pollable.rs
+++ b/src/polly/src/pollable.rs
@@ -1,8 +1,11 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 use std::convert::From;
 use std::fmt::Formatter;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+
+use epoll;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Pollable {
@@ -80,20 +83,20 @@ impl EventSet {
     }
 }
 
-impl From<EventSet> for epoll::Events {
-    fn from(event: EventSet) -> epoll::Events {
-        let mut epoll_event_mask = epoll::Events::empty();
+impl From<EventSet> for epoll::EventType {
+    fn from(event: EventSet) -> epoll::EventType {
+        let mut epoll_event_mask = epoll::EventType::empty();
 
         if event.is_readable() {
-            epoll_event_mask |= epoll::Events::EPOLLIN;
+            epoll_event_mask |= epoll::EventType::IN;
         }
 
         if event.is_writeable() {
-            epoll_event_mask |= epoll::Events::EPOLLOUT;
+            epoll_event_mask |= epoll::EventType::OUT;
         }
 
         if event.is_closed() {
-            epoll_event_mask |= epoll::Events::EPOLLRDHUP;
+            epoll_event_mask |= epoll::EventType::READ_HANG_UP;
         }
 
         epoll_event_mask
@@ -158,6 +161,7 @@ impl PollableOpBuilder {
 mod tests {
     use super::*;
     use std::io;
+
     #[test]
     fn test_pollable() {
         let mut pollable = Pollable::from(&io::stdin());


### PR DESCRIPTION
## Reason for This PR

Remove epoll crate dependency in order to reduce number of external dependencies.
Fixes #1259 

## Description of Changes

Implement our own epoll wrapper.
Add some renames and comments in polly.
Remove API channel functionality from polly crate.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
