### PR TITLE
Implement (de)serialization for net devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,10 @@ dependencies = [
  "mmds 0.1.0",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snapshot 0.1.0",
  "utils 0.1.0",
+ "versionize 0.1.0",
+ "versionize_derive 0.1.0",
 ]
 
 [[package]]

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -15,6 +15,7 @@ pub const TX_INDEX: usize = 1;
 
 pub mod device;
 pub mod event_handler;
+pub mod persist;
 
 pub use self::device::Net;
 pub use self::event_handler::*;

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -1,0 +1,178 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the structures needed for saving/restoring net devices.
+
+use std::io;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use dumbo::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState, MAC_ADDR_LEN};
+use rate_limiter::{persist::RateLimiterState, RateLimiter};
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use vm_memory::GuestMemoryMmap;
+
+use super::device::{ConfigSpace, Net};
+
+use crate::virtio::persist::VirtioDeviceState;
+use crate::virtio::{DeviceState, Queue};
+
+#[derive(Versionize)]
+pub struct NetConfigSpaceState {
+    guest_mac: [u8; MAC_ADDR_LEN],
+}
+
+#[derive(Versionize)]
+pub struct NetState {
+    id: String,
+    tap_if_name: String,
+    rx_rate_limiter_state: RateLimiterState,
+    tx_rate_limiter_state: RateLimiterState,
+    mmds_ns: Option<MmdsNetworkStackState>,
+    config_space: NetConfigSpaceState,
+    virtio_state: VirtioDeviceState,
+}
+
+pub struct NetConstructorArgs {
+    mem: GuestMemoryMmap,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    CreateNet(super::Error),
+    CreateRateLimiter(io::Error),
+}
+
+impl Persist for Net {
+    type State = NetState;
+    type ConstructorArgs = NetConstructorArgs;
+    type Error = Error;
+
+    fn save(&self) -> Self::State {
+        NetState {
+            id: self.id().clone(),
+            tap_if_name: self.tap_if_name.clone(),
+            rx_rate_limiter_state: self.rx_rate_limiter.save(),
+            tx_rate_limiter_state: self.tx_rate_limiter.save(),
+            mmds_ns: self.mmds_ns.as_ref().map(|mmds| mmds.save()),
+            config_space: NetConfigSpaceState {
+                guest_mac: self.config_space.guest_mac,
+            },
+            virtio_state: VirtioDeviceState::from_device(self),
+        }
+    }
+
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error> {
+        // RateLimiter::restore() can fail at creating a timerfd.
+        let rx_rate_limiter = RateLimiter::restore((), &state.rx_rate_limiter_state)
+            .map_err(Error::CreateRateLimiter)?;
+        let tx_rate_limiter = RateLimiter::restore((), &state.tx_rate_limiter_state)
+            .map_err(Error::CreateRateLimiter)?;
+        let mut net = Net::new_with_tap(
+            state.id.clone(),
+            state.tap_if_name.clone(),
+            None,
+            rx_rate_limiter,
+            tx_rate_limiter,
+            state.mmds_ns.is_some(),
+        )
+        .map_err(Error::CreateNet)?;
+
+        // Safe to unwrap because MmdsNetworkStack::restore() cannot fail.
+        net.mmds_ns = state
+            .mmds_ns
+            .as_ref()
+            .map(|mmds_state| MmdsNetworkStack::restore((), &mmds_state).unwrap());
+
+        // Safe to unwrap because Queue::restore() cannot fail.
+        net.queues = state
+            .virtio_state
+            .queues
+            .iter()
+            .map(|queue_state| Queue::restore((), &queue_state).unwrap())
+            .collect();
+        net.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        net.avail_features = state.virtio_state.avail_features;
+        net.acked_features = state.virtio_state.acked_features;
+        net.config_space = ConfigSpace {
+            guest_mac: state.config_space.guest_mac,
+        };
+
+        if state.virtio_state.activated {
+            net.device_state = DeviceState::Activated(constructor_args.mem);
+        }
+
+        Ok(net)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtio::device::VirtioDevice;
+    use crate::virtio::net::device::tests::*;
+    use crate::virtio::TYPE_NET;
+
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_persistence() {
+        let guest_mem = Net::default_guest_memory();
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        let id;
+        let tap_if_name;
+        let allow_mmds_requests;
+        let virtio_state;
+
+        // Create and save the net device.
+        {
+            let mut net = Net::default_net(TestMutators::default());
+            net.activate(guest_mem.clone()).unwrap();
+
+            <Net as Persist>::save(&net)
+                .serialize(&mut mem.as_mut_slice(), &version_map, 1)
+                .unwrap();
+
+            // Save some fields that we want to check later.
+            id = net.id.clone();
+            tap_if_name = net.tap_if_name.clone();
+            allow_mmds_requests = net.mmds_ns.is_some();
+            virtio_state = VirtioDeviceState::from_device(&net);
+        }
+
+        // Deserialize and restore the net device.
+        {
+            let restored_net = Net::restore(
+                NetConstructorArgs {
+                    mem: guest_mem.clone(),
+                },
+                &NetState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
+            )
+            .unwrap();
+
+            // Test that virtio specific fields are the same.
+            assert_eq!(restored_net.device_type(), TYPE_NET);
+            assert_eq!(restored_net.avail_features(), virtio_state.avail_features);
+            assert_eq!(restored_net.acked_features(), virtio_state.acked_features);
+            assert_eq!(
+                restored_net.interrupt_status().load(Ordering::Relaxed),
+                virtio_state.interrupt_status
+            );
+            assert_eq!(restored_net.is_activated(), virtio_state.activated);
+
+            // Test that net specific fields are the same.
+            assert_eq!(&restored_net.id, &id);
+            assert_eq!(&restored_net.tap_if_name, &tap_if_name);
+            assert_eq!(restored_net.mmds_ns.is_some(), allow_mmds_requests);
+            assert_eq!(restored_net.rx_rate_limiter, RateLimiter::default());
+            assert_eq!(restored_net.tx_rate_limiter, RateLimiter::default());
+        }
+    }
+}

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -10,6 +10,9 @@ serde = ">=1.0.27"
 utils = { path = "../utils" }
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
+snapshot = { path = "../snapshot" }
+versionize = { path = "../versionize" }
+versionize_derive = { path = "../versionize_derive" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -11,11 +11,15 @@ extern crate bitflags;
 extern crate logger;
 extern crate mmds;
 extern crate serde;
+extern crate snapshot;
 extern crate utils;
+extern crate versionize;
+extern crate versionize_derive;
 
 mod mac;
 pub mod ns;
 mod pdu;
+pub mod persist;
 mod tcp;
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};

--- a/src/dumbo/src/ns.rs
+++ b/src/dumbo/src/ns.rs
@@ -53,15 +53,15 @@ pub struct MmdsNetworkStack {
     // Network interface MAC address used by frames/packets heading to MMDS server.
     remote_mac_addr: MacAddr,
     // The Ethernet MAC address of the MMDS server.
-    mac_addr: MacAddr,
+    pub(crate) mac_addr: MacAddr,
     // MMDS server IPv4 address.
-    ipv4_addr: Ipv4Addr,
+    pub(crate) ipv4_addr: Ipv4Addr,
     // ARP reply destination IPv4 address (requester of address resolution reply).
     // It is the Ipv4Addr of the network interface for which the MmdsNetworkStack
     // routes the packets.
     pending_arp_reply_dest: Option<Ipv4Addr>,
     // This handles MMDS<->guest interaction at the TCP level.
-    tcp_handler: TcpIPv4Handler,
+    pub(crate) tcp_handler: TcpIPv4Handler,
 }
 
 impl MmdsNetworkStack {

--- a/src/dumbo/src/persist.rs
+++ b/src/dumbo/src/persist.rs
@@ -1,0 +1,93 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the structures needed for saving/restoring MmdsNetworkStack.
+
+use std::net::Ipv4Addr;
+
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+
+use super::ns::MmdsNetworkStack;
+use super::*;
+
+/// State of a MmdsNetworkStack.
+#[derive(Versionize)]
+pub struct MmdsNetworkStackState {
+    mac_addr: [u8; MAC_ADDR_LEN],
+    ipv4_addr: u32,
+    tcp_port: u16,
+    max_connections: usize,
+    max_pending_resets: usize,
+}
+
+impl Persist for MmdsNetworkStack {
+    type State = MmdsNetworkStackState;
+    type ConstructorArgs = ();
+    type Error = ();
+
+    fn save(&self) -> Self::State {
+        let mut mac_addr = [0; MAC_ADDR_LEN];
+        mac_addr.copy_from_slice(self.mac_addr.get_bytes());
+
+        MmdsNetworkStackState {
+            mac_addr,
+            ipv4_addr: self.ipv4_addr.into(),
+            tcp_port: self.tcp_handler.local_port,
+            max_connections: self.tcp_handler.max_connections,
+            max_pending_resets: self.tcp_handler.max_pending_resets,
+        }
+    }
+
+    fn restore(
+        _: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(MmdsNetworkStack::new(
+            MacAddr::from_bytes_unchecked(&state.mac_addr),
+            Ipv4Addr::from(state.ipv4_addr),
+            state.tcp_port,
+            std::num::NonZeroUsize::new(state.max_connections).unwrap(),
+            std::num::NonZeroUsize::new(state.max_pending_resets).unwrap(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_persistence() {
+        let ns = MmdsNetworkStack::new_with_defaults(None);
+
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        ns.save()
+            .serialize(&mut mem.as_mut_slice(), &version_map, 1)
+            .unwrap();
+
+        let restored_ns = MmdsNetworkStack::restore(
+            (),
+            &MmdsNetworkStackState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(restored_ns.mac_addr, ns.mac_addr);
+        assert_eq!(restored_ns.ipv4_addr, ns.ipv4_addr);
+        assert_eq!(
+            restored_ns.tcp_handler.local_port,
+            ns.tcp_handler.local_port
+        );
+        assert_eq!(
+            restored_ns.tcp_handler.max_connections,
+            ns.tcp_handler.max_connections
+        );
+        assert_eq!(
+            restored_ns.tcp_handler.max_pending_resets,
+            ns.tcp_handler.max_pending_resets
+        );
+    }
+}

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -123,11 +123,11 @@ pub struct TcpIPv4Handler {
     // Handler IPv4 address used for every connection.
     local_ipv4_addr: Ipv4Addr,
     // Handler TCP port used for every connection.
-    local_port: u16,
+    pub(crate) local_port: u16,
     // This map holds the currently active endpoints, identified by their connection tuple.
     connections: HashMap<ConnectionTuple, Endpoint>,
     // Maximum number of concurrent connections we are willing to handle.
-    max_connections: usize,
+    pub(crate) max_connections: usize,
     // Holds connections which are able to send segments immediately.
     active_connections: HashSet<ConnectionTuple>,
     // Remembers the closest timestamp into the future when one of the connections has to deal
@@ -136,7 +136,7 @@ pub struct TcpIPv4Handler {
     // RST segments awaiting to be sent.
     rst_queue: Vec<(ConnectionTuple, RstConfig)>,
     // Maximum size of the RST queue.
-    max_pending_resets: usize,
+    pub(crate) max_pending_resets: usize,
 }
 
 // Only used locally, in the receive_packet method, to differentiate between different outcomes

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -601,7 +601,9 @@ mod tests {
         );
 
         match VmResources::from_json(json.as_str(), "some_version") {
-            Err(Error::NetDevice(NetworkInterfaceError::OpenTap { .. })) => (),
+            Err(Error::NetDevice(NetworkInterfaceError::CreateNetworkDevice(
+                devices::virtio::net::Error::TapOpen { .. },
+            ))) => (),
             _ => unreachable!(),
         }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.37
+COVERAGE_TARGET_PCT = 84.42
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -178,7 +178,7 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
         guest_mac='06:00:00:00:00:01'
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert "Cannot open TAP device. Invalid name/permissions. CreateTap" \
+    assert "Could not create Network Device" \
         in response.text
 
     # Updates to a network interface with an available name are allowed.


### PR DESCRIPTION
## Reason for This PR

Fixes #1425 

## Description of Changes

- The Net device constructor receives the Tap interface name and opens it. This is similar to how the Block device handles the disk file.
- Implement the Persist trait for the Net device in order to be able to save/restore it.
- Derive Versionize for the NetState.


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] No newly added `unsafe` code.
- [x] No API changes.
- [x] No user-facing changes.
