### PR TITLE
Fix links in logger and metrics docs

### DIFF
--- a/docs/logger.md
+++ b/docs/logger.md
@@ -37,7 +37,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
 ```
 
 Details about the required and optional fields can be found in the
-[swagger definition](../../src/api_server/swagger/firecracker.yaml).
+[swagger definition](../src/api_server/swagger/firecracker.yaml).
 
 ## Using command line parameters for configuration
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,7 +32,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
 ```
 
 Details about this configuration can be found in the
-[swagger definition](../../src/api_server/swagger/firecracker.yaml).
+[swagger definition](../src/api_server/swagger/firecracker.yaml).
 
 The metrics are written to the `metrics_path` in JSON format.
 
@@ -42,7 +42,7 @@ The metrics get flushed in two ways:
 
 * without user intervention every 60 seconds;
 * upon user demand, by issuing a `FlushMetrics` request. You can
-find how to use this request in the [actions API](../api_requests/actions.md).
+find how to use this request in the [actions API](api_requests/actions.md).
 
 If the path provided is a named pipe, you can use the script below to
 read from it:


### PR DESCRIPTION
## Reason for This PR

Links in logger and metrics were broken.

## Description of Changes

Fix those links.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
