### PR TITLE
tests: Run 'screen -ls' in a busy-waiting loop

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generic utility functions that are used in the framework."""
+import re
+import subprocess
+import typing
+
+
+def search_output_from_cmd(cmd: str,
+                           find_regex: typing.Pattern) -> typing.Match:
+    """
+    Run a shell command and search a given regex object in stdout.
+
+    If the regex object is not found, a RuntimeError exception is raised.
+
+    :param cmd: command to run
+    :param find_regex: regular expression object to search for
+    :return: result of re.search()
+    """
+    # Run the given command in a shell
+    out = subprocess.run(cmd, shell=True, check=True,
+                         stdout=subprocess.PIPE).stdout.decode("utf-8")
+
+    # Search for the object
+    content = re.search(find_regex, out)
+
+    # If the result is not None, return it
+    if content:
+        return content
+
+    raise RuntimeError("Could not find '%s' in output for '%s'" %
+                       (find_regex.pattern, cmd))

--- a/tests/integration_tests/build/test_licenses.py
+++ b/tests/integration_tests/build/test_licenses.py
@@ -7,7 +7,7 @@ import platform
 
 import pytest
 
-AMAZON_COPYRIGHT_YEARS = (2018, 2019)
+AMAZON_COPYRIGHT_YEARS = (2018, 2019, 2020)
 AMAZON_COPYRIGHT = (
     "Copyright {} Amazon.com, Inc. or its affiliates. All Rights Reserved."
     )


### PR DESCRIPTION
Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

## Reason for This PR

Occasionally tests would fail due to the fact that the output of 'screen -ls' did not contain the screen session name.

Due to this issue, re.search() would return 'None', which would throw a generic exception.

## Description of Changes

Run 'screen -ls' in a busy waiting loop to wait for the given regular expression object. 
If the object is not found within the default time frame, raise an exception.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR
- [x] The changes in this PR have no user impact
- [x] No new `unsafe` code has been added
 