### PR TITLE
Migrate the Vmm-exit and Api events to EventManager (polly)

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex, RwLock};
@@ -8,74 +9,77 @@ use std::thread;
 
 use api_server::{ApiRequest, ApiResponse, ApiServer};
 use mmds::MMDS;
-use polly::event_manager::EventManager;
+use polly::event_manager::{EventHandler, EventManager};
+use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
 use utils::eventfd::EventFd;
 use vmm::controller::VmmController;
 use vmm::rpc_interface::{PrebootApiController, RuntimeApiController};
 use vmm::vmm_config::instance_info::InstanceInfo;
-use vmm::EpollDispatch;
 
 struct ApiServerAdapter {
     api_event_fd: EventFd,
     from_api: Receiver<ApiRequest>,
     to_api: Sender<ApiResponse>,
+    controller: RuntimeApiController,
 }
 
 impl ApiServerAdapter {
-    pub fn new(
+    /// Runs the vmm to completion, while any arising control events are deferred
+    /// to a `RuntimeApiController`.
+    fn run_microvm(
         api_event_fd: EventFd,
         from_api: Receiver<ApiRequest>,
         to_api: Sender<ApiResponse>,
-    ) -> Self {
-        ApiServerAdapter {
+        vmm_controller: VmmController,
+        event_manager: &mut EventManager,
+    ) {
+        let api_adapter = Arc::new(Mutex::new(Self {
             api_event_fd,
             from_api,
             to_api,
+            controller: RuntimeApiController(vmm_controller),
+        }));
+        event_manager
+            .register(api_adapter.clone())
+            .expect("Cannot register the api event to the event manager.");
+        loop {
+            event_manager
+                .run()
+                .expect("EventManager events driver fatal error");
         }
     }
-
-    /// Runs the vmm to completion, while any arising control events are deferred
-    /// to a `RuntimeApiController`.
-    fn run_microvm(&self, vmm_controller: VmmController) {
-        let mut controller = RuntimeApiController(vmm_controller);
-        let exit_code = loop {
-            match controller.0.run_event_loop() {
-                Err(e) => {
-                    error!("Abruptly exited VMM control loop: {:?}", e);
-                    break vmm::FC_EXIT_CODE_GENERIC_ERROR;
+}
+impl EventHandler for ApiServerAdapter {
+    /// Handle a read event (EPOLLIN).
+    fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
+        if source == self.api_event_fd.as_raw_fd() {
+            let _ = self.api_event_fd.read();
+            match self.from_api.try_recv() {
+                Ok(api_request) => {
+                    let response = self.controller.handle_request(*api_request);
+                    // Send back the result.
+                    self.to_api
+                        .send(Box::new(response))
+                        .map_err(|_| ())
+                        .expect("one-shot channel closed");
                 }
-                Ok(exit_reason) => match exit_reason {
-                    vmm::EventLoopExitReason::Break => {
-                        info!("Gracefully terminated VMM control loop");
-                        break vmm::FC_EXIT_CODE_OK;
-                    }
-                    vmm::EventLoopExitReason::ControlAction => {
-                        if let Err(e) = self.api_event_fd.read() {
-                            error!("VMM: Failed to read the API event_fd: {}", e);
-                            break vmm::FC_EXIT_CODE_GENERIC_ERROR;
-                        };
-
-                        match self.from_api.try_recv() {
-                            Ok(api_request) => {
-                                let response = controller.handle_request(*api_request);
-                                // Send back the result.
-                                self.to_api
-                                    .send(Box::new(response))
-                                    .map_err(|_| ())
-                                    .expect("one-shot channel closed");
-                            }
-                            Err(TryRecvError::Empty) => {
-                                warn!("Got a spurious notification from api thread");
-                            }
-                            Err(TryRecvError::Disconnected) => {
-                                panic!("The channel's sending half was disconnected. Cannot receive data.");
-                            }
-                        };
-                    }
-                },
+                Err(TryRecvError::Empty) => {
+                    warn!("Got a spurious notification from api thread");
+                }
+                Err(TryRecvError::Disconnected) => {
+                    panic!("The channel's sending half was disconnected. Cannot receive data.");
+                }
             };
-        };
-        controller.0.stop(i32::from(exit_code));
+        } else {
+            error!("Spurious EventManager event for handler: ApiServerAdapter");
+        }
+        vec![]
+    }
+
+    fn init(&self) -> Vec<PollableOp> {
+        vec![PollableOpBuilder::new(self.api_event_fd.as_raw_fd())
+            .readable()
+            .register()]
     }
 }
 
@@ -88,9 +92,7 @@ pub fn run_with_api(
     start_time_cpu_us: Option<u64>,
 ) {
     // FD to notify of API events.
-    let api_event_fd = EventFd::new(libc::EFD_NONBLOCK)
-        .map_err(api_server::Error::Eventfd)
-        .expect("Cannot create API Eventfd.");
+    let api_event_fd = EventFd::new(libc::EFD_NONBLOCK).expect("Cannot create API Eventfd.");
     // Channels for both directions between Vmm and Api threads.
     let (to_vmm, from_api) = channel();
     let (to_api, from_vmm) = channel();
@@ -137,20 +139,12 @@ pub fn run_with_api(
     let mut epoll_context = vmm::EpollContext::new().expect("Cannot create the epoll context.");
     // The event manager to replace EpollContext.
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");
-    // Cascade EventManager in EpollContext.
-    epoll_context
-        .add_epollin_event(&event_manager, EpollDispatch::PollyEvent)
-        .expect("Cannot cascade EventManager from epoll_context");
 
     // Create the firecracker metrics object responsible for periodically printing metrics.
     let firecracker_metrics = Arc::new(Mutex::new(super::metrics::PeriodicMetrics::new()));
     event_manager
         .register(firecracker_metrics.clone())
         .expect("Cannot register the metrics event to the event manager.");
-
-    epoll_context
-        .add_epollin_event(&api_event_fd, EpollDispatch::VmmActionRequest)
-        .expect("Cannot add vmm control_fd to epoll.");
 
     let firecracker_version = crate_version!().to_string();
     // Configure, build and start the microVM.
@@ -195,11 +189,15 @@ pub fn run_with_api(
     // Update the api shared instance info.
     api_shared_info.write().unwrap().started = true;
 
-    let api_handler = ApiServerAdapter::new(api_event_fd, from_api, to_api);
-    api_handler.run_microvm(VmmController::new(
-        epoll_context,
-        event_manager,
-        vm_resources,
-        vmm,
-    ));
+    // TODO: remove this when last epoll_context user is migrated to EventManager.
+    let epoll_context = Arc::new(Mutex::new(epoll_context));
+    event_manager.register(epoll_context).unwrap();
+
+    ApiServerAdapter::run_microvm(
+        api_event_fd,
+        from_api,
+        to_api,
+        VmmController::new(vm_resources, vmm),
+        &mut event_manager,
+    );
 }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -44,7 +44,7 @@ impl ApiServerAdapter {
         epoll_context: &mut vmm::EpollContext,
         event_manager: &mut EventManager,
         firecracker_version: String,
-    ) -> (VmResources, vmm::Vmm) {
+    ) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
         let mut vm_resources = VmResources::default();
         let mut built_vmm = None;
         // Need to drop the pre-boot controller to pass ownership of vm_resources.

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -11,7 +11,6 @@ use mmds::MMDS;
 use polly::event_manager::EventManager;
 use utils::eventfd::EventFd;
 use vmm::controller::VmmController;
-use vmm::resources::VmResources;
 use vmm::rpc_interface::{PrebootApiController, RuntimeApiController};
 use vmm::vmm_config::instance_info::InstanceInfo;
 use vmm::EpollDispatch;
@@ -33,65 +32,6 @@ impl ApiServerAdapter {
             from_api,
             to_api,
         }
-    }
-
-    /// Default implementation for the function that builds and starts a microVM.
-    ///
-    /// Returns a populated `VmResources` object and a running `Vmm` object.
-    fn build_microvm_from_requests(
-        &self,
-        seccomp_level: u32,
-        epoll_context: &mut vmm::EpollContext,
-        event_manager: &mut EventManager,
-        firecracker_version: String,
-    ) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
-        let mut vm_resources = VmResources::default();
-        let mut built_vmm = None;
-        // Need to drop the pre-boot controller to pass ownership of vm_resources.
-        {
-            let mut preboot_controller = PrebootApiController::new(
-                seccomp_level,
-                firecracker_version,
-                &mut vm_resources,
-                epoll_context,
-                event_manager,
-            );
-            // Configure and start microVM through successive API calls.
-            // Iterate through API calls to configure microVm.
-            // The loop breaks when a microVM is successfully started, and returns a running Vmm.
-            while built_vmm.is_none() {
-                built_vmm = self
-                    .from_api
-                    .recv()
-                    .map_err(|_| {
-                        panic!("The channel's sending half was disconnected. Cannot receive data.")
-                    })
-                    .map(|vmm_request| {
-                        // Also consume the API event. This is safe since communication
-                        // between this thread and the API thread is synchronous.
-                        let _ = self.api_event_fd.read().map_err(|e| {
-                            error!("VMM: Failed to read the API event_fd: {}", e);
-                            std::process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
-                        });
-
-                        let (response, maybe_vmm) =
-                            preboot_controller.handle_preboot_request(*vmm_request);
-
-                        // Send back the result.
-                        self.to_api
-                            .send(Box::new(response))
-                            .map_err(|_| ())
-                            .expect("one-shot channel closed");
-
-                        maybe_vmm
-                    })
-                    // Safe to unwrap the result since in case of Err(), map_err will panic anyway.
-                    .unwrap()
-            }
-        }
-
-        // Safe to unwrap because previous loop cannot end on None.
-        (vm_resources, built_vmm.unwrap())
     }
 
     /// Runs the vmm to completion, while any arising control events are deferred
@@ -212,7 +152,6 @@ pub fn run_with_api(
         .add_epollin_event(&api_event_fd, EpollDispatch::VmmActionRequest)
         .expect("Cannot add vmm control_fd to epoll.");
 
-    let api_handler = ApiServerAdapter::new(api_event_fd, from_api, to_api);
     let firecracker_version = crate_version!().to_string();
     // Configure, build and start the microVM.
     let (vm_resources, vmm) = match config_json {
@@ -223,11 +162,27 @@ pub fn run_with_api(
             firecracker_version,
             json,
         ),
-        None => api_handler.build_microvm_from_requests(
+        None => PrebootApiController::build_microvm_from_requests(
             seccomp_level,
             &mut epoll_context,
             &mut event_manager,
             firecracker_version,
+            || {
+                let req = from_api
+                    .recv()
+                    .expect("The channel's sending half was disconnected. Cannot receive data.");
+                // Also consume the API event along with the message. It is safe to unwrap()
+                // since communication between this thread and the API thread is synchronous.
+                api_event_fd
+                    .read()
+                    .expect("VMM: Failed to read the API event_fd");
+                *req
+            },
+            |response| {
+                to_api
+                    .send(Box::new(response))
+                    .expect("one-shot channel closed")
+            },
         ),
     };
 
@@ -240,6 +195,7 @@ pub fn run_with_api(
     // Update the api shared instance info.
     api_shared_info.write().unwrap().started = true;
 
+    let api_handler = ApiServerAdapter::new(api_event_fd, from_api, to_api);
     api_handler.run_microvm(VmmController::new(
         epoll_context,
         event_manager,

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -202,7 +202,7 @@ fn build_microvm_from_json(
     event_manager: &mut EventManager,
     firecracker_version: String,
     config_json: String,
-) -> (VmResources, vmm::Vmm) {
+) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
     let vm_resources =
         VmResources::from_json(&config_json, &firecracker_version).unwrap_or_else(|err| {
             error!(

--- a/src/polly/src/event_manager.rs
+++ b/src/polly/src/event_manager.rs
@@ -63,7 +63,7 @@ impl EventHandlerData {
 
 /// A trait to express the ability to respond to I/O event readiness
 /// using callbacks.
-pub trait EventHandler: Send {
+pub trait EventHandler {
     /// Handle a read event (EPOLLIN).
     fn handle_read(&mut self, _source: Pollable) -> Vec<PollableOp> {
         vec![]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 use super::{EpollContext, Vmm};
 
 use super::Error;
-use device_manager;
 #[cfg(target_arch = "x86_64")]
 use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
@@ -22,6 +21,7 @@ use devices::virtio::MmioTransport;
 use memory_model::{GuestAddress, GuestMemory, GuestMemoryError};
 use polly::event_manager::{Error as EventManagerError, EventManager};
 use utils::eventfd::EventFd;
+use utils::terminal::Terminal;
 use utils::time::TimestampUs;
 use vmm_config;
 use vmm_config::boot_source::BootConfig;
@@ -29,6 +29,7 @@ use vmm_config::drive::BlockDeviceConfigs;
 use vmm_config::net::NetworkInterfaceConfigs;
 use vmm_config::vsock::VsockDeviceConfig;
 use vstate::{KvmContext, Vcpu, VcpuConfig, Vm};
+use {device_manager, VmmEventsObserver};
 
 /// Errors associated with starting the instance.
 #[derive(Debug)]
@@ -169,8 +170,14 @@ impl Display for StartMicrovmError {
     }
 }
 
-// Wrapper over io::Stdin that implements `ReadableFd`.
+// Wrapper over io::Stdin that implements `Serial::ReadableFd` and `vmm::VmmEventsObserver`.
 struct SerialStdin(io::Stdin);
+impl SerialStdin {
+    /// Returns a `SerialStdin` wrapper over `io::stdin`.
+    pub fn get() -> Self {
+        SerialStdin(io::stdin())
+    }
+}
 impl io::Read for SerialStdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
@@ -182,6 +189,21 @@ impl AsRawFd for SerialStdin {
     }
 }
 impl devices::legacy::ReadableFd for SerialStdin {}
+impl VmmEventsObserver for SerialStdin {
+    fn on_vmm_boot(&mut self) -> std::result::Result<(), utils::errno::Error> {
+        // Set raw mode for stdin.
+        self.0.lock().set_raw_mode().map_err(|e| {
+            warn!("Cannot set raw mode for the terminal. {:?}", e);
+            e
+        })
+    }
+    fn on_vmm_stop(&mut self) -> std::result::Result<(), utils::errno::Error> {
+        self.0.lock().set_canon_mode().map_err(|e| {
+            warn!("Cannot set canonical mode for the terminal. {:?}", e);
+            e
+        })
+    }
+}
 
 /// Builds and starts a microVM based on the current Firecracker VmResources configuration.
 ///
@@ -217,7 +239,7 @@ pub fn build_microvm(
     {
         Some(setup_serial_device(
             event_manager,
-            Box::new(SerialStdin(io::stdin())),
+            Box::new(SerialStdin::get()),
             Box::new(io::stdout()),
         )?)
     } else {
@@ -277,7 +299,7 @@ pub fn build_microvm(
     }
 
     let mut vmm = Vmm {
-        stdin_handle: io::stdin(),
+        events_observer: Some(Box::new(SerialStdin::get())),
         guest_memory,
         kernel_cmdline,
         vcpus_handles: Vec::new(),

--- a/src/vmm/src/controller.rs
+++ b/src/vmm/src/controller.rs
@@ -7,28 +7,23 @@ use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Mutex};
 
-use super::{EpollContext, EventLoopExitReason, Vmm};
-
-use super::Result;
 use arch::DeviceType;
 use device_manager::mmio::MMIO_CFG_SPACE_OFF;
 use devices::virtio::{self, MmioTransport, Net, TYPE_BLOCK, TYPE_NET};
 use logger::LOGGER;
-use polly::event_manager::EventManager;
 use resources::VmResources;
 use rpc_interface::VmmActionError;
 use vmm_config;
 use vmm_config::drive::DriveError;
 use vmm_config::machine_config::VmConfig;
 use vmm_config::net::NetworkInterfaceUpdateConfig;
+use Vmm;
 
 /// Shorthand result type for external VMM commands.
 pub type ActionResult = std::result::Result<(), VmmActionError>;
 
 /// Enables runtime configuration of a Firecracker VMM.
 pub struct VmmController {
-    epoll_context: EpollContext,
-    event_manager: EventManager,
     vm_resources: VmResources,
     vmm: Arc<Mutex<Vmm>>,
 }
@@ -70,23 +65,8 @@ impl VmmController {
     }
 
     /// Creates a new `VmmController`.
-    pub fn new(
-        epoll_context: EpollContext,
-        event_manager: EventManager,
-        vm_resources: VmResources,
-        vmm: Arc<Mutex<Vmm>>,
-    ) -> Self {
-        VmmController {
-            epoll_context,
-            event_manager,
-            vm_resources,
-            vmm,
-        }
-    }
-
-    /// Wait for and dispatch events. Will defer to the inner Vmm loop after it's started.
-    pub fn run_event_loop(&mut self) -> Result<EventLoopExitReason> {
-        Vmm::run_event_loop(&mut self.epoll_context, &mut self.event_manager)
+    pub fn new(vm_resources: VmResources, vmm: Arc<Mutex<Vmm>>) -> Self {
+        VmmController { vm_resources, vmm }
     }
 
     /// Triggers a rescan of the host file backing the emulated block device with id `drive_id`.
@@ -205,6 +185,8 @@ impl VmmController {
     ) -> ActionResult {
         if let Some(busdev) = self
             .vmm
+            .lock()
+            .unwrap()
             .get_bus_device(DeviceType::Virtio(TYPE_NET), &new_cfg.iface_id)
         {
             let virtio_device = busdev

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -71,7 +71,7 @@ use logger::error::LoggerError;
 use logger::LogOption;
 use logger::{Metric, LOGGER, METRICS};
 use memory_model::GuestMemory;
-use polly::event_manager::{self, EventHandler, EventManager};
+use polly::event_manager::{self, EventHandler};
 use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
 use utils::eventfd::EventFd;
 use utils::time::TimestampUs;
@@ -92,26 +92,10 @@ pub const FC_EXIT_CODE_SIGSEGV: u8 = 150;
 /// Bad configuration for microvm's resources, when using a single json.
 pub const FC_EXIT_CODE_BAD_CONFIGURATION: u8 = 151;
 
-/// Describes all possible reasons which may cause the event loop to return to the caller in
-/// the absence of errors.
-#[derive(Debug)]
-pub enum EventLoopExitReason {
-    /// A break statement interrupted the event loop during normal execution. This is the
-    /// default exit reason.
-    Break,
-    /// The control action file descriptor has data available for reading.
-    ControlAction,
-}
-
 /// Dispatch categories for epoll events.
-#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EpollDispatch {
-    /// Cascaded polly event.
-    PollyEvent,
     /// Event has to be dispatch to an EpollHandler.
     DeviceHandler(usize, DeviceEventT),
-    /// The event loop has to be temporarily suspended for an external action request.
-    VmmActionRequest,
 }
 
 struct MaybeHandler {
@@ -296,6 +280,67 @@ impl EpollContext {
 
         // And return the appropriate event.
         Ok(self.events[self.event_index - 1])
+    }
+
+    /// Wait for and dispatch events.
+    pub fn run_event_loop(&mut self) {
+        let event = self.get_event().unwrap();
+        let evset = match epoll::Events::from_bits(event.events) {
+            Some(evset) => evset,
+            None => {
+                let evbits = event.events;
+                warn!("epoll: ignoring unknown event set: 0x{:x}", evbits);
+                return;
+            }
+        };
+
+        match self.dispatch_table[event.data as usize] {
+            Some(EpollDispatch::DeviceHandler(device_idx, device_token)) => {
+                METRICS.vmm.device_events.inc();
+                match self.get_device_handler_by_handler_id(device_idx) {
+                    Ok(handler) => match handler.handle_event(device_token, evset) {
+                        Err(devices::Error::PayloadExpected) => {
+                            panic!("Received update disk image event with empty payload.")
+                        }
+                        Err(devices::Error::UnknownEvent { device, event }) => {
+                            panic!("Unknown event: {:?} {:?}", device, event)
+                        }
+                        _ => (),
+                    },
+                    Err(e) => warn!("invalid handler for device {}: {:?}", device_idx, e),
+                }
+            }
+            None => {
+                panic!("what do you mean nothing?!");
+                // Do nothing.
+            }
+        };
+        // Currently, we never get to return with Ok(EventLoopExitReason::Break) because
+        // we just invoke stop() whenever that would happen.
+    }
+}
+
+impl AsRawFd for EpollContext {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll_raw_fd
+    }
+}
+
+impl EventHandler for EpollContext {
+    /// Handle a read event (EPOLLIN).
+    fn handle_read(&mut self, source: Pollable) -> Vec<PollableOp> {
+        if source == self.epoll_raw_fd {
+            self.run_event_loop();
+        } else {
+            error!("Spurious EventManager event for handler: EpollContext");
+        }
+        vec![]
+    }
+
+    fn init(&self) -> Vec<PollableOp> {
+        vec![PollableOpBuilder::new(self.as_raw_fd())
+            .readable()
+            .register()]
     }
 }
 
@@ -582,56 +627,6 @@ impl Vmm {
         unsafe {
             libc::_exit(exit_code);
         }
-    }
-
-    /// Wait on VMM events and dispatch them to the appropriate handler. Returns to the caller
-    /// when a control action occurs.
-    pub fn run_event_loop(
-        epoll_context: &mut EpollContext,
-        event_manager: &mut EventManager,
-    ) -> Result<EventLoopExitReason> {
-        loop {
-            let event = epoll_context.get_event()?;
-            let evset = match epoll::Events::from_bits(event.events) {
-                Some(evset) => evset,
-                None => {
-                    let evbits = event.events;
-                    warn!("epoll: ignoring unknown event set: 0x{:x}", evbits);
-                    continue;
-                }
-            };
-
-            match epoll_context.dispatch_table[event.data as usize] {
-                Some(EpollDispatch::DeviceHandler(device_idx, device_token)) => {
-                    METRICS.vmm.device_events.inc();
-                    match epoll_context.get_device_handler_by_handler_id(device_idx) {
-                        Ok(handler) => match handler.handle_event(device_token, evset) {
-                            Err(devices::Error::PayloadExpected) => {
-                                panic!("Received update disk image event with empty payload.")
-                            }
-                            Err(devices::Error::UnknownEvent { device, event }) => {
-                                panic!("Unknown event: {:?} {:?}", device, event)
-                            }
-                            _ => (),
-                        },
-                        Err(e) => warn!("invalid handler for device {}: {:?}", device_idx, e),
-                    }
-                }
-                Some(EpollDispatch::VmmActionRequest) => {
-                    return Ok(EventLoopExitReason::ControlAction);
-                }
-                // Cascaded polly: We are doing this until all devices have been ported away
-                // from epoll_context to polly.
-                Some(EpollDispatch::PollyEvent) => {
-                    event_manager.run().map_err(Error::EventManager)?;
-                }
-                None => {
-                    // Do nothing.
-                }
-            }
-        }
-        // Currently, we never get to return with Ok(EventLoopExitReason::Break) because
-        // we just invoke stop() whenever that would happen.
     }
 
     // Count the number of pages dirtied since the last call to this function.

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Formatter};
+use std::sync::{Arc, Mutex};
 
 use super::{EpollContext, Vmm};
 
@@ -163,7 +164,10 @@ impl<'a> PrebootApiController<'a> {
     pub fn handle_preboot_request(
         &mut self,
         request: VmmAction,
-    ) -> (std::result::Result<VmmData, VmmActionError>, Option<Vmm>) {
+    ) -> (
+        std::result::Result<VmmData, VmmActionError>,
+        Option<Arc<Mutex<Vmm>>>,
+    ) {
         use self::VmmAction::*;
 
         let mut maybe_vmm = None;

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -278,11 +278,6 @@ impl<'a> PrebootApiController<'a> {
 /// Enables RPC interraction with a running Firecracker VMM.
 pub struct RuntimeApiController(pub VmmController);
 impl RuntimeApiController {
-    /// Constructor for the RuntimeApiController.
-    pub fn new(vmm_controller: VmmController) -> RuntimeApiController {
-        RuntimeApiController(vmm_controller)
-    }
-
     /// Handles the incoming runtime `VmmAction` request and provides a response for it.
     pub fn handle_request(
         &mut self,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 74.6
+COVERAGE_TARGET_PCT = 74.7
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1524 
Fixes #1546 

## Description of Changes

### Exit event

The `Vmm` object registers its exit event to `EventManager` and provides a `handle_read` routine for it.
On EPOLLIN/read events, the `Vmm` will call its `stop()` routine and exit the process.
`Vmm::run_event_loop` becomes a static function since it no longer needs a `self: &Vmm`, this brings us one step closer to removing it altogether.
Since `Vmm` implements `EventHandler`, it now has to be wrapped in an `Arc<Mutex>`.

### Api events

The RPC `PrebootApiController` now also has a method to drive itself all the way to the `Vmm` being built.
The same logic was previously in the `firecracker` crate, but through some refactoring, it's now generic enough to live in `rpc_interface.rs`.

The `ApiServerAdapter` registers itself to `EventManager` and dispatches runtime api messages to the `RuntimeApiController`.

The legacy `EpollContext` is now cascaded under `EventManager` instead of the other way around. `EpollContext` currently only handles `DeviceHandler` events for `net` and `vsock`. Once `net` and `vsock` are also migrated to using `EventManager`, `EpollContext` can be removed.

`EventManager` is no longer a member of `VmmController`, it needs to live at the top level since it now contains all other Firecracker components.

### Bonus: decouple Vmm from io::Stdin

Created `vmm::CustomData` trait that defines two functions which will be called on microVm boot and on microVm teardown respectivelly.

The Vmm now holds an Option<Box<dyn CustomData>> and calls the init and stop functions implemented by the actual custom object on `start_vcpus()` and on `stop()` respectivelly.

The Firecracker-specific Vmm is given a `SerialStdin` which implements the `CustomData` trait and which sets the terminal in raw mode on boot and back to canonic mode on Vmm stop.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.