### PR TITLE
vsock: Use TempFile when generating file names

### DIFF
--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -754,6 +754,7 @@ mod tests {
     use std::ops::Drop;
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::path::{Path, PathBuf};
+    use utils::tempfile::TempFile;
 
     use super::super::super::csm::defs as csm_defs;
     use super::super::super::tests::TestContext as VsockTestContext;
@@ -776,6 +777,17 @@ mod tests {
         }
     }
 
+    // Create a TempFile with a given prefix and return it as a nice String
+    fn get_file(fprefix: &str) -> String {
+        let listener_path = TempFile::new_with_prefix(fprefix.to_owned()).unwrap();
+        listener_path
+            .as_path()
+            .as_os_str()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
     impl MuxerTestContext {
         fn new(name: &str) -> Self {
             let vsock_test_ctx = VsockTestContext::new();
@@ -786,9 +798,8 @@ mod tests {
                     .unwrap(),
             )
             .unwrap();
-            let uds_path = format!("test_vsock_{}.sock", name);
-            let muxer = VsockMuxer::new(PEER_CID, uds_path).unwrap();
 
+            let muxer = VsockMuxer::new(PEER_CID, get_file(name)).unwrap();
             Self {
                 _vsock_test_ctx: vsock_test_ctx,
                 pkt,


### PR DESCRIPTION
## Reason for This PR

Occasionally, the vsock tests fail because the created file descriptors already exist. This PR tries to avoid that situation by trying multiple file names.
This can also happen when concurrent firecracker test runs are executed from the same path.

## Description of Changes

When a file is created, first, check if it exists. If it does, try to append a number to the file name.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] no docs need to be updated as part of this PR
- [x] code-level documentation for touched code is included in this PR.
- [x] no API changes are included in this PR
- [x] the changes in this PR have no user impact
- [x] Either no new `unsafe` code has been added
