### PR TITLE
removed superfluous code

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -41,7 +41,7 @@ pub fn build_config_space(disk_size: u64) -> Vec<u8> {
     }
     let mut config = Vec::with_capacity(CONFIG_SPACE_SIZE);
     let num_sectors = disk_size >> SECTOR_SHIFT;
-    for i in 0..8 {
+    for i in 0..CONFIG_SPACE_SIZE {
         config.push((num_sectors >> (8 * i)) as u8);
     }
     config

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -21,7 +21,6 @@ pub use self::block::*;
 pub use self::device::*;
 pub use self::mmio::*;
 pub use self::net::*;
-pub use self::net::*;
 pub use self::queue::*;
 pub use self::vsock::*;
 

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -111,20 +111,13 @@ impl TokenBucket {
         // refill_token_count = (delta_time * size) / (complete_refill_time_ms * 1_000_000)
         // In order to avoid overflows, simplify the fractions by computing greatest common divisor.
 
-        // Get the greatest common factor between `size` and `complete_refill_time_ms`.
-        let common_factor = gcd(size, complete_refill_time_ms);
+        let complete_refill_time_ns = complete_refill_time_ms * NANOSEC_IN_ONE_MILLISEC;
+        // Get the greatest common factor between `size` and `complete_refill_time_ns`.
+        let common_factor = gcd(size, complete_refill_time_ns);
         // The division will be exact since `common_factor` is a factor of `size`.
-        let mut processed_capacity: u64 = size / common_factor;
-        // The division will be exact since `common_factor` is a factor of `complete_refill_time_ms`.
-        let mut processed_refill_time: u64 = complete_refill_time_ms / common_factor;
-
-        // Get the gcd between `processed_capacity` and `NANOSEC_IN_ONE_MILLISEC`
-        // which is 1_000_000 (see formula from above).
-        let common_factor = gcd(processed_capacity, NANOSEC_IN_ONE_MILLISEC);
-        // Reduce the capacity factor even further.
-        processed_capacity /= common_factor;
-        // `processed_refill_time` was ms; turn to nanoseconds and reduce by `common_factor`.
-        processed_refill_time *= NANOSEC_IN_ONE_MILLISEC / common_factor;
+        let processed_capacity: u64 = size / common_factor;
+        // The division will be exact since `common_factor` is a factor of `complete_refill_time_ns`.
+        let processed_refill_time: u64 = complete_refill_time_ns / common_factor;
 
         TokenBucket {
             size,


### PR DESCRIPTION
Signed-off-by: karthik nedunchezhiyan <karthik.n@zohocorp.com>

## Description of Changes
 
This PR has the following changes:
* block-device: replaced hardcoded value with `CONFIG_SPACE_SIZE`.
* virtio: removed redundant import statements.
* rate-limiter (nit): previously gcd took for `complete_refill_time_ms` and `NANOSEC_IN_ONE_MILLISEC` separately. current implementation provides the same result but this time with lesser code. I hope `complete_refill_time_ms * NANOSEC_IN_ONE_MILLISEC` should not cause overflow issue as it is `unsigned 64`. Overflow issues will happen if user provides a huge `complete_refill_time_ms` value for more than 580 years (I hope fc users will not have such use-case). 
* vmm-builder (nit): previously single logic is split into two parts (some outside the for loop and some inside the for loop), as a reader, I thought it will be better if we merge into one (just to make better readability).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [ ] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
