### PR TITLE
Event Manager Cleanup

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -273,7 +273,7 @@ impl BusDevice for Serial {
 
 impl Subscriber for Serial {
     /// Handle a read event (EPOLLIN) on the serial input fd.
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
@@ -380,7 +380,8 @@ mod tests {
         // A serial without in does not have any events in the list.
         assert!(serial.interest_list().is_empty());
         // Even though there is no in, process should not panic. Call it to validate this.
-        serial.process(EpollEvent::new(EventSet::IN, 0), &mut event_manager);
+        let epoll_event = EpollEvent::new(EventSet::IN, 0);
+        serial.process(&epoll_event, &mut event_manager);
     }
 
     #[test]
@@ -400,11 +401,11 @@ mod tests {
 
         // Process an invalid event type does not panic.
         let invalid_event = EpollEvent::new(EventSet::OUT, intr_evt.as_raw_fd() as u64);
-        serial.process(invalid_event, &mut event_manager);
+        serial.process(&invalid_event, &mut event_manager);
 
         // Process an event with a `RawFd` that does not correspond to `intr_evt` does not panic.
         let invalid_event = EpollEvent::new(EventSet::IN, 0);
-        serial.process(invalid_event, &mut event_manager);
+        serial.process(&invalid_event, &mut event_manager);
     }
 
     #[test]

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -427,7 +427,7 @@ mod tests {
         b.queue_evt.write(1).unwrap();
         // Handle event.
         b.process(
-            EpollEvent::new(EventSet::IN, b.queue_evt.as_raw_fd() as u64),
+            &EpollEvent::new(EventSet::IN, b.queue_evt.as_raw_fd() as u64),
             &mut EventManager::new().unwrap(),
         );
         // Validate the queue operation finished successfully.
@@ -835,7 +835,7 @@ mod tests {
         {
             // Trigger the attempt to write.
             block.queue_evt.write(1).unwrap();
-            block.process(queue_evt, &mut event_manager);
+            block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter().is_blocked());
@@ -851,7 +851,7 @@ mod tests {
 
         // Following write procedure should succeed because bandwidth should now be available.
         {
-            block.process(rate_limiter_evt, &mut event_manager);
+            block.process(&rate_limiter_evt, &mut event_manager);
             // Validate the rate_limiter is no longer blocked.
             assert!(!block.rate_limiter().is_blocked());
             // Make sure the virtio queue operation completed this time.
@@ -904,7 +904,7 @@ mod tests {
         {
             // Trigger the attempt to write.
             block.queue_evt.write(1).unwrap();
-            block.process(queue_evt, &mut event_manager);
+            block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter().is_blocked());
@@ -918,7 +918,7 @@ mod tests {
         {
             // Trigger the attempt to write.
             block.queue_evt.write(1).unwrap();
-            block.process(queue_evt, &mut event_manager);
+            block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter().is_blocked());
@@ -934,7 +934,7 @@ mod tests {
 
         // Following write procedure should succeed because ops budget should now be available.
         {
-            block.process(rate_limiter_evt, &mut event_manager);
+            block.process(&rate_limiter_evt, &mut event_manager);
             // Validate the rate_limiter is no longer blocked.
             assert!(!block.rate_limiter().is_blocked());
             // Make sure the virtio queue operation completed this time.

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -10,7 +10,7 @@ use crate::virtio::VirtioDevice;
 
 impl Subscriber for Block {
     // Handle an event for queue or rate limiter.
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         if !self.is_activated() {
             warn!("The device is not yet activated. Events can not be handled.");
             return;

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -992,7 +992,7 @@ mod tests {
 
             net.queue_evts[TX_INDEX].write(1).unwrap();
             let event = EpollEvent::new(EventSet::IN, net.queue_evts[TX_INDEX].as_raw_fd() as u64);
-            net.process(event, &mut event_manager);
+            net.process(&event, &mut event_manager);
             // Make sure the data queue advanced.
             assert_eq!(txq.used.idx.get(), 1);
         }
@@ -1009,7 +1009,7 @@ mod tests {
 
             net.interrupt_evt.write(1).unwrap();
             let tap_event = EpollEvent::new(EventSet::IN, net.tap.as_raw_fd() as u64);
-            net.process(tap_event, &mut event_manager);
+            net.process(&tap_event, &mut event_manager);
             assert!(net.rx_deferred_frame);
             assert_eq!(net.interrupt_evt.read().unwrap(), 3);
             // The #cfg(test) enabled version of read_tap always returns 1234 bytes (or the len of
@@ -1025,7 +1025,7 @@ mod tests {
 
             // this should also be successful
             net.interrupt_evt.write(1).unwrap();
-            net.process(tap_event, &mut event_manager);
+            net.process(&tap_event, &mut event_manager);
             assert!(net.rx_deferred_frame);
             assert_eq!(net.interrupt_evt.read().unwrap(), 2);
 
@@ -1040,7 +1040,7 @@ mod tests {
             check_metric_after_block!(
                 &METRICS.net.rx_fails,
                 1,
-                net.process(tap_event, &mut event_manager)
+                net.process(&tap_event, &mut event_manager)
             );
             assert!(net.rx_deferred_frame);
             assert_eq!(net.interrupt_evt.read().unwrap(), 2);
@@ -1067,7 +1067,7 @@ mod tests {
             check_metric_after_block!(
                 &METRICS.net.rx_count,
                 2,
-                net.process(rx_event, &mut event_manager)
+                net.process(&rx_event, &mut event_manager)
             );
             assert_eq!(net.interrupt_evt.read().unwrap(), 2);
         }
@@ -1225,7 +1225,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(rx_rate_limiter_ev, &mut event_manager)
+            net.process(&rx_rate_limiter_ev, &mut event_manager)
         );
 
         // TX rate limiter events should error since the limiter is not blocked.
@@ -1235,7 +1235,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(tx_rate_limiter_ev, &mut event_manager)
+            net.process(&tx_rate_limiter_ev, &mut event_manager)
         );
     }
 
@@ -1251,7 +1251,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(invalid_event, &mut event_manager)
+            net.process(&invalid_event, &mut event_manager)
         );
     }
 
@@ -1275,7 +1275,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(tap_event, &mut event_manager)
+            net.process(&tap_event, &mut event_manager)
         );
 
         // Fake an avail buffer; this time, tap reading should error out.
@@ -1283,7 +1283,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.rx_fails,
             1,
-            net.process(tap_event, &mut event_manager)
+            net.process(&tap_event, &mut event_manager)
         );
     }
 
@@ -1301,7 +1301,7 @@ mod tests {
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(rate_limiter_event, &mut event_manager)
+            net.process(&rate_limiter_event, &mut event_manager)
         );
     }
 
@@ -1316,11 +1316,11 @@ mod tests {
         net.tx_rate_limiter = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
         let rate_limiter_event =
             EpollEvent::new(EventSet::IN, net.tx_rate_limiter.as_raw_fd() as u64);
-        net.process(rate_limiter_event, &mut event_manager);
+        net.process(&rate_limiter_event, &mut event_manager);
         check_metric_after_block!(
             &METRICS.net.event_fails,
             1,
-            net.process(rate_limiter_event, &mut event_manager)
+            net.process(&rate_limiter_event, &mut event_manager)
         );
     }
 
@@ -1356,7 +1356,7 @@ mod tests {
                 net.queue_evts[TX_INDEX].write(1).unwrap();
                 let tx_event =
                     EpollEvent::new(EventSet::IN, net.queue_evts[TX_INDEX].as_raw_fd() as u64);
-                net.process(tx_event, &mut event_manager);
+                net.process(&tx_event, &mut event_manager);
 
                 // assert that limiter is blocked
                 assert!(net.tx_rate_limiter.is_blocked());
@@ -1376,7 +1376,7 @@ mod tests {
                 check_metric_after_block!(
                     &METRICS.net.tx_count,
                     2,
-                    net.process(tx_limiter_event, &mut event_manager)
+                    net.process(&tx_limiter_event, &mut event_manager)
                 );
                 // validate the rate_limiter is no longer blocked
                 assert!(!net.tx_rate_limiter.is_blocked());
@@ -1407,7 +1407,7 @@ mod tests {
                 net.interrupt_evt.write(1).unwrap();
                 // trigger the RX handler
                 let rx_event = EpollEvent::new(EventSet::IN, net.tap.as_raw_fd() as u64);
-                net.process(rx_event, &mut event_manager);
+                net.process(&rx_event, &mut event_manager);
 
                 // assert that limiter is blocked
                 assert!(net.rx_rate_limiter.is_blocked());
@@ -1428,7 +1428,7 @@ mod tests {
                 net.interrupt_evt.write(1).unwrap();
                 let rx_limiter_event =
                     EpollEvent::new(EventSet::IN, net.rx_rate_limiter.as_raw_fd() as u64);
-                net.process(rx_limiter_event, &mut event_manager);
+                net.process(&rx_limiter_event, &mut event_manager);
                 // validate the rate_limiter is no longer blocked
                 assert!(!net.rx_rate_limiter.is_blocked());
                 // make sure the virtio queue operation completed this time
@@ -1474,7 +1474,7 @@ mod tests {
                 net.queue_evts[TX_INDEX].write(1).unwrap();
                 let tx_event =
                     EpollEvent::new(EventSet::IN, net.queue_evts[TX_INDEX].as_raw_fd() as u64);
-                net.process(tx_event, &mut event_manager);
+                net.process(&tx_event, &mut event_manager);
 
                 // assert that limiter is blocked
                 assert!(net.tx_rate_limiter.is_blocked());
@@ -1490,7 +1490,7 @@ mod tests {
             {
                 let tx_rate_limiter_event =
                     EpollEvent::new(EventSet::IN, net.tx_rate_limiter.as_raw_fd() as u64);
-                net.process(tx_rate_limiter_event, &mut event_manager);
+                net.process(&tx_rate_limiter_event, &mut event_manager);
                 // validate the rate_limiter is no longer blocked
                 assert!(!net.tx_rate_limiter.is_blocked());
                 // make sure the data queue advanced
@@ -1520,7 +1520,7 @@ mod tests {
                 net.interrupt_evt.write(1).unwrap();
                 // trigger the RX handler
                 let rx_event = EpollEvent::new(EventSet::IN, net.tap.as_raw_fd() as u64);
-                net.process(rx_event, &mut event_manager);
+                net.process(&rx_event, &mut event_manager);
 
                 // assert that limiter is blocked
                 assert!(net.rx_rate_limiter.is_blocked());
@@ -1533,7 +1533,7 @@ mod tests {
                 // leave at least one event here so that reading it later won't block
                 net.interrupt_evt.write(1).unwrap();
                 // trigger the RX handler again, this time it should do the limiter fast path exit
-                net.process(rx_event, &mut event_manager);
+                net.process(&rx_event, &mut event_manager);
                 // assert that no operation actually completed, that the limiter blocked it
                 assert_eq!(net.interrupt_evt.read().unwrap(), 1);
                 // make sure the data is still queued for processing
@@ -1550,7 +1550,7 @@ mod tests {
                 net.interrupt_evt.write(1).unwrap();
                 let rx_rate_limiter_event =
                     EpollEvent::new(EventSet::IN, net.rx_rate_limiter.as_raw_fd() as u64);
-                net.process(rx_rate_limiter_event, &mut event_manager);
+                net.process(&rx_rate_limiter_event, &mut event_manager);
                 // make sure the virtio queue operation completed this time
                 assert_eq!(net.interrupt_evt.read().unwrap(), 2);
                 // make sure the data queue advanced
@@ -1616,7 +1616,7 @@ mod tests {
         // trigger the TX handler
         net.queue_evts[TX_INDEX].write(1).unwrap();
         let tx_event = EpollEvent::new(EventSet::IN, net.queue_evts[TX_INDEX].as_raw_fd() as u64);
-        net.process(tx_event, &mut event_manager);
+        net.process(&tx_event, &mut event_manager);
 
         // Verify if TX queue was processed.
         assert_eq!(txq.used.idx.get(), 1);

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -11,7 +11,7 @@ use crate::virtio::net::device::Net;
 use crate::virtio::{VirtioDevice, RX_INDEX, TX_INDEX};
 
 impl Subscriber for Net {
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         if !self.is_activated() {
             warn!("The device is not yet activated. Events can not be handled.");
             return;

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -34,7 +34,7 @@ impl<B> Vsock<B>
 where
     B: VsockBackend + 'static,
 {
-    pub(crate) fn handle_rxq_event(&mut self, event: EpollEvent) -> bool {
+    pub(crate) fn handle_rxq_event(&mut self, event: &EpollEvent) -> bool {
         debug!("vsock: RX queue event");
 
         let event_set = event.event_set();
@@ -52,7 +52,7 @@ where
         raise_irq
     }
 
-    pub(crate) fn handle_txq_event(&mut self, event: EpollEvent) -> bool {
+    pub(crate) fn handle_txq_event(&mut self, event: &EpollEvent) -> bool {
         debug!("vsock: TX queue event");
 
         let event_set = event.event_set();
@@ -76,7 +76,7 @@ where
         raise_irq
     }
 
-    fn handle_evq_event(&mut self, event: EpollEvent) -> bool {
+    fn handle_evq_event(&mut self, event: &EpollEvent) -> bool {
         debug!("vsock: event queue event");
 
         let event_set = event.event_set();
@@ -91,7 +91,7 @@ where
         false
     }
 
-    fn notify_backend(&mut self, event: EpollEvent) -> bool {
+    fn notify_backend(&mut self, event: &EpollEvent) -> bool {
         debug!("vsock: backend event");
 
         self.backend.notify(event.event_set());
@@ -183,7 +183,7 @@ impl<B> Subscriber for Vsock<B>
 where
     B: VsockBackend + 'static,
 {
-    fn process(&mut self, event: EpollEvent, event_manager: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
         let source = event.fd();
         let rxq = self.queue_events[RXQ_INDEX].as_raw_fd();
         let txq = self.queue_events[TXQ_INDEX].as_raw_fd();
@@ -331,7 +331,7 @@ mod tests {
 
             assert!(!ctx
                 .device
-                .handle_txq_event(EpollEvent::new(EventSet::IN, 0)));
+                .handle_txq_event(&EpollEvent::new(EventSet::IN, 0)));
         }
     }
 
@@ -389,7 +389,7 @@ mod tests {
             ctx.device.backend.set_pending_rx(false);
             assert!(!ctx
                 .device
-                .handle_rxq_event(EpollEvent::new(EventSet::IN, 0)));
+                .handle_rxq_event(&EpollEvent::new(EventSet::IN, 0)));
         }
     }
 
@@ -402,7 +402,7 @@ mod tests {
             ctx.device.backend.set_pending_rx(false);
             assert!(!ctx
                 .device
-                .handle_evq_event(EpollEvent::new(EventSet::IN, 0)));
+                .handle_evq_event(&EpollEvent::new(EventSet::IN, 0)));
         }
     }
 
@@ -416,7 +416,7 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
 
             ctx.device.backend.set_pending_rx(true);
-            ctx.device.notify_backend(EpollEvent::new(EventSet::IN, 0));
+            ctx.device.notify_backend(&EpollEvent::new(EventSet::IN, 0));
 
             // The backend should've received this event.
             assert_eq!(ctx.device.backend.evset, Some(EventSet::IN));
@@ -434,7 +434,7 @@ mod tests {
             let mut ctx = test_ctx.create_event_handler_context();
 
             ctx.device.backend.set_pending_rx(false);
-            ctx.device.notify_backend(EpollEvent::new(EventSet::IN, 0));
+            ctx.device.notify_backend(&EpollEvent::new(EventSet::IN, 0));
 
             // The backend should've received this event.
             assert_eq!(ctx.device.backend.evset, Some(EventSet::IN));

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -310,12 +310,12 @@ mod tests {
         pub fn signal_txq_event(&mut self) {
             self.device.queue_events[TXQ_INDEX].write(1).unwrap();
             self.device
-                .handle_txq_event(EpollEvent::new(EventSet::IN, 0));
+                .handle_txq_event(&EpollEvent::new(EventSet::IN, 0));
         }
         pub fn signal_rxq_event(&mut self) {
             self.device.queue_events[RXQ_INDEX].write(1).unwrap();
             self.device
-                .handle_rxq_event(EpollEvent::new(EventSet::IN, 0));
+                .handle_rxq_event(&EpollEvent::new(EventSet::IN, 0));
         }
     }
 }

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -525,7 +525,11 @@ impl VsockMuxer {
         };
 
         self.epoll
-            .ctl(ControlOperation::Add, fd, EpollEvent::new(evset, fd as u64))
+            .ctl(
+                ControlOperation::Add,
+                fd,
+                &EpollEvent::new(evset, fd as u64),
+            )
             .and_then(|_| {
                 self.listener_map.insert(fd, listener);
                 Ok(())
@@ -541,7 +545,7 @@ impl VsockMuxer {
 
         if maybe_listener.is_some() {
             self.epoll
-                .ctl(ControlOperation::Delete, fd, EpollEvent::default())
+                .ctl(ControlOperation::Delete, fd, &EpollEvent::default())
                 .unwrap_or_else(|err| {
                     warn!(
                         "vosck muxer: error removing epoll listener for fd {:?}: {:?}",
@@ -667,7 +671,7 @@ impl VsockMuxer {
                         .ctl(
                             ControlOperation::Modify,
                             fd,
-                            EpollEvent::new(new_evset, fd as u64),
+                            &EpollEvent::new(new_evset, fd as u64),
                         )
                         .unwrap_or_else(|err| {
                             // This really shouldn't happen, like, ever. However, "famous last

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -51,7 +51,7 @@ impl ApiServerAdapter {
 }
 impl Subscriber for ApiServerAdapter {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -62,7 +62,7 @@ impl PeriodicMetrics {
 
 impl Subscriber for PeriodicMetrics {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
@@ -124,7 +124,7 @@ pub mod tests {
         // Test invalid read event.
         let unrelated_object = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let unrelated_event = EpollEvent::new(EventSet::IN, unrelated_object.as_raw_fd() as u64);
-        metrics.process(unrelated_event, &mut event_manager);
+        metrics.process(&unrelated_event, &mut event_manager);
         // No flush happened.
         assert_eq!(metrics.flush_counter, 0);
 
@@ -133,7 +133,7 @@ pub mod tests {
             EventSet::OUT,
             metrics.write_metrics_event_fd.as_raw_fd() as u64,
         );
-        metrics.process(unsupported_event, &mut event_manager);
+        metrics.process(&unsupported_event, &mut event_manager);
         assert_eq!(metrics.flush_counter, 0);
 
         let metrics = Arc::new(Mutex::new(metrics));

--- a/src/polly/src/epoll.rs
+++ b/src/polly/src/epoll.rs
@@ -212,6 +212,16 @@ impl AsRawFd for Epoll {
     }
 }
 
+impl std::ops::Drop for Epoll {
+    fn drop(&mut self) {
+        // Safe because this fd is opened with `epoll_create` and we trust
+        // the kernel to give us a valid fd.
+        unsafe {
+            libc::close(self.epoll_fd);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/polly/src/epoll.rs
+++ b/src/polly/src/epoll.rs
@@ -130,7 +130,7 @@ impl EpollEvent {
 }
 
 /// Wrapper over epoll functionality.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Epoll {
     epoll_fd: RawFd,
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -413,7 +413,7 @@ impl Vmm {
 
 impl Subscriber for Vmm {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 


### PR DESCRIPTION
## Reason for This PR

Fixes: #1536

## Description of Changes

Implemented Drop for Epoll and remove copy & clone from Epoll and copy from epoll_event.
Also use reference instead of copying the epoll & epoll_event.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
