### PR TITLE
arg_parse.rs: Add two static method - value_argument and flag_argument to Argument struct

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -84,20 +84,17 @@ fn main() {
 
     let mut arg_parser = ArgParser::new()
         .arg(
-            Argument::new("api-sock")
-                .takes_value(true)
+            Argument::value_argument("api-sock")
                 .default_value(DEFAULT_API_SOCK_PATH)
                 .help("Path to unix domain socket used by the API."),
         )
         .arg(
-            Argument::new("id")
-                .takes_value(true)
+            Argument::value_argument("id")
                 .default_value(DEFAULT_INSTANCE_ID)
                 .help("MicroVM unique identifier."),
         )
         .arg(
-            Argument::new("seccomp-level")
-                .takes_value(true)
+            Argument::value_argument("seccomp-level")
                 .default_value("2")
                 .help(
                     "Level of seccomp filtering that will be passed to executed path as \
@@ -109,45 +106,37 @@ fn main() {
                 ),
         )
         .arg(
-            Argument::new("start-time-us")
-                .takes_value(true),
+            Argument::value_argument("start-time-us")
         )
         .arg(
-            Argument::new("start-time-cpu-us")
-                .takes_value(true),
+            Argument::value_argument("start-time-cpu-us")
         )
         .arg(
-            Argument::new("config-file")
-                .takes_value(true)
+            Argument::value_argument("config-file")
                 .help("Path to a file that contains the microVM configuration in JSON format."),
         )
         .arg(
-            Argument::new("no-api")
-                .takes_value(false)
+            Argument::flag_argument("no-api")
                 .requires("config-file")
                 .help("Optional parameter which allows starting and using a microVM without an active API socket.")
         )
         .arg(
-            Argument::new("log-path")
-                .takes_value(true)
+            Argument::value_argument("log-path")
                 .help("Path to a fifo or a file used for configuring the logger on startup.")
         )
         .arg(
-            Argument::new("level")
-                .takes_value(true)
+            Argument::value_argument("level")
                 .requires("log-path")
                 .default_value("Warning")
                 .help("Set the logger level.")
         )
         .arg(
-            Argument::new("show-level")
-                .takes_value(false)
+            Argument::flag_argument("show-level")
                 .requires("log-path")
                 .help("Whether or not to output the level in the logs.")
         )
         .arg(
-            Argument::new("show-log-origin")
-                .takes_value(false)
+            Argument::flag_argument("show-log-origin")
                 .requires("log-path")
                 .help("Whether or not to include the file path and line number of the log's origin.")
         );

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -219,53 +219,45 @@ pub type Result<T> = result::Result<T, Error>;
 pub fn build_arg_parser() -> ArgParser<'static> {
     ArgParser::new()
         .arg(
-            Argument::new("id")
+            Argument::value_argument("id")
                 .required(true)
-                .takes_value(true)
                 .help("Jail ID."),
         )
         .arg(
-            Argument::new("exec-file")
+            Argument::value_argument("exec-file")
                 .required(true)
-                .takes_value(true)
                 .help("File path to exec into."),
         )
         .arg(
-            Argument::new("node")
+            Argument::value_argument("node")
                 .required(true)
-                .takes_value(true)
                 .help("NUMA node to assign this microVM to."),
         )
         .arg(
-            Argument::new("uid")
+            Argument::value_argument("uid")
                 .required(true)
-                .takes_value(true)
                 .help("The user identifier the jailer switches to after exec."),
         )
         .arg(
-            Argument::new("gid")
+            Argument::value_argument("gid")
                 .required(true)
-                .takes_value(true)
                 .help("The group identifier the jailer switches to after exec."),
         )
         .arg(
-            Argument::new("chroot-base-dir")
-                .takes_value(true)
+            Argument::value_argument("chroot-base-dir")
                 .default_value("/srv/jailer")
                 .help("The base folder where chroot jails are located."),
         )
         .arg(
-            Argument::new("netns")
-                .takes_value(true)
+            Argument::value_argument("netns")
                 .help("Path to the network namespace this microVM should join."),
         )
-        .arg(Argument::new("daemonize").takes_value(false).help(
+        .arg(Argument::flag_argument("daemonize").help(
             "Daemonize the jailer before exec, by invoking setsid(), and redirecting \
              the standard I/O file descriptors to /dev/null.",
         ))
         .arg(
-            Argument::new("extra-args")
-                .takes_value(true)
+            Argument::value_argument("extra-args")
                 .help("Arguments that will be passed verbatim to the exec file."),
         )
 }


### PR DESCRIPTION
Signed-off-by: Anish Shah <shah.anish07@gmail.com>

## Reason for This PR

Fixes #1685

## Description of Changes

Introduced two static method to Argument struct - 
1. `value_argument` - returns an argument that can take user value 
2.  `flag_argument` -  returns a flag.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
