### PR TITLE
VirtioDevice trait cleanup

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -317,12 +317,8 @@ impl VirtioDevice for Block {
         self.device_activated
     }
 
-    fn set_device_activated(&mut self, device_activated: bool) {
-        self.device_activated = device_activated;
-    }
-
-    fn activate(&mut self, _mem: GuestMemoryMmap) -> ActivateResult {
-        // TODO: to be removed
+    fn activate(&mut self) -> ActivateResult {
+        self.device_activated = true;
         Ok(())
     }
 }
@@ -499,7 +495,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -524,7 +520,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -582,7 +578,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -612,7 +608,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -671,7 +667,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -714,7 +710,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -780,7 +776,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -845,7 +841,7 @@ mod tests {
         let mem = block.mem.clone();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         block.set_queue(0, vq.create_queue());
-        block.set_device_activated(true);
+        block.activate().unwrap();
         initialize_virtqueue(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -93,7 +93,7 @@ pub struct Block {
     queues: Vec<Queue>,
     interrupt_status: Arc<AtomicUsize>,
     interrupt_evt: EventFd,
-    pub(crate) queue_evt: EventFd,
+    pub(crate) queue_evts: [EventFd; 1],
     mem: GuestMemoryMmap,
 
     device_activated: bool,
@@ -120,7 +120,7 @@ impl Block {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
         };
 
-        let queue_evt = EventFd::new(libc::EFD_NONBLOCK)?;
+        let queue_evts = [EventFd::new(libc::EFD_NONBLOCK)?];
 
         let queues = QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
 
@@ -135,7 +135,7 @@ impl Block {
             mem,
             interrupt_status: Arc::new(AtomicUsize::new(0)),
             interrupt_evt: EventFd::new(libc::EFD_NONBLOCK)?,
-            queue_evt,
+            queue_evts,
             queues,
             device_activated: false,
         })
@@ -143,7 +143,7 @@ impl Block {
 
     pub(crate) fn process_queue_event(&mut self) {
         METRICS.block.queue_event_count.inc();
-        if let Err(e) = self.queue_evt.read() {
+        if let Err(e) = self.queue_evts[0].read() {
             error!("Failed to get queue event: {:?}", e);
             METRICS.block.event_fails.inc();
         } else if !self.rate_limiter.is_blocked() && self.process_queue(0) {
@@ -258,20 +258,20 @@ impl VirtioDevice for Block {
         TYPE_BLOCK
     }
 
-    fn get_queues(&mut self) -> &mut Vec<Queue> {
+    fn queues(&mut self) -> &mut [Queue] {
         &mut self.queues
     }
 
-    fn get_queue_events(&self) -> Result<Vec<EventFd>, std::io::Error> {
-        Ok(vec![self.queue_evt.try_clone()?])
+    fn queue_events(&self) -> &[EventFd] {
+        &self.queue_evts
     }
 
-    fn get_interrupt(&self) -> Result<EventFd, std::io::Error> {
-        Ok(self.interrupt_evt.try_clone()?)
+    fn interrupt_evt(&self) -> &EventFd {
+        &self.interrupt_evt
     }
 
     /// Returns the current device interrupt status.
-    fn get_interrupt_status(&self) -> Arc<AtomicUsize> {
+    fn interrupt_status(&self) -> Arc<AtomicUsize> {
         self.interrupt_status.clone()
     }
 
@@ -418,10 +418,10 @@ mod tests {
 
     fn invoke_handler_for_queue_event(b: &mut Block) {
         // Trigger the queue event.
-        b.queue_evt.write(1).unwrap();
+        b.queue_evts[0].write(1).unwrap();
         // Handle event.
         b.process(
-            &EpollEvent::new(EventSet::IN, b.queue_evt.as_raw_fd() as u64),
+            &EpollEvent::new(EventSet::IN, b.queue_evts[0].as_raw_fd() as u64),
             &mut EventManager::new().unwrap(),
         );
         // Validate the queue operation finished successfully.
@@ -788,7 +788,7 @@ mod tests {
         let status_addr = GuestAddress(vq.dtable[2].addr.get());
 
         let mut event_manager = EventManager::new().unwrap();
-        let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evt.as_raw_fd() as u64);
+        let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evts[0].as_raw_fd() as u64);
 
         // Create bandwidth rate limiter that allows only 80 bytes/s with bucket size of 8 bytes.
         let mut rl = RateLimiter::new(8, None, 100, 0, None, 0).unwrap();
@@ -808,7 +808,7 @@ mod tests {
         // Following write procedure should fail because of bandwidth rate limiting.
         {
             // Trigger the attempt to write.
-            block.queue_evt.write(1).unwrap();
+            block.queue_evts[0].write(1).unwrap();
             block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.
@@ -853,7 +853,7 @@ mod tests {
         let status_addr = GuestAddress(vq.dtable[2].addr.get());
 
         let mut event_manager = EventManager::new().unwrap();
-        let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evt.as_raw_fd() as u64);
+        let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evts[0].as_raw_fd() as u64);
 
         // Create ops rate limiter that allows only 10 ops/s with bucket size of 1 ops.
         let mut rl = RateLimiter::new(0, None, 0, 1, None, 100).unwrap();
@@ -873,7 +873,7 @@ mod tests {
         // Following write procedure should fail because of ops rate limiting.
         {
             // Trigger the attempt to write.
-            block.queue_evt.write(1).unwrap();
+            block.queue_evts[0].write(1).unwrap();
             block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.
@@ -887,7 +887,7 @@ mod tests {
         // Do a second write that still fails but this time on the fast path.
         {
             // Trigger the attempt to write.
-            block.queue_evt.write(1).unwrap();
+            block.queue_evts[0].write(1).unwrap();
             block.process(&queue_evt, &mut event_manager);
 
             // Assert that limiter is blocked.

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -16,7 +16,7 @@ impl Subscriber for Block {
             return;
         }
 
-        let queue_evt = self.queue_evt.as_raw_fd();
+        let queue_evt = self.queue_evts[0].as_raw_fd();
         let rate_limiter_evt = self.rate_limiter.as_raw_fd();
 
         let source = event.fd();
@@ -45,7 +45,7 @@ impl Subscriber for Block {
     fn interest_list(&self) -> Vec<EpollEvent> {
         vec![
             EpollEvent::new(EventSet::IN, self.rate_limiter.as_raw_fd() as u64),
-            EpollEvent::new(EventSet::IN, self.queue_evt.as_raw_fd() as u64),
+            EpollEvent::new(EventSet::IN, self.queue_evts[0].as_raw_fd() as u64),
         ]
     }
 }

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -10,7 +10,6 @@ use std::sync::{atomic::AtomicUsize, Arc};
 use super::{ActivateResult, Queue};
 use crate::virtio::AsAny;
 use utils::eventfd::EventFd;
-use vm_memory::GuestMemoryMmap;
 
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
@@ -87,15 +86,11 @@ pub trait VirtioDevice: AsAny + Send {
     /// Writes to this device configuration space at `offset`.
     fn write_config(&mut self, offset: u64, data: &[u8]);
 
-    // TODO: this method is not necessary anymore, and is
-    // kept only for vsock case, which is not ported on polly yet.
-    fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult;
+    /// Performs the formal activation for a device, which can be verified also with `is_activated`.
+    fn activate(&mut self) -> ActivateResult;
 
     /// Checks if the resources of this device are activated.
     fn is_activated(&self) -> bool;
-
-    /// Performs the formal activation for a device, which can be verified also with `is_activated`.
-    fn set_device_activated(&mut self, device_activated: bool);
 
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
     /// event, and queue events.

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -33,16 +33,16 @@ pub trait VirtioDevice: AsAny + Send {
     fn device_type(&self) -> u32;
 
     /// Returns the device queues.
-    fn get_queues(&mut self) -> &mut Vec<Queue>;
+    fn queues(&mut self) -> &mut [Queue];
 
     /// Returns the device queues event fds.
-    fn get_queue_events(&self) -> Result<Vec<EventFd>, std::io::Error>;
+    fn queue_events(&self) -> &[EventFd];
 
     /// Returns the device interrupt eventfd.
-    fn get_interrupt(&self) -> Result<EventFd, std::io::Error>;
+    fn interrupt_evt(&self) -> &EventFd;
 
     /// Returns the current device interrupt status.
-    fn get_interrupt_status(&self) -> Arc<AtomicUsize>;
+    fn interrupt_status(&self) -> Arc<AtomicUsize>;
 
     /// The set of feature bits shifted by `page * 32`.
     fn avail_features_by_page(&self, page: u32) -> u32 {

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -60,7 +60,7 @@ impl MmioTransport {
         let interrupt_status = device
             .lock()
             .expect("Poisoned device lock")
-            .get_interrupt_status();
+            .interrupt_status();
 
         Ok(MmioTransport {
             device,
@@ -89,7 +89,7 @@ impl MmioTransport {
 
     fn are_queues_valid(&self) -> bool {
         self.locked_device()
-            .get_queues()
+            .queues()
             .iter()
             .all(|q| q.is_valid(&self.mem))
     }
@@ -100,7 +100,7 @@ impl MmioTransport {
     {
         match self
             .locked_device()
-            .get_queues()
+            .queues()
             .get(self.queue_select as usize)
         {
             Some(queue) => f(queue),
@@ -111,7 +111,7 @@ impl MmioTransport {
     fn with_queue_mut<F: FnOnce(&mut Queue)>(&mut self, f: F) -> bool {
         if let Some(queue) = self
             .locked_device()
-            .get_queues()
+            .queues()
             .get_mut(self.queue_select as usize)
         {
             f(queue);
@@ -149,7 +149,7 @@ impl MmioTransport {
         //   notifications in those eventfds, but nothing will happen other
         //   than supurious wakeups.
         // . Do not reset config_generation and keep it monotonically increasing
-        for queue in self.locked_device().get_queues().as_mut_slice() {
+        for queue in self.locked_device().queues() {
             *queue = Queue::new(queue.get_max_size());
         }
     }
@@ -338,7 +338,7 @@ impl BusDevice for MmioTransport {
         // interrupt_evt() is safe to unwrap because the inner interrupt_evt is initialized in the
         // constructor.
         // write() is safe to unwrap because the inner syscall is tailored to be safe as well.
-        self.locked_device().get_interrupt()?.write(1).unwrap();
+        self.locked_device().interrupt_evt().write(1).unwrap();
         Ok(())
     }
 }
@@ -348,7 +348,6 @@ mod tests {
     use utils::byte_order::{read_le_u32, write_le_u32};
 
     use super::*;
-    use std::result;
     use utils::eventfd::EventFd;
     use vm_memory::GuestMemoryMmap;
 
@@ -416,19 +415,19 @@ mod tests {
             Ok(())
         }
 
-        fn get_queues(&mut self) -> &mut Vec<Queue> {
+        fn queues(&mut self) -> &mut [Queue] {
             &mut self.queues
         }
 
-        fn get_queue_events(&self) -> result::Result<Vec<EventFd>, std::io::Error> {
-            self.queue_evts.iter().map(|evt| evt.try_clone()).collect()
+        fn queue_events(&self) -> &[EventFd] {
+            &self.queue_evts
         }
 
-        fn get_interrupt(&self) -> result::Result<EventFd, std::io::Error> {
-            self.interrupt_evt.try_clone()
+        fn interrupt_evt(&self) -> &EventFd {
+            &self.interrupt_evt
         }
 
-        fn get_interrupt_status(&self) -> Arc<AtomicUsize> {
+        fn interrupt_status(&self) -> Arc<AtomicUsize> {
             self.interrupt_status.clone()
         }
 
@@ -458,27 +457,19 @@ mod tests {
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
 
-        assert_eq!(d.locked_device().get_queue_events().unwrap().len(), 2);
-
-        assert!(d.locked_device().get_interrupt().is_ok());
+        assert_eq!(d.locked_device().queue_events().len(), 2);
 
         assert!(!d.are_queues_valid());
 
         d.queue_select = 0;
         assert_eq!(d.with_queue(0, Queue::get_max_size), 16);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(
-            d.locked_device().get_queues()[d.queue_select as usize].size,
-            16
-        );
+        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
 
         d.queue_select = 1;
         assert_eq!(d.with_queue(0, Queue::get_max_size), 32);
         assert!(d.with_queue_mut(|q| q.size = 16));
-        assert_eq!(
-            d.locked_device().get_queues()[d.queue_select as usize].size,
-            16
-        );
+        assert_eq!(d.locked_device().queues()[d.queue_select as usize].size, 16);
 
         d.queue_select = 2;
         assert_eq!(d.with_queue(0, Queue::get_max_size), 0);
@@ -647,45 +638,42 @@ mod tests {
         assert_eq!(d.queue_select, 3);
 
         d.queue_select = 0;
-        assert_eq!(d.locked_device().get_queues()[0].size, 0);
+        assert_eq!(d.locked_device().queues()[0].size, 0);
         write_le_u32(&mut buf[..], 16);
         d.write(0x38, &buf[..]);
-        assert_eq!(d.locked_device().get_queues()[0].size, 16);
+        assert_eq!(d.locked_device().queues()[0].size, 16);
 
-        assert!(!d.locked_device().get_queues()[0].ready);
+        assert!(!d.locked_device().queues()[0].ready);
         write_le_u32(&mut buf[..], 1);
         d.write(0x44, &buf[..]);
-        assert!(d.locked_device().get_queues()[0].ready);
+        assert!(d.locked_device().queues()[0].ready);
 
-        assert_eq!(d.locked_device().get_queues()[0].desc_table.0, 0);
+        assert_eq!(d.locked_device().queues()[0].desc_table.0, 0);
         write_le_u32(&mut buf[..], 123);
         d.write(0x80, &buf[..]);
-        assert_eq!(d.locked_device().get_queues()[0].desc_table.0, 123);
+        assert_eq!(d.locked_device().queues()[0].desc_table.0, 123);
         d.write(0x84, &buf[..]);
         assert_eq!(
-            d.locked_device().get_queues()[0].desc_table.0,
+            d.locked_device().queues()[0].desc_table.0,
             123 + (123 << 32)
         );
 
-        assert_eq!(d.locked_device().get_queues()[0].avail_ring.0, 0);
+        assert_eq!(d.locked_device().queues()[0].avail_ring.0, 0);
         write_le_u32(&mut buf[..], 124);
         d.write(0x90, &buf[..]);
-        assert_eq!(d.locked_device().get_queues()[0].avail_ring.0, 124);
+        assert_eq!(d.locked_device().queues()[0].avail_ring.0, 124);
         d.write(0x94, &buf[..]);
         assert_eq!(
-            d.locked_device().get_queues()[0].avail_ring.0,
+            d.locked_device().queues()[0].avail_ring.0,
             124 + (124 << 32)
         );
 
-        assert_eq!(d.locked_device().get_queues()[0].used_ring.0, 0);
+        assert_eq!(d.locked_device().queues()[0].used_ring.0, 0);
         write_le_u32(&mut buf[..], 125);
         d.write(0xa0, &buf[..]);
-        assert_eq!(d.locked_device().get_queues()[0].used_ring.0, 125);
+        assert_eq!(d.locked_device().queues()[0].used_ring.0, 125);
         d.write(0xa4, &buf[..]);
-        assert_eq!(
-            d.locked_device().get_queues()[0].used_ring.0,
-            125 + (125 << 32)
-        );
+        assert_eq!(d.locked_device().queues()[0].used_ring.0, 125 + (125 << 32));
 
         set_device_status(
             &mut d,
@@ -762,7 +750,7 @@ mod tests {
         );
 
         let mut buf = vec![0; 4];
-        let queue_len = d.locked_device().get_queues().len();
+        let queue_len = d.locked_device().queues().len();
         for q in 0..queue_len {
             d.queue_select = q as u32;
             write_le_u32(&mut buf[..], 16);
@@ -815,7 +803,7 @@ mod tests {
 
         // Setup queue data structures
         let mut buf = vec![0; 4];
-        let queues_count = d.locked_device().get_queues().len();
+        let queues_count = d.locked_device().queues().len();
         for q in 0..queues_count {
             d.queue_select = q as u32;
             write_le_u32(&mut buf[..], 16);

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -679,12 +679,8 @@ impl VirtioDevice for Net {
         self.device_activated
     }
 
-    fn set_device_activated(&mut self, device_activated: bool) {
-        self.device_activated = device_activated;
-    }
-
-    fn activate(&mut self, _mem: GuestMemoryMmap) -> ActivateResult {
-        // TODO: to be removed
+    fn activate(&mut self) -> ActivateResult {
+        self.device_activated = true;
         Ok(())
     }
 }
@@ -816,7 +812,7 @@ mod tests {
             self.queues.clear();
             self.queues.push(rxq);
             self.queues.push(txq);
-            self.set_device_activated(true);
+            self.activate().unwrap();
         }
     }
 

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -252,7 +252,7 @@ where
         );
     }
 
-    fn activate(&mut self, _mem: GuestMemoryMmap) -> ActivateResult {
+    fn activate(&mut self) -> ActivateResult {
         if self.queues.len() != defs::NUM_QUEUES {
             error!(
                 "Cannot perform activate. Expected {} queue(s), got {}",
@@ -267,15 +267,13 @@ where
             return Err(ActivateError::BadActivate);
         }
 
+        self.device_activated = true;
+
         Ok(())
     }
 
     fn is_activated(&self) -> bool {
         self.device_activated
-    }
-
-    fn set_device_activated(&mut self, device_activated: bool) {
-        self.device_activated = device_activated;
     }
 }
 
@@ -353,6 +351,6 @@ mod tests {
         // }
 
         // Test a correct activation.
-        ctx.device.activate(ctx.mem.clone()).unwrap();
+        ctx.device.activate().unwrap();
     }
 }

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -211,24 +211,19 @@ where
         uapi::VIRTIO_ID_VSOCK
     }
 
-    fn get_queues(&mut self) -> &mut Vec<VirtQueue> {
+    fn queues(&mut self) -> &mut [VirtQueue] {
         &mut self.queues
     }
 
-    fn get_queue_events(&self) -> std::io::Result<Vec<EventFd>> {
-        let mut queue_evts_copy = Vec::new();
-        for evt in self.queue_events.iter() {
-            queue_evts_copy.push(evt.try_clone()?);
-        }
-
-        Ok(queue_evts_copy)
+    fn queue_events(&self) -> &[EventFd] {
+        &self.queue_events
     }
 
-    fn get_interrupt(&self) -> std::io::Result<EventFd> {
-        Ok(self.interrupt_evt.try_clone()?)
+    fn interrupt_evt(&self) -> &EventFd {
+        &self.interrupt_evt
     }
 
-    fn get_interrupt_status(&self) -> Arc<AtomicUsize> {
+    fn interrupt_status(&self) -> Arc<AtomicUsize> {
         self.interrupt_status.clone()
     }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -389,17 +389,13 @@ mod tests {
             let _ = data;
         }
 
-        #[allow(unused_variables)]
-        #[allow(unused_mut)]
-        fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {
+        fn activate(&mut self) -> ActivateResult {
             Ok(())
         }
 
         fn is_activated(&self) -> bool {
             false
         }
-
-        fn set_device_activated(&mut self, _device_activated: bool) {}
     }
 
     #[test]
@@ -475,15 +471,7 @@ mod tests {
         let mut dummy = DummyDevice::new();
         assert_eq!(dummy.device_type(), 0);
         assert_eq!(dummy.queues().len(), QUEUE_SIZES.len());
-
-        let start_addr1 = GuestAddress(0x0);
-        let start_addr2 = GuestAddress(0x1000);
-        let guest_mem =
-            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-
-        // test activate
-        let result = dummy.activate(guest_mem);
-        assert!(result.is_ok());
+        dummy.activate().unwrap();
     }
 
     #[test]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.00
+COVERAGE_TARGET_PCT = 82.08
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1620 

## Description of Changes

Some small changes to the VirtioDevice trait interface:
- The VirtioDevice trait can work with references instead of owned objects for Queues and QueueEvents so no cloning is necessary. Also use slice references instead of owned Vecs.
- For a short while we were also using `activate`/`reset` and `set_device_activated`. This moves all devices and tests to using `activate`/`reset` to activate, respectivelly reset a VirtioDevice.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
