### PR TITLE
vmm: add KVM dirty bitmap fetching functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Decreased release binary size by ~15%.
 - Changed default API socket path to `/run/firecracker.socket`. This path
   also applies when running with the jailer.
-- Disabled KVM dirty page tracking by default.
+- Enabled KVM dirty page tracking by default.
 - Removed redundant RescanBlockDevice action from the /actions API.
   The functionality is available through the PATCH /drives API.
   See `docs/api_requests/patch-block.md`.

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 libc = ">=0.2.39"
 utils = { path = "../utils" }
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 vmm-sys-util = ">=0.2.1"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 libc = ">=0.2.39"
 epoll = ">=4.0.1"
 serde = ">=1.0.27"

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -43,6 +43,7 @@ const KVM_CREATE_VM: u64 = 0xae01;
 const KVM_CHECK_EXTENSION: u64 = 0xae03;
 const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
 const KVM_CREATE_VCPU: u64 = 0xae41;
+const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
 const KVM_SET_TSS_ADDR: u64 = 0xae47;
 const KVM_CREATE_IRQCHIP: u64 = 0xae60;
 const KVM_RUN: u64 = 0xae80;
@@ -78,6 +79,7 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_IRQCHIP,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_PIT2)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VCPU)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_TSS_ADDR,)?],

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -111,7 +111,7 @@ impl MMIODeviceManager {
         &mut self,
         vm: &VmFd,
         device: Box<dyn devices::virtio::VirtioDevice>,
-        cmdline: &mut kernel_cmdline::Cmdline,
+        _cmdline: &mut kernel_cmdline::Cmdline,
         type_id: u32,
         device_id: &str,
     ) -> Result<u64> {
@@ -145,7 +145,7 @@ impl MMIODeviceManager {
         // transform it to decimal
 
         #[cfg(target_arch = "x86_64")]
-        cmdline
+        _cmdline
             .insert(
                 "virtio_mmio.device",
                 &format!("{}K@0x{:08x}:{}", MMIO_LEN / 1024, self.mmio_base, self.irq),

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -134,6 +134,7 @@ pub enum EventLoopExitReason {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum EpollDispatch {
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     Exit,
     Stdin,
     DeviceHandler(usize, DeviceEventT),

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -25,6 +25,7 @@ use kvm_bindings::{kvm_userspace_memory_region, KVM_API_VERSION};
 use kvm_ioctls::*;
 use logger::{Metric, METRICS};
 use seccomp::{BpfProgram, SeccompFilter};
+#[cfg(target_arch = "x86_64")]
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
@@ -863,16 +864,23 @@ enum VcpuEmulation {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86_64")]
     use std::convert::TryInto;
     use std::fs::File;
+    #[cfg(target_arch = "x86_64")]
     use std::path::PathBuf;
-    use std::sync::{mpsc, Arc, Barrier};
+    #[cfg(target_arch = "x86_64")]
+    use std::sync::mpsc;
+    use std::sync::{Arc, Barrier};
+    #[cfg(target_arch = "x86_64")]
     use std::time::Duration;
 
     use super::super::devices;
     use super::*;
 
+    #[cfg(target_arch = "x86_64")]
     use kernel::cmdline as kernel_cmdline;
+    #[cfg(target_arch = "x86_64")]
     use kernel::loader as kernel_loader;
     use utils::signal::validate_signal_num;
 
@@ -1167,6 +1175,7 @@ mod tests {
         entry_addr
     }
 
+    #[cfg(target_arch = "x86_64")]
     // Sends an event to a vcpu and expects a particular response.
     fn queue_event_expect_response(handle: &VcpuHandle, event: VcpuEvent, response: VcpuResponse) {
         handle
@@ -1181,6 +1190,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_arch = "x86_64")]
     // Sends an event to a vcpu and expects no response.
     fn queue_event_expect_timeout(handle: &VcpuHandle, event: VcpuEvent) {
         handle

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -35,6 +35,8 @@ use vm_memory::{
 #[cfg(target_arch = "x86_64")]
 use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig};
 
+const KVM_MEM_LOG_DIRTY_PAGES: u32 = 0x1;
+
 #[cfg(target_arch = "x86_64")]
 const MAGIC_IOPORT_SIGNAL_GUEST_BOOT_COMPLETE: u64 = 0x03f0;
 #[cfg(target_arch = "aarch64")]
@@ -226,7 +228,7 @@ impl Vm {
                     guest_phys_addr: region.start_addr().raw_value() as u64,
                     memory_size: region.len() as u64,
                     userspace_addr: host_addr as u64,
-                    flags: 0,
+                    flags: KVM_MEM_LOG_DIRTY_PAGES,
                 };
                 // Safe because we mapped the memory region, we made sure that the regions
                 // are not overlapping.


### PR DESCRIPTION
## Reason for This PR

Adds a function in `vmm` to fetch the KVM dirty bitmap.

## Description of Changes

* the 1st commit cleans up some build warnings on `aarch64`, to make new warnings easier to spot.
* the 2nd commit reverts https://github.com/firecracker-microvm/firecracker/commit/ebc15f2eacaa4c26782a05f8e0cebe4c47512553 and *enables* KVM dirty page tracking by default, so that the dirty bitmap is always available.
* the 3rd commit introduces the actual function, which just calls the corresponding fn in [`kvm-ioctls`](https://github.com/rust-vmm/kvm-ioctls/blob/ee9a81a1241b320b4067b7d9bcf911da438e4db6/src/ioctls/vm.rs#L792) and aggregates the results per memory region.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is  clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] No new `unsafe` code has been added.