### PR TITLE
[GuestMemoryMmap] rename new() to from_ranges()

### DIFF
--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn test_create_fdt_with_devices() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         let dev_info: HashMap<(DeviceType, std::string::String), MMIODeviceInfo> = [
             (
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_create_fdt() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1).unwrap();
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn test_create_fdt_with_initrd() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let gic = create_gic(&vm, 1).unwrap();

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -131,15 +131,15 @@ mod tests {
     #[test]
     fn test_get_fdt_addr() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }
 }

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -164,7 +164,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = GuestMemoryMmap::new(&regions).expect("Cannot initialize memory");
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {
             Error::SetCoreRegister(ref e) => assert_eq!(e.errno(), libc::ENOEXEC),

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let config_err = configure_system(&gm, GuestAddress(0), 0, &None, 1);
         assert!(config_err.is_err());
         assert_eq!(
@@ -224,19 +224,19 @@ mod tests {
         // Now assigning some memory that falls before the 32bit memory hole.
         let mem_size = 128 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemoryMmap::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemoryMmap::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = GuestMemoryMmap::new(&arch_mem_regions).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
     }
 

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -302,8 +302,11 @@ mod tests {
     #[test]
     fn bounds_check() {
         let num_cpus = 4;
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))])
-            .unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(MPTABLE_START),
+            compute_mp_size(num_cpus),
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
     }
@@ -311,9 +314,11 @@ mod tests {
     #[test]
     fn bounds_check_fails() {
         let num_cpus = 4;
-        let mem =
-            GuestMemoryMmap::new(&[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus) - 1)])
-                .unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(MPTABLE_START),
+            compute_mp_size(num_cpus) - 1,
+        )])
+        .unwrap();
 
         assert!(setup_mptable(&mem, num_cpus).is_err());
     }
@@ -321,8 +326,11 @@ mod tests {
     #[test]
     fn mpf_intel_checksum() {
         let num_cpus = 1;
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))])
-            .unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(MPTABLE_START),
+            compute_mp_size(num_cpus),
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
 
@@ -337,8 +345,11 @@ mod tests {
     #[test]
     fn mpc_table_checksum() {
         let num_cpus = 4;
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))])
-            .unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(MPTABLE_START),
+            compute_mp_size(num_cpus),
+        )])
+        .unwrap();
 
         setup_mptable(&mem, num_cpus).unwrap();
 
@@ -367,7 +378,7 @@ mod tests {
 
     #[test]
     fn cpu_entry_count() {
-        let mem = GuestMemoryMmap::new(&[(
+        let mem = GuestMemoryMmap::from_ranges(&[(
             GuestAddress(MPTABLE_START),
             compute_mp_size(MAX_SUPPORTED_CPUS as u8),
         )])
@@ -404,9 +415,11 @@ mod tests {
     #[test]
     fn cpu_entry_count_max() {
         let cpus = MAX_SUPPORTED_CPUS + 1;
-        let mem =
-            GuestMemoryMmap::new(&[(GuestAddress(MPTABLE_START), compute_mp_size(cpus as u8))])
-                .unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(MPTABLE_START),
+            compute_mp_size(cpus as u8),
+        )])
+        .unwrap();
 
         let result = setup_mptable(&mem, cpus as u8).unwrap_err();
         assert_eq!(result, Error::TooManyCpus);

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -196,7 +196,7 @@ mod tests {
     use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 
     fn create_guest_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap()
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap()
     }
 
     fn read_u64(gm: &GuestMemoryMmap, offset: u64) -> u64 {

--- a/src/devices/src/virtio/block.rs
+++ b/src/devices/src/virtio/block.rs
@@ -782,7 +782,7 @@ mod tests {
         bad_qlen: bool,
         bad_evtlen: bool,
     ) -> ActivateResult {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let ievt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let stat = Arc::new(AtomicUsize::new(0));
 
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_read_request_header() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let addr = GuestAddress(0);
         let sector = 123_454_321;
 
@@ -864,7 +864,7 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let m = &GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), &m, 16);
 
         assert!(vq.end().0 < 0x1000);
@@ -1088,7 +1088,7 @@ mod tests {
 
     #[test]
     fn test_invalid_event_handler() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _vq) = default_test_blockepollhandler(&m);
         let r = h.handle_event(BLOCK_EVENTS_COUNT as DeviceEventT, EPOLLIN);
         match r {
@@ -1107,7 +1107,7 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_handler() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, vq) = default_test_blockepollhandler(&m);
 
         let blk_metadata = h.disk_image.metadata();

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -521,7 +521,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let mut dummy = DummyDevice::new();
         // Validate reset is no-op.
         assert!(dummy.reset().is_none());
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_bus_device_read() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
 
         let mut buf = vec![0xff, 0, 0xfe, 0];
@@ -641,7 +641,7 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_bus_device_write() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
 
         let mut dummy_box = Box::new(DummyDevice::new());
         let dummy_dev_acked_features = &dummy_box.acked_features as *const u64;
@@ -801,7 +801,7 @@ mod tests {
 
     #[test]
     fn test_bus_device_activate() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
 
         assert!(!d.are_queues_valid());
@@ -917,7 +917,7 @@ mod tests {
 
     #[test]
     fn test_bus_device_reset() {
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let mut d = MmioDevice::new(m, Box::new(DummyDevice::new())).unwrap();
         let mut buf = vec![0; 4];
 

--- a/src/devices/src/virtio/net.rs
+++ b/src/devices/src/virtio/net.rs
@@ -1086,7 +1086,7 @@ mod tests {
     }
 
     fn activate_some_net(n: &mut Net, bad_qlen: bool, bad_evtlen: bool) -> ActivateResult {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let interrupt_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let status = Arc::new(AtomicUsize::new(0));
 
@@ -1302,7 +1302,7 @@ mod tests {
 
     #[test]
     fn test_mmds_detour_and_injection() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let sha = MacAddr::parse_str("11:11:11:11:11:11").unwrap();
@@ -1363,7 +1363,7 @@ mod tests {
 
     #[test]
     fn test_mac_spoofing_detection() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let guest_mac = MacAddr::parse_str("11:11:11:11:11:11").unwrap();
@@ -1430,7 +1430,7 @@ mod tests {
 
     #[test]
     fn test_handler_error_cases() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         // RX rate limiter events should error since the limiter is not blocked.
@@ -1452,7 +1452,7 @@ mod tests {
 
     #[test]
     fn test_invalid_event_handler() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let bad_event = 1000;
@@ -1476,7 +1476,7 @@ mod tests {
         let test_mutators = TestMutators {
             tap_read_fail: true,
         };
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, rxq) = default_test_netepollhandler(&mem, test_mutators);
 
         // The RX queue is empty.
@@ -1495,7 +1495,7 @@ mod tests {
 
     #[test]
     fn test_rx_rate_limited_event_handler() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
         let rl = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
         h.set_rx_rate_limiter(rl);
@@ -1508,7 +1508,7 @@ mod tests {
 
     #[test]
     fn test_tx_rate_limited_event_handler() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, TestMutators::default());
         let rl = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
         h.set_tx_rate_limiter(rl);
@@ -1521,7 +1521,7 @@ mod tests {
 
     #[test]
     fn test_handler() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1661,7 +1661,7 @@ mod tests {
             let test_mutators = TestMutators {
                 tap_read_fail: true,
             };
-            let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
             let (mut h, _txq, _rxq) = default_test_netepollhandler(&mem, test_mutators);
 
             check_metric_after_block!(&METRICS.net.rx_fails, 1, h.process_rx());
@@ -1670,7 +1670,7 @@ mod tests {
 
     #[test]
     fn test_bandwidth_rate_limiter() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1778,7 +1778,7 @@ mod tests {
 
     #[test]
     fn test_ops_rate_limiter() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, txq, rxq) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;
@@ -1888,7 +1888,7 @@ mod tests {
 
     #[test]
     fn test_patch_rate_limiters() {
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, _, _) = default_test_netepollhandler(&mem, TestMutators::default());
 
         h.set_rx_rate_limiter(RateLimiter::new(10, None, 10, 2, None, 2).unwrap());
@@ -1921,7 +1921,7 @@ mod tests {
     #[test]
     fn test_tx_queue_interrupt() {
         // Regression test for https://github.com/firecracker-microvm/firecracker/issues/1436 .
-        let mem = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let (mut h, txq, _) = default_test_netepollhandler(&mem, TestMutators::default());
 
         let daddr = 0x2000;

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -608,9 +608,11 @@ pub mod tests {
 
     #[test]
     fn test_checked_new_descriptor_chain() {
-        let m =
-            &GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000), (GuestAddress(0x20000), 0x2000)])
-                .unwrap();
+        let m = &GuestMemoryMmap::from_ranges(&[
+            (GuestAddress(0), 0x10000),
+            (GuestAddress(0x20000), 0x2000),
+        ])
+        .unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         assert!(vq.end().0 < 0x1000);
@@ -656,7 +658,7 @@ pub mod tests {
 
     #[test]
     fn test_queue_validation() {
-        let m = &GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
@@ -707,7 +709,7 @@ pub mod tests {
 
     #[test]
     fn test_queue_processing() {
-        let m = &GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
@@ -775,7 +777,7 @@ pub mod tests {
 
     #[test]
     fn test_add_used() {
-        let m = &GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();

--- a/src/devices/src/virtio/vsock/epoll_handler.rs
+++ b/src/devices/src/virtio/vsock/epoll_handler.rs
@@ -513,7 +513,7 @@ mod tests {
         const MIB: usize = 1 << 20;
 
         let mut test_ctx = TestContext::new();
-        test_ctx.mem = GuestMemoryMmap::new(&[
+        test_ctx.mem = GuestMemoryMmap::from_ranges(&[
             (GuestAddress(0), 8 * MIB),
             (GuestAddress((GAP_START_ADDR - MIB) as u64), MIB),
             (GuestAddress(FIRST_AFTER_GAP as u64), MIB),

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -299,7 +299,7 @@ mod tests {
             let (sender, _handler_receiver) = mpsc::channel();
             Self {
                 cid: CID,
-                mem: GuestMemoryMmap::new(&[(GuestAddress(0), MEM_SIZE)]).unwrap(),
+                mem: GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap(),
                 mem_size: MEM_SIZE,
                 device: Vsock::new(
                     CID,

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -269,7 +269,7 @@ mod tests {
     const MEM_SIZE: usize = 0x18_0000;
 
     fn create_guest_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::new(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn test_load_kernel_no_memory() {
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0x0), 79)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 79)]).unwrap();
         let image = make_test_bin();
         assert_eq!(
             Err(Error::ReadKernelImage),

--- a/src/vm-memory/src/guest_memory.rs
+++ b/src/vm-memory/src/guest_memory.rs
@@ -120,7 +120,7 @@ pub trait GuestMemory {
     /// fn test_map_fold() -> Result<(), ()> {
     ///     let start_addr1 = GuestAddress(0x0);
     ///     let start_addr2 = GuestAddress(0x400);
-    ///     let mem = GuestMemoryMmap::new(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+    ///     let mem = GuestMemoryMmap::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
     ///     let total_size = mem.map_and_fold(
     ///         0,
     ///         |(_, region)| region.len() / 1024,
@@ -143,7 +143,7 @@ pub trait GuestMemory {
     /// use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap, MemoryMapping};
     /// fn test_last_addr() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let mut gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     assert_eq!(start_addr.checked_add(0x3ff), Some(gm.last_addr()));
     ///     Ok(())
     /// }
@@ -175,7 +175,7 @@ pub trait GuestMemory {
     /// use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
     /// fn test_host_addr() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let mut gm = GuestMemoryMmap::new(&vec![(start_addr, 0x500)]).map_err(|_| ())?;
+    ///     let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x500)]).map_err(|_| ())?;
     ///     let addr = gm.get_host_address(GuestAddress(0x1200)).unwrap();
     ///     println!("Host address is {:p}", addr);
     ///     Ok(())
@@ -193,7 +193,7 @@ pub struct GuestMemoryMmap {
 impl GuestMemoryMmap {
     /// Creates a container for guest memory regions.
     /// Valid memory regions are specified as a Vec of (Address, Size) tuples sorted by Address.
-    pub fn new(ranges: &[(GuestAddress, usize)]) -> Result<GuestMemoryMmap> {
+    pub fn from_ranges(ranges: &[(GuestAddress, usize)]) -> Result<GuestMemoryMmap> {
         if ranges.is_empty() {
             return Err(Error::NoMemoryRegions);
         }
@@ -352,7 +352,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     /// use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap, MemoryMapping};
     /// fn test_write_u64() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let mut gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     let res = gm
     ///         .write_slice(&[1, 2, 3, 4, 5], GuestAddress(0x200))
     ///         .map_err(|_| ())?;
@@ -374,7 +374,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     /// use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap, MemoryMapping};
     /// fn test_write_u64() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let mut gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     let buf = &mut [0u8; 16];
     ///     let res = gm
     ///         .read_slice(buf, GuestAddress(0x200))
@@ -397,7 +397,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     /// use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap, MemoryMapping};
     /// fn test_write_u64() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let mut gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     gm.write_obj(55u64, GuestAddress(0x1100))
     ///         .map_err(|_| ())
     /// }
@@ -423,7 +423,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     ///     let start_addr1 = GuestAddress(0x0);
     ///     let start_addr2 = GuestAddress(0x400);
     ///     let mut gm =
-    ///         GuestMemoryMmap::new(&vec![(start_addr1, 0x400), (start_addr2, 0x400)]).map_err(|_| ())?;
+    ///         GuestMemoryMmap::from_ranges(&vec![(start_addr1, 0x400), (start_addr2, 0x400)]).map_err(|_| ())?;
     ///     let num1: u64 = gm.read_obj(GuestAddress(32)).map_err(|_| ())?;
     ///     let num2: u64 = gm
     ///         .read_obj(GuestAddress(0x400 + 32))
@@ -449,7 +449,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     /// use std::path::Path;
     /// fn test_read_random() -> Result<u32, ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     let mut file = File::open(Path::new("/dev/urandom")).map_err(|_| ())?;
     ///     let addr = GuestAddress(0x1010);
     ///     gm.read_from(addr, &mut file, 128).map_err(|_| ())?;
@@ -485,7 +485,7 @@ impl Bytes<GuestAddress> for GuestMemoryMmap {
     /// use std::path::Path;
     /// fn test_write_null() -> Result<(), ()> {
     ///     let start_addr = GuestAddress(0x1000);
-    ///     let gm = GuestMemoryMmap::new(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
+    ///     let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)]).map_err(|_| ())?;
     ///     let mut file = File::open(Path::new("/dev/null")).map_err(|_| ())?;
     ///     let addr = GuestAddress(0x1010);
     ///     gm.write_to(addr, &mut file, 128).map_err(|_| ())?;
@@ -521,14 +521,14 @@ mod tests {
     fn test_regions() {
         // No regions provided should return error.
         assert_eq!(
-            format!("{:?}", GuestMemoryMmap::new(&[]).err().unwrap()),
+            format!("{:?}", GuestMemoryMmap::from_ranges(&[]).err().unwrap()),
             format!("{:?}", Error::NoMemoryRegions)
         );
 
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x800);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
         assert_eq!(guest_mem.num_regions(), 2);
         assert!(guest_mem.address_in_range(GuestAddress(0x200)));
         assert!(!guest_mem.address_in_range(GuestAddress(0x600)));
@@ -572,7 +572,7 @@ mod tests {
     fn overlap_memory() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let res = GuestMemoryMmap::new(&[(start_addr1, 0x2000), (start_addr2, 0x2000)]);
+        let res = GuestMemoryMmap::from_ranges(&[(start_addr1, 0x2000), (start_addr2, 0x2000)]);
         assert_eq!(
             format!("{:?}", res.err().unwrap()),
             format!("{:?}", Error::MemoryRegionOverlap)
@@ -586,7 +586,8 @@ mod tests {
         let bad_addr = GuestAddress(0x2001);
         let bad_addr2 = GuestAddress(0x1ffc);
 
-        let gm = GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let gm =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
 
         let val1: u64 = 0xaa55_aa55_aa55_aa55;
         let val2: u64 = 0x55aa_55aa_55aa_55aa;
@@ -618,7 +619,7 @@ mod tests {
     #[test]
     fn write_and_read_slice() {
         let mut start_addr = GuestAddress(0x1000);
-        let gm = GuestMemoryMmap::new(&[(start_addr, 0x400)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(start_addr, 0x400)]).unwrap();
         let sample_buf = &[1, 2, 3, 4, 5];
 
         assert!(gm.write_slice(sample_buf, start_addr).is_ok());
@@ -635,7 +636,7 @@ mod tests {
 
     #[test]
     fn read_to_and_write_from_mem() {
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0x1000), 0x400)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0x1000), 0x400)]).unwrap();
         let addr = GuestAddress(0x1010);
         gm.write_obj(!0u32, addr).unwrap();
         gm.read_from(
@@ -660,7 +661,7 @@ mod tests {
             (GuestAddress(0x1000), region_size),
         ];
         let mut iterated_regions = Vec::new();
-        let gm = GuestMemoryMmap::new(&regions).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&regions).unwrap();
 
         let res: Result<()> = gm.with_regions(|_, region| {
             assert_eq!(region.len(), region_size);
@@ -687,7 +688,8 @@ mod tests {
     fn test_guest_to_host() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x100);
-        let mem = GuestMemoryMmap::new(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
+        let mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
 
         assert!(mem.get_host_address(start_addr1).is_ok());
 
@@ -712,7 +714,8 @@ mod tests {
     fn test_map_fold() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x400);
-        let mem = GuestMemoryMmap::new(&[(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+        let mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
 
         assert_eq!(
             mem.map_and_fold(0, |(_, region)| region.len() / 1024, |acc, size| acc + size),
@@ -724,7 +727,8 @@ mod tests {
     fn test_region_size() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let mem = GuestMemoryMmap::new(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
+        let mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x100), (start_addr2, 0x400)]).unwrap();
 
         assert_eq!(mem.region_size(0).unwrap(), 0x100);
         assert_eq!(mem.region_size(1).unwrap(), 0x400);

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -426,7 +426,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
@@ -445,7 +445,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
@@ -483,7 +483,7 @@ mod tests {
         assert_eq!(dummy.queue_max_sizes(), QUEUE_SIZES);
 
         // test activate
-        let m = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let ievt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let stat = Arc::new(AtomicUsize::new(0));
         let queue_evts = vec![EventFd::new(libc::EFD_NONBLOCK).unwrap()];
@@ -496,7 +496,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -560,7 +560,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -583,7 +583,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -622,7 +622,7 @@ mod tests {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
-            GuestMemoryMmap::new(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(guest_mem, &mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let dummy_device = Arc::new(Mutex::new(DummyDevice { dummy: 0 }));

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -698,7 +698,7 @@ impl Vmm {
 
         self.vm
             .memory_init(
-                GuestMemoryMmap::new(&arch_mem_regions)
+                GuestMemoryMmap::from_ranges(&arch_mem_regions)
                     .map_err(StartMicrovmError::GuestMemoryMmap)?,
                 &self.kvm,
             )
@@ -2826,13 +2826,13 @@ mod tests {
     }
 
     fn create_guest_mem_at(at: GuestAddress, size: usize) -> GuestMemoryMmap {
-        GuestMemoryMmap::new(&[(at, size)]).unwrap()
+        GuestMemoryMmap::from_ranges(&[(at, size)]).unwrap()
     }
 
     fn create_guest_mem_with_size(size: usize) -> GuestMemoryMmap {
         const MEM_START: GuestAddress = GuestAddress(0x0);
 
-        GuestMemoryMmap::new(&[(MEM_START, size)]).unwrap()
+        GuestMemoryMmap::from_ranges(&[(MEM_START, size)]).unwrap()
     }
 
     fn make_test_bin() -> Vec<u8> {

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -879,7 +879,7 @@ mod tests {
     // Auxiliary function being used throughout the tests.
     fn setup_vcpu(mem_size: usize) -> (Vm, Vcpu) {
         let kvm = KvmContext::new().unwrap();
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0), mem_size)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), mem_size)]).unwrap();
         let mut vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
         assert!(vm.memory_init(gm, &kvm).is_ok());
 
@@ -932,15 +932,17 @@ mod tests {
         let mut vm = Vm::new(kvm_context.fd()).expect("Cannot create new vm");
 
         // Create valid memory region and test that the initialization is successful.
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         assert!(vm.memory_init(gm, &kvm_context).is_ok());
 
         // Set the maximum number of memory slots to 1 in KvmContext to check the error
         // path of memory_init. Create 2 non-overlapping memory slots.
         kvm_context.max_memslots = 1;
-        let gm =
-            GuestMemoryMmap::new(&[(GuestAddress(0x0), 0x1000), (GuestAddress(0x1001), 0x2000)])
-                .unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[
+            (GuestAddress(0x0), 0x1000),
+            (GuestAddress(0x1001), 0x2000),
+        ])
+        .unwrap();
         assert!(vm.memory_init(gm, &kvm_context).is_err());
     }
 
@@ -1013,7 +1015,7 @@ mod tests {
     #[test]
     fn test_configure_vcpu() {
         let kvm = KvmContext::new().unwrap();
-        let gm = GuestMemoryMmap::new(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let mut vm = Vm::new(kvm.fd()).expect("new vm failed");
         assert!(vm.memory_init(gm, &kvm).is_ok());
         let vm_mem = vm.memory().unwrap();


### PR DESCRIPTION
## Reason for This PR

Part of #1400 

## Description of Changes

The PR https://github.com/rust-vmm/vm-memory/pull/70 has introduced some
changes in the rust-vmm/vm-memory crate. We have to keep our interface
aligned.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
