### PR TITLE
Implement (de)serialization for block devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.0",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,10 @@ dependencies = [
  "net_gen 0.1.0",
  "polly 0.0.1",
  "rate_limiter 0.1.0",
+ "snapshot 0.1.0",
  "utils 0.1.0",
+ "versionize 0.1.0",
+ "versionize_derive 0.1.0",
  "virtio_gen 0.1.0",
  "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -13,4 +13,7 @@ utils = { path = "../utils" }
 net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
+snapshot = { path = "../snapshot" }
+versionize = { path = "../versionize" }
+versionize_derive = { path = "../versionize_derive" } 
 virtio_gen = { path = "../virtio_gen" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -15,5 +15,5 @@ polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
 versionize = { path = "../versionize" }
-versionize_derive = { path = "../versionize_derive" } 
+versionize_derive = { path = "../versionize_derive" }
 virtio_gen = { path = "../virtio_gen" }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -18,6 +18,10 @@ extern crate rate_limiter;
 extern crate virtio_gen;
 extern crate vm_memory;
 
+extern crate snapshot;
+extern crate versionize;
+extern crate versionize_derive;
+
 use rate_limiter::Error as RateLimiterError;
 use std::io;
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -294,7 +294,11 @@ impl VirtioDevice for Block {
         TYPE_BLOCK
     }
 
-    fn queues(&mut self) -> &mut [Queue] {
+    fn queues(&self) -> &[Queue] {
+        &self.queues
+    }
+
+    fn queues_mut(&mut self) -> &mut [Queue] {
         &mut self.queues
     }
 

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -3,10 +3,12 @@
 
 pub mod device;
 pub mod event_handler;
+pub mod persist;
 pub mod request;
 
 pub use self::device::Block;
 pub use self::event_handler::*;
+pub use self::persist::*;
 pub use self::request::*;
 
 use vm_memory::GuestMemoryError;

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -1,0 +1,146 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the structures needed for saving/restoring block devices.
+
+use std::io;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use rate_limiter::{persist::RateLimiterState, RateLimiter};
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use virtio_gen::virtio_blk::VIRTIO_BLK_F_RO;
+use vm_memory::GuestMemoryMmap;
+
+use super::*;
+
+use crate::virtio::persist::VirtioDeviceState;
+use crate::virtio::{DeviceState, Queue};
+
+#[derive(Versionize)]
+pub struct BlockState {
+    id: String,
+    partuuid: Option<String>,
+    root_device: bool,
+    disk_path: String,
+    virtio_state: VirtioDeviceState,
+    rate_limiter_state: RateLimiterState,
+}
+
+pub struct BlockConstructorArgs {
+    mem: GuestMemoryMmap,
+}
+
+impl Persist for Block {
+    type State = BlockState;
+    type ConstructorArgs = BlockConstructorArgs;
+    type Error = io::Error;
+
+    fn save(&self) -> Self::State {
+        BlockState {
+            id: self.id.clone(),
+            partuuid: self.partuuid.clone(),
+            root_device: self.root_device,
+            disk_path: self.disk_image_path.clone(),
+            virtio_state: VirtioDeviceState::from_device(self),
+            rate_limiter_state: self.rate_limiter.save(),
+        }
+    }
+
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> Result<Self, Self::Error> {
+        let is_disk_read_only = state.virtio_state.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0;
+        let rate_limiter = RateLimiter::restore((), &state.rate_limiter_state)?;
+
+        let mut block = Block::new(
+            state.id.clone(),
+            state.partuuid.clone(),
+            state.disk_path.clone(),
+            is_disk_read_only,
+            state.root_device,
+            rate_limiter,
+        )?;
+
+        block.queues = state
+            .virtio_state
+            .queues
+            .iter()
+            .map(|queue_state| Queue::restore((), &queue_state).unwrap())
+            .collect();
+        block.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        block.avail_features = state.virtio_state.avail_features;
+        block.acked_features = state.virtio_state.acked_features;
+
+        if state.virtio_state.activated {
+            block.device_state = DeviceState::Activated(constructor_args.mem);
+        }
+
+        Ok(block)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtio::block::device::tests::default_mem;
+    use crate::virtio::device::VirtioDevice;
+    use crate::virtio::TYPE_BLOCK;
+    use utils::tempfile::TempFile;
+
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_persistence() {
+        // We create the backing file here so that it exists for the whole lifetime of the test.
+        let f = TempFile::new().unwrap();
+        f.as_file().set_len(0x1000).unwrap();
+
+        let id = "test".to_string();
+        let mut block = Block::new(
+            id,
+            None,
+            f.as_path().to_str().unwrap().to_string(),
+            false,
+            false,
+            RateLimiter::default(),
+        )
+        .unwrap();
+        let guest_mem = default_mem();
+        block.activate(guest_mem.clone()).unwrap();
+
+        // Save the block device.
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        <Block as Persist>::save(&block)
+            .serialize(&mut mem.as_mut_slice(), &version_map, 1)
+            .unwrap();
+
+        // Restore the block device.
+        let restored_block = Block::restore(
+            BlockConstructorArgs {
+                mem: guest_mem.clone(),
+            },
+            &BlockState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
+        )
+        .unwrap();
+
+        // Test that virtio specific fields are the same.
+        assert_eq!(restored_block.device_type(), TYPE_BLOCK);
+        assert_eq!(restored_block.avail_features(), block.avail_features());
+        assert_eq!(restored_block.acked_features(), block.acked_features());
+        assert_eq!(restored_block.queues(), block.queues());
+        assert_eq!(
+            restored_block.interrupt_status().load(Ordering::Relaxed),
+            block.interrupt_status().load(Ordering::Relaxed)
+        );
+        assert_eq!(restored_block.is_activated(), block.is_activated());
+
+        // Test that block specific fields are the same.
+        assert_eq!(&restored_block.disk_image_path, &block.disk_image_path);
+    }
+}

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -40,7 +40,10 @@ pub trait VirtioDevice: AsAny + Send {
     fn device_type(&self) -> u32;
 
     /// Returns the device queues.
-    fn queues(&mut self) -> &mut [Queue];
+    fn queues(&self) -> &[Queue];
+
+    /// Returns a mutable reference to the device queues.
+    fn queues_mut(&mut self) -> &mut [Queue];
 
     /// Returns the device queues event fds.
     fn queue_events(&self) -> &[EventFd];

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -14,6 +14,7 @@ pub mod block;
 pub mod device;
 mod mmio;
 pub mod net;
+pub mod persist;
 mod queue;
 pub mod vsock;
 
@@ -21,6 +22,7 @@ pub use self::block::*;
 pub use self::device::*;
 pub use self::mmio::*;
 pub use self::net::*;
+pub use self::persist::*;
 pub use self::queue::*;
 pub use self::vsock::*;
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -655,7 +655,11 @@ impl VirtioDevice for Net {
         TYPE_NET
     }
 
-    fn queues(&mut self) -> &mut [Queue] {
+    fn queues(&self) -> &[Queue] {
+        &self.queues
+    }
+
+    fn queues_mut(&mut self) -> &mut [Queue] {
         &mut self.queues
     }
 

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -1,0 +1,98 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the structures needed for saving/restoring Virtio primitives.
+
+use super::queue::*;
+use crate::vm_memory::Address;
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use vm_memory::GuestAddress;
+
+use std::num::Wrapping;
+
+#[derive(Clone, Debug, PartialEq, Versionize)]
+pub struct QueueState {
+    /// The maximal size in elements offered by the device
+    max_size: u16,
+
+    /// The queue size in elements the driver selected
+    size: u16,
+
+    /// Indicates if the queue is finished with configuration
+    ready: bool,
+
+    /// Guest physical address of the descriptor table
+    desc_table: u64,
+
+    /// Guest physical address of the available ring
+    avail_ring: u64,
+
+    /// Guest physical address of the used ring
+    used_ring: u64,
+
+    next_avail: Wrapping<u16>,
+    next_used: Wrapping<u16>,
+}
+
+impl Persist for Queue {
+    type State = QueueState;
+    type ConstructorArgs = ();
+    type Error = ();
+
+    fn save(&self) -> Self::State {
+        QueueState {
+            max_size: self.max_size,
+            size: self.size,
+            ready: self.ready,
+            desc_table: self.desc_table.0,
+            avail_ring: self.avail_ring.0,
+            used_ring: self.used_ring.0,
+            next_avail: self.next_avail,
+            next_used: self.next_used,
+        }
+    }
+
+    fn restore(
+        _: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(Queue {
+            max_size: state.max_size,
+            size: state.size,
+            ready: state.ready,
+            desc_table: GuestAddress::new(state.desc_table),
+            avail_ring: GuestAddress::new(state.avail_ring),
+            used_ring: GuestAddress::new(state.used_ring),
+            next_avail: state.next_avail,
+            next_used: state.next_used,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_persistence() {
+        let queue = Queue::new(128);
+
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        queue
+            .save()
+            .serialize(&mut mem.as_mut_slice(), &version_map, 1)
+            .unwrap();
+
+        let restored_queue = Queue::restore(
+            (),
+            &QueueState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(restored_queue, queue);
+    }
+}

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -140,11 +140,11 @@ impl<'a> DescriptorChain<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 /// A virtio queue's parameters.
 pub struct Queue {
     /// The maximal size in elements offered by the device
-    max_size: u16,
+    pub(crate) max_size: u16,
 
     /// The queue size in elements the driver selected
     pub size: u16,
@@ -161,8 +161,8 @@ pub struct Queue {
     /// Guest physical address of the used ring
     pub used_ring: GuestAddress,
 
-    next_avail: Wrapping<u16>,
-    next_used: Wrapping<u16>,
+    pub(crate) next_avail: Wrapping<u16>,
+    pub(crate) next_used: Wrapping<u16>,
 }
 
 impl Queue {

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -222,7 +222,11 @@ where
         uapi::VIRTIO_ID_VSOCK
     }
 
-    fn queues(&mut self) -> &mut [VirtQueue] {
+    fn queues(&self) -> &[VirtQueue] {
+        &self.queues
+    }
+
+    fn queues_mut(&mut self) -> &mut [VirtQueue] {
         &mut self.queues
     }
 

--- a/src/versionize/Cargo.toml
+++ b/src/versionize/Cargo.toml
@@ -9,6 +9,7 @@ serde_derive = ">=1.0.27"
 bincode = "1.2.1"
 versionize_derive = { path = "../versionize_derive" }
 crc64 = "1.0.0"
+vm-memory = { version = ">=0.2.0" }
 vmm-sys-util = ">=0.4.0"
 
 [build-dependencies]

--- a/src/versionize/src/lib.rs
+++ b/src/versionize/src/lib.rs
@@ -17,6 +17,7 @@ extern crate crc64;
 extern crate serde;
 extern crate serde_derive;
 extern crate versionize_derive;
+extern crate vm_memory;
 extern crate vmm_sys_util;
 
 pub mod crc;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -860,7 +860,13 @@ pub mod tests {
             block_files.push(TempFile::new().unwrap());
             let block_device_config = BlockDeviceConfig {
                 drive_id: String::from(&custom_block_cfg.drive_id),
-                path_on_host: block_files.last().unwrap().as_path().to_path_buf(),
+                path_on_host: block_files
+                    .last()
+                    .unwrap()
+                    .as_path()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
                 is_root_device: custom_block_cfg.is_root_device,
                 partuuid: custom_block_cfg.partuuid.clone(),
                 is_read_only: custom_block_cfg.is_read_only,

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -363,7 +363,11 @@ mod tests {
             0
         }
 
-        fn queues(&mut self) -> &mut [Queue] {
+        fn queues(&self) -> &[Queue] {
+            &self.queues
+        }
+
+        fn queues_mut(&mut self) -> &mut [Queue] {
             &mut self.queues
         }
 
@@ -473,7 +477,7 @@ mod tests {
 
     #[test]
     fn test_dummy_device() {
-        let mut dummy = DummyDevice::new();
+        let dummy = DummyDevice::new();
         assert_eq!(dummy.device_type(), 0);
         assert_eq!(dummy.queues().len(), QUEUE_SIZES.len());
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -316,7 +316,7 @@ mod tests {
         (
             BlockDeviceConfig {
                 drive_id: "block1".to_string(),
-                path_on_host: tmp_file.as_path().to_path_buf(),
+                path_on_host: tmp_file.as_path().to_str().unwrap().to_string(),
                 is_root_device: false,
                 partuuid: Some("0eaa91a0-01".to_string()),
                 is_read_only: false,
@@ -778,7 +778,7 @@ mod tests {
         let (mut new_block_device_cfg, _file) = default_block_cfg();
         let tmp_file = TempFile::new().unwrap();
         new_block_device_cfg.drive_id = "block2".to_string();
-        new_block_device_cfg.path_on_host = tmp_file.as_path().to_path_buf();
+        new_block_device_cfg.path_on_host = tmp_file.as_path().to_str().unwrap().to_string();
         assert_eq!(vm_resources.block.list.len(), 1);
         vm_resources.set_block_device(new_block_device_cfg).unwrap();
         assert_eq!(vm_resources.block.list.len(), 2);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.05
+COVERAGE_TARGET_PCT = 83.19
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Fixes #1424


## Description of Changes

- Introduce a VirtioDeviceState that captures the generic Virtio fields that all devices have
- Implement the Persist trait for the block device in order to be able to save/restore it
- Derive Versionize for the BlockState


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] No newly added `unsafe` code.
- [x] No API changes.
- [x] No user-facing changes.
