### PR TITLE
micro_http: use case-insensitive match for header names

### DIFF
--- a/src/micro_http/src/common/headers.rs
+++ b/src/micro_http/src/common/headers.rs
@@ -32,13 +32,14 @@ impl Header {
     }
 
     fn try_from(string: &[u8]) -> Result<Self, RequestError> {
-        if let Ok(utf8_string) = String::from_utf8(string.to_vec()) {
+        if let Ok(mut utf8_string) = String::from_utf8(string.to_vec()) {
+            utf8_string.make_ascii_lowercase();
             match utf8_string.trim() {
-                "Content-Length" => Ok(Header::ContentLength),
-                "Content-Type" => Ok(Header::ContentType),
-                "Expect" => Ok(Header::Expect),
-                "Transfer-Encoding" => Ok(Header::TransferEncoding),
-                "Server" => Ok(Header::Server),
+                "content-length" => Ok(Header::ContentLength),
+                "content-type" => Ok(Header::ContentType),
+                "expect" => Ok(Header::Expect),
+                "transfer-encoding" => Ok(Header::TransferEncoding),
+                "server" => Ok(Header::Server),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -393,5 +394,8 @@ mod tests {
 
         let header = Header::try_from(b"Transfer-Encoding").unwrap();
         assert_eq!(header.raw(), b"Transfer-Encoding");
+
+        let header = Header::try_from(b"content-length").unwrap();
+        assert_eq!(header.raw(), b"Content-Length");
     }
 }


### PR DESCRIPTION
## Reason for This PR

HTTP header matching should be case-insensitive. In particular the `hyper` http client appears to use lower case headers which causes an `Empty Put Request` (b/c `content-length` header not found) error.

## Description of Changes

Do a case insensitive comparison.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
