### PR TITLE
Fix regression in jailer

### DIFF
--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -24,8 +24,8 @@ pub fn chroot(path: &Path) -> Result<()> {
         .into_empty_result()
         .map_err(Error::UnshareNewNs)?;
 
-    let root_dir = CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED)
-        .map_err(|_| Error::FromBytesWithNul(ROOT_DIR_NUL_TERMINATED))?;
+    let root_dir =
+        CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
 
     // Recursively change the propagation type of all the mounts in this namespace to SLAVE, so
     // we can call pivot_root. Safe because we provide valid parameters.
@@ -65,7 +65,7 @@ pub fn chroot(path: &Path) -> Result<()> {
     // We use the CStr conversion to make sure the contents of the byte slice would be a
     // valid C string (and for the as_ptr() method).
     let old_root_dir = CStr::from_bytes_with_nul(OLD_ROOT_DIR_NAME_NUL_TERMINATED)
-        .map_err(|_| Error::FromBytesWithNul(OLD_ROOT_DIR_NAME_NUL_TERMINATED))?;
+        .map_err(Error::FromBytesWithNul)?;
 
     // Create the old_root folder we're going to use for pivot_root, using a relative path. The call
     // is safe because we provide valid arguments.
@@ -73,8 +73,8 @@ pub fn chroot(path: &Path) -> Result<()> {
         .into_empty_result()
         .map_err(Error::MkdirOldRoot)?;
 
-    let cwd = CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED)
-        .map_err(|_| Error::FromBytesWithNul(CURRENT_DIR_NUL_TERMINATED))?;
+    let cwd =
+        CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
 
     // We are now ready to call pivot_root. We have to use sys_call because there is no libc
     // wrapper for pivot_root. Safe because we provide valid parameters.

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -144,8 +144,7 @@ impl Env {
         dev_major: u32,
         dev_minor: u32,
     ) -> Result<()> {
-        let dev_path = CStr::from_bytes_with_nul(dev_path_str)
-            .map_err(|_| Error::FromBytesWithNul(dev_path_str))?;
+        let dev_path = CStr::from_bytes_with_nul(dev_path_str).map_err(Error::FromBytesWithNul)?;
         // As per sysstat.h:
         // S_IFCHR -> character special device
         // S_IRUSR -> read permission, owner
@@ -263,8 +262,8 @@ impl Env {
 
         // Change ownership of the jail root to Firecracker's UID and GID. This is necessary
         // so Firecracker can create the unix domain socket in its own jail.
-        let jail_root_path = CStr::from_bytes_with_nul(ROOT_PATH_WITH_NUL)
-            .map_err(|_| Error::FromBytesWithNul(ROOT_PATH_WITH_NUL))?;
+        let jail_root_path =
+            CStr::from_bytes_with_nul(ROOT_PATH_WITH_NUL).map_err(Error::FromBytesWithNul)?;
         SyscallReturnCode(unsafe { libc::chown(jail_root_path.as_ptr(), self.uid(), self.gid()) })
             .into_empty_result()
             .map_err(|e| {

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -163,7 +163,7 @@ impl Env {
 
         SyscallReturnCode(unsafe { libc::chown(dev_path.as_ptr(), self.uid(), self.gid()) })
             .into_empty_result()
-            .map_err(|e| Error::ChangeFileOwner(e, std::str::from_utf8(dev_path_str).unwrap()))
+            .map_err(|e| Error::ChangeFileOwner(dev_path.to_str().unwrap(), e))
     }
 
     pub fn run(mut self) -> Result<()> {
@@ -266,9 +266,7 @@ impl Env {
             CStr::from_bytes_with_nul(ROOT_PATH_WITH_NUL).map_err(Error::FromBytesWithNul)?;
         SyscallReturnCode(unsafe { libc::chown(jail_root_path.as_ptr(), self.uid(), self.gid()) })
             .into_empty_result()
-            .map_err(|e| {
-                Error::ChangeFileOwner(e, std::str::from_utf8(ROOT_PATH_WITH_NUL).unwrap())
-            })?;
+            .map_err(|e| Error::ChangeFileOwner(jail_root_path.to_str().unwrap(), e))?;
 
         // Daemonize before exec, if so required (when the dev_null variable != None).
         if let Some(fd) = dev_null {

--- a/tests/framework/decorators.py
+++ b/tests/framework/decorators.py
@@ -4,7 +4,7 @@
 
 import time
 
-from framework.defs import API_USOCKET_NAME, MAX_API_CALL_DURATION_MS
+from framework.defs import MAX_API_CALL_DURATION_MS
 
 
 def timed_request(method):
@@ -30,8 +30,7 @@ def timed_request(method):
                 # The positional arguments are:
                 # 1. The Session object
                 # 2. The URL from which we extract the resource for readability
-                resource = args[1][args[1].find(
-                    API_USOCKET_NAME)+len(API_USOCKET_NAME):]
+                resource = args[1][(args[1].rfind("/")):]
             except IndexError:
                 # Ignore formatting errors.
                 resource = ''

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 API_USOCKET_URL_PREFIX = 'http+unix://'
 """URL prefix used for the API calls through a UNIX domain socket."""
-API_USOCKET_NAME = 'api.socket'
+API_USOCKET_NAME = 'run/firecracker.socket'
 """Default name for the socket used for API calls."""
 FC_BINARY_NAME = 'firecracker'
 """Firecracker's binary name."""

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 API_USOCKET_URL_PREFIX = 'http+unix://'
 """URL prefix used for the API calls through a UNIX domain socket."""
-API_USOCKET_NAME = 'run/firecracker.socket'
-"""Default name for the socket used for API calls."""
 FC_BINARY_NAME = 'firecracker'
 """Firecracker's binary name."""
 JAILER_BINARY_NAME = 'jailer'
@@ -16,8 +14,6 @@ FC_WORKSPACE_DIR = Path(__file__).parent.parent.parent.resolve()
 """The Firecracker sources workspace dir."""
 FC_WORKSPACE_TARGET_DIR = Path(FC_WORKSPACE_DIR).joinpath("build/cargo_target")
 """Cargo target dir for the Firecracker workspace. Set via .cargo/config."""
-JAILER_DEFAULT_CHROOT = '/srv/jailer'
-"""The default location for the chroot."""
 MAX_API_CALL_DURATION_MS = 300
 """Maximum accepted duration of an API call, in milliseconds."""
 MICROVM_KERNEL_RELPATH = 'kernel/'

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -10,8 +10,12 @@ from subprocess import run, PIPE
 
 from retry.api import retry_call
 
-from framework.defs import API_USOCKET_NAME, FC_BINARY_NAME, \
-    JAILER_DEFAULT_CHROOT
+from framework.defs import FC_BINARY_NAME
+
+# Default name for the socket used for API calls.
+API_USOCKET_NAME = 'run/firecracker.socket'
+# The default location for the chroot.
+JAILER_DEFAULT_CHROOT = '/srv/jailer'
 
 
 class JailerContext:

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -92,14 +92,12 @@ class JailerContext:
         if self.daemonize:
             jailer_param_list.append('--daemonize')
         # applying neccessory extra args if needed
-        if self.extra_args is not None:
+        if len(self.extra_args) > 0:
             jailer_param_list.append('--')
             for key, value in self.extra_args.items():
                 jailer_param_list.append('--{}'.format(key))
                 if value is not None:
                     jailer_param_list.append(value)
-        if self.extra_args.get("api-sock") is None:
-            jailer_param_list.extend(['--api-sock', str(API_USOCKET_NAME)])
         return jailer_param_list
 
     def chroot_base_with_id(self):

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -13,9 +13,9 @@ from retry.api import retry_call
 from framework.defs import FC_BINARY_NAME
 
 # Default name for the socket used for API calls.
-API_USOCKET_NAME = 'run/firecracker.socket'
+DEFAULT_USOCKET_NAME = 'run/firecracker.socket'
 # The default location for the chroot.
-JAILER_DEFAULT_CHROOT = '/srv/jailer'
+DEFAULT_CHROOT_PATH = '/srv/jailer'
 
 
 class JailerContext:
@@ -34,6 +34,7 @@ class JailerContext:
     netns = None
     daemonize = None
     extra_args = None
+    api_socket_name = None
 
     def __init__(
             self,
@@ -42,7 +43,7 @@ class JailerContext:
             numa_node=0,
             uid=1234,
             gid=1234,
-            chroot_base=JAILER_DEFAULT_CHROOT,
+            chroot_base=DEFAULT_CHROOT_PATH,
             netns=None,
             daemonize=True,
             **extra_args
@@ -62,6 +63,7 @@ class JailerContext:
         self.netns = netns if netns is not None else jailer_id
         self.daemonize = daemonize
         self.extra_args = extra_args
+        self.api_socket_name = DEFAULT_USOCKET_NAME
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -102,20 +104,22 @@ class JailerContext:
                 jailer_param_list.append('--{}'.format(key))
                 if value is not None:
                     jailer_param_list.append(value)
+                    if key == "api-sock":
+                        self.api_socket_name = value
         return jailer_param_list
 
     def chroot_base_with_id(self):
         """Return the MicroVM chroot base + MicroVM ID."""
         return os.path.join(
             self.chroot_base if self.chroot_base is not None
-            else JAILER_DEFAULT_CHROOT,
+            else DEFAULT_CHROOT_PATH,
             FC_BINARY_NAME,
             self.jailer_id
         )
 
     def api_socket_path(self):
         """Return the MicroVM API socket path."""
-        return os.path.join(self.chroot_path(), API_USOCKET_NAME)
+        return os.path.join(self.chroot_path(), self.api_socket_name)
 
     def chroot_path(self):
         """Return the MicroVM chroot path."""
@@ -170,7 +174,7 @@ class JailerContext:
         """Set up this jailer context."""
         os.makedirs(
             self.chroot_base if self.chroot_base is not None
-            else JAILER_DEFAULT_CHROOT,
+            else DEFAULT_CHROOT_PATH,
             exist_ok=True
         )
         if self.netns:

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -10,6 +10,7 @@ REG_PERMS = stat.S_IRUSR | stat.S_IWUSR | \
             stat.S_IROTH | stat.S_IXOTH
 DIR_STATS = stat.S_IFDIR | REG_PERMS
 FILE_STATS = stat.S_IFREG | REG_PERMS
+SOCK_STATS = stat.S_IFSOCK | REG_PERMS
 # These are the stats of the devices created by tha jailer.
 CHAR_STATS = stat.S_IFCHR | stat.S_IRUSR | stat.S_IWUSR
 
@@ -79,3 +80,15 @@ def test_default_chroot_hierarchy(test_microvm_with_initrd):
                 CHAR_STATS, test_microvm.jailer.uid, test_microvm.jailer.gid)
     check_stats(os.path.join(test_microvm.jailer.chroot_path(),
                              "firecracker"), FILE_STATS, 0, 0)
+
+
+def test_arbitrary_usocket_location(test_microvm_with_initrd):
+    """Test arbitrary location scenario for the api socket."""
+    test_microvm = test_microvm_with_initrd
+    test_microvm.jailer.extra_args = {'api-sock': 'api.socket'}
+
+    test_microvm.spawn()
+
+    check_stats(os.path.join(test_microvm.jailer.chroot_path(),
+                             "api.socket"), SOCK_STATS,
+                test_microvm.jailer.uid, test_microvm.jailer.gid)


### PR DESCRIPTION
## Reason for This PR

Fix for [regression](https://github.com/firecracker-microvm/firecracker/pull/1500/commits/1e5e6ac45fb0b4cdbadbf11d9355876f5a09089e).
When run only with the required parameter the  jailer would crash.
Fixes #1551.

## Description of Changes

* Added a new function which constructs the required folder hierarchy for firecracker to be able to run. Momentarily these are `dev`, `dev/net` and `run.` 
* The function also gives the necessary permissions.
* First two commits are nit's. The third one is the one fixing the regression.
* The 4th, 5th, 6th and 7th are integration tests related commits.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.