### PR TITLE
Unit tests in net and block configs

### DIFF
--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -568,7 +568,7 @@ pub mod tests {
             }
         }
 
-        fn size(&self) -> u16 {
+        pub fn size(&self) -> u16 {
             self.dtable.len() as u16
         }
 

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -580,4 +580,27 @@ mod tests {
             .is_ok());
         assert!(block_devices_configs.has_partuuid_root);
     }
+
+    #[test]
+    fn test_block_config() {
+        let dummy_block_file = TempFile::new().unwrap();
+        let expected_partuuid = "0eaa91a0-01".to_string();
+        let expected_is_read_only = true;
+
+        let block_config = BlockDeviceConfig {
+            drive_id: "dummy_drive".to_string(),
+            path_on_host: dummy_block_file.as_path().to_path_buf(),
+            is_root_device: false,
+            partuuid: Some("0eaa91a0-01".to_string()),
+            is_read_only: true,
+            rate_limiter: None,
+        };
+
+        assert_eq!(
+            block_config.get_partuuid().unwrap().to_string(),
+            expected_partuuid
+        );
+        assert_eq!(block_config.path_on_host(), dummy_block_file.as_path());
+        assert_eq!(block_config.is_read_only(), expected_is_read_only);
+    }
 }

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -424,4 +424,18 @@ mod tests {
             ))
         );
     }
+
+    #[test]
+    fn test_net_config() {
+        let net_id = "id";
+        let host_dev_name = "dev";
+        let guest_mac = "01:23:45:67:89:0b";
+
+        let net_if = create_netif(net_id, host_dev_name, guest_mac);
+        assert_eq!(
+            *net_if.guest_mac().unwrap(),
+            MacAddr::parse_str(guest_mac).unwrap()
+        );
+        assert_eq!(net_if.allow_mmds_requests(), false);
+    }
 }


### PR DESCRIPTION
## Reason for This PR

Having https://github.com/firecracker-microvm/firecracker/pull/1589 merged recently, we've introduced coverage which touched code paths uncovered through unit tests. This PR aims to resolve this situation. It comprises unit tests for few overlapping code paths, already covered by our current suite of unit tests.

Closes #1621.

## Description of Changes

Added remaining viritio device unit tests for `Net` device, unit tests for `NetworkInterfaceConfig` implementation and unit tests for `BlockDeviceConfig` implementation. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
