### PR TITLE
seccomp: Allow to copy and clone SeccompLevel

### DIFF
--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -1159,7 +1159,7 @@ impl Display for SeccompError {
 
 /// Possible values for seccomp level.
 #[repr(u8)]
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SeccompLevel {
     /// Seccomp filtering disabled.
     None = 0,


### PR DESCRIPTION
Since the enum SeccompLevel values are simple integers, it's safe and
convenient to be able to copy and clone its values. That's the reason
why this patch derives both Clone and Copy trait for the enum type
SeccompLevel.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>