### PR TITLE
tests: Return when pytest is in discovery mode

### DIFF
--- a/tests/framework/scheduler.py
+++ b/tests/framework/scheduler.py
@@ -94,6 +94,10 @@ class PytestScheduler(mpsing.MultiprocessSingleton):
 
         Called in the server process context.
         """
+        # Don't run tests on test discovery
+        if session.config.option.collectonly:
+            return True
+
         max_concurrency = self.session.config.option.concurrency
         schedule = [
             {


### PR DESCRIPTION
## Reason for This PR

When running pytest in test discovery mode `pytest --co`, tests were being executed when they should have not.

## Description of Changes

When adding a custom hook on test discovery through pytest_runtestloop(), we should check whether pytest is running in test discovery mode or not, as implemented in pytest  https://github.com/pytest-dev/pytest/blob/master/src/_pytest/main.py#L278

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR
- [x] The changes in this PR have no user impact
- [x] No new `unsafe` code has been added
