### PR TITLE
Add trait for Event Manager

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -273,7 +273,7 @@ impl BusDevice for Serial {
 
 impl Subscriber for Serial {
     /// Handle a read event (EPOLLIN) on the serial input fd.
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
@@ -323,7 +323,7 @@ mod tests {
     use std::os::unix::io::RawFd;
     use std::sync::{Arc, Mutex};
 
-    use polly::event_manager::EventManager;
+    use polly::event_manager::EpollManager;
 
     struct SharedBufferInternal {
         read_buf: Vec<u8>,
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_event_handling_no_in() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
 
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let serial_out = SharedBuffer::new();
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_event_handling_with_in() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
 
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let serial_in_out = SharedBuffer::new();
@@ -485,7 +485,7 @@ mod tests {
             guard.evfd.write(1).unwrap();
         }
 
-        let mut evmgr = EventManager::new().unwrap();
+        let mut evmgr = EpollManager::new().unwrap();
         let serial_wrap = Arc::new(Mutex::new(serial));
         evmgr.add_subscriber(serial_wrap.clone()).unwrap();
 

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -10,7 +10,7 @@ use crate::virtio::VirtioDevice;
 
 impl Subscriber for Block {
     // Handle an event for queue or rate limiter.
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         if !self.is_activated() {
             warn!("The device is not yet activated. Events can not be handled.");
             return;

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -703,7 +703,7 @@ mod tests {
     use logger::{Metric, METRICS};
     use memory_model::{GuestAddress, GuestMemory};
     use polly::epoll::{EpollEvent, EventSet};
-    use polly::event_manager::{EventManager, Subscriber};
+    use polly::event_manager::{EpollManager, Subscriber};
     use rate_limiter::{RateLimiter, TokenBucket, TokenType};
     use std::net::Ipv4Addr;
     use std::os::unix::io::AsRawFd;
@@ -931,7 +931,7 @@ mod tests {
 
     #[test]
     fn test_event_handling() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1212,7 +1212,7 @@ mod tests {
 
     #[test]
     fn test_process_error_cases() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1241,7 +1241,7 @@ mod tests {
 
     #[test]
     fn test_invalid_event() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1260,7 +1260,7 @@ mod tests {
     //  * interrupt_evt.write
     #[test]
     fn test_read_tap_fail_event_handler() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let test_mutators = TestMutators {
             tap_read_fail: true,
         };
@@ -1289,7 +1289,7 @@ mod tests {
 
     #[test]
     fn test_rx_rate_limiter_handling() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1307,7 +1307,7 @@ mod tests {
 
     #[test]
     fn test_tx_rate_limiter_handling() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1326,7 +1326,7 @@ mod tests {
 
     #[test]
     fn test_bandwidth_rate_limiter() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1444,7 +1444,7 @@ mod tests {
 
     #[test]
     fn test_ops_rate_limiter() {
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);
@@ -1599,7 +1599,7 @@ mod tests {
     #[test]
     fn test_tx_queue_interrupt() {
         // Regression test for https://github.com/firecracker-microvm/firecracker/issues/1436 .
-        let mut event_manager = EventManager::new().unwrap();
+        let mut event_manager = EpollManager::new().unwrap();
         let mut net = Net::default_net(TestMutators::default());
         let mem_clone = net.mem.clone();
         let (rxq, txq) = Net::virtqueues(&mem_clone);

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -11,7 +11,7 @@ use crate::virtio::net::device::Net;
 use crate::virtio::{VirtioDevice, RX_INDEX, TX_INDEX};
 
 impl Subscriber for Net {
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         if !self.is_activated() {
             warn!("The device is not yet activated. Events can not be handled.");
             return;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -29,7 +29,7 @@ use std::process;
 use std::sync::{Arc, Mutex};
 
 use logger::{Metric, LOGGER, METRICS};
-use polly::event_manager::EventManager;
+use polly::event_manager::EpollManager;
 use utils::terminal::Terminal;
 use utils::validators::validate_instance_id;
 use vmm::resources::VmResources;
@@ -198,7 +198,7 @@ fn main() {
 fn build_microvm_from_json(
     seccomp_level: u32,
     epoll_context: &mut vmm::EpollContext,
-    event_manager: &mut EventManager,
+    event_manager: &mut EpollManager,
     firecracker_version: String,
     config_json: String,
 ) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
@@ -227,7 +227,7 @@ fn build_microvm_from_json(
 fn run_without_api(seccomp_level: u32, config_json: Option<String>) {
     // The driving epoll engine.
     let mut epoll_context = vmm::EpollContext::new().expect("Cannot create the epoll context.");
-    let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+    let mut event_manager = EpollManager::new().expect("Unable to create EventManager");
 
     // Create the firecracker metrics object responsible for periodically printing metrics.
     let firecracker_metrics = Arc::new(Mutex::new(metrics::PeriodicMetrics::new()));

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -62,7 +62,7 @@ impl PeriodicMetrics {
 
 impl Subscriber for PeriodicMetrics {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
@@ -98,7 +98,7 @@ pub mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use polly::event_manager::EventManager;
+    use polly::event_manager::EpollManager;
     use utils::eventfd::EventFd;
 
     #[test]
@@ -118,7 +118,7 @@ pub mod tests {
 
     #[test]
     fn test_periodic_metrics() {
-        let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+        let mut event_manager = EpollManager::new().expect("Unable to create EventManager");
         let mut metrics = PeriodicMetrics::new();
 
         // Test invalid read event.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -328,7 +328,7 @@ impl AsRawFd for EpollContext {
 
 impl Subscriber for EpollContext {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
@@ -669,7 +669,7 @@ impl Vmm {
 
 impl Subscriber for Vmm {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: EpollEvent, _: &mut dyn EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -9,7 +9,7 @@ use super::{EpollContext, Vmm};
 use super::Error as VmmError;
 use builder::StartMicrovmError;
 use controller::VmmController;
-use polly::event_manager::EventManager;
+use polly::event_manager::EpollManager;
 use resources::VmResources;
 use vmm_config;
 use vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
@@ -138,7 +138,7 @@ pub struct PrebootApiController<'a> {
     firecracker_version: String,
     vm_resources: &'a mut VmResources,
     epoll_context: &'a mut EpollContext,
-    event_manager: &'a mut EventManager,
+    event_manager: &'a mut EpollManager,
 
     built_vmm: Option<Arc<Mutex<Vmm>>>,
 }
@@ -150,7 +150,7 @@ impl<'a> PrebootApiController<'a> {
         firecracker_version: String,
         vm_resources: &'a mut VmResources,
         epoll_context: &'a mut EpollContext,
-        event_manager: &'a mut EventManager,
+        event_manager: &'a mut EpollManager,
     ) -> PrebootApiController<'a> {
         PrebootApiController {
             seccomp_level,
@@ -171,7 +171,7 @@ impl<'a> PrebootApiController<'a> {
     pub fn build_microvm_from_requests<F, G>(
         seccomp_level: u32,
         epoll_context: &mut EpollContext,
-        event_manager: &mut EventManager,
+        event_manager: &mut EpollManager,
         firecracker_version: String,
         recv_req: F,
         respond: G,


### PR DESCRIPTION
## Reason for This PR

Improvements to `EventManager`.


## Description of Changes

Introduced the EventManager trait with the following functions:
register, unregister, modify, and subscriber. Previously the
name `EventManager` was used for the implementation of the event
manager. This one is now renamed to `EpollManager` as it uses epoll
to handle events. The main drive for creating this trait is the need
to pass a reference to the event manager when calling process in
Subscriber. The only methods that are  safe to call are the ones
now defined in the trait.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
