### PR TITLE
api_server: convert the VmmActionError to a JSON object

### DIFF
--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -118,6 +118,23 @@ def test_error_logs(test_microvm_with_ssh):
     )
 
 
+def test_log_config_failure(test_microvm_with_api):
+    """Check passing invalid FIFOs is detected and reported as an error."""
+    microvm = test_microvm_with_api
+    microvm.spawn()
+    microvm.basic_config()
+
+    response = microvm.logger.put(
+        log_fifo='invalid log fifo',
+        metrics_fifo='invalid metrics fifo',
+        level='Info',
+        show_level=True,
+        show_log_origin=True,
+    )
+    assert microvm.api_session.is_status_bad_request(response.status_code)
+    assert response.json()['fault_message']
+
+
 def log_file_contains_strings(log_fifo, string_list):
     """Check if the log file contains all strings in string_list.
 


### PR DESCRIPTION
The response from this function has content-type:application/json and
Swagger specifies that the JSON object must have "fault_message".

However the implementation was returning a plan string such as
"vCPUs resume failed." which broke clients.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

## Reason for This PR

The response from this function has content-type:application/json and
Swagger specifies that the JSON object must have "fault_message".

However the implementation was returning a plan string such as
"vCPUs resume failed." which broke clients.

## Description of Changes

It adds ApiServer::json_fault_message() to convert a string to a valid JSON document.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
