### PR TITLE
[RFC] Remove metrics from net device unit tests

### DIFF
--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -1,8 +1,10 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::update_net_metrics;
 use crate::virtio::net::device::Net;
 use crate::virtio::{VirtioDevice, RX_INDEX, TX_INDEX};
+#[cfg(not(test))]
 use logger::{Metric, METRICS};
 use polly::event_manager::EventHandler;
 use polly::pollable::{Pollable, PollableOp, PollableOpBuilder};
@@ -29,7 +31,7 @@ impl EventHandler for Net {
             _ if source == tx_rate_limiter_fd => self.process_tx_rate_limiter_event(),
             _ => {
                 error!("Unknown event source.");
-                METRICS.net.event_fails.inc();
+                update_net_metrics!(self, event_fails, 1);
             }
         }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 74.6
+COVERAGE_TARGET_PCT = 74.3
 COVERAGE_MAX_DELTA = 0.01
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

#1568 #1569 

## Description of Changes

Currently, net device unit tests use global `METRICS` to test functionality related to the device.
In this PR it is implemented an alternative to the global `METRICS`, for testing the net device functionality. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.