### PR TITLE
MMDS JSON response support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - Added a [guide](docs/devctr-image.md) for updating the dev container image.
 - Added a new API call, `PUT /mmds/config`, for configuring the
   `MMDS` with a custom valid link-local IPv4 address.
-
+- Added experimental JSON response format support for MMDS guest applications
+  requests.
+   
 ### Fixed
 - Added `--version` flag to both Firecracker and Jailer.
 
@@ -32,6 +34,14 @@
   updates to existing configurations.
 - `PATCH /network-interfaces/{id}` only allowed post-boot. Use `PUT` for
   pre-boot updates to existing configurations.
+- Changed returned status code from `500 Internal Server Error` to `501 Not Implemented`,
+  for queries on the MMDS endpoint in IMDS format, when the requested resource value type
+  is unsupported.
+- Allowed the MMDS data store to be initialized with all supported JSON types.
+  Retrieval of these values within the guest, besides String, Array, and Dictionary,
+  is only possible in JSON mode.
+- `PATCH` request on `/mmds` before the data store is initialized returns 
+  `403 BadRequest`.
 
 ## [0.21.0]
 
@@ -211,7 +221,7 @@
 - When running with `jailer` the location of the API socket has changed to
   `<jail-root-path>/api.socket` (API socket was moved _inside_ the jail).
 - `PUT` and `PATCH` requests on `/mmds` with data containing any value type
-  other than `String`, `Array`, `Object` will return status code 400.
+  other than `String`, `Array`, `Object` will returns status code 400.
 - Improved multiple error messages.
 - Removed all kernel modules from the recommended kernel config.
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -86,6 +86,37 @@ ip route add 169.254.169.200 dev eth0
 If MMDS configuration is not provided before booting up the guest, the MMDS
 IPv4 address defaults to `169.254.169.254`.
 
+# MMDS requests 
+
+Guests workloads that request metadata from MMDS  can choose to receive the response in IMDS or JSON format.
+IMDS documentation can be found [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
+
+Request example to retrieve IMDS format response:
+```bash
+curl -s "http://169.254.169.200/latest/meta-data/network/interfaces/macs/02:29:96:8f:6a:2d"
+```
+
+IMDS output:
+```text
+device-number
+local-hostname
+subnet-id
+```
+
+Request example to retrieve JSON format response:
+```bash
+curl -s -H "Accept: application/json" "http://169.254.169.200/latest/meta-data/network/interfaces/macs/02:29:96:8f:6a:2d"
+```
+
+JSON output:
+```text
+{
+    "device-number": "13345342",
+    "local-hostname": "localhost",
+    "subnet-id": "subnet-be9b61d"
+}
+```
+
 ### Example use case: credential rotation
 
 For this example, the guest expects to find some sort of credentials (say, a

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -12,14 +12,23 @@ pub mod data_store;
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
 
-use data_store::{Error as MmdsError, Mmds};
-use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
+use data_store::{Error as MmdsError, Mmds, OutputFormat};
+use micro_http::{Body, MediaType, Request, RequestError, Response, StatusCode, Version};
 
 lazy_static! {
     // A static reference to a global Mmds instance. We currently use this for ease of access during
     // prototyping. We'll consider something like passing Arc<Mutex<Mmds>> references to the
     // appropriate threads in the future.
     pub static ref MMDS: Arc<Mutex<Mmds>> = Arc::new(Mutex::new(Mmds::default()));
+}
+
+impl Into<OutputFormat> for MediaType {
+    fn into(self) -> OutputFormat {
+        match self {
+            MediaType::ApplicationJson => OutputFormat::Json,
+            MediaType::PlainText => OutputFormat::Imds,
+        }
+    }
 }
 
 /// Patch provided JSON document (given as `serde_json::Value`) in-place with JSON Merge Patch
@@ -74,39 +83,30 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
             let response = MMDS
                 .lock()
                 .expect("Failed to build MMDS response due to poisoned lock")
-                .get_value(uri.to_string());
+                .get_value(uri.to_string(), request.headers.accept().into());
+
             match response {
-                Ok(response) => {
-                    let response_body = response.join("\n");
-                    build_response(
-                        request.http_version(),
-                        StatusCode::OK,
-                        Body::new(response_body),
-                    )
-                }
-                Err(e) => {
-                    match e {
-                        MmdsError::NotFound => {
-                            // NotFound
-                            let error_msg = format!("Resource not found: {}.", uri);
-                            build_response(
-                                request.http_version(),
-                                StatusCode::NotFound,
-                                Body::new(error_msg),
-                            )
-                        }
-                        MmdsError::UnsupportedValueType => {
-                            // InternalServerError
-                            let error_msg =
-                                format!("The resource {} has an invalid format.", uri.to_string());
-                            build_response(
-                                request.http_version(),
-                                StatusCode::InternalServerError,
-                                Body::new(error_msg),
-                            )
-                        }
+                Ok(response_body) => build_response(
+                    request.http_version(),
+                    StatusCode::OK,
+                    Body::new(response_body),
+                ),
+                Err(e) => match e {
+                    MmdsError::NotFound => {
+                        let error_msg = format!("Resource not found: {}.", uri);
+                        build_response(
+                            request.http_version(),
+                            StatusCode::NotFound,
+                            Body::new(error_msg),
+                        )
                     }
-                }
+                    MmdsError::UnsupportedValueType => build_response(
+                        request.http_version(),
+                        StatusCode::NotImplemented,
+                        Body::new(e.to_string()),
+                    ),
+                    MmdsError::NotInitialized => unreachable!(),
+                },
             }
         }
         Err(e) => match e {
@@ -149,13 +149,13 @@ mod tests {
                 "first": "John",
                 "second": "Doe"
             },
-            "age": "43",
+            "age": 43,
             "phones": {
                 "home": {
-                    "RO": "+40 1234567",
-                    "UK": "+44 1234567"
+                    "RO": "+401234567",
+                    "UK": "+441234567"
                 },
-                "mobile": "+44 2345678"
+                "mobile": "+442345678"
             }
         }"#;
         MMDS.lock()
@@ -219,9 +219,25 @@ mod tests {
         assert!(expected_response.http_version() == actual_response.http_version());
 
         // Test Ok path.
-        let request = b"GET http://169.254.169.254/ HTTP/1.0\r\n\r\n";
+        let request = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
+                                    Accept: application/json\r\n\r\n";
         let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
-        let body = "age\nname/\nphones/".to_string();
+        let mut body = r#"{
+                "age": 43,
+                "name": {
+                    "first": "John",
+                    "second": "Doe"
+                },
+                "phones": {
+                    "home": {
+                        "RO": "+401234567",
+                        "UK": "+441234567"
+                    },
+                    "mobile": "+442345678"
+                }
+        }"#
+        .to_string();
+        body.retain(|c| !c.is_whitespace());
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
 
@@ -230,28 +246,14 @@ mod tests {
         assert!(expected_response.http_version() == actual_response.http_version());
 
         let request = b"GET /age HTTP/1.1\r\n\r\n";
-        let mut expected_response = Response::new(Version::Http11, StatusCode::OK);
-        let body = "43".to_string();
+        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
+        let body = "Cannot retrieve value. The value has an unsupported type.".to_string();
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
 
         assert!(expected_response.status() == actual_response.status());
         assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
         assert!(expected_response.http_version() == actual_response.http_version());
-
-        let data = r#"{
-            "name": {
-                "first": "John",
-                "second": "Doe"
-            },
-            "age": 43
-        }"#;
-        assert_eq!(
-            MMDS.lock()
-                .unwrap()
-                .put_data(serde_json::from_str(data).unwrap()),
-            Err(MmdsError::UnsupportedValueType)
-        );
     }
 
     #[test]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -16,6 +16,7 @@ use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
 use devices::legacy::Serial;
 use devices::virtio::{MmioTransport, Vsock, VsockUnixBackend};
+
 use polly::event_manager::{Error as EventManagerError, EventManager};
 use seccomp::BpfProgramRef;
 use utils::eventfd::EventFd;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -296,9 +296,9 @@ mod tests {
     use resources::VmResources;
     use utils::tempfile::TempFile;
     use vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
-    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig, DriveError};
+    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
-    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
+    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use vmm_config::vsock::tests::{default_config, TempSockFile};
     use vmm_config::RateLimiterConfig;
     use vstate::VcpuConfig;
@@ -648,6 +648,7 @@ mod tests {
         // Test all configuration, this time trying to configure the MMDS with an
         // empty body. It will make it access the code path in which it sets the
         // default MMDS configuration.
+        let kernel_file = TempFile::new().unwrap();
         json = format!(
             r#"{{
                     "boot-source": {{
@@ -665,7 +666,7 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif",
-                            "host_dev_name": "hostname8",
+                            "host_dev_name": "hostname9",
                             "allow_mmds_requests": true
                         }}
                     ],


### PR DESCRIPTION
## Reason for This PR

Closes #1775. 

## Description of Changes

This PR adds full JSON support for MMDS, on both storage and retrieving metadata.
JSON response format is activated if an `Accept: application/json` header is present
in the MMDS request. Added relevant documentation in `mmds.md`. Further detailed documentation
is provided in #1800.

IMDS format response is kept intact.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
