### PR TITLE
clean-up: get rid of misplaced cfg(test)

### DIFF
--- a/src/dumbo/src/pdu/arp.rs
+++ b/src/dumbo/src/pdu/arp.rs
@@ -9,8 +9,6 @@
 //! [here]: https://en.wikipedia.org/wiki/Address_Resolution_Protocol
 
 use std::convert::From;
-#[cfg(test)]
-use std::fmt;
 use std::net::Ipv4Addr;
 use std::result::Result;
 
@@ -341,6 +339,7 @@ pub fn test_speculative_tpa(buf: &[u8], addr: Ipv4Addr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt;
 
     impl<'a, T: NetworkBytes> fmt::Debug for EthIPv4ArpFrame<'a, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -298,6 +298,12 @@ mod tests {
     use pdu::tcp::Flags as TcpFlags;
     use tcp::connection::tests::ConnectionTester;
 
+    impl Endpoint {
+        pub fn set_eviction_threshold(&mut self, value: u64) {
+            self.eviction_threshold = value;
+        }
+    }
+
     impl fmt::Debug for Endpoint {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "(Endpoint)")
@@ -504,12 +510,5 @@ mod tests {
                 .unwrap();
             assert_eq!(s.inner().flags_after_ns(), TcpFlags::RST);
         }
-    }
-}
-
-#[cfg(test)]
-impl Endpoint {
-    pub fn set_eviction_threshold(&mut self, value: u64) {
-        self.eviction_threshold = value;
     }
 }

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -5,10 +5,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
-#[cfg(test)]
-#[macro_use]
-extern crate log;
-#[cfg(not(test))]
+#[cfg_attr(test, macro_use)]
 extern crate log;
 extern crate serde;
 #[macro_use]

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -501,7 +501,6 @@ impl Log for Logger {
 
 #[cfg(test)]
 mod tests {
-
     use std::fs::{File, OpenOptions};
     use std::io::{BufRead, BufReader, ErrorKind};
     use std::ops::Deref;

--- a/src/micro_http/src/common/headers.rs
+++ b/src/micro_http/src/common/headers.rs
@@ -179,15 +179,6 @@ impl Headers {
         self.expect
     }
 
-    #[cfg(test)]
-    pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
-        Self {
-            content_length,
-            expect,
-            chunked,
-        }
-    }
-
     /// Parses a byte slice into a Headers structure for a HTTP request.
     ///
     /// The byte slice is expected to have the following format: </br>
@@ -298,6 +289,16 @@ impl MediaType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    impl Headers {
+        pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
+            Self {
+                content_length,
+                expect,
+                chunked,
+            }
+        }
+    }
 
     #[test]
     fn test_default() {

--- a/src/micro_http/src/request.rs
+++ b/src/micro_http/src/request.rs
@@ -128,15 +128,6 @@ impl RequestLine {
     fn min_len() -> usize {
         Method::Get.raw().len() + 1 + Version::Http10.raw().len() + 2
     }
-
-    #[cfg(test)]
-    pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
-        Self {
-            method,
-            uri: Uri::new(uri),
-            http_version,
-        }
-    }
 }
 
 /// Wrapper over an HTTP Request.
@@ -273,6 +264,16 @@ mod tests {
                 && self.headers.content_length() == other.headers.content_length()
                 && self.headers.expect() == other.headers.expect()
                 && self.headers.chunked() == other.headers.chunked()
+        }
+    }
+
+    impl RequestLine {
+        pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
+            Self {
+                method,
+                uri: Uri::new(uri),
+                http_version,
+            }
         }
     }
 


### PR DESCRIPTION
## Reason for This PR

Some cfg(test) helper could very well been placed inside the `mod tests` section.
As per my investigation, there is no other helper that needs to be replaced. Fixes #605.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
