### PR TITLE
vmm: Make output of serial console configurable at Vmm level

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -15,7 +15,7 @@ extern crate vmm;
 use backtrace::Backtrace;
 
 use std::fs;
-use std::io;
+use std::io::{self, stdout};
 use std::panic;
 use std::path::PathBuf;
 use std::process;
@@ -270,7 +270,8 @@ fn start_vmm(
     config_json: Option<String>,
 ) {
     // If this fails, consider it fatal. Use expect().
-    let mut vmm = Vmm::new(api_shared_info, &api_event_fd).expect("Cannot create VMM");
+    let mut vmm =
+        Vmm::new(api_shared_info, &api_event_fd, Box::new(stdout())).expect("Cannot create VMM");
     let vmm_seccomp_filter = seccomp_filter.clone();
     let vcpu_seccomp_filter = seccomp_filter.clone();
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -333,6 +333,7 @@ mod tests {
     use arch;
     use devices::virtio::{ActivateResult, VirtioDevice, TYPE_BLOCK};
     use kernel_cmdline;
+    use std::io::stdout;
     use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, RwLock};
     use utils::errno;
@@ -417,6 +418,7 @@ mod tests {
         Vmm::new(
             shared_info,
             &EventFd::new(libc::EFD_NONBLOCK).expect("cannot create eventFD"),
+            Box::new(stdout()),
         )
         .expect("Cannot Create VMM")
     }


### PR DESCRIPTION
## Reason for This PR

Make Vmm code a bit more flexible for future uses.

## Description of Changes

Currently, PortIoDeviceManager decides that the output of the serial should go
to stdout(), this is not flexible at all for any consumers of the Vmm struct
which may want to redirect the output to any object that implements Write +
Sync.

Fix this by just adding a new extra parameter to Vmm::new and plumb everything
all the way to the PortIODeviceManager.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
