### PR TITLE
Fixes for the arg parser

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -306,7 +306,7 @@ impl Env {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use build_app;
+    use build_arg_parser;
 
     #[derive(Clone)]
     struct ArgVals<'a> {
@@ -373,8 +373,8 @@ mod tests {
             daemonize: true,
         };
 
-        let app = build_app();
-        let mut args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        let mut args = arg_parser.arguments().clone();
         args.parse(&make_args(&good_arg_vals)).unwrap();
         // This should be fine.
         let good_env =
@@ -398,8 +398,8 @@ mod tests {
             ..good_arg_vals
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&another_good_arg_vals)).unwrap();
         let another_good_env = Env::new(&args, 0, 0)
             .expect("This another new environment should be created successfully.");
@@ -415,8 +415,8 @@ mod tests {
             ..base_invalid_arg_vals.clone()
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_node_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 
@@ -425,8 +425,8 @@ mod tests {
             ..base_invalid_arg_vals.clone()
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_id_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 
@@ -435,8 +435,8 @@ mod tests {
             ..base_invalid_arg_vals.clone()
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&inexistent_exec_file_arg_vals))
             .unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
@@ -446,8 +446,8 @@ mod tests {
             ..base_invalid_arg_vals.clone()
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_uid_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 
@@ -456,8 +456,8 @@ mod tests {
             ..base_invalid_arg_vals.clone()
         };
 
-        let app = build_app();
-        args = app.arguments().clone();
+        let arg_parser = build_arg_parser();
+        args = arg_parser.arguments().clone();
         args.parse(&make_args(&invalid_gid_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 


### PR DESCRIPTION
## Reason for This PR

Some renames and small changes in order to have in `arg_parser` file only
the functionality of a command line argument parser.

## Description of Changes

App struct was renamed ArgParser and app specific fields
were removed in order to keep in `arg_parser.rs` only the
functionality that is related to a command line argument
parser.
ArgInfo struct was renamed Argument because it contains
the `user_value` field which is not actually an info about
the argument.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched
      code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
