### PR TITLE
vmm: relax resume_vcpus's timeout

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -947,7 +947,7 @@ impl Vmm {
         for handle in self.vcpus_handles.iter() {
             match handle
                 .response_receiver()
-                .recv_timeout(Duration::from_millis(100))
+                .recv_timeout(Duration::from_millis(1000))
             {
                 Ok(VcpuResponse::Resumed) => (),
                 _ => return Err(StartMicrovmError::VcpuResume),


### PR DESCRIPTION

## Reason for This PR

Starting 100 VMs on a EC2 m5d.metal host sometimes didn't work due to
the timeout.

Fixes #1555.

## Description of Changes

Changing the timeout from 100ms to 1000ms, as we discussed in #1555.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
