### PR TITLE
Create Vsock device during configuration instead of boot-time

### DIFF
--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -107,6 +107,10 @@ where
         Self::with_queues(cid, backend, queues)
     }
 
+    pub fn id(&self) -> &str {
+        defs::VSOCK_DEV_ID
+    }
+
     pub fn cid(&self) -> u64 {
         self.cid
     }

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -23,6 +23,10 @@ use vm_memory::GuestMemoryError;
 use packet::VsockPacket;
 
 mod defs {
+    /// Device ID used in MMIO device identification.
+    /// Because Vsock is unique per-vm, this ID can be hardcoded.
+    pub const VSOCK_DEV_ID: &str = "vsock";
+
     /// Number of virtio queues.
     pub const NUM_QUEUES: usize = 3;
     /// Virtio queue sizes, in number of descriptor chain heads.
@@ -292,12 +296,12 @@ mod tests {
             guest_txvq.avail.ring[0].set(0);
             guest_txvq.avail.idx.set(1);
 
+            let queues = vec![rxvq, txvq, evvq];
             EventHandlerContext {
                 guest_rxvq,
                 guest_txvq,
                 guest_evvq,
-                device: Vsock::with_queues(self.cid, TestBackend::new(), vec![rxvq, txvq, evvq])
-                    .unwrap(),
+                device: Vsock::with_queues(self.cid, TestBackend::new(), queues).unwrap(),
             }
         }
     }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -21,7 +21,7 @@ use vmm_config::metrics::{MetricsConfig, MetricsConfigError};
 use vmm_config::net::{
     NetworkInterfaceConfig, NetworkInterfaceError, NetworkInterfaceUpdateConfig,
 };
-use vmm_config::vsock::{VsockDeviceConfig, VsockError};
+use vmm_config::vsock::VsockDeviceConfig;
 
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.).
@@ -92,8 +92,6 @@ pub enum VmmActionError {
     OperationNotSupportedPreBoot,
     /// The action `StartMicroVm` failed because of an internal error.
     StartMicrovm(StartMicrovmError),
-    /// The action `set_vsock_device` failed because of bad user input.
-    VsockConfig(VsockError),
 }
 
 impl Display for VmmActionError {
@@ -120,7 +118,6 @@ impl Display for VmmActionError {
                         .to_string()
                 }
                 StartMicrovm(err) => err.to_string(),
-                VsockConfig(err) => err.to_string(),
             }
         )
     }

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -41,8 +41,6 @@ pub enum BootSourceConfigError {
     InvalidInitrdPath(io::Error),
     /// The kernel command line is invalid.
     InvalidKernelCommandLine(String),
-    /// The boot source cannot be update post boot.
-    UpdateNotAllowedPostBoot,
 }
 
 impl Display for BootSourceConfigError {
@@ -58,9 +56,6 @@ impl Display for BootSourceConfigError {
             ),
             InvalidKernelCommandLine(ref e) => {
                 write!(f, "The kernel command line is invalid: {}", e.as_str())
-            }
-            UpdateNotAllowedPostBoot => {
-                write!(f, "The update operation is not allowed after boot.")
             }
         }
     }

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -16,8 +16,6 @@ pub enum VmConfigError {
     InvalidVcpuCount,
     /// The memory size is invalid. The memory can only be an unsigned integer.
     InvalidMemorySize,
-    /// Cannot update the configuration of the microvm post boot.
-    UpdateNotAllowedPostBoot,
 }
 
 impl fmt::Display for VmConfigError {
@@ -30,9 +28,6 @@ impl fmt::Display for VmConfigError {
                  be 1 or an even number when hyperthreading is enabled.",
             ),
             InvalidMemorySize => write!(f, "The memory size (MiB) is invalid.",),
-            UpdateNotAllowedPostBoot => {
-                write!(f, "The update operation is not allowed after boot.")
-            }
         }
     }
 }
@@ -138,11 +133,5 @@ mod tests {
 
         let expected_str = "The memory size (MiB) is invalid.";
         assert_eq!(VmConfigError::InvalidMemorySize.to_string(), expected_str);
-
-        let expected_str = "The update operation is not allowed after boot.";
-        assert_eq!(
-            VmConfigError::UpdateNotAllowedPostBoot.to_string(),
-            expected_str
-        );
     }
 }

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -23,8 +23,6 @@ pub struct MetricsConfig {
 pub enum MetricsConfigError {
     /// Cannot initialize the metrics system due to bad user input.
     InitializationFailure(String),
-    /// Cannot flush the metrics.
-    FlushMetrics(String),
 }
 
 impl Display for MetricsConfigError {
@@ -32,7 +30,6 @@ impl Display for MetricsConfigError {
         use self::MetricsConfigError::*;
         match *self {
             InitializationFailure(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
-            FlushMetrics(ref err_msg) => write!(f, "{}", err_msg.replace("\"", "")),
         }
     }
 }
@@ -81,13 +78,6 @@ mod tests {
                 ))
             ),
             "Failed to initialize metrics"
-        );
-        assert_eq!(
-            format!(
-                "{}",
-                MetricsConfigError::FlushMetrics(String::from("Failed to flush metrics"))
-            ),
-            "Failed to flush metrics"
         );
     }
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Display, Formatter, Result};
-
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -14,22 +12,4 @@ pub struct VsockDeviceConfig {
     pub guest_cid: u32,
     /// Path to local unix socket.
     pub uds_path: String,
-}
-
-/// Errors associated with `VsockDeviceConfig`.
-#[derive(Debug)]
-pub enum VsockError {
-    /// The update is not allowed after booting the microvm.
-    UpdateNotAllowedPostBoot,
-}
-
-impl Display for VsockError {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        use self::VsockError::*;
-        match *self {
-            UpdateNotAllowedPostBoot => {
-                write!(f, "The update operation is not allowed after boot.",)
-            }
-        }
-    }
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -1,6 +1,36 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use devices::virtio::{Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError};
+
+type MutexVsockUnix = Arc<Mutex<Vsock<VsockUnixBackend>>>;
+
+/// Errors associated with `NetworkInterfaceConfig`.
+#[derive(Debug)]
+pub enum VsockConfigError {
+    /// Failed to create the backend for the vsock device.
+    CreateVsockBackend(VsockUnixBackendError),
+    /// Failed to create the vsock device.
+    CreateVsockDevice(VsockError),
+}
+
+impl fmt::Display for VsockConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::VsockConfigError::*;
+        match *self {
+            CreateVsockBackend(ref e) => {
+                write!(f, "Cannot create backend for vsock device: {:?}", e)
+            }
+            CreateVsockDevice(ref e) => write!(f, "Cannot create vsock device: {:?}", e),
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, VsockConfigError>;
+
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -12,4 +42,129 @@ pub struct VsockDeviceConfig {
     pub guest_cid: u32,
     /// Path to local unix socket.
     pub uds_path: String,
+}
+
+struct VsockAndUnixPath {
+    vsock: MutexVsockUnix,
+    uds_path: String,
+}
+
+/// A builder of Vsock with Unix backend from 'VsockDeviceConfig'.
+#[derive(Default)]
+pub struct VsockBuilder {
+    inner: Option<VsockAndUnixPath>,
+}
+
+impl VsockBuilder {
+    /// Creates an empty Vsock with Unix backend Store.
+    pub fn new() -> Self {
+        Self { inner: None }
+    }
+
+    /// Inserts a Unix backend Vsock in the store.
+    /// If an entry already exists, it will overwrite it.
+    pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<()> {
+        // Make sure to drop the old one and remove the socket before creating a new one.
+        if let Some(existing) = self.inner.take() {
+            std::fs::remove_file(existing.uds_path)
+                .map_err(VsockUnixBackendError::UnixBind)
+                .map_err(VsockConfigError::CreateVsockBackend)?;
+        }
+        self.inner = Some(VsockAndUnixPath {
+            uds_path: cfg.uds_path.clone(),
+            vsock: Arc::new(Mutex::new(Self::create_unixsock_vsock(cfg)?)),
+        });
+        Ok(())
+    }
+
+    /// Provides a reference to the Vsock if present.
+    pub fn get(&self) -> Option<&MutexVsockUnix> {
+        self.inner.as_ref().map(|pair| &pair.vsock)
+    }
+
+    /// Creates a Vsock device from a VsockDeviceConfig.
+    pub fn create_unixsock_vsock(cfg: VsockDeviceConfig) -> Result<Vsock<VsockUnixBackend>> {
+        let backend = VsockUnixBackend::new(u64::from(cfg.guest_cid), cfg.uds_path)
+            .map_err(VsockConfigError::CreateVsockBackend)?;
+
+        Ok(Vsock::new(u64::from(cfg.guest_cid), backend)
+            .map_err(VsockConfigError::CreateVsockDevice)?)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use utils::tempfile::TempFile;
+
+    // Placeholder for the path where a socket file will be created.
+    // The socket file will be removed when the scope ends.
+    pub(crate) struct TempSockFile {
+        path: String,
+    }
+
+    impl TempSockFile {
+        pub fn new(tmp_file: TempFile) -> Self {
+            TempSockFile {
+                path: String::from(tmp_file.as_path().to_str().unwrap()),
+            }
+        }
+        pub fn path(&self) -> &String {
+            &self.path
+        }
+    }
+
+    impl Drop for TempSockFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    pub(crate) fn default_config(tmp_sock_file: &TempSockFile) -> VsockDeviceConfig {
+        let vsock_dev_id = "vsock";
+        VsockDeviceConfig {
+            vsock_id: vsock_dev_id.to_string(),
+            guest_cid: 3,
+            uds_path: tmp_sock_file.path().clone(),
+        }
+    }
+
+    #[test]
+    fn test_vsock_create() {
+        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let vsock_config = default_config(&tmp_sock_file);
+        VsockBuilder::create_unixsock_vsock(vsock_config).unwrap();
+    }
+
+    #[test]
+    fn test_vsock_insert() {
+        let mut store = VsockBuilder::new();
+        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let mut vsock_config = default_config(&tmp_sock_file);
+
+        store.insert(vsock_config.clone()).unwrap();
+        let vsock = store.get().unwrap();
+        assert_eq!(vsock.lock().unwrap().id(), &vsock_config.vsock_id);
+
+        let new_cid = vsock_config.guest_cid + 1;
+        vsock_config.guest_cid = new_cid;
+        store.insert(vsock_config).unwrap();
+        let vsock = store.get().unwrap();
+        assert_eq!(vsock.lock().unwrap().cid(), new_cid as u64);
+    }
+
+    #[test]
+    fn test_error_messages() {
+        use super::VsockConfigError::*;
+        use std::io;
+        let err = CreateVsockBackend(devices::virtio::VsockUnixBackendError::EpollAdd(
+            io::Error::from_raw_os_error(0),
+        ));
+        let _ = format!("{}{:?}", err, err);
+
+        let err = CreateVsockDevice(devices::virtio::VsockError::EventFd(
+            io::Error::from_raw_os_error(0),
+        ));
+        let _ = format!("{}{:?}", err, err);
+    }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -19,7 +19,7 @@ import pytest
 
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 82.85
+COVERAGE_TARGET_PCT = 82.96
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Fixes #1709 

Prerequisite for #1713 

## Description of Changes

Following the more decoupled design we can now create the `Vsock` device on its configuration path, rather than saving a config and delaying creation to boot-time.

Such a model allows user-errors (like invalid resources or permissions) to be reported as part of the configuration step rather than later at attempted boot.

It would also remove the time window between configuration and boot where changes to the host system (creating Sockets, changing permissions, etc) would cause microVM boot failures (race condition between validation and commitment of resources).

Such a model should also decrease code complexity and should provide better efficiency to the process of configuring and starting a microVM (no more moving configurations around in memory and validating resources both at config time and boot-time).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
