### PR TITLE
Gracefully handle EINTR events in our async loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "micro_http"
 version = "0.1.0"
 dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
 

--- a/src/micro_http/Cargo.toml
+++ b/src/micro_http/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
+libc = ">=0.2.39"
 utils = { path = "../utils" }

--- a/src/micro_http/src/lib.rs
+++ b/src/micro_http/src/lib.rs
@@ -109,6 +109,7 @@
 //! }
 //! ```
 
+extern crate libc;
 extern crate utils;
 
 mod common;


### PR DESCRIPTION
## Reason for This PR

Fixes #197 

## Description of Changes

Gracefully handle EINTR errors in our `EventManager` and `HttpServer` requests loops, they are internally consumed and treated as a `epoll` timeout with no events rather than io (fatal) errors.

The inner `vsock epoll` loop doesn't care about EINTR because it always runs non-blocking (with `timeout=0`) and also doesn't `break` on errors.

### Fix Validation

**Before**
```
kata@kata-devo:~/code/firecracker-demo$ sudo gdb -p `pidof firecracker`

Attaching to process 9345
[New LWP 9346]
[New LWP 9466]
0x000000000079a6a7 in epoll_pwait ()
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /home/kata/code/firecracker-demo/firecracker.
Use `info auto-load python-scripts [REGEXP]' to list them.
(gdb) c
Continuing.

Thread 1 "firecracker" received signal SIGSYS, Bad system call.
0x00000000007a069b in getcwd ()
(gdb) 
Continuing.
[LWP 9466 exited]
[LWP 9346 exited]
[Inferior 1 (process 9345) exited with code 0224]
```

**After**
```
kata@kata-devo:~/code/firecracker-demo$ sudo gdb -p `pidof firecracker`

Attaching to process 8020
[New LWP 8021]
[New LWP 8468]
0x000000000079a807 in epoll_pwait ()
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /home/kata/code/firecracker-demo/firecracker.
Use `info auto-load python-scripts [REGEXP]' to list them.
(gdb) c
Continuing.
^C
Thread 1 "firecracker" received signal SIGINT, Interrupt.
0x000000000079a807 in epoll_pwait ()
(gdb) c
Continuing.
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
