### PR TITLE
test_shut_down.py: assert reboot flushes metrics

### DIFF
--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -123,6 +123,7 @@ impl I8042Device {
 
     pub fn trigger_kbd_interrupt(&self) -> Result<()> {
         if (self.control & CB_KBD_INT) == 0 {
+            warn!("Failed to trigger i8042 kbd interrupt (disabled by guest OS)");
             return Err(Error::KbdInterruptDisabled);
         }
         self.kbd_interrupt_evt
@@ -141,10 +142,7 @@ impl I8042Device {
         self.push_byte((key & 0xff) as u8)?;
 
         match self.trigger_kbd_interrupt() {
-            Ok(_) | Err(Error::KbdInterruptDisabled) => {
-                warn!("Failed to trigger i8042 kbd interrupt (disabled by guest OS)");
-                Ok(())
-            }
+            Ok(_) | Err(Error::KbdInterruptDisabled) => Ok(()),
             Err(e) => Err(e),
         }
     }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -411,6 +411,3 @@ impl Subscriber for Vmm {
         )]
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/tests/host_tools/logging.py
+++ b/tests/host_tools/logging.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Utilities for testing the logging system (metrics, common logs)."""
 
-import fcntl
 import os
 import sys
 
 from queue import Queue
-from subprocess import run
 from threading import Thread
 
 
@@ -22,8 +20,7 @@ class Fifo:
         if os.path.exists(path):
             raise FileExistsError("Named pipe {} already exists.".format(path))
         os.mkfifo(path)
-        
-	# Open the FIFO and set O_NONBLOCK flag.
+        # Open the FIFO and set O_NONBLOCK flag.
         fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
         self.fifo = os.fdopen(fd, "r")
         self.path = path
@@ -60,10 +57,9 @@ class Fifo:
         Failures and exceptions are propagated to the main thread
         through the `exceptions_queue`.
         """
-        fifo = self._open_nonblocking()
         max_iter = 20
         while max_iter > 0:
-            data = fifo.readline()
+            data = self.fifo.readline()
             if not data:
                 break
             try:

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -3,7 +3,6 @@
 """Tests the metrics system."""
 
 import os
-
 import host_tools.logging as log_tools
 
 

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests scenarios for shutting down Firecracker/VM."""
 import os
-
 from subprocess import run, PIPE
 import time
 
+import host_tools.logging as log_tools
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 
@@ -24,6 +24,14 @@ def test_reboot(test_microvm_with_ssh, network_config):
     test_microvm.basic_config(vcpu_count=4)
     _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
 
+    # Configure metrics system.
+    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+    response = test_microvm.metrics.put(
+        metrics_fifo=test_microvm.create_jailed_resource(metrics_fifo.path)
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
     test_microvm.start()
 
     # Get Firecracker PID so we can count the number of threads.
@@ -37,6 +45,9 @@ def test_reboot(test_microvm_with_ssh, network_config):
     nr_of_threads = process.stdout.decode('utf-8').rstrip()
     assert int(nr_of_threads) == 6
 
+    # Consume existing metrics
+    lines = metrics_fifo.sequential_reader(100)
+    assert len(lines) == 1
     # Rebooting Firecracker sends an exit event and should gracefully kill.
     # the instance.
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
@@ -49,3 +60,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
             time.sleep(0.01)
         except OSError:
             break
+
+    # Consume existing metrics
+    lines = metrics_fifo.sequential_reader(100)
+    assert len(lines) == 1

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -28,9 +28,8 @@ def test_sigbus_sigsegv(test_microvm_with_api, signum):
     # Configure logging.
     log_fifo_path = os.path.join(test_microvm.path, 'log_fifo')
     log_fifo = log_tools.Fifo(log_fifo_path)
-
     response = test_microvm.logger.put(
-        log_fifo=test_microvm.create_jailed_resource(log_fifo.path),
+        log_fifo=test_microvm.create_jailed_resource(log_fifo_path),
         level='Error',
         show_level=False,
         show_log_origin=False
@@ -44,7 +43,9 @@ def test_sigbus_sigsegv(test_microvm_with_api, signum):
     os.kill(firecracker_pid, signum)
 
     msg = 'Shutting down VM after intercepting signal {}'.format(signum)
+    log_fifo.flags = log_fifo.flags & ~os.O_NONBLOCK
     lines = log_fifo.sequential_reader(5)
+
     msg_found = False
     for line in lines:
         if msg in line:


### PR DESCRIPTION
## Reason for This PR

#1624

## Description of Changes

Updated `test_shut_down.py` to assert the flushing of metrics when a reboot is issued from within the booted microVM.

`mod tests` from vmm/lib.rs is not neccessary for this file, since the units testing fit better for integration tests, which are already covered by our current integration tests.

Modified the API for creation and flags manipulation of a `logging::Fifo`. These changes offer flexibility in choosing if the opened pipe is blocking or non blocking and support for changing file descriptor flags for the opened fifo.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] This PR is linked to an issue.
- [x] The description of changes is clear and encompassing.
- [x] Bo docs need to be updated as part of this PR.
- [x] Code-level documentation for touched code is included in this PR.
- [x] No API changes are included in this PR.
- [x] The changes in this PR have no user impact.
- [x] No new `unsafe` code has been added.
