### PR TITLE
Create Net devices during configuration instead of boot-time

### DIFF
--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -53,16 +53,13 @@ pub struct MmioTransport {
 
 impl MmioTransport {
     /// Constructs a new MMIO transport for the given virtio device.
-    pub fn new(
-        mem: GuestMemoryMmap,
-        device: Arc<Mutex<dyn VirtioDevice>>,
-    ) -> std::io::Result<MmioTransport> {
+    pub fn new(mem: GuestMemoryMmap, device: Arc<Mutex<dyn VirtioDevice>>) -> MmioTransport {
         let interrupt_status = device
             .lock()
             .expect("Poisoned device lock")
             .interrupt_status();
 
-        Ok(MmioTransport {
+        MmioTransport {
             device,
             features_select: 0,
             acked_features_select: 0,
@@ -71,7 +68,7 @@ impl MmioTransport {
             config_generation: 0,
             mem,
             interrupt_status,
-        })
+        }
     }
 
     pub fn locked_device(&self) -> MutexGuard<dyn VirtioDevice + 'static> {
@@ -441,7 +438,7 @@ mod tests {
         let mut dummy = DummyDevice::new();
         // Validate reset is no-op.
         assert!(dummy.reset().is_none());
-        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(dummy))).unwrap();
+        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(dummy)));
 
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
@@ -470,7 +467,7 @@ mod tests {
     #[test]
     fn test_bus_device_read() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new()))).unwrap();
+        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
 
         let mut buf = vec![0xff, 0, 0xfe, 0];
         let buf_copy = buf.to_vec();
@@ -549,7 +546,7 @@ mod tests {
     fn test_bus_device_write() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let dummy_dev = Arc::new(Mutex::new(DummyDevice::new()));
-        let mut d = MmioTransport::new(m, dummy_dev.clone()).unwrap();
+        let mut d = MmioTransport::new(m, dummy_dev.clone());
         let mut buf = vec![0; 5];
         write_le_u32(&mut buf[..4], 1);
 
@@ -706,7 +703,7 @@ mod tests {
     #[test]
     fn test_bus_device_activate() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new()))).unwrap();
+        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
 
         assert!(!d.are_queues_valid());
         assert!(!d.locked_device().is_activated());
@@ -824,7 +821,7 @@ mod tests {
     #[test]
     fn test_bus_device_reset() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new()))).unwrap();
+        let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
         let mut buf = vec![0; 4];
 
         assert!(!d.are_queues_valid());

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -57,6 +57,8 @@ fn init_vnet_hdr(buf: &mut [u8]) {
 }
 
 pub struct Net {
+    id: String,
+
     pub(crate) tap: Tap,
     avail_features: u64,
     acked_features: u64,
@@ -94,6 +96,7 @@ pub struct Net {
 impl Net {
     /// Create a new virtio network device with the given TAP interface.
     pub fn new_with_tap(
+        id: String,
         tap: Tap,
         guest_mac: Option<&MacAddr>,
         rx_rate_limiter: RateLimiter,
@@ -145,6 +148,7 @@ impl Net {
         };
 
         Ok(Net {
+            id,
             tap,
             avail_features,
             acked_features: 0u64,
@@ -169,6 +173,16 @@ impl Net {
             #[cfg(test)]
             test_mutators: tests::TestMutators::default(),
         })
+    }
+
+    /// Provides the ID of this net device.
+    pub fn id(&self) -> &String {
+        &self.id
+    }
+
+    /// Provides the MAC of this net device.
+    pub fn guest_mac(&self) -> Option<&MacAddr> {
+        self.guest_mac.as_ref()
     }
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
@@ -784,6 +798,7 @@ pub(crate) mod tests {
             let guest_mac = Net::default_guest_mac();
 
             let mut net = Net::new_with_tap(
+                format!("net-device{}", next_tap),
                 tap,
                 Some(&guest_mac),
                 RateLimiter::default(),

--- a/src/utils/src/net/tap.rs
+++ b/src/utils/src/net/tap.rs
@@ -367,6 +367,13 @@ mod tests {
     }
 
     #[test]
+    fn test_tap_exclusive_open() {
+        let _tap1 = Tap::open_named("exclusivetap").unwrap();
+        // Opening same tap device a second time should not be permitted.
+        Tap::open_named("exclusivetap").unwrap_err();
+    }
+
+    #[test]
     fn test_tap_partial_eq() {
         assert_ne!(Tap::new().unwrap(), Tap::new().unwrap());
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -739,8 +739,6 @@ fn attach_net_devices(
     use self::StartMicrovmError::*;
 
     for cfg in network_ifaces.iter() {
-        let allow_mmds_requests = cfg.allow_mmds_requests();
-
         let rx_rate_limiter = cfg
             .rx_rate_limiter
             .map(vmm_config::RateLimiterConfig::try_into)
@@ -757,10 +755,10 @@ fn attach_net_devices(
         let net_device = Arc::new(Mutex::new(
             devices::virtio::net::Net::new_with_tap(
                 tap,
-                cfg.guest_mac(),
+                cfg.guest_mac.as_ref(),
                 rx_rate_limiter.unwrap_or_default(),
                 tx_rate_limiter.unwrap_or_default(),
-                allow_mmds_requests,
+                cfg.allow_mmds_requests,
             )
             .map_err(CreateNetDevice)?,
         ));

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -753,6 +753,7 @@ fn attach_net_devices(
         let tap = cfg.open_tap().map_err(|_| NetDeviceNotConfigured)?;
         let net_device = Arc::new(Mutex::new(
             devices::virtio::net::Net::new_with_tap(
+                cfg.iface_id.clone(),
                 tap,
                 cfg.guest_mac.as_ref(),
                 rx_rate_limiter.unwrap_or_default(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -722,8 +722,7 @@ fn attach_block_devices(
         attach_mmio_device(
             vmm,
             drive_config.drive_id.clone(),
-            MmioTransport::new(vmm.guest_memory().clone(), block_device.clone())
-                .map_err(CreateBlockDevice)?,
+            MmioTransport::new(vmm.guest_memory().clone(), block_device.clone()),
         )
         .map_err(RegisterBlockDevice)?;
     }
@@ -769,9 +768,7 @@ fn attach_net_devices(
         attach_mmio_device(
             vmm,
             cfg.iface_id.clone(),
-            MmioTransport::new(vmm.guest_memory().clone(), net_device).map_err(|e| {
-                RegisterNetDevice(super::device_manager::mmio::Error::CreateMmioDevice(e))
-            })?,
+            MmioTransport::new(vmm.guest_memory().clone(), net_device),
         )
         .map_err(RegisterNetDevice)?;
     }
@@ -803,9 +800,7 @@ fn attach_vsock_device(
     attach_mmio_device(
         vmm,
         vsock.vsock_id.clone(),
-        MmioTransport::new(vmm.guest_memory().clone(), vsock_device)
-            .map_err(device_manager::mmio::Error::CreateMmioDevice)
-            .map_err(RegisterVsockDevice)?,
+        MmioTransport::new(vmm.guest_memory().clone(), vsock_device),
     )
     .map_err(RegisterVsockDevice)?;
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -25,8 +25,6 @@ use utils::eventfd::EventFd;
 pub enum Error {
     /// Failed to perform an operation on the bus.
     BusError(devices::BusError),
-    /// Could not create the mmio device to wrap a VirtioDevice.
-    CreateMmioDevice(io::Error),
     /// Appending to kernel command line failed.
     Cmdline(kernel_cmdline::Error),
     /// Failure in creating or cloning an event fd.
@@ -47,7 +45,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::BusError(ref e) => write!(f, "failed to perform bus operation: {}", e),
-            Error::CreateMmioDevice(ref e) => write!(f, "failed to create mmio device: {}", e),
             Error::Cmdline(ref e) => {
                 write!(f, "unable to add device to kernel command line: {}", e)
             }
@@ -300,9 +297,7 @@ mod tests {
             type_id: u32,
             device_id: &str,
         ) -> Result<u64> {
-            let mmio_device = devices::virtio::MmioTransport::new(guest_mem, device)
-                .map_err(Error::CreateMmioDevice)?;
-
+            let mmio_device = devices::virtio::MmioTransport::new(guest_mem, device);
             self.register_mmio_device(vm, mmio_device, cmdline, type_id, device_id)
         }
 
@@ -507,16 +502,6 @@ mod tests {
             format!(
                 "failed to perform bus operation: {}",
                 devices::BusError::Overlap
-            )
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                Error::CreateMmioDevice(io::Error::from_raw_os_error(0))
-            ),
-            format!(
-                "failed to create mmio device: {}",
-                io::Error::from_raw_os_error(0)
             )
         );
         assert_eq!(

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -67,7 +67,7 @@ pub struct VmResources {
     /// The configurations for block devices.
     pub block: BlockDeviceConfigs,
     /// The configurations for network interface devices.
-    pub network_interface: NetworkInterfaceConfigs,
+    pub network_interface: NetBuilder,
     /// The configurations for vsock devices.
     pub vsock: Option<VsockDeviceConfig>,
 }
@@ -244,29 +244,31 @@ mod tests {
     use vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
     use vmm_config::drive::{BlockDeviceConfig, BlockDeviceConfigs, DriveError};
     use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
-    use vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceConfigs, NetworkInterfaceError};
+    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
     use vmm_config::vsock::VsockDeviceConfig;
     use vmm_config::RateLimiterConfig;
     use vstate::VcpuConfig;
 
-    fn default_net_cfgs() -> NetworkInterfaceConfigs {
-        let mut net_if_cfgs = NetworkInterfaceConfigs::new();
-        net_if_cfgs
-            .insert(NetworkInterfaceConfig {
-                iface_id: "net_if1".to_string(),
-                // TempFile::new_with_prefix("") generates a random file name used as random net_if name.
-                host_dev_name: TempFile::new_with_prefix("")
-                    .unwrap()
-                    .as_path()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-                guest_mac: Some(MacAddr::parse_str("01:23:45:67:89:0a").unwrap()),
-                rx_rate_limiter: Some(RateLimiterConfig::default()),
-                tx_rate_limiter: Some(RateLimiterConfig::default()),
-                allow_mmds_requests: false,
-            })
-            .unwrap();
+    fn default_net_cfg() -> NetworkInterfaceConfig {
+        NetworkInterfaceConfig {
+            iface_id: "net_if1".to_string(),
+            // TempFile::new_with_prefix("") generates a random file name used as random net_if name.
+            host_dev_name: TempFile::new_with_prefix("")
+                .unwrap()
+                .as_path()
+                .to_str()
+                .unwrap()
+                .to_string(),
+            guest_mac: Some(MacAddr::parse_str("01:23:45:67:89:0a").unwrap()),
+            rx_rate_limiter: Some(RateLimiterConfig::default()),
+            tx_rate_limiter: Some(RateLimiterConfig::default()),
+            allow_mmds_requests: false,
+        }
+    }
+
+    fn default_net_devs() -> NetBuilder {
+        let mut net_if_cfgs = NetBuilder::new();
+        net_if_cfgs.insert(default_net_cfg()).unwrap();
 
         net_if_cfgs
     }
@@ -303,7 +305,7 @@ mod tests {
             vm_config: VmConfig::default(),
             boot_config: Some(default_boot_cfg()),
             block: default_block_cfgs(),
-            network_interface: default_net_cfgs(),
+            network_interface: default_net_devs(),
             vsock: None,
         }
     }
@@ -538,7 +540,7 @@ mod tests {
         );
 
         match VmResources::from_json(json.as_str(), "some_version") {
-            Err(Error::NetDevice(NetworkInterfaceError::HostDeviceNameInUse { .. })) => (),
+            Err(Error::NetDevice(NetworkInterfaceError::OpenTap { .. })) => (),
             _ => unreachable!(),
         }
 
@@ -720,12 +722,7 @@ mod tests {
         let mut vm_resources = default_vm_resources();
 
         // Clone the existing net config in order to obtain a new one.
-        let mut new_net_device_cfg = vm_resources
-            .network_interface
-            .iter()
-            .next()
-            .unwrap()
-            .clone();
+        let mut new_net_device_cfg = default_net_cfg();
         new_net_device_cfg.iface_id = "new_net_if".to_string();
         new_net_device_cfg.guest_mac = Some(MacAddr::parse_str("01:23:45:67:89:0c").unwrap());
         new_net_device_cfg.host_dev_name = "dummy_path2".to_string();

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -5,7 +5,6 @@ use std::fmt::{Display, Formatter, Result};
 use std::result;
 
 use super::RateLimiterConfig;
-use devices;
 use dumbo::MacAddr;
 use utils::net::{Tap, TapError};
 
@@ -181,7 +180,6 @@ impl NetworkInterfaceConfigs {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
     use std::str;
 
     use super::*;

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -178,8 +178,8 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
         guest_mac='06:00:00:00:00:01'
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert "The host device name {} is already in use.".\
-        format(second_if_name) in response.text
+    assert "Cannot open TAP device. Invalid name/permissions. CreateTap" \
+        in response.text
 
     # Updates to a network interface with an available name are allowed.
     iface_id = '1'


### PR DESCRIPTION
## Reason for This PR

Fixes #1708 

Prerequisite for #1713 

## Description of Changes

### Simplify code in NetworkInterfaceConfig

Refactored the `insert()` function to remove duplicated code between the create and update cases. Also removed a couple of redundant getters.

### Create Net devices during config instead of boot

Following the more decoupled design we can now create net devices on their configuration path, rather than saving a config and delaying creation to boot-time.

Such a model allows user-errors (like invalid resources or permissions) to be reported as part of the configuration step rather than later at attempted boot.

It would also remove the time window between configuration and boot where changes to the host system (creating Taps, changing permissions, etc) would cause microVM boot failures (race condition between validation and commitment of resources).

Such a model should also decrease code complexity and should provide better efficiency to the process of configuring and starting a microVM (no more moving configurations around in memory and validating resources both at config time and boot-time).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
