### PR TITLE
[StateMachine] replace end_state flag with Option

### DIFF
--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -1094,7 +1094,7 @@ impl Vcpu {
         let barrier = Barrier::new(2);
         barrier.wait();
 
-        StateMachine::finish(Self::exited)
+        StateMachine::finish()
     }
 }
 


### PR DESCRIPTION
###  Reason for This PR

Simplify the state machine by removing the `end_state` flag

## Description of Changes

Simplify the state machine by removing the `end_state` flag

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
