### PR TITLE
cargo/config: disallow build warnings

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -637,14 +637,13 @@ fn attach_mmio_device(
         .lock()
         .expect("Poisoned device lock")
         .device_type();
-    let cmdline = &mut vmm.kernel_cmdline;
 
     let (_mmio_base, _irq) =
         vmm.mmio_device_manager
             .register_mmio_device(vmm.vm.fd(), device, type_id, id)?;
     #[cfg(target_arch = "x86_64")]
     vmm.mmio_device_manager
-        .add_device_to_cmdline(cmdline, _mmio_base, _irq)?;
+        .add_device_to_cmdline(&mut vmm.kernel_cmdline, _mmio_base, _irq)?;
 
     Ok(())
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -298,7 +298,7 @@ mod tests {
             vm: &VmFd,
             guest_mem: GuestMemoryMmap,
             device: Arc<Mutex<dyn devices::virtio::VirtioDevice>>,
-            cmdline: &mut kernel_cmdline::Cmdline,
+            _cmdline: &mut kernel_cmdline::Cmdline,
             type_id: u32,
             device_id: &str,
         ) -> Result<u64> {
@@ -306,7 +306,7 @@ mod tests {
             let (mmio_base, _irq) =
                 self.register_mmio_device(vm, mmio_device, type_id, device_id.to_string())?;
             #[cfg(target_arch = "x86_64")]
-            self.add_device_to_cmdline(cmdline, mmio_base, _irq)?;
+            self.add_device_to_cmdline(_cmdline, mmio_base, _irq)?;
             Ok(mmio_base)
         }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -63,6 +63,7 @@ use arch::InitrdConfig;
 #[cfg(target_arch = "x86_64")]
 use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
+#[cfg(target_arch = "x86_64")]
 use devices::virtio::{
     vsock::persist::VsockState, Block, MmioTransport, Net, Vsock, VsockUnixBackend, TYPE_BLOCK,
     TYPE_NET, TYPE_VSOCK,

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -38,7 +38,9 @@ use seccomp::{BpfProgram, SeccompFilter};
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
+#[cfg(target_arch = "x86_64")]
 use versionize::{VersionMap, Versionize, VersionizeResult};
+#[cfg(target_arch = "x86_64")]
 use versionize_derive::Versionize;
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,


### PR DESCRIPTION
## Reason for This PR

Treat build errors as warnings.

## Description of Changes

Changed cargo/config.
**Obs** Tests are expected to fail until #1693 gets merged.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
