### PR TITLE
Create Block devices during configuration instead of boot-time

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3,9 +3,7 @@
 
 //! Enables pre-boot setup, instantiation and booting of a Firecracker VMM.
 
-use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
-use std::fs::OpenOptions;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
@@ -25,18 +23,16 @@ use utils::terminal::Terminal;
 use utils::time::TimestampUs;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 use vmm_config::boot_source::BootConfig;
-use vmm_config::drive::BlockDeviceConfigs;
+use vmm_config::drive::BlockBuilder;
 use vmm_config::net::NetBuilder;
-use vmm_config::RateLimiterConfig;
 use vstate::{KvmContext, Vcpu, VcpuConfig, Vm};
 use {device_manager, VmmEventsObserver};
 
 /// Errors associated with starting the instance.
 #[derive(Debug)]
 pub enum StartMicrovmError {
-    /// Unable to seek the block device backing file due to invalid permissions or
-    /// the file was deleted/corrupted.
-    CreateBlockDevice(io::Error),
+    /// Unable to attach block device to Vmm.
+    AttachBlockDevice(io::Error),
     /// Internal errors are due to resource exhaustion.
     CreateNetDevice(devices::virtio::net::Error),
     /// Failed to create a `RateLimiter` object.
@@ -87,12 +83,9 @@ impl Display for StartMicrovmError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::StartMicrovmError::*;
         match *self {
-            CreateBlockDevice(ref err) => write!(
-                f,
-                "Unable to seek the block device backing file due to invalid permissions or \
-                 the file was deleted/corrupted. Error number: {}",
-                err
-            ),
+            AttachBlockDevice(ref err) => {
+                write!(f, "Unable to attach block device to Vmm. Error: {}", err)
+            }
             CreateRateLimiter(ref err) => write!(f, "Cannot create RateLimiter: {}", err),
             CreateNetDevice(ref err) => {
                 let mut err_msg = format!("{:?}", err);
@@ -646,77 +639,47 @@ fn attach_mmio_device(
         .device_type();
     let cmdline = &mut vmm.kernel_cmdline;
 
-    vmm.mmio_device_manager.register_mmio_device(
-        vmm.vm.fd(),
-        device,
-        cmdline,
-        type_id,
-        id.as_str(),
-    )?;
+    vmm.mmio_device_manager
+        .register_mmio_device(vmm.vm.fd(), device, cmdline, type_id, id)?;
 
     Ok(())
 }
 
 fn attach_block_devices(
     vmm: &mut Vmm,
-    blocks: &BlockDeviceConfigs,
+    blocks: &BlockBuilder,
     event_manager: &mut EventManager,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
-    for drive_config in blocks.config_list.iter() {
-        // Add the block device from file.
-        let block_file = OpenOptions::new()
-            .read(true)
-            .write(!drive_config.is_read_only)
-            .open(&drive_config.path_on_host)
-            .map_err(OpenBlockDevice)?;
+    for block in blocks.list.iter() {
+        let id;
+        {
+            let locked = block.lock().unwrap();
+            if locked.is_root_device() {
+                let kernel_cmdline = &mut vmm.kernel_cmdline;
+                kernel_cmdline.insert_str(if let Some(partuuid) = locked.partuuid() {
+                    format!("root=PARTUUID={}", partuuid)
+                } else {
+                    // If no PARTUUID was specified for the root device, try with the /dev/vda.
+                    "root=/dev/vda".to_string()
+                })?;
 
-        if drive_config.is_root_device {
-            let kernel_cmdline = &mut vmm.kernel_cmdline;
-
-            kernel_cmdline.insert_str(if let Some(partuuid) = &drive_config.partuuid {
-                format!("root=PARTUUID={}", partuuid)
-            } else {
-                // If no PARTUUID was specified for the root device, try with the /dev/vda.
-                "root=/dev/vda".to_string()
-            })?;
-
-            let flags = if drive_config.is_read_only {
-                "ro"
-            } else {
-                "rw"
-            };
-
-            kernel_cmdline.insert_str(flags)?;
+                let flags = if locked.is_read_only() { "ro" } else { "rw" };
+                kernel_cmdline.insert_str(flags)?;
+            }
+            id = locked.id().clone();
         }
 
-        let rate_limiter = drive_config
-            .rate_limiter
-            .map(RateLimiterConfig::try_into)
-            .transpose()
-            .map_err(CreateRateLimiter)?;
-
-        let block_device = Arc::new(Mutex::new(
-            devices::virtio::Block::new(
-                drive_config.drive_id.clone(),
-                block_file,
-                drive_config.partuuid.clone(),
-                drive_config.is_read_only,
-                drive_config.is_root_device,
-                rate_limiter.unwrap_or_default(),
-            )
-            .map_err(CreateBlockDevice)?,
-        ));
-
         event_manager
-            .add_subscriber(block_device.clone())
-            .map_err(StartMicrovmError::RegisterEvent)?;
+            .add_subscriber(block.clone())
+            .map_err(RegisterEvent)?;
 
+        // The device mutex mustn't be locked here otherwise it will deadlock.
         attach_mmio_device(
             vmm,
-            drive_config.drive_id.clone(),
-            MmioTransport::new(vmm.guest_memory().clone(), block_device.clone()),
+            id,
+            MmioTransport::new(vmm.guest_memory().clone(), block.clone()),
         )
         .map_err(RegisterBlockDevice)?;
     }
@@ -888,7 +851,7 @@ pub mod tests {
         #[cfg(target_arch = "aarch64")]
         setup_interrupt_controller(&mut vmm.vm, 1).unwrap();
 
-        let mut block_dev_configs = BlockDeviceConfigs::new();
+        let mut block_dev_configs = BlockBuilder::new();
         let mut block_files = Vec::new();
         for custom_block_cfg in &custom_block_cfgs {
             block_files.push(TempFile::new().unwrap());
@@ -1232,12 +1195,11 @@ pub mod tests {
     #[test]
     fn test_error_messages() {
         use builder::StartMicrovmError::*;
-        let err = CreateBlockDevice(io::Error::from_raw_os_error(0));
+        let err = AttachBlockDevice(io::Error::from_raw_os_error(0));
         assert_eq!(
             format!("{}", err),
             format!(
-                "Unable to seek the block device backing file due to invalid permissions or \
-                 the file was deleted/corrupted. Error number: {}",
+                "Unable to attach block device to Vmm. Error: {}",
                 io::Error::from_raw_os_error(0)
             )
         );

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -699,8 +699,11 @@ fn attach_block_devices(
 
         let block_device = Arc::new(Mutex::new(
             devices::virtio::Block::new(
+                drive_config.drive_id.clone(),
                 block_file,
+                drive_config.partuuid.clone(),
                 drive_config.is_read_only,
+                drive_config.is_root_device,
                 rate_limiter.unwrap_or_default(),
             )
             .map_err(CreateBlockDevice)?,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1196,156 +1196,67 @@ pub mod tests {
     fn test_error_messages() {
         use builder::StartMicrovmError::*;
         let err = AttachBlockDevice(io::Error::from_raw_os_error(0));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Unable to attach block device to Vmm. Error: {}",
-                io::Error::from_raw_os_error(0)
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = CreateNetDevice(devices::virtio::net::Error::EventFd(
             io::Error::from_raw_os_error(0),
         ));
-        let mut inner_err_msg = format!(
-            "{:?}",
-            devices::virtio::net::Error::EventFd(io::Error::from_raw_os_error(0))
-        );
-        inner_err_msg = inner_err_msg.replace("\"", "");
-        assert_eq!(
-            format!("{}", err),
-            format!("Cannot create network device. {}", inner_err_msg)
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = CreateRateLimiter(io::Error::from_raw_os_error(0));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot create RateLimiter: {}",
-                io::Error::from_raw_os_error(0)
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = Internal(Error::Serial(io::Error::from_raw_os_error(0)));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Internal error while starting microVM: {:?}",
-                Error::Serial(io::Error::from_raw_os_error(0))
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = KernelCmdline(String::from("dummy --cmdline"));
-        assert_eq!(
-            format!("{}", err),
-            "Invalid kernel command line: dummy --cmdline"
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = KernelLoader(kernel::loader::Error::InvalidElfMagicNumber);
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot load kernel due to invalid memory configuration or invalid kernel \
-                 image. {}",
-                kernel::loader::Error::InvalidElfMagicNumber
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = LoadCommandline(kernel::cmdline::Error::TooLarge);
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot load command line string. {}",
-                kernel::cmdline::Error::TooLarge
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = MicroVMAlreadyRunning;
-        assert_eq!(format!("{}", err), "Microvm already running.");
+        let _ = format!("{}{:?}", err, err);
 
         let err = MissingKernelConfig;
-        assert_eq!(
-            format!("{}", err),
-            "Cannot start microvm without kernel configuration."
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = MissingMemSizeConfig;
-        assert_eq!(
-            format!("{}", err),
-            "Cannot start microvm without guest mem_size config."
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = NetDeviceNotConfigured;
-        assert_eq!(
-            format!("{}", err),
-            "The net device configuration is missing the tap device."
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = OpenBlockDevice(io::Error::from_raw_os_error(0));
-        let mut inner_err_msg = format!("{:?}", io::Error::from_raw_os_error(0));
-        inner_err_msg = inner_err_msg.replace("\"", "");
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot open the block device backing file. {}",
-                inner_err_msg
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = RegisterBlockDevice(device_manager::mmio::Error::EventFd(
             io::Error::from_raw_os_error(0),
         ));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot initialize a MMIO Block Device or add a device to the MMIO Bus. {}",
-                device_manager::mmio::Error::EventFd(io::Error::from_raw_os_error(0))
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = RegisterEvent(EventManagerError::EpollCreate(
             io::Error::from_raw_os_error(0),
         ));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot register EventHandler. {:?}",
-                EventManagerError::EpollCreate(io::Error::from_raw_os_error(0))
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = RegisterNetDevice(device_manager::mmio::Error::EventFd(
             io::Error::from_raw_os_error(0),
         ));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot initialize a MMIO Network Device or add a device to the MMIO Bus. {}",
-                device_manager::mmio::Error::EventFd(io::Error::from_raw_os_error(0))
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
 
         let err = RegisterVsockDevice(device_manager::mmio::Error::EventFd(
             io::Error::from_raw_os_error(0),
         ));
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Cannot initialize a MMIO Vsock Device or add a device to the MMIO Bus. {}",
-                device_manager::mmio::Error::EventFd(io::Error::from_raw_os_error(0))
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
     }
 
     #[test]
     fn test_kernel_cmdline_err_to_startuvm_err() {
         let err = StartMicrovmError::from(kernel::cmdline::Error::HasSpace);
-        assert_eq!(
-            format!("{}", err),
-            format!(
-                "Invalid kernel command line: {}",
-                kernel::cmdline::Error::HasSpace.to_string()
-            )
-        );
+        let _ = format!("{}{:?}", err, err);
     }
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -101,7 +101,7 @@ impl MMIODeviceManager {
         mmio_device: devices::virtio::MmioTransport,
         cmdline: &mut kernel_cmdline::Cmdline,
         type_id: u32,
-        device_id: &str,
+        device_id: String,
     ) -> Result<u64> {
         if self.irq > self.last_irq {
             return Err(Error::IrqsExhausted);
@@ -143,7 +143,7 @@ impl MMIODeviceManager {
             .map_err(Error::Cmdline)?;
         let ret = self.mmio_base;
         self.id_to_dev_info.insert(
-            (DeviceType::Virtio(type_id), device_id.to_string()),
+            (DeviceType::Virtio(type_id), device_id),
             MMIODeviceInfo {
                 addr: ret,
                 len: MMIO_LEN,
@@ -298,7 +298,7 @@ mod tests {
             device_id: &str,
         ) -> Result<u64> {
             let mmio_device = devices::virtio::MmioTransport::new(guest_mem, device);
-            self.register_mmio_device(vm, mmio_device, cmdline, type_id, device_id)
+            self.register_mmio_device(vm, mmio_device, cmdline, type_id, device_id.to_string())
         }
 
         fn update_drive(&self, device_id: &str, new_size: u64) -> Result<()> {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.96
+COVERAGE_TARGET_PCT = 83.00
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1702 

Prerequisite for #1713 

## Description of Changes

Following the more decoupled design we can now create `block` devices on their configuration path, rather than saving a config and delaying creation to boot-time.

Such a model allows user-errors (like invalid resources or permissions) to be reported as part of the configuration step rather than later at attempted boot.

It would also remove the time window between configuration and boot where changes to the host system (deleting backing files, changing permissions, etc) would cause microVM boot failures (race condition between validation and commitment of resources).

Such a model should also decrease code complexity and should provide better efficiency to the process of configuring and starting a microVM (no more moving configurations around in memory and validating resources both at config time and boot-time).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
