### PR TITLE
Backport v0.21.1: Add flag `--version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.21.1]
+
+### Fixed
+
+- Added `--version` flag to both Firecracker and Jailer.
+
 ## [0.21.0]
 
 ### Added

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -144,6 +144,14 @@ fn main() {
                     process::exit(i32::from(vmm::FC_EXIT_CODE_OK));
                 }
             }
+
+            if let Some(version) = arg_parser.arguments().value_as_bool("version") {
+                if version {
+                    println!("Firecracker v{}\n", FIRECRACKER_VERSION);
+                    process::exit(i32::from(vmm::FC_EXIT_CODE_OK));
+                }
+            }
+
             arg_parser.arguments()
         }
     };

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -326,6 +326,13 @@ fn main() {
                     process::exit(0);
                 }
             }
+
+            if let Some(version) = arg_parser.arguments().value_as_bool("version") {
+                if version {
+                    println!("Jailer v{}\n", JAILER_VERSION);
+                    process::exit(0);
+                }
+            }
         }
     }
 

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -11,6 +11,7 @@ pub type Result<T> = result::Result<T, Error>;
 const ARG_PREFIX: &str = "--";
 const ARG_SEPARATOR: &str = "--";
 const HELP_ARG: &str = "--help";
+const VERSION_ARG: &str = "--version";
 
 /// Errors associated with parsing and validating arguments.
 #[derive(Debug, PartialEq)]
@@ -277,6 +278,16 @@ impl<'a> Arguments<'a> {
             return Ok(());
         }
 
+        // If `--version` is provided as a parameter, we artificially skip the parsing of other
+        // command line arguments by adding just the version argument to the parsed list and
+        // returning.
+        if args.contains(&VERSION_ARG.to_string()) {
+            let mut version_arg = Argument::new("version").help("Print the binary version number.");
+            version_arg.user_value = Some(Value::Bool(true));
+            self.insert_arg(version_arg);
+            return Ok(());
+        }
+
         // Otherwise, we continue the parsing of the other arguments.
         self.populate_args(args)
     }
@@ -465,9 +476,10 @@ mod tests {
     #[test]
     fn test_parse() {
         let arg_parser = build_arg_parser();
-        let mut arguments = arg_parser.arguments().clone();
 
         // Test different scenarios for the command line arguments provided by user.
+        let mut arguments = arg_parser.arguments().clone();
+
         let args = vec!["binary-name", "--exec-file", "foo", "--help"]
             .into_iter()
             .map(String::from)
@@ -476,7 +488,16 @@ mod tests {
         assert!(arguments.parse(&args).is_ok());
         assert!(arguments.args.contains_key("help"));
 
-        let arg_parser = build_arg_parser();
+        arguments = arg_parser.arguments().clone();
+
+        let args = vec!["binary-name", "--exec-file", "foo", "--version"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        assert!(arguments.parse(&args).is_ok());
+        assert!(arguments.args.contains_key("version"));
+
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -496,7 +517,6 @@ mod tests {
             Err(Error::MissingValue("api-sock".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -517,7 +537,6 @@ mod tests {
             Err(Error::DuplicateArgument("api-sock".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec!["binary-name", "--api-sock", "foo"]
@@ -530,7 +549,6 @@ mod tests {
             Err(Error::MissingArgument("exec-file".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -550,7 +568,6 @@ mod tests {
             Err(Error::UnexpectedArgument("invalid-arg".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -572,7 +589,6 @@ mod tests {
             Err(Error::MissingArgument("config-file".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -592,7 +608,6 @@ mod tests {
             Err(Error::MissingValue("id".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -613,7 +628,6 @@ mod tests {
             Err(Error::UnexpectedArgument("foobar".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![
@@ -633,7 +647,6 @@ mod tests {
             Err(Error::UnexpectedArgument("foobar".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec!["binary-name", "foo"]
@@ -646,7 +659,6 @@ mod tests {
             Err(Error::UnexpectedArgument("foo".to_string()))
         );
 
-        let arg_parser = build_arg_parser();
         arguments = arg_parser.arguments().clone();
 
         let args = vec![


### PR DESCRIPTION
## Reason for This PR

#1632

Back-porting PR https://github.com/firecracker-microvm/firecracker/pull/1633 to `v0.21.1`

## Description of Changes

In new release Firecracker `v0.21.0`, the command line arg `--version` is missing.
```
$ ./firecracker-v0.21.0-x86_64 --version
2020-02-26T03:15:13.135125190 [anonymous-instance:ERROR:src/firecracker/src/main.rs:132] Arguments parsing error: Found argument 'version' which wasn't expected, or isn't valid in this context.
```
And the `--version` is quite an universal command line arg to print application version number.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [ ] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [ ] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [ ] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [ ] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [ ] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
