### PR TITLE
tests: refactor batch assignment mechanism

### DIFF
--- a/tests/framework/scheduler.py
+++ b/tests/framework/scheduler.py
@@ -146,17 +146,16 @@ class PytestScheduler(mpsing.MultiprocessSingleton):
         # Go through the list of tests and assign each of them to its
         # corresponding batch in the schedule.
         for item in session.items:
-            for batch in schedule:
-                # A test can match any of the patterns defined by the batch,
-                # in order to get assigned to it.
-                re_pattern = "|".join(
-                    ["({})".format(x) for x in batch['patterns']]
-                )
-                item_full_name = "/".join(item.listnames())
-                if re.search(re_pattern, item_full_name) is not None:
-                    # Found a matching batch. No need to look any further.
-                    batch['items'].append(item)
-                    break
+            # A test can match any of the patterns defined by the batch,
+            # in order to get assigned to it.
+            next(
+                # Found a matching batch. No need to look any further.
+                batch['items'].append(item) for batch in schedule
+                if re.search(
+                    "|".join(["({})".format(x) for x in batch['patterns']]),
+                    "/".join(item.listnames()),
+                ) is not None
+            )
 
         # Filter out empty batches.
         schedule = [batch for batch in schedule if batch['items']]


### PR DESCRIPTION
To build one generator to stop the iteration when the
matching batch in schedule found. And then yield the
batch item, to instead loop breaking statement.

This introduces a little more graceful mechanism to
set stopping condition for python generator.

Signed-off-by: keyangxie <keyang.xie@gmail.com>

## Reason for This PR

To introduces a little more graceful mechanism for function `pytest_runtestloop`.

## Description of Changes

To build one generator to stop the iteration when the
matching batch in schedule found. And then yield the
batch item, to instead loop breaking statement.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
