### PR TITLE
tests: Log all commands through custom endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,9 +70,6 @@ be run on every microvm image in the bucket, each as a separate test case.
 - Reading up on pytest fixtures is probably needed when editing this file.
 
 # TODO
-
-- A fixture that wraps `subprocess.run('<command>, shell=True, check=True)`,
-  and also controls output verbosity by appending `>/dev/null [&2>1]`.
 - A fixture that allows per-test-function dependency installation.
 - Support generating fixtures with more than one capability. This is supported
   by the MicrovmImageFetcher, but not by the fixture template.
@@ -81,7 +78,6 @@ be run on every microvm image in the bucket, each as a separate test case.
 import os
 import platform
 import shutil
-from subprocess import run
 import sys
 import tempfile
 import uuid
@@ -91,6 +87,7 @@ import pytest
 import host_tools.cargo_build as build_tools
 import host_tools.network as net_tools
 
+import framework.utils as utils
 from framework.microvm import Microvm
 from framework.s3fetcher import MicrovmImageS3Fetcher
 from framework.scheduler import PytestScheduler
@@ -201,11 +198,7 @@ def _gcc_compile(src_file, output_file):
         src_file,
         output_file
     )
-    run(
-        compile_cmd,
-        shell=True,
-        check=True
-    )
+    utils.run_cmd(compile_cmd)
 
 
 @pytest.fixture(scope='session')

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -5,7 +5,7 @@
 import os
 import platform
 
-from subprocess import run
+import framework.utils as utils
 
 from framework.defs import (
     FC_BINARY_NAME, FC_WORKSPACE_DIR, FC_WORKSPACE_TARGET_DIR,
@@ -37,7 +37,7 @@ def cargo_build(path, extra_args='', src_dir='', extra_env=''):
     if src_dir:
         cmd = 'cd {} && {}'.format(src_dir, cmd)
 
-    run(cmd, shell=True, check=True)
+    utils.run_cmd(cmd)
 
 
 def cargo_test(path, extra_args='', extra_env=''):
@@ -46,7 +46,7 @@ def cargo_test(path, extra_args='', extra_env=''):
     cmd = 'CARGO_TARGET_DIR={} {} RUST_TEST_THREADS=1 RUST_BACKTRACE=1 ' \
           'cargo test {} ' \
           '--all --no-fail-fast'.format(path, extra_env, extra_args)
-    run(cmd, shell=True, check=True)
+    utils.run_cmd(cmd)
 
 
 def get_firecracker_binaries():
@@ -61,7 +61,7 @@ def get_firecracker_binaries():
     cargo_cmd = "cargo build --release --target {}".format(target)
     cmd = "{} && {} {}".format(cd_cmd, env_cmd, cargo_cmd)
 
-    run(cmd, shell=True, check=True)
+    utils.run_cmd(cmd)
 
     out_dir = "{target_dir}/{target}/release".format(
         target_dir=FC_WORKSPACE_TARGET_DIR, target=target

--- a/tests/host_tools/drive.py
+++ b/tests/host_tools/drive.py
@@ -4,7 +4,7 @@
 
 import os
 
-from subprocess import run
+import framework.utils as utils
 
 
 class FilesystemFile:
@@ -29,24 +29,17 @@ class FilesystemFile:
         if os.path.isfile(path):
             raise FileExistsError("File already exists: " + path)
 
-        run(
+        utils.run_cmd(
             'dd status=none if=/dev/zero'
             '    of=' + path +
-            '    bs=1M count=' + str(size),
-            shell=True,
-            check=True
-        )
-        run('mkfs.ext4 -qF ' + path, shell=True, check=True)
+            '    bs=1M count=' + str(size))
+        utils.run_cmd('mkfs.ext4 -qF ' + path)
         self.path = path
 
     def resize(self, new_size):
         """Resize the filesystem."""
-        run(
-            'truncate --size ' + str(new_size) + 'M ' + self.path,
-            shell=True,
-            check=True
-        )
-        run('resize2fs ' + self.path, shell=True, check=True)
+        utils.run_cmd('truncate --size ' + str(new_size) + 'M ' + self.path)
+        utils.run_cmd('resize2fs ' + self.path)
 
     def size(self):
         """Return the size of the filesystem."""

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -3,8 +3,9 @@
 """Utilities for measuring memory utilization for a process."""
 import time
 
-from subprocess import run, CalledProcessError, PIPE
 from threading import Thread
+
+import framework.utils as utils
 
 
 MAX_MEMORY = 5 * 1024
@@ -47,13 +48,9 @@ def _memory_cop(mem_size_mib, pid, exceeded_queue):
     while True:
         mem_total = 0
         try:
-            pmap_out = run(
-                pmap_cmd,
-                shell=True,
-                check=True,
-                stdout=PIPE
-            ).stdout.decode('utf-8').split('\n')
-        except CalledProcessError:
+            _, stdout, _ = utils.run_cmd(pmap_cmd)
+            pmap_out = stdout.split("\n")
+        except ChildProcessError:
             break
         for line in pmap_out:
             tokens = line.split()

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -12,11 +12,9 @@
 import os
 import platform
 import re
-
-from subprocess import run
-
 import pytest
 
+import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 COVERAGE_TARGET_PCT = 82.78
@@ -73,7 +71,7 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
     )
     # By default, `cargo kcov` passes `--exclude-pattern=$CARGO_HOME --verify`
     # to kcov. To pass others arguments, we need to include the defaults.
-    run(cmd, shell=True, check=True)
+    utils.run_cmd(cmd)
 
     coverage_file = os.path.join(test_session_tmp_path, KCOV_COVERAGE_FILE)
     with open(coverage_file) as cov_output:

--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests ensuring codebase style compliance for Rust and Python."""
 
-from subprocess import run, PIPE
-
 import os
 import platform
 
@@ -23,14 +21,11 @@ SUCCESS_CODE = 0
 def test_rust_style():
     """Fail if there's misbehaving Rust style in this repo."""
     # Check that the output is empty.
-    process = run(
-        'cargo fmt --all -- --check',
-        shell=True,
-        check=True,
-        stdout=PIPE
-    )
+    _, stdout, _ = utils.run_cmd(
+        'cargo fmt --all -- --check')
+
     # rustfmt prepends `"Diff in"` to the reported output.
-    assert "Diff in" not in process.stdout.decode('utf-8')
+    assert "Diff in" not in stdout
 
 
 @pytest.mark.timeout(120)
@@ -77,12 +72,8 @@ def test_python_style():
 )
 def test_rust_clippy():
     """Fails if clippy generates any error, warnings are ignored."""
-    run(
-        'cargo clippy --all --profile test -- -D warnings',
-        shell=True,
-        check=True,
-        stdout=PIPE
-    )
+    utils.run_cmd(
+        'cargo clippy --all --profile test -- -D warnings')
 
 
 def check_swagger_style(yaml_spec):

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -43,9 +43,9 @@ def _check_guest_cmd_output(test_microvm, guest_cmd, expected_header,
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
     _, stdout, stderr = ssh_connection.execute_command(guest_cmd)
 
-    assert stderr.read().decode("utf-8") == ''
+    assert stderr.read() == ''
     while True:
-        line = stdout.readline().decode('utf-8')
+        line = stdout.readline()
         if line != '':
             # All the keys have been matched. Stop.
             if not expected_key_value_store:
@@ -280,9 +280,9 @@ def test_brand_string(test_microvm_with_ssh, network_config):
 
     guest_cmd = "cat /proc/cpuinfo | grep 'model name' | head -1"
     _, stdout, stderr = ssh_connection.execute_command(guest_cmd)
-    assert stderr.read().decode("utf-8") == ''
+    assert stderr.read() == ''
 
-    line = stdout.readline().decode('utf-8').rstrip()
+    line = stdout.readline().rstrip()
     mo = re.search("^model name\\s+:\\s+(.+)$", line)
     assert mo
     guest_brand_string = mo.group(1)
@@ -338,9 +338,9 @@ def test_cpu_template(test_microvm_with_ssh, network_config, cpu_template):
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
     guest_cmd = "cat /proc/cpuinfo | grep 'flags' | head -1"
     _, stdout, stderr = ssh_connection.execute_command(guest_cmd)
-    assert stderr.read().decode("utf-8") == ''
+    assert stderr.read() == ''
 
-    cpu_flags_output = stdout.readline().decode('utf-8').rstrip()
+    cpu_flags_output = stdout.readline().rstrip()
 
     if cpu_template == "C3":
         for feature in c3_masked_features:

--- a/tests/integration_tests/functional/test_max_vcpus.py
+++ b/tests/integration_tests/functional/test_max_vcpus.py
@@ -20,5 +20,5 @@ def test_max_vcpus(test_microvm_with_ssh, network_config):
     ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
     cmd = "nproc"
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    assert stderr.read().decode("utf-8") == ""
-    assert int(stdout.read().decode("utf-8")) == MAX_VCPUS
+    assert stderr.read() == ""
+    assert int(stdout.read()) == MAX_VCPUS

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -6,15 +6,15 @@ import host_tools.network as net_tools
 
 
 def _assert_out(stdout, stderr, expected):
-    assert stderr.read().decode('utf-8') == ''
-    assert stdout.read().decode('utf-8') == expected
+    assert stderr.read() == ''
+    assert stdout.read() == expected
 
 
 # Used when the output consists of a set of lines in no particular order, and
 # thus may differ from one run to another.
 def _assert_out_multiple(stdout, stderr, lines):
-    assert stderr.read().decode('utf-8') == ''
-    out = stdout.read().decode('utf-8')
+    assert stderr.read() == ''
+    out = stdout.read()
     assert sorted(out.split('\n')) == sorted(lines)
 
 

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests scenarios for shutting down Firecracker/VM."""
 import os
-from subprocess import run, PIPE
 import time
+
+import framework.utils as utils
 
 import host_tools.logging as log_tools
 import host_tools.network as net_tools  # pylint: disable=import-error
@@ -41,8 +42,8 @@ def test_reboot(test_microvm_with_ssh, network_config):
     cmd = 'ps -o nlwp {} | tail -1 | awk \'{{print $1}}\''.format(
         firecracker_pid
     )
-    process = run(cmd, stdout=PIPE, stderr=PIPE, shell=True, check=True)
-    nr_of_threads = process.stdout.decode('utf-8').rstrip()
+    _, stdout, _ = utils.run_cmd(cmd)
+    nr_of_threads = stdout.rstrip()
     assert int(nr_of_threads) == 6
 
     # Consume existing metrics

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -57,13 +57,13 @@ def test_handled_signals(test_microvm_with_ssh, network_config):
     # Just validate a simple command: `nproc`
     cmd = "nproc"
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    assert stderr.read().decode("utf-8") == ""
-    assert int(stdout.read().decode("utf-8")) == 2
+    assert stderr.read() == ""
+    assert int(stdout.read()) == 2
 
     # We have a handler installed for this signal.
     os.kill(firecracker_pid, SIGRTMIN+1)
 
     # Validate the microVM is still up and running.
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    assert stderr.read().decode("utf-8") == ""
-    assert int(stdout.read().decode("utf-8")) == 2
+    assert stderr.read() == ""
+    assert int(stdout.read()) == 2

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests ensuring security vulnerabilities are not present in dependencies."""
 
-from subprocess import run, PIPE
 
 import os
 import platform
-
 import pytest
+
+import framework.utils as utils
 
 
 @pytest.mark.skipif(
@@ -22,10 +22,6 @@ def test_cargo_audit():
             os.path.dirname(os.path.realpath(__file__)),
             '../../../Cargo.lock')
     )
-    process = run(
-        'cargo audit -f {}'.format(cargo_lock_path),
-        shell=True,
-        check=True,
-        stdout=PIPE
-    )
-    assert process.returncode == 0
+
+    # Run command and raise exception if non-zero return code
+    utils.run_cmd('cargo audit -q -f {}'.format(cargo_lock_path))


### PR DESCRIPTION
Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

## Reason for This PR

Since subprocess.run is widely used in the testing framework, we should route all calls through a custom function which logs all the commands.
This is useful for both developing tests and debugging failures.

## Description of Changes

Add a custom shell call endpoint that logs all commands.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist


- [x] All commits in this PR are signed (`git commit -s`).
- [x] the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated
- [x] code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR
- [x] Either the changes in this PR have no user impact
- [x] Either no new `unsafe` code has been added
