### PR TITLE
Added VmResources unit tests

### DIFF
--- a/src/kernel/src/cmdline/mod.rs
+++ b/src/kernel/src/cmdline/mod.rs
@@ -77,7 +77,7 @@ fn valid_element(s: &str) -> Result<()> {
 
 /// A builder for a kernel command line string that validates the string as its being built. A
 /// `CString` can be constructed from this directly using `CString::new`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Cmdline {
     line: String,
     capacity: usize,

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -241,7 +241,7 @@ impl<'a> PrebootApiController<'a> {
             }
             SetVmConfiguration(machine_config_body) => self
                 .vm_resources
-                .set_vm_config(machine_config_body)
+                .set_vm_config(&machine_config_body)
                 .map(|_| VmmData::Empty)
                 .map_err(VmmActionError::MachineConfig),
             UpdateBlockDevicePath(drive_id, path_on_host) => self

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -67,6 +67,7 @@ impl Display for BootSourceConfigError {
 }
 
 /// Holds the kernel configuration.
+#[derive(Debug)]
 pub struct BootConfig {
     /// The commandline validated against correctness.
     pub cmdline: kernel::cmdline::Cmdline,

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -60,7 +60,7 @@ impl NetworkInterfaceConfig {
 
 /// The data fed into a network iface update request. Currently, only the RX and TX rate limiters
 /// can be updated.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkInterfaceUpdateConfig {
     /// The net iface ID, as provided by the user at iface creation time.
@@ -250,6 +250,16 @@ impl NetworkInterfaceConfigs {
         self.if_list.push(netif_config);
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.if_list.len()
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.if_list.len() == 0
     }
 }
 

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -566,6 +566,7 @@ pub struct VmState {
 }
 
 /// Encapsulates configuration parameters for the guest vCPUS.
+#[derive(Debug, PartialEq)]
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.08
+COVERAGE_TARGET_PCT = 82.44
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Closes #1641 

## Description of Changes

Added unit tests for `VmResources` (vmm::resources.rs).
Note: `VmResources::from_json` is covered in [`Refactor logger`](https://github.com/firecracker-microvm/firecracker/pull/1614) PR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] No docs need to be updated as part of this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
