### PR TITLE
docs: Fix link to kernel configuration.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -150,8 +150,8 @@ support:
 CONFIG_PTP_1588_CLOCK=y
 CONFIG_PTP_1588_CLOCK_KVM=y
 ```
-Our [recommended guest kernel config](resources/microvm-kernel-config) already
-has these included.
+Our [recommended guest kernel config](resources/microvm-kernel-x86_64.config)
+already has these included.
 
 Now `/dev/ptp0` should be available in the guest. Next you need to configure
 `/dev/ptp0` as a NTP time source.

--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -26,8 +26,8 @@ can boot:
    ```
 
 3. You will need to configure your Linux build. You can start from
-   [our recommended config](../resources/microvm-kernel-config) - just copy
-   it to `.config` (under the Linux sources dir). You can make interactive
+   [our recommended config](../resources/microvm-kernel-x86_64.config) - just 
+   copy it to `.config` (under the Linux sources dir). You can make interactive
    config adjustments using:
 
    ```bash


### PR DESCRIPTION
Recommended kernel configuration links in the docs are pointing to an
incorrect location after recent file rename.

Signed-off-by: Fraser Pringle <fraser.pringle@gmail.com>

## Reason for This PR

Fixes:  #1766   

## Description of Changes

Correct the documentation links to the recommended kernel configuration.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
