### PR TITLE
vmm: simplify block device rescan

### DIFF
--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -5,7 +5,7 @@ pub mod device;
 pub mod event_handler;
 pub mod request;
 
-pub use self::device::{build_config_space, Block};
+pub use self::device::Block;
 pub use self::event_handler::*;
 pub use self::request::*;
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -684,14 +684,14 @@ fn attach_block_devices(
         if drive_config.is_root_device {
             let kernel_cmdline = &mut vmm.kernel_cmdline;
 
-            kernel_cmdline.insert_str(if let Some(partuuid) = drive_config.get_partuuid() {
+            kernel_cmdline.insert_str(if let Some(partuuid) = &drive_config.partuuid {
                 format!("root=PARTUUID={}", partuuid)
             } else {
                 // If no PARTUUID was specified for the root device, try with the /dev/vda.
                 "root=/dev/vda".to_string()
             })?;
 
-            let flags = if drive_config.is_read_only() {
+            let flags = if drive_config.is_read_only {
                 "ro"
             } else {
                 "rw"

--- a/src/vmm/src/controller.rs
+++ b/src/vmm/src/controller.rs
@@ -160,7 +160,7 @@ impl VmmController {
         // Try to open the file specified by path_on_host using the permissions of the block_device.
         let disk_file = OpenOptions::new()
             .read(true)
-            .write(!self.vm_resources.block.config_list[block_device_index].is_read_only())
+            .write(!self.vm_resources.block.config_list[block_device_index].is_read_only)
             .open(&file_path)
             .map_err(DriveError::CannotOpenBlockDevice)
             .map_err(VmmActionError::DriveConfig)?;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -309,7 +309,7 @@ mod tests {
         fn update_drive(&self, device_id: &str, new_size: u64) -> Result<()> {
             match self.get_device(DeviceType::Virtio(TYPE_BLOCK), device_id) {
                 Some(device) => {
-                    let data = devices::virtio::build_config_space(new_size);
+                    let data = devices::virtio::block::device::build_config_space(new_size);
                     let mut busdev = device.lock().map_err(|_| Error::UpdateFailed)?;
 
                     busdev.write(MMIO_CFG_SPACE_OFF, &data[..]);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -234,7 +234,7 @@ impl VmResources {
         // Try to open the file specified by path_on_host using the permissions of the block_device.
         let _ = OpenOptions::new()
             .read(true)
-            .write(!self.block.config_list[block_device_index].is_read_only())
+            .write(!self.block.config_list[block_device_index].is_read_only)
             .open(&file_path)
             .map_err(DriveError::CannotOpenBlockDevice)?;
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.46
+COVERAGE_TARGET_PCT = 82.56
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Reduce code complexity.
Fixes #1711 

## Description of Changes

We were using two different functions each with its own way to get to the underlying block device and update its backing file, then update its virtio configuration space.

This commit drops the `rescan_block_device()` function and just updated the virtio configuration space in the `update_drive_disk_image()` function.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
