### PR TITLE
API/RPC: UpdateBlockDevicePath only allowed post-boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   `metrics_fifo` field from MetricsConfig to `metrics_path`.
 - `PATCH /drives/{id}` only allowed post-boot. Use `PUT` for pre-boot
   updates to existing configurations.
+- `PATCH /network-interfaces/{id}` only allowed post-boot. Use `PUT` for
+  pre-boot updates to existing configurations.
 
 ## [0.21.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Removed `metrics_fifo` field from the logger configuration.
 - Renamed `log_fifo` field from LoggerConfig to `log_path` and
   `metrics_fifo` field from MetricsConfig to `metrics_path`.
+- `PATCH /drives/{id}` only allowed post-boot. Use `PUT` for pre-boot
+  updates to existing configurations.
 
 ## [0.21.0]
 

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -62,11 +62,10 @@ paths:
 
   /boot-source:
     put:
-      summary: Creates or updates the boot source.
+      summary: Creates or updates the boot source. Pre-boot only.
       description:
         Creates new boot source if one does not already exist, otherwise updates it.
         Will fail if update is not possible.
-        Note that the only currently supported boot source is LocalImage.
       operationId: putGuestBootSource
       parameters:
       - name: body
@@ -89,7 +88,7 @@ paths:
 
   /drives/{drive_id}:
     put:
-      summary: Creates or updates a drive.
+      summary: Creates or updates a drive. Pre-boot only.
       description:
         Creates new drive with ID specified by drive_id path parameter.
         If a drive with the specified ID already exists, updates its state based on new input.
@@ -119,7 +118,7 @@ paths:
           schema:
             $ref: "#/definitions/Error"
     patch:
-      summary: Updates the properties of a drive.
+      summary: Updates the properties of a drive. Post-boot only.
       description:
         Updates the properties of the drive with the ID specified by drive_id path parameter.
         Will fail if update is not possible.
@@ -190,7 +189,7 @@ paths:
             $ref: "#/definitions/Error"
 
     put:
-      summary: Updates the Machine Configuration of the VM.
+      summary: Updates the Machine Configuration of the VM. Pre-boot only.
       description:
         Updates the Virtual Machine Configuration with the specified input.
         Firecracker starts with default values for vCPU count (=1) and memory size (=128 MiB).
@@ -217,7 +216,7 @@ paths:
             $ref: "#/definitions/Error"
 
     patch:
-      summary: Partially updates the Machine Configuration of the VM.
+      summary: Partially updates the Machine Configuration of the VM. Pre-boot only.
       description:
         Partially updates the Virtual Machine Configuration with the specified input.
         If any of the parameters has an incorrect value, the whole update fails.
@@ -320,7 +319,7 @@ paths:
 
   /network-interfaces/{iface_id}:
     put:
-      summary: Creates a network interface.
+      summary: Creates a network interface. Pre-boot only.
       description:
         Creates new network interface with ID specified by iface_id path parameter.
       operationId: putGuestNetworkInterfaceByID
@@ -348,7 +347,7 @@ paths:
           schema:
             $ref: "#/definitions/Error"
     patch:
-      summary: Updates the rate limiters applied to a network interface.
+      summary: Updates the rate limiters applied to a network interface. Post-boot only.
       description:
         Updates the rate limiters applied to a network interface.
       operationId: patchGuestNetworkInterfaceByID
@@ -378,7 +377,7 @@ paths:
 
   /vsock:
     put:
-      summary: Creates/updates a vsock device.
+      summary: Creates/updates a vsock device. Pre-boot only.
       description:
         The first call creates the device with the configuration specified
         in body. Subsequent calls will update the device configuration.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -225,36 +225,6 @@ impl VmResources {
         self.network_interface.insert(body)
     }
 
-    /// Updates configuration for an emulated net device as described in `new_cfg`.
-    pub fn update_net_rate_limiters(
-        &mut self,
-        new_cfg: NetworkInterfaceUpdateConfig,
-    ) -> Result<NetworkInterfaceError> {
-        let old_cfg = self
-            .network_interface
-            .iter_mut()
-            .find(|&&mut ref c| c.iface_id == new_cfg.iface_id)
-            .ok_or(NetworkInterfaceError::DeviceIdNotFound)?;
-
-        macro_rules! update_rate_limiter {
-            ($rate_limiter: ident) => {{
-                if let Some(new_rlim_cfg) = new_cfg.$rate_limiter {
-                    if let Some(ref mut old_rlim_cfg) = old_cfg.$rate_limiter {
-                        // We already have an RX rate limiter set, so we'll update it.
-                        old_rlim_cfg.update(&new_rlim_cfg);
-                    } else {
-                        // No old RX rate limiter; create one now.
-                        old_cfg.$rate_limiter = Some(new_rlim_cfg);
-                    }
-                }
-            }};
-        }
-
-        update_rate_limiter!(rx_rate_limiter);
-        update_rate_limiter!(tx_rate_limiter);
-        Ok(())
-    }
-
     /// Sets a vsock device to be attached when the VM starts.
     pub fn set_vsock_device(&mut self, config: VsockDeviceConfig) {
         self.vsock = Some(config);
@@ -274,12 +244,9 @@ mod tests {
     use vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
     use vmm_config::drive::{BlockDeviceConfig, BlockDeviceConfigs, DriveError};
     use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
-    use vmm_config::net::{
-        NetworkInterfaceConfig, NetworkInterfaceConfigs, NetworkInterfaceError,
-        NetworkInterfaceUpdateConfig,
-    };
+    use vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceConfigs, NetworkInterfaceError};
     use vmm_config::vsock::VsockDeviceConfig;
-    use vmm_config::{RateLimiterConfig, TokenBucketConfig};
+    use vmm_config::RateLimiterConfig;
     use vstate::VcpuConfig;
 
     fn default_net_cfgs() -> NetworkInterfaceConfigs {
@@ -766,53 +733,5 @@ mod tests {
 
         vm_resources.set_net_device(new_net_device_cfg).unwrap();
         assert_eq!(vm_resources.network_interface.len(), 2);
-    }
-
-    #[test]
-    fn test_update_net_rate_limiters() {
-        let bw_tb = TokenBucketConfig {
-            size: 15,
-            one_time_burst: Some(5),
-            refill_time: 5,
-        };
-
-        let ops_tb = TokenBucketConfig {
-            size: 10,
-            one_time_burst: Some(2),
-            refill_time: 2,
-        };
-
-        let expected_rl_cfg = RateLimiterConfig {
-            bandwidth: Some(bw_tb),
-            ops: Some(ops_tb),
-        };
-
-        let mut vm_resources = default_vm_resources();
-        let actual_net_cfg = vm_resources.network_interface.iter().next().unwrap();
-        let actual_rx_rl_cfg = actual_net_cfg.rx_rate_limiter.unwrap();
-        let actual_tx_rl_cfg = actual_net_cfg.tx_rate_limiter.unwrap();
-        assert_ne!(actual_rx_rl_cfg, expected_rl_cfg);
-        assert_ne!(actual_tx_rl_cfg, expected_rl_cfg);
-
-        let mut net_if_cfg_update = NetworkInterfaceUpdateConfig {
-            iface_id: actual_net_cfg.iface_id.clone(),
-            rx_rate_limiter: Some(expected_rl_cfg),
-            tx_rate_limiter: Some(expected_rl_cfg),
-        };
-        vm_resources
-            .update_net_rate_limiters(net_if_cfg_update.clone())
-            .unwrap();
-        let actual_net_cfg = vm_resources.network_interface.iter().next().unwrap();
-        let actual_rx_rl_cfg = actual_net_cfg.rx_rate_limiter.unwrap();
-        let actual_tx_rl_cfg = actual_net_cfg.tx_rate_limiter.unwrap();
-        assert_eq!(actual_rx_rl_cfg, expected_rl_cfg);
-        assert_eq!(actual_tx_rl_cfg, expected_rl_cfg);
-
-        // DeviceIdNotFound.
-        net_if_cfg_update.iface_id = "net_if_does_not_exist".to_string();
-        match vm_resources.update_net_rate_limiters(net_if_cfg_update) {
-            Err(NetworkInterfaceError::DeviceIdNotFound { .. }) => (),
-            _ => unreachable!(),
-        }
     }
 }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -244,11 +244,6 @@ impl<'a> PrebootApiController<'a> {
                 .set_vm_config(&machine_config_body)
                 .map(|_| VmmData::Empty)
                 .map_err(VmmActionError::MachineConfig),
-            UpdateBlockDevicePath(drive_id, path_on_host) => self
-                .vm_resources
-                .update_block_device_path(drive_id, path_on_host)
-                .map(|_| VmmData::Empty)
-                .map_err(VmmActionError::DriveConfig),
             UpdateNetworkInterface(netif_update) => self
                 .vm_resources
                 .update_net_rate_limiters(netif_update)
@@ -266,7 +261,9 @@ impl<'a> PrebootApiController<'a> {
             .map_err(VmmActionError::StartMicrovm),
 
             // Operations not allowed pre-boot.
-            FlushMetrics => Err(VmmActionError::OperationNotSupportedPreBoot),
+            UpdateBlockDevicePath(_, _) | FlushMetrics => {
+                Err(VmmActionError::OperationNotSupportedPreBoot)
+            }
             #[cfg(target_arch = "x86_64")]
             SendCtrlAltDel => Err(VmmActionError::OperationNotSupportedPreBoot),
         }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -244,11 +244,6 @@ impl<'a> PrebootApiController<'a> {
                 .set_vm_config(&machine_config_body)
                 .map(|_| VmmData::Empty)
                 .map_err(VmmActionError::MachineConfig),
-            UpdateNetworkInterface(netif_update) => self
-                .vm_resources
-                .update_net_rate_limiters(netif_update)
-                .map(|_| VmmData::Empty)
-                .map_err(VmmActionError::NetworkConfig),
             StartMicroVm => super::builder::build_microvm(
                 &self.vm_resources,
                 &mut self.event_manager,
@@ -261,7 +256,7 @@ impl<'a> PrebootApiController<'a> {
             .map_err(VmmActionError::StartMicrovm),
 
             // Operations not allowed pre-boot.
-            UpdateBlockDevicePath(_, _) | FlushMetrics => {
+            UpdateBlockDevicePath(_, _) | UpdateNetworkInterface(_) | FlushMetrics => {
                 Err(VmmActionError::OperationNotSupportedPreBoot)
             }
             #[cfg(target_arch = "x86_64")]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.60
+COVERAGE_TARGET_PCT = 82.53
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -447,8 +447,9 @@ def test_api_patch_pre_boot(test_microvm_with_api):
     fs1 = drive_tools.FilesystemFile(
         os.path.join(test_microvm.fsfiles, 'scratch')
     )
+    drive_id = 'scratch'
     response = test_microvm.drive.put(
-        drive_id='scratch',
+        drive_id=drive_id,
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False
@@ -491,6 +492,23 @@ def test_api_patch_pre_boot(test_microvm_with_api):
     response = test_microvm.logger.patch(level='Error')
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert "Invalid request method" in response.text
+
+    # Patching drive before boot is not allowed.
+    response = test_microvm.drive.patch(
+        drive_id=drive_id,
+        path_on_host='foo.bar'
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "The requested operation is not supported before starting the " \
+           "microVM." in response.text
+
+    # Patching net before boot is not allowed.
+    response = test_microvm.network.patch(
+        iface_id=iface_id
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "The requested operation is not supported before starting the " \
+           "microVM." in response.text
 
 
 def test_api_patch_post_boot(test_microvm_with_api):

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -575,7 +575,14 @@ def test_drive_patch(test_microvm_with_api):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    _drive_patch(test_microvm)
+    # Patching drive before boot is not allowed.
+    response = test_microvm.drive.patch(
+        drive_id='scratch',
+        path_on_host='foo.bar'
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "The requested operation is not supported before starting the " \
+        "microVM." in response.text
 
     test_microvm.start()
 


### PR DESCRIPTION
## Reason for This PR

Reduces code complexity.
Adds missing information to our API specification.
Fixes #1710 

## Description of Changes

The dedicated Block device PATCH/update that only updates the underlying backing file doesn't make sense pre-boot.

Before boot, users can simply PUT/create on `/drives/{id}` using an existing `id` to update any part of its configuration.

This PR removes pre-boot support for `UpdateBlockDevicePath` to reduce code complexity. It also removes `UpdateNetworkInterface` based on the same reasoning.

Since some API operations are only allowed pre-boot and some only post-boot, this PR adds description for API operations restrictions to our swagger API spec.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
