### PR TITLE
upgrade vm-memory dependency to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ dependencies = [
  "rate_limiter 0.1.0",
  "utils 0.1.0",
  "virtio_gen 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "utils 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -370,7 +370,7 @@ version = "0.1.0"
 
 [[package]]
 name = "vm-memory"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +398,7 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -456,7 +456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0123bba5b202eb298259401ae5611d3a34e852f1d9b6963bbf266b344355a93d"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d5563ea4d856645b13bc9623e6a0617457a77555a22301d896597cbc5131c2b"
+"checksum vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98d50eb34b2ec250e098fbad7486e81f592a1bdeff2b10f0433638f3ce6a0828"
 "checksum vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "048b10a74f061d87dacca196a1964052a7135651641ab8d100aef21e58f33571"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -10,7 +10,7 @@ libc = ">=0.2.39"
 utils = { path = "../utils" }
 
 arch_gen = { path = "../arch_gen" }
-vm-memory = { version = ">=0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 
 [dev-dependencies]
 utils = { path = "../utils" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 libc = ">=0.2.39"
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 utils = { path = "../utils" }
 net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -17,7 +17,7 @@
 use std::result;
 
 use utils::byte_order;
-use vm_memory::{self, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+use vm_memory::{self, GuestAddress, GuestMemory, GuestMemoryError};
 
 use super::super::DescriptorChain;
 use super::defs;
@@ -102,18 +102,7 @@ fn get_host_address<T: GuestMemory>(
     guest_addr: GuestAddress,
     size: usize,
 ) -> result::Result<*mut u8, GuestMemoryError> {
-    let region = mem
-        .find_region(guest_addr)
-        .ok_or(GuestMemoryError::InvalidGuestAddress(guest_addr))?;
-    let region_addr = region
-        .to_region_addr(guest_addr)
-        .ok_or(GuestMemoryError::InvalidGuestAddress(guest_addr))?;
-
-    if size > 0 && region.checked_offset(region_addr, size - 1).is_none() {
-        return Err(GuestMemoryError::InvalidGuestAddress(guest_addr));
-    }
-
-    Ok(region.get_host_address(region_addr)?)
+    Ok(mem.get_slice(guest_addr, size)?.as_ptr())
 }
 
 impl VsockPacket {

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -3,5 +3,5 @@ name = "kernel"
 version = "0.1.0"
 
 [dependencies]
-vm-memory = { version = ">=0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 utils = { path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -16,7 +16,7 @@ devices = { path = "../devices" }
 dumbo = { path = "../dumbo" }
 kernel = { path = "../kernel" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 mmds = { path = "../mmds" }
 utils = { path = "../utils"}
 rate_limiter = { path = "../rate_limiter" }


### PR DESCRIPTION
## Reason for This PR

PArtially addresses #1683

## Description of Changes

- upgrade vm-memory dependency to 0.2.0
- simplify `get_host_address()`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
