### PR TITLE
device.rs: increment metric instead of logging error

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -224,6 +224,10 @@ impl Block {
             used_any = true;
         }
 
+        if !used_any {
+            METRICS.block.no_avail_buffer.inc();
+        }
+
         used_any
     }
 

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -326,6 +326,8 @@ pub struct BlockDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of times when interacting with the space config of a block device failed.
     pub cfg_fails: SharedMetric,
+    /// No available buffer for the block queue.
+    pub no_avail_buffer: SharedMetric,
     /// Number of times when handling events on a block device failed.
     pub event_fails: SharedMetric,
     /// Number of failures in executing a request on a block device.
@@ -416,6 +418,10 @@ pub struct NetDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of times when interacting with the space config of a network device failed.
     pub cfg_fails: SharedMetric,
+    /// No available buffer for the net device rx queue.
+    pub no_rx_avail_buffer: SharedMetric,
+    /// No available buffer for the net device tx queue.
+    pub no_tx_avail_buffer: SharedMetric,
     /// Number of times when handling events on a network device failed.
     pub event_fails: SharedMetric,
     /// Number of events associated with the receiving queue.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.40
+COVERAGE_TARGET_PCT = 82.46
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
We've introduced an error log for the case when there is no available buffer for RX data. This can happen for heavy network traffic usage, and it is not an actual error, rather a limitation for which we must increment a metric.

Signed-off-by: iulianbarbu <iul@amazon.com>

## Reason for This PR

Fixes #1677 

## Description of Changes

Removed an unnecessary error log.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
