### PR TITLE
CI: adjust test_multiple_microvm_boottime_* integration tests 

### DIFF
--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Ensure multiple microVMs work correctly when spawned simultaneously."""
+
+from framework import decorators
+
+import host_tools.network as net_tools
+
+NO_OF_MICROVMS = 20
+
+
+@decorators.test_context('ssh', NO_OF_MICROVMS)
+def test_run_concurrency(test_multiple_microvms, network_config):
+    """Check we can spawn multiple microvms."""
+    microvms = test_multiple_microvms
+
+    for i in range(NO_OF_MICROVMS):
+        microvm = microvms[i]
+        _ = _configure_and_run(microvm, {
+            "config": network_config, "iface_id": str(i)
+        })
+        # We check that the vm is running by testing that the ssh does
+        # not time out.
+        _ = net_tools.SSHConnection(microvm.ssh_config)
+
+
+def _configure_and_run(microvm, network_info):
+    """Auxiliary function for configuring and running microVM."""
+    microvm.spawn()
+
+    # Machine configuration specified in the SLA.
+    config = {
+        'vcpu_count': 1,
+        'mem_size_mib': 128
+    }
+
+    microvm.basic_config(**config)
+
+    _tap, _, _ = microvm.ssh_network_config(
+        network_info["config"],
+        network_info["iface_id"]
+    )
+
+    microvm.start()
+    return _tap

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -11,8 +11,6 @@ import re
 import time
 import platform
 
-from framework import decorators
-
 # The maximum acceptable boot time in us.
 MAX_BOOT_TIME_US = 150000
 # NOTE: for aarch64 most of the boot time is spent by the kernel to unpack the
@@ -23,10 +21,8 @@ INITRD_BOOT_TIME_US = 160000 if platform.machine() == "x86_64" else 500000
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
-NO_OF_MICROVMS = 10
 
-
-def test_single_microvm_boottime_no_network(test_microvm_with_boottime):
+def test_boottime_no_network(test_microvm_with_boottime):
     """Check guest boottime of microvm without network."""
     _ = _configure_vm(test_microvm_with_boottime)
     time.sleep(0.4)
@@ -34,44 +30,7 @@ def test_single_microvm_boottime_no_network(test_microvm_with_boottime):
     print("Boot time with no network is: " + str(boottime_us) + " us")
 
 
-@decorators.test_context('boottime', NO_OF_MICROVMS)
-def test_multiple_microvm_boottime_no_network(test_multiple_microvms):
-    """Check guest boottime without network when spawning multiple microvms."""
-    microvms = test_multiple_microvms
-    assert microvms
-    assert len(microvms) == NO_OF_MICROVMS
-    log_fifos_data = []
-    for i in range(NO_OF_MICROVMS):
-        _ = _configure_vm(microvms[i])
-        time.sleep(0.4)
-        log_fifos_data.append(microvms[i].log_data)
-    for i in range(NO_OF_MICROVMS):
-        _ = _test_microvm_boottime(log_fifos_data[i])
-
-
-@decorators.test_context('boottime', NO_OF_MICROVMS)
-def test_multiple_microvm_boottime_with_network(
-        test_multiple_microvms,
-        network_config
-):
-    """Check guest boottime with network when spawning multiple microvms."""
-    microvms = test_multiple_microvms
-    assert microvms
-    assert len(microvms) == NO_OF_MICROVMS
-    log_fifos_data = []
-    _taps = []
-    for i in range(NO_OF_MICROVMS):
-        _tap = _configure_vm(microvms[i], {
-            "config": network_config, "iface_id": str(i)
-        })
-        time.sleep(0.4)
-        log_fifos_data.append(microvms[i].log_data)
-        _taps.append(_tap)
-    for i in range(NO_OF_MICROVMS):
-        _ = _test_microvm_boottime(log_fifos_data[i])
-
-
-def test_single_microvm_boottime_with_network(
+def test_boottime_with_network(
         test_microvm_with_boottime,
         network_config
 ):
@@ -84,7 +43,7 @@ def test_single_microvm_boottime_with_network(
     print("Boot time with network configured is: " + str(boottime_us) + " us")
 
 
-def test_single_microvm_initrd_boottime(
+def test_initrd_boottime(
         test_microvm_with_initrd):
     """Check guest boottime of microvm with initrd."""
     _tap = _configure_vm(test_microvm_with_initrd, initrd=True)


### PR DESCRIPTION
## Reason for This PR

The integration tests exercising boot time when spawned
with multiple microVMs are irrelevant due to them happening
in an unoptimized environment and also due to spawning a
small number of microVMs. However, making sure that concurrent run of multiple
microVMs runs smoothly is still relevant. Added a separate integration test for that.

## Description of Changes

Removed test_multiple_microvm_boottime_no_network and test_multiple_microvm_boottime_with_network from test_boottime.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria. Where there are two options, keep one.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] Either this PR is linked to an issue, or, the reason for this PR is
      clearly provided.
- [x] The description of changes is clear and encompassing.
- [x] Either no docs need to be updated as part of this PR, or, the required
      doc changes are included in this PR. Docs in scope are all `*.md` files
      located either in the repository root, or in the `docs/` directory.
- [x] Either no code has been touched, or, code-level documentation for touched
      code is included in this PR.
- [x] Either no API changes are included in this PR, or, the API changes are
      reflected in `firecracker/swagger.yaml`.
- [x] Either the changes in this PR have no user impact, or, the changes in
      this PR have user impact and have been added to the `CHANGELOG.md` file.
- [x] Either no new `unsafe` code has been added, or, the newly added `unsafe`
      code is unavoidable and properly documented.
