### PR TITLE
tempfile: make use of into_file

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -325,7 +325,7 @@ impl VirtioDevice for Block {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{metadata, OpenOptions};
+    use std::fs::metadata;
     use std::os::unix::io::AsRawFd;
     use std::thread;
     use std::time::Duration;
@@ -926,12 +926,7 @@ mod tests {
         id[..cmp::min(part_id.len(), VIRTIO_BLK_ID_BYTES as usize)]
             .clone_from_slice(&part_id[..cmp::min(part_id.len(), VIRTIO_BLK_ID_BYTES as usize)]);
 
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .unwrap();
-        block.update_disk_image(file).unwrap();
+        block.update_disk_image(f.into_file()).unwrap();
 
         assert_eq!(
             block.disk_image.metadata().unwrap().st_ino(),

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -261,25 +261,18 @@ mod tests {
         // 2. If parent file exists and is empty, will go one level up, and return error because
         // the grandparent file does not exist.
         let named_file = TempFile::new_in(dir.as_path()).expect("Cannot create named file.");
-        let result = inherit_from_parent(
-            &mut path2.clone(),
-            named_file.as_path().file_name().unwrap().to_str().unwrap(),
-        );
+        let result =
+            inherit_from_parent(&mut path2.clone(), named_file.as_path().to_str().unwrap());
         assert!(result.is_err());
         assert!(format!("{:?}", result).contains("CgroupInheritFromParent"));
 
-        let child_file = dir2
-            .as_path()
-            .join(named_file.as_path().file_name().unwrap().to_str().unwrap());
+        let child_file = dir2.as_path().join(named_file.as_path().to_str().unwrap());
 
         // 3. If parent file exists and is not empty, will return ok and child file will have its
         // contents.
         let some_line = "Parent line";
         writeln!(named_file.as_file(), "{}", some_line).expect("Cannot write to file.");
-        let result = inherit_from_parent(
-            &mut path2,
-            named_file.as_path().file_name().unwrap().to_str().unwrap(),
-        );
+        let result = inherit_from_parent(&mut path2, named_file.as_path().to_str().unwrap());
         assert!(result.is_ok());
         let res = readln_special(&child_file).expect("Cannot read from file.");
         assert!(res == some_line);

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -571,7 +571,6 @@ mod tests {
     extern crate serde_json;
     use super::*;
 
-    use std::fs::OpenOptions;
     use std::io::ErrorKind;
     use std::sync::Arc;
     use std::thread;
@@ -586,30 +585,14 @@ mod tests {
         let res = m.write();
         assert!(res.is_ok() && !res.unwrap());
 
-        let metrics_file_temp = TempFile::new().expect("Failed to create temporary metrics file.");
-        assert!(m
-            .init(Box::new(
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(metrics_file_temp.as_path())
-                    .unwrap()
-            ),)
-            .is_ok());
+        let f = TempFile::new().expect("Failed to create temporary metrics file");
+        assert!(m.init(Box::new(f.into_file()),).is_ok());
 
         assert!(m.write().is_ok());
 
-        let metrics_file_temp2 = TempFile::new().unwrap();
+        let f = TempFile::new().expect("Failed to create temporary metrics file");
 
-        assert!(m
-            .init(Box::new(
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(metrics_file_temp2.as_path())
-                    .unwrap()
-            ),)
-            .is_err());
+        assert!(m.init(Box::new(f.into_file()),).is_err());
     }
 
     #[test]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1017,8 +1017,7 @@ pub mod tests {
     #[test]
     fn test_setup_serial_device() {
         let read_tempfile = TempFile::new().unwrap();
-        let read_file = File::open(read_tempfile.as_path()).unwrap();
-        let read_handle = SerialInput(read_file);
+        let read_handle = SerialInput(read_tempfile.into_file());
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
 
         assert!(setup_serial_device(

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -101,7 +101,6 @@ pub fn init_logger(
 #[cfg(test)]
 mod tests {
 
-    use std::fs::File;
     use std::io::BufRead;
     use std::io::BufReader;
 
@@ -137,8 +136,7 @@ mod tests {
         // Validate logfile works.
         warn!("this is a test");
 
-        let f = File::open(log_file.as_path()).unwrap();
-        let mut reader = BufReader::new(f);
+        let mut reader = BufReader::new(log_file.into_file());
 
         let mut line = String::new();
         loop {


### PR DESCRIPTION
## Reason for This PR

Previous version of tempfile from vmm_sys_util
did not offer the interface for owning the File inside
the TempFile. This limitation was solved by https://github.com/rust-vmm/vmm-sys-util/pull/70.

## Description of Changes

Adjusted all unit tests. Fixes #1466.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
