### PR TITLE
[WIP] dumbo: remove the dependency on mmds

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -14,3 +14,4 @@ net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 virtio_gen = { path = "../virtio_gen" }
+mmds = { path = "../mmds" }

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -12,10 +12,10 @@ use crate::virtio::{
     ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_NET, VIRTIO_MMIO_INT_VRING,
 };
 use crate::{report_net_event_fail, Error as DeviceError};
-use dumbo::ns::MmdsNetworkStack;
 use dumbo::{EthernetFrame, MacAddr, MAC_ADDR_LEN};
 use libc::EAGAIN;
 use logger::{Metric, METRICS};
+use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{RateLimiter, TokenBucket, TokenType};
 #[cfg(not(test))]
 use std::io::Read;

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -9,7 +9,6 @@ serde = ">=1.0.27"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }
-mmds = { path = "../mmds" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -9,12 +9,10 @@
 extern crate bitflags;
 
 extern crate logger;
-extern crate mmds;
 extern crate serde;
 extern crate utils;
 
 mod mac;
-pub mod ns;
 mod pdu;
 mod tcp;
 

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -8,3 +8,6 @@ lazy_static = ">=1.1.0"
 serde_json = ">=1.0.9"
 
 micro_http = { path = "../micro_http" }
+utils = { path = "../utils" }
+logger = { path = "../logger" }
+dumbo = { path = "../dumbo" }

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -5,9 +5,13 @@
 extern crate lazy_static;
 extern crate serde_json;
 
+extern crate dumbo;
+extern crate logger;
 extern crate micro_http;
+extern crate utils;
 
 pub mod data_store;
+pub mod ns;
 
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -9,15 +9,21 @@ use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 use std::result::Result;
 
-use crate::MacAddr;
+use dumbo::mac::MacAddr;
+use dumbo::pdu::arp::{
+    test_speculative_tpa, Error as ArpFrameError, EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN,
+};
+use dumbo::pdu::ethernet::{
+    Error as EthernetFrameError, EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4,
+};
+use dumbo::pdu::ipv4::{
+    test_speculative_dst_addr, Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP,
+};
+use dumbo::pdu::tcp::Error as TcpSegmentError;
+use dumbo::pdu::Incomplete;
+use dumbo::tcp::handler::{self, RecvEvent, TcpIPv4Handler, WriteEvent};
+use dumbo::tcp::NextSegmentStatus;
 use logger::{Metric, METRICS};
-use pdu::arp::{test_speculative_tpa, Error as ArpFrameError, EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
-use pdu::ethernet::{Error as EthernetFrameError, EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4};
-use pdu::ipv4::{test_speculative_dst_addr, Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};
-use pdu::tcp::Error as TcpSegmentError;
-use pdu::Incomplete;
-use tcp::handler::{self, RecvEvent, TcpIPv4Handler, WriteEvent};
-use tcp::NextSegmentStatus;
 use utils::time::timestamp_cycles;
 
 const DEFAULT_MAC_ADDR: &str = "06:01:23:45:67:01";
@@ -281,7 +287,7 @@ impl MmdsNetworkStack {
 mod tests {
     use super::*;
 
-    use pdu::tcp::{Flags as TcpFlags, TcpSegment};
+    use dumbo::pdu::tcp::{Flags as TcpFlags, TcpSegment};
     use std::str::FromStr;
 
     // We use LOCALHOST here because const new() is not stable yet, so just reuse this const, since


### PR DESCRIPTION
Move dumbo::ns to mmds crate

Signed-off-by: moricho <ikeda.morito@gmail.com>

## Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/1770

## Description of Changes

This PR moves `dumbo::ns` to `mmds` crate, but haven't removed the dependency on `mmds::parse_request` method yet.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
