### PR TITLE
[RFC] Add functionality in VMM to fetch the KVM dirty bitmap

### DIFF
--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -80,6 +80,12 @@ impl ParsedRequest {
     ) -> Response {
         match request_outcome {
             Ok(vmm_data) => match vmm_data {
+                VmmData::DirtyBitmap(bitmap) => {
+                    info!("The request was executed successfully. Status code: 200 OK.");
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    response.set_body(Body::new(format!("{:?}", bitmap)));
+                    response
+                }
                 VmmData::Empty => {
                     info!("The request was executed successfully. Status code: 204 No Content.");
                     Response::new(Version::Http11, StatusCode::NoContent)

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 libc = ">=0.2.39"
 utils = { path = "../utils" }
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 vmm-sys-util = ">=0.2.1"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
 kvm-bindings = { version = ">=0.2", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.4"
+kvm-ioctls = ">=0.5"
 libc = ">=0.2.39"
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"

--- a/src/vmm/src/controller.rs
+++ b/src/vmm/src/controller.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
@@ -13,6 +14,7 @@ use devices::virtio::{Block, MmioTransport, Net, TYPE_BLOCK, TYPE_NET};
 use logger::METRICS;
 use resources::VmResources;
 use rpc_interface::VmmActionError;
+use vm_memory::{GuestMemory, GuestMemoryRegion, GuestRegionMmap};
 use vmm_config;
 use vmm_config::drive::DriveError;
 use vmm_config::machine_config::VmConfig;
@@ -224,5 +226,244 @@ impl VmmController {
         }
 
         Ok(())
+    }
+
+    /// Retrieves the KVM dirty bitmap for each of the guest's memory regions.
+    pub fn get_dirty_bitmap(
+        &self,
+    ) -> std::result::Result<HashMap<usize, Vec<u64>>, VmmActionError> {
+        let mut bitmap: HashMap<usize, Vec<u64>> = HashMap::new();
+        let vmm_handle = self.vmm.lock().unwrap();
+        vmm_handle.guest_memory.with_regions_mut(
+            |slot: usize, region: &GuestRegionMmap| -> std::result::Result<(), VmmActionError> {
+                let bitmap_region = vmm_handle
+                    .vm
+                    .fd()
+                    .get_dirty_log(slot as u32, region.len() as usize)
+                    .map_err(|e| VmmActionError::InternalVmm(super::Error::DirtyBitmap(e)))?;
+                bitmap.insert(slot, bitmap_region);
+                Ok(())
+            },
+        )?;
+        Ok(bitmap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate kernel;
+
+    use super::*;
+
+    use arch::arch_memory_regions;
+    #[cfg(target_arch = "x86_64")]
+    use device_manager::legacy::PortIODeviceManager;
+    use device_manager::mmio::MMIODeviceManager;
+    #[cfg(target_arch = "x86_64")]
+    use devices::legacy::Serial;
+    use kernel::cmdline::Cmdline;
+    use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
+    use kvm_ioctls::{VcpuExit, VcpuFd, VmFd};
+    use utils::eventfd::EventFd;
+    use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+    use vstate::{KvmContext, Vm};
+
+    struct DeviceManagers {
+        mmio_device_manager: MMIODeviceManager,
+        #[cfg(target_arch = "x86_64")]
+        pio_device_manager: PortIODeviceManager,
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn create_guest_workload() -> (Vec<u8>, GuestAddress) {
+        // HLT instruction.
+        (vec![0xf4u8], GuestAddress(0))
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn create_guest_workload() -> (Vec<u8>, GuestAddress) {
+        (
+            vec![
+                0x01, 0x00, 0x00, 0x10, /* adr x1, <this address> */
+                0x22, 0x10, 0x00, 0xb9, /* str w2, [x1, #16]; write to this page */
+                0x02, 0x00, 0x00, 0xb9, /* str w2, [x0]; force MMIO exit */
+                0x00, 0x00, 0x00,
+                0x14, /* b <this address>; shouldn't get here, but if so loop forever */
+            ],
+            GuestAddress(arch::aarch64::layout::DRAM_MEM_START),
+        )
+    }
+
+    fn create_device_managers() -> DeviceManagers {
+        DeviceManagers {
+            mmio_device_manager: MMIODeviceManager::new(
+                &mut (arch::MMIO_MEM_START as u64),
+                (arch::IRQ_BASE, arch::IRQ_MAX),
+            ),
+            #[cfg(target_arch = "x86_64")]
+            pio_device_manager: PortIODeviceManager::new(
+                Arc::new(Mutex::new(Serial::new_sink(
+                    EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+                ))),
+                EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            )
+            .unwrap(),
+        }
+    }
+
+    fn create_guest_memory(mem_size: usize, vm_fd: &VmFd) -> GuestMemoryMmap {
+        let mem_regions = arch_memory_regions(mem_size);
+        let guest_memory = GuestMemoryMmap::from_ranges(&mem_regions).unwrap();
+        config_guest_memory(&guest_memory, false, vm_fd);
+        guest_memory
+    }
+
+    fn config_guest_memory(guest_memory: &GuestMemoryMmap, track_dirty_pages: bool, vm_fd: &VmFd) {
+        guest_memory
+            .with_regions(|index, region| {
+                // It's safe to unwrap because the guest address is valid.
+                let host_addr = guest_memory.get_host_address(region.start_addr()).unwrap();
+                let memory_region = kvm_userspace_memory_region {
+                    slot: index as u32,
+                    guest_phys_addr: region.start_addr().raw_value() as u64,
+                    memory_size: region.len() as u64,
+                    userspace_addr: host_addr as u64,
+                    flags: if track_dirty_pages {
+                        KVM_MEM_LOG_DIRTY_PAGES
+                    } else {
+                        0
+                    },
+                };
+                unsafe { vm_fd.set_user_memory_region(memory_region) }
+            })
+            .unwrap();
+    }
+
+    impl Vmm {
+        fn empty(guest_memory: GuestMemoryMmap, vm: Vm, device_managers: DeviceManagers) -> Self {
+            Vmm {
+                events_observer: None,
+                guest_memory,
+                kernel_cmdline: Cmdline::new(100),
+                vcpus_handles: vec![],
+                exit_evt: EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+                vm,
+                mmio_device_manager: device_managers.mmio_device_manager,
+                #[cfg(target_arch = "x86_64")]
+                pio_device_manager: device_managers.pio_device_manager,
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        fn config_vcpu(&self, vcpu_fd: &mut VcpuFd, guest_addr: GuestAddress) {
+            // x86_64 specific registry setup.
+            let mut vcpu_sregs = vcpu_fd.get_sregs().unwrap();
+            vcpu_sregs.cs.base = 0;
+            vcpu_sregs.cs.selector = 0;
+            vcpu_fd.set_sregs(&vcpu_sregs).unwrap();
+
+            let mut vcpu_regs = vcpu_fd.get_regs().unwrap();
+            // Set the Instruction Pointer to the guest address where we loaded the code.
+            vcpu_regs.rip = guest_addr.0 as u64;
+            vcpu_regs.rax = 2;
+            vcpu_regs.rbx = 3;
+            vcpu_regs.rflags = 2;
+            vcpu_fd.set_regs(&vcpu_regs).unwrap();
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        fn config_vcpu(&self, vcpu_fd: &mut VcpuFd, guest_addr: GuestAddress) {
+            // aarch64 specific registry setup.
+            let mut kvi = kvm_bindings::kvm_vcpu_init::default();
+            self.vm.fd().get_preferred_target(&mut kvi).unwrap();
+            vcpu_fd.vcpu_init(&kvi).unwrap();
+
+            let core_reg_base: u64 = 0x6030_0000_0010_0000;
+            let mut mem_size = 0;
+            self.guest_memory
+                .with_regions_mut(|_, region| -> std::result::Result<(), std::io::Error> {
+                    mem_size += region.len();
+                    Ok(())
+                })
+                .unwrap();
+            let mmio_addr: u64 = (guest_addr.0 + mem_size) as u64;
+            vcpu_fd
+                .set_one_reg(core_reg_base + 2 * 32, guest_addr.0 as u64)
+                .unwrap(); // set PC
+            vcpu_fd
+                .set_one_reg(core_reg_base + 2 * 0, mmio_addr)
+                .unwrap(); // set X0
+        }
+
+        fn write_code_to_guest_memory(&self) -> GuestAddress {
+            let (asm_code, guest_addr) = create_guest_workload();
+            let host_addr = self.guest_memory.get_host_address(guest_addr).unwrap();
+            let code_slice: &mut [u8] =
+                unsafe { std::slice::from_raw_parts_mut(host_addr as *mut u8, asm_code.len()) };
+            code_slice.copy_from_slice(&asm_code);
+            guest_addr
+        }
+
+        // Prepare a VM with 1 MB memory and 1 vCPU.
+        // Dirty a page and run the VM.
+        // Return after the first VM exit.
+        fn setup_with_code_and_run(&mut self) {
+            // Fill guest memory with an asm code snippet.
+            let guest_addr = self.write_code_to_guest_memory();
+
+            // Create a vCPU.
+            let mut vcpu_fd = self.vm.fd().create_vcpu(0).unwrap();
+            self.config_vcpu(&mut vcpu_fd, guest_addr);
+
+            // Run the VM. It will trigger a vCPU exit.
+            match vcpu_fd.run().unwrap() {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                VcpuExit::Hlt => (),
+                #[cfg(target_arch = "aarch64")]
+                VcpuExit::MmioWrite(_, _) => (),
+                exit_reason => panic!("unexpected exit reason: {:?}", exit_reason),
+            }
+        }
+    }
+
+    impl VmmController {
+        fn setup_vmm_with_code_and_run(&mut self) {
+            self.vmm.lock().unwrap().setup_with_code_and_run()
+        }
+
+        fn set_dirty_page_tracking(&self, track_dirty_pages: bool) {
+            let vmm = self.vmm.lock().unwrap();
+            config_guest_memory(vmm.guest_memory(), track_dirty_pages, vmm.vm.fd());
+        }
+    }
+
+    #[test]
+    fn test_dirty_bitmap() {
+        let kvm = KvmContext::new().unwrap();
+        let vm = Vm::new(kvm.fd()).unwrap();
+        let device_managers = create_device_managers();
+        let guest_memory = create_guest_memory(1 << 20, vm.fd());
+
+        let vmm = Vmm::empty(guest_memory, vm, device_managers);
+
+        let mut vmm_controller =
+            VmmController::new(VmResources::default(), Arc::new(Mutex::new(vmm)));
+
+        // Error case: dirty tracking off.
+        assert_eq!(
+            format!("{:?}", vmm_controller.get_dirty_bitmap().err()),
+            "Some(InternalVmm(DirtyBitmap(Error(2))))"
+        );
+
+        // VM didn't run => empty bitmap.
+        vmm_controller.set_dirty_page_tracking(true);
+        let mut expected: HashMap<usize, Vec<u64>> = HashMap::new();
+        expected.insert(0, vec![0u64; 4]);
+        assert_eq!(expected, vmm_controller.get_dirty_bitmap().unwrap());
+
+        // VM ran and dirtied 1 page.
+        vmm_controller.setup_vmm_with_code_and_run();
+        expected.insert(0, vec![1u64, 0u64, 0u64, 0u64]);
+        assert_eq!(expected, vmm_controller.get_dirty_bitmap().unwrap());
     }
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -102,7 +102,7 @@ impl MMIODeviceManager {
         &mut self,
         vm: &VmFd,
         mmio_device: devices::virtio::MmioTransport,
-        cmdline: &mut kernel_cmdline::Cmdline,
+        _cmdline: &mut kernel_cmdline::Cmdline,
         type_id: u32,
         device_id: &str,
     ) -> Result<u64> {
@@ -138,7 +138,7 @@ impl MMIODeviceManager {
         // transform it to decimal
 
         #[cfg(target_arch = "x86_64")]
-        cmdline
+        _cmdline
             .insert(
                 "virtio_mmio.device",
                 &format!("{}K@0x{:08x}:{}", MMIO_LEN / 1024, self.mmio_base, self.irq),

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -49,8 +49,6 @@ pub mod signal_handler;
 pub mod vmm_config;
 mod vstate;
 
-#[cfg(target_arch = "aarch64")]
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::os::unix::io::AsRawFd;
@@ -61,8 +59,6 @@ use arch::DeviceType;
 use arch::InitrdConfig;
 #[cfg(target_arch = "x86_64")]
 use device_manager::legacy::PortIODeviceManager;
-#[cfg(target_arch = "aarch64")]
-use device_manager::mmio::MMIODeviceInfo;
 use device_manager::mmio::MMIODeviceManager;
 use devices::BusDevice;
 use kernel::cmdline::Cmdline as KernelCmdline;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -99,6 +99,8 @@ pub enum Error {
     /// of resource exhaustion.
     #[cfg(target_arch = "x86_64")]
     CreateLegacyDevice(device_manager::legacy::Error),
+    /// Cannot fetch the KVM dirty bitmap.
+    DirtyBitmap(kvm_ioctls::Error),
     /// Cannot read from an Event file descriptor.
     EventFd(io::Error),
     /// Polly error wrapper.
@@ -136,7 +138,7 @@ pub enum Error {
     /// vCPU resume failed.
     VcpuResume,
     /// Cannot spawn a new Vcpu thread.
-    VcpuSpawn(std::io::Error),
+    VcpuSpawn(io::Error),
     /// Vm error.
     Vm(vstate::Error),
     /// Error thrown by observer object on Vmm initialization.
@@ -153,6 +155,7 @@ impl Display for Error {
             ConfigureSystem(e) => write!(f, "System configuration error: {:?}", e),
             #[cfg(target_arch = "x86_64")]
             CreateLegacyDevice(e) => write!(f, "Error creating legacy device: {:?}", e),
+            DirtyBitmap(e) => write!(f, "Error getting the KVM dirty bitmap. {}", e),
             EventFd(e) => write!(f, "Event fd error: {}", e),
             EventManager(e) => write!(f, "Event manager error: {:?}", e),
             I8042Error(e) => write!(f, "I8042 error: {}", e),

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -12,6 +12,7 @@ use std::io;
 use std::result;
 use std::sync::atomic::{fence, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::Barrier;
 use std::thread;
 
 use super::TimestampUs;
@@ -33,7 +34,6 @@ use kvm_bindings::{kvm_userspace_memory_region, KVM_API_VERSION};
 use kvm_ioctls::*;
 use logger::{Metric, METRICS};
 use seccomp::{BpfProgram, SeccompFilter};
-use std::sync::Barrier;
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
@@ -1310,7 +1310,9 @@ mod tests {
     use std::os::unix::io::AsRawFd;
     #[cfg(target_arch = "x86_64")]
     use std::path::PathBuf;
-    use std::sync::{mpsc, Arc, Barrier};
+    #[cfg(target_arch = "x86_64")]
+    use std::sync::mpsc;
+    use std::sync::{Arc, Barrier};
     #[cfg(target_arch = "x86_64")]
     use std::time::Duration;
 
@@ -1318,6 +1320,7 @@ mod tests {
     use super::*;
 
     use utils::signal::validate_signal_num;
+    #[cfg(target_arch = "x86_64")]
     use vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
 
     // Auxiliary function being used throughout the tests.


### PR DESCRIPTION
## Reason for This PR

Added a new `pub fn` in the VMM runtime controller that retrieves the KVM dirty bitmap.

## Description of Changes

The functionality is **not ready** and **RFC only** because:
* the dirty bitmap won't be fetch-able because the microVM starts with dirty tracking disabled and the piece that toggles dirty tracking is not included in this PR (also, not written);
* the functionality is exclusive to the programmatic API => no HTTP API => no integration test for it => added scaffolding in the VMM controller to start a VM in the unit tests;
* said scaffolding is **not complete** as the VM can't be cleanly stopped in the unit tests and leaks resources.

So why am I still posting this?

I mostly want to get feedback on the unit test approach. If @firecracker-microvm/compute-capsule you find it too cumbersome to create the VMM in the controller unit test code, we can switch to integration tests for HTTP-less APIs and figure out how that goes.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

The core component is already present in `kvm-ioctls`, and the rest is glue.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
