### PR TITLE
Fix field sizes vec for union (de)serialization

### DIFF
--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -795,6 +795,7 @@ mod tests {
         union kvm_irq_level__bindgen_ty_1 {
             pub irq: ::std::os::raw::c_uint,
             pub status: ::std::os::raw::c_int,
+            pub other_status: ::std::os::raw::c_longlong,
 
             #[version(start = 1, end = 1)]
             _bindgen_union_align: u32,
@@ -828,8 +829,10 @@ mod tests {
             .unwrap();
         unsafe {
             assert_eq!(restored_state.irq, 0x8765_4321);
+            assert_eq!(restored_state.other_status, 0x1234_5678_8765_4321);
         }
     }
+
     #[test]
     fn test_kvm_bindings_struct() {
         #[repr(C)]

--- a/src/versionize_derive/src/descriptors/union_desc.rs
+++ b/src/versionize_derive/src/descriptors/union_desc.rs
@@ -123,7 +123,7 @@ impl UnionDescriptor {
 
             // Generate the vec initializer content.
             sizes.extend(quote! {
-                std::mem::size_of::<#field_type> as usize,
+                std::mem::size_of::<#field_type>() as usize,
             });
 
             // Generate match arms for select fields by index.
@@ -152,7 +152,7 @@ impl UnionDescriptor {
             let field_deserializer = field.generate_deserializer(source_version);
 
             sizes.extend(quote! {
-                std::mem::size_of::<#field_type> as usize,
+                std::mem::size_of::<#field_type>() as usize,
             });
 
             matcher.extend(quote! {


### PR DESCRIPTION
## Reason for This PR

Fixes #1730

## Description of Changes

Replaced `std::mem::size_of::<#field_type>` with  `std::mem::size_of::<#field_type>()` in order to return the correct size of union fields.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
