### PR TITLE
Add support for saving and resuming x86_64 vm and vcpu states

### DIFF
--- a/src/vmm/src/error.rs
+++ b/src/vmm/src/error.rs
@@ -816,9 +816,9 @@ mod tests {
             ErrorKind::Internal
         );
         assert_eq!(
-            error_kind(StartMicrovmError::VcpuConfigure(
-                vstate::Error::SetSupportedCpusFailed(utils::errno::Error::new(0))
-            )),
+            error_kind(StartMicrovmError::VcpuConfigure(vstate::Error::VcpuFd(
+                utils::errno::Error::new(0)
+            ))),
             ErrorKind::Internal
         );
         assert_eq!(

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -885,6 +885,7 @@ impl Vmm {
                     cpu_index,
                     self.vm.fd(),
                     self.vm.supported_cpuid().clone(),
+                    self.vm.supported_msrs().clone(),
                     self.pio_device_manager.io_bus.clone(),
                     vcpu_exit_evt,
                     request_ts.clone(),

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -49,52 +49,57 @@ pub enum Error {
     #[cfg(target_arch = "x86_64")]
     /// A call to cpuid instruction failed.
     CpuId(cpuid::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Error configuring the floating point related registers
+    FPUConfiguration(arch::x86_64::regs::Error),
     /// Invalid guest memory configuration.
     GuestMemoryMmap(GuestMemoryError),
     /// Hyperthreading flag is not initialized.
     HTNotInitialized,
+    /// Cannot configure the IRQ.
+    Irq(kvm_ioctls::Error),
     /// The host kernel reports an invalid KVM API version.
     KvmApiVersion(i32),
     /// Cannot initialize the KVM context due to missing capabilities.
     KvmCap(kvm_ioctls::Cap),
-    /// vCPU count is not initialized.
-    VcpuCountNotInitialized,
-    /// Cannot open the VM file descriptor.
-    VmFd(kvm_ioctls::Error),
-    /// Cannot open the VCPU file descriptor.
-    VcpuFd(kvm_ioctls::Error),
-    /// Cannot configure the microvm.
-    VmSetup(kvm_ioctls::Error),
-    /// Cannot run the VCPUs.
-    VcpuRun(kvm_ioctls::Error),
-    /// The call to KVM_SET_CPUID2 failed.
-    SetSupportedCpusFailed(kvm_ioctls::Error),
-    /// The number of configured slots is bigger than the maximum reported by KVM.
-    NotEnoughMemorySlots,
     #[cfg(target_arch = "x86_64")]
     /// Cannot set the local interruption due to bad configuration.
     LocalIntConfiguration(arch::x86_64::interrupts::Error),
-    /// Cannot set the memory regions.
-    SetUserMemoryRegion(kvm_ioctls::Error),
     #[cfg(target_arch = "x86_64")]
     /// Error configuring the MSR registers
     MSRSConfiguration(arch::x86_64::msr::Error),
+    /// The number of configured slots is bigger than the maximum reported by KVM.
+    NotEnoughMemorySlots,
     #[cfg(target_arch = "aarch64")]
     /// Error configuring the general purpose aarch64 registers.
     REGSConfiguration(arch::aarch64::regs::Error),
     #[cfg(target_arch = "x86_64")]
     /// Error configuring the general purpose registers
     REGSConfiguration(arch::x86_64::regs::Error),
+    /// The call to KVM_SET_CPUID2 failed.
+    SetSupportedCpusFailed(kvm_ioctls::Error),
+    #[cfg(target_arch = "aarch64")]
+    /// Error setting up the global interrupt controller.
+    SetupGIC(arch::aarch64::gic::Error),
+    /// Cannot set the memory regions.
+    SetUserMemoryRegion(kvm_ioctls::Error),
+    /// Failed to signal Vcpu.
+    SignalVcpu(utils::errno::Error),
     #[cfg(target_arch = "x86_64")]
     /// Error configuring the special registers
     SREGSConfiguration(arch::x86_64::regs::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Error configuring the floating point related registers
-    FPUConfiguration(arch::x86_64::regs::Error),
-    /// Cannot configure the IRQ.
-    Irq(kvm_ioctls::Error),
-    /// Failed to signal Vcpu.
-    SignalVcpu(utils::errno::Error),
+    #[cfg(target_arch = "aarch64")]
+    /// Error doing Vcpu Init on Arm.
+    VcpuArmInit(kvm_ioctls::Error),
+    #[cfg(target_arch = "aarch64")]
+    /// Error getting the Vcpu preferred target on Arm.
+    VcpuArmPreferredTarget(kvm_ioctls::Error),
+    /// vCPU count is not initialized.
+    VcpuCountNotInitialized,
+    /// Cannot open the VCPU file descriptor.
+    VcpuFd(kvm_ioctls::Error),
+    /// Cannot run the VCPUs.
+    VcpuRun(kvm_ioctls::Error),
     /// Cannot spawn a new vCPU thread.
     VcpuSpawn(io::Error),
     /// Cannot cleanly initialize vcpu TLS.
@@ -103,15 +108,10 @@ pub enum Error {
     VcpuTlsNotPresent,
     /// Unexpected KVM_RUN exit reason
     VcpuUnhandledKvmExit,
-    #[cfg(target_arch = "aarch64")]
-    /// Error setting up the global interrupt controller.
-    SetupGIC(arch::aarch64::gic::Error),
-    #[cfg(target_arch = "aarch64")]
-    /// Error getting the Vcpu preferred target on Arm.
-    VcpuArmPreferredTarget(kvm_ioctls::Error),
-    #[cfg(target_arch = "aarch64")]
-    /// Error doing Vcpu Init on Arm.
-    VcpuArmInit(kvm_ioctls::Error),
+    /// Cannot open the VM file descriptor.
+    VmFd(kvm_ioctls::Error),
+    /// Cannot configure the microvm.
+    VmSetup(kvm_ioctls::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 85.10
+COVERAGE_TARGET_PCT = 85.05
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1389 and fixes #1390 

## Description of Changes

x86_64 support for saving and restoring `kvm vm` and `kvm vcpu` states.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
