### PR TITLE
[GuestMemory] import GuestMemoryRegion and GuestMemory traits from rust-vmm/vm-memory

### DIFF
--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -18,7 +18,7 @@ use super::get_fdt_addr;
 use super::gic::GICDevice;
 use super::layout::FDT_MAX_SIZE;
 use aarch64::fdt::Error::CstringFDTTransform;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 
 // This is a value for uniquely identifying the FDT node declaring the interrupt controller.
 const GIC_PHANDLE: u32 = 1;

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -17,7 +17,7 @@ use std::ffi::CStr;
 use std::fmt::Debug;
 
 use self::gic::GICDevice;
-use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug)]

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -17,7 +17,7 @@ pub mod msr;
 pub mod regs;
 
 use arch_gen::x86::bootparam::{boot_params, E820_RAM};
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 use InitrdConfig;
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -13,7 +13,7 @@ use std::slice;
 use libc::c_char;
 
 use arch_gen::x86::mpspec;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `ByteValued`) where:

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -10,7 +10,7 @@ use std::mem;
 use super::gdt::{gdt_entry, kvm_segment_from_gdt};
 use kvm_bindings::{kvm_fpu, kvm_regs, kvm_sregs};
 use kvm_ioctls::VcpuFd;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 // Initial pagetables.
 const PML4_START: u64 = 0x9000;

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -9,7 +9,7 @@ use std::cmp::min;
 use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
 
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 pub(super) const VIRTQ_DESC_F_NEXT: u16 = 0x1;
 pub(super) const VIRTQ_DESC_F_WRITE: u16 = 0x2;

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -15,7 +15,7 @@ use std::mem;
 
 use super::cmdline::Error as CmdlineError;
 use utils::structs::read_struct;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 #[allow(non_camel_case_types)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/vm-memory/src/guest_memory.rs
+++ b/src/vm-memory/src/guest_memory.rs
@@ -85,6 +85,9 @@ impl GuestMemoryRegion for MemoryRegion {
 pub trait GuestMemory {
     /// Type of objects hosted by the address space.
     type R: GuestMemoryRegion;
+
+    /// Returns the number of regions in the collection.
+    fn num_regions(&self) -> usize;
 }
 
 /// Tracks all memory regions allocated for the guest in the current process.
@@ -165,11 +168,6 @@ impl GuestMemoryMmap {
         }
 
         None
-    }
-
-    /// Returns the size of the memory region.
-    pub fn num_regions(&self) -> usize {
-        self.regions.len()
     }
 
     /// Returns the size of the region identified by passed index
@@ -322,6 +320,11 @@ impl GuestMemoryMmap {
 
 impl GuestMemory for GuestMemoryMmap {
     type R = MemoryRegion;
+
+    /// Returns the size of the memory region.
+    fn num_regions(&self) -> usize {
+        self.regions.len()
+    }
 }
 
 impl Bytes<GuestAddress> for GuestMemoryMmap {

--- a/src/vm-memory/src/guest_memory.rs
+++ b/src/vm-memory/src/guest_memory.rs
@@ -74,6 +74,19 @@ impl GuestMemoryRegion for MemoryRegion {
     }
 }
 
+/// Represents a container for a collection of GuestMemoryRegion objects.
+///
+/// The main responsibilities of the GuestMemory trait are:
+/// - hide the detail of accessing guest's physical address.
+/// - map a request address to a GuestMemoryRegion object and relay the request to it.
+/// - handle cases where an access request spanning two or more GuestMemoryRegion objects.
+///
+/// Note: all regions in a GuestMemory object must not intersect with each other.
+pub trait GuestMemory {
+    /// Type of objects hosted by the address space.
+    type R: GuestMemoryRegion;
+}
+
 /// Tracks all memory regions allocated for the guest in the current process.
 #[derive(Clone)]
 pub struct GuestMemoryMmap {
@@ -305,6 +318,10 @@ impl GuestMemoryMmap {
         }
         Err(Error::InvalidGuestAddress(guest_addr))
     }
+}
+
+impl GuestMemory for GuestMemoryMmap {
+    type R = MemoryRegion;
 }
 
 impl Bytes<GuestAddress> for GuestMemoryMmap {

--- a/src/vm-memory/src/lib.rs
+++ b/src/vm-memory/src/lib.rs
@@ -21,5 +21,6 @@ pub use guest_address::Address;
 pub use guest_address::GuestAddress;
 pub use guest_memory::Error as GuestMemoryError;
 pub use guest_memory::GuestMemoryMmap;
+pub use guest_memory::GuestMemoryRegion;
 pub use guest_memory::MemoryRegion;
 pub use mmap::{Error as MemoryMappingError, MemoryMapping};

--- a/src/vm-memory/src/lib.rs
+++ b/src/vm-memory/src/lib.rs
@@ -20,6 +20,7 @@ pub use bytes::{ByteValued, Bytes};
 pub use guest_address::Address;
 pub use guest_address::GuestAddress;
 pub use guest_memory::Error as GuestMemoryError;
+pub use guest_memory::GuestMemory;
 pub use guest_memory::GuestMemoryMmap;
 pub use guest_memory::GuestMemoryRegion;
 pub use guest_memory::MemoryRegion;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -1666,6 +1666,8 @@ impl Vmm {
 
 #[cfg(test)]
 mod tests {
+    use vm_memory::GuestMemory;
+
     macro_rules! assert_match {
         ($x:expr, $y:pat) => {{
             if let $y = $x {

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -28,7 +28,7 @@ use seccomp::{BpfProgram, SeccompFilter};
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
-use vm_memory::{Address, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 #[cfg(target_arch = "x86_64")]
 use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig};
 


### PR DESCRIPTION
## Reason for This PR

addresses #1543 

## Description of Changes

We need this in order to align our interface to the `rust-vmm/vm-memory` interface. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
