### PR TITLE
MMDS data store support for numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Removed redundant RescanBlockDevice action from the /actions API.
   The functionality is available through the PATCH /drives API.
   See `docs/api_requests/patch-block.md`.
+- Within guest, MMDS response content is changed to JSON.
 
 ## [0.20.0]
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -15,7 +15,8 @@ MMDS is no longer available.
 Users can add/update the MMDS contents via the backend, which is accessible
 through the Firecracker API. Setting the initial contents involves a `PUT`
 request to the `/mmds` API resource, with a JSON body that describes the
-desired data store structure and contents. Here's a JSON example:
+desired data store structure and contents. The supported JSON data types are
+string, object and array. Here's a JSON example:
 
 ```json
 {
@@ -67,9 +68,10 @@ Users can set up a custom IPv4 address for MMDS. This can be achieved through a
 }
 ```
 
-The `ipv4_address` value must be a valid IPv4 address. The configured IPv4 address
-can be used from within the microVM to issue `GET` requests  to the MMDS. An
-example of MMDS request from within the guest might look like the following:
+The `ipv4_address` value is optional, and must be a valid IPv4 address. The
+configured IPv4 address can be used from within the microVM to issue `GET`
+requests  to the MMDS. An example of MMDS request from within the guest might
+look like the following:
 
 ```bash
 curl -s "http://169.254.169.200/latest/meta-data/ami-id"

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -15,8 +15,9 @@ MMDS is no longer available.
 Users can add/update the MMDS contents via the backend, which is accessible
 through the Firecracker API. Setting the initial contents involves a `PUT`
 request to the `/mmds` API resource, with a JSON body that describes the
-desired data store structure and contents. The supported JSON data types are
-string, object and array. Here's a JSON example:
+desired data store structure and contents. An important note here is that
+the supported JSON data types are: number, string, object and array. Here's
+a JSON example:
 
 ```json
 {

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -670,7 +670,7 @@ mod tests {
             .write_all(
                 b"PUT /mmds/config HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
-                Content-Length: 26\r\n\r\n{\"ipv4_address\":\"1.1.1.1\"}",
+                Content-Length: 32\r\n\r\n{\"ipv4_address\":\"169.254.170.2\"}",
             )
             .unwrap();
         assert!(connection.try_read().is_ok());

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -241,7 +241,8 @@ mod tests {
                 "first": "John",
                 "second": "Doe"
             },
-            "age": 43
+            "age": 12,
+            "invalid": true
         }"#;
         assert_eq!(
             MMDS.lock()

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -76,14 +76,11 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
                 .expect("Failed to build MMDS response due to poisoned lock")
                 .get_value(uri.to_string());
             match response {
-                Ok(response) => {
-                    let response_body = response.join("\n");
-                    build_response(
-                        request.http_version(),
-                        StatusCode::OK,
-                        Body::new(response_body),
-                    )
-                }
+                Ok(response_body) => build_response(
+                    request.http_version(),
+                    StatusCode::OK,
+                    Body::new(response_body),
+                ),
                 Err(e) => {
                     match e {
                         MmdsError::NotFound => {
@@ -221,7 +218,7 @@ mod tests {
         // Test Ok path.
         let request = b"GET http://169.254.169.254/ HTTP/1.0\r\n\r\n";
         let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
-        let body = "age\nname/\nphones/".to_string();
+        let body = r#"{"age":"43","name":{"first":"John","second":"Doe"},"phones":{"home":{"RO":"+40 1234567","UK":"+44 1234567"},"mobile":"+44 2345678"}}"#.to_string();
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
 
@@ -231,7 +228,7 @@ mod tests {
 
         let request = b"GET /age HTTP/1.1\r\n\r\n";
         let mut expected_response = Response::new(Version::Http11, StatusCode::OK);
-        let body = "43".to_string();
+        let body = r#""43""#.to_string();
         expected_response.set_body(Body::new(body));
         let actual_response = parse_request(request);
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -16,6 +16,7 @@ use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
 use devices::legacy::Serial;
 use devices::virtio::{MmioTransport, Vsock, VsockUnixBackend};
+
 use polly::event_manager::{Error as EventManagerError, EventManager};
 use seccomp::BpfProgramRef;
 use utils::eventfd::EventFd;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -280,9 +280,9 @@ mod tests {
     use resources::VmResources;
     use utils::tempfile::TempFile;
     use vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
-    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig, DriveError};
+    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
-    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
+    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use vmm_config::vsock::tests::{default_config, TempSockFile};
     use vmm_config::RateLimiterConfig;
     use vstate::VcpuConfig;
@@ -617,46 +617,7 @@ mod tests {
                         "vcpu_count": 2,
                         "mem_size_mib": 1024,
                         "ht_enabled": false
-                    }},
-                    "mmds-config": {{
-                        "ipv4_address": "169.254.170.2"
                     }}
-            }}"#,
-            kernel_file.as_path().to_str().unwrap(),
-            rootfs_file.as_path().to_str().unwrap(),
-        );
-        assert!(VmResources::from_json(json.as_str(), "some_version").is_ok());
-
-        // Test all configuration, this time trying to configure the MMDS with an
-        // empty body. It will make it access the code path in which it sets the
-        // default MMDS configuration.
-        json = format!(
-            r#"{{
-                    "boot-source": {{
-                        "kernel_image_path": "{}",
-                        "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
-                    }},
-                    "drives": [
-                        {{
-                            "drive_id": "rootfs",
-                            "path_on_host": "{}",
-                            "is_root_device": true,
-                            "is_read_only": false
-                        }}
-                    ],
-                    "network-interfaces": [
-                        {{
-                            "iface_id": "netif",
-                            "host_dev_name": "hostname8",
-                            "allow_mmds_requests": true
-                        }}
-                    ],
-                    "machine-config": {{
-                        "vcpu_count": 2,
-                        "mem_size_mib": 1024,
-                        "ht_enabled": false
-                    }},
-                    "mmds-config": {{}}
             }}"#,
             kernel_file.as_path().to_str().unwrap(),
             rootfs_file.as_path().to_str().unwrap(),

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.19
+COVERAGE_TARGET_PCT = 82.96
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -10,15 +10,7 @@ def _assert_out(stdout, stderr, expected):
     assert stdout.read() == expected
 
 
-# Used when the output consists of a set of lines in no particular order, and
-# thus may differ from one run to another.
-def _assert_out_multiple(stdout, stderr, lines):
-    assert stderr.read() == ''
-    out = stdout.read()
-    assert sorted(out.split('\n')) == sorted(lines)
-
-
-def test_custom_ipv4_support_config(test_microvm_with_ssh, network_config):
+def test_custom_ipv4(test_microvm_with_ssh, network_config):
     """Test the API for MMDS custom ipv4 support."""
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
@@ -88,38 +80,121 @@ def test_custom_ipv4_support_config(test_microvm_with_ssh, network_config):
 
     cmd = pre + 'latest/meta-data/ami-id'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'ami-12345678')
+    _assert_out(stdout, stderr, '"ami-12345678"')
 
     # The request is still valid if we append a
     # trailing slash to a leaf node.
     cmd = pre + 'latest/meta-data/ami-id/'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'ami-12345678')
+    _assert_out(stdout, stderr, '"ami-12345678"')
 
     cmd = pre + 'latest/meta-data/network/interfaces/macs/'\
         '02:29:96:8f:6a:2d/subnet-id'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'subnet-be9b61d')
+    _assert_out(stdout, stderr, '"subnet-be9b61d"')
 
     # Test reading a non-leaf node WITHOUT a trailing slash.
     cmd = pre + 'latest/meta-data'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out_multiple(
+    _assert_out(
         stdout,
         stderr,
-        ['ami-id', 'reservation-id', 'local-hostname', 'public-hostname',
-            'network/']
-    )
+        '{"ami-id":"ami-12345678","local-hostname":\
+"ip-10-251-50-12.ec2.internal","network":{"interfaces":\
+{"macs":{"02:29:96:8f:6a:2d":{"device-number":"13345342",\
+"local-hostname":"localhost","subnet-id":"subnet-be9b61d"}}}},\
+"public-hostname":"ec2-203-0-113-25.compute-1.amazonaws.com",\
+"reservation-id":"r-fea54097"}')
 
     # Test reading a non-leaf node with a trailing slash.
     cmd = pre + 'latest/meta-data/'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out_multiple(
+    _assert_out(
         stdout,
         stderr,
-        ['ami-id', 'reservation-id', 'local-hostname', 'public-hostname',
-            'network/']
+        '{"ami-id":"ami-12345678","local-hostname":\
+"ip-10-251-50-12.ec2.internal","network":{"interfaces":\
+{"macs":{"02:29:96:8f:6a:2d":{"device-number":"13345342",\
+"local-hostname":"localhost","subnet-id":"subnet-be9b61d"}}}},\
+"public-hostname":"ec2-203-0-113-25.compute-1.amazonaws.com",\
+"reservation-id":"r-fea54097"}')
+
+
+def test_json_response(test_microvm_with_ssh, network_config):
+    """Test the MMDS json response."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+
+    response = test_microvm.mmds.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == {}
+
+    data_store = {
+        'latest': {
+            'meta-data': {
+                'ami-id': 'ami-12345678',
+                'reservation-id': 'r-fea54097',
+                'local-hostname': 'ip-10-251-50-12.ec2.internal',
+                'public-hostname': 'ec2-203-0-113-25.compute-1.amazonaws.com',
+                'dummy_res': ['res1', 'res2']
+            }
+        }
+    }
+    response = test_microvm.mmds.put(json=data_store)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    response = test_microvm.mmds.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == data_store
+
+    config_data = {
+        'ipv4_address': '169.254.169.250',
+    }
+    response = test_microvm.mmds.put_config(json=config_data)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    test_microvm.basic_config(vcpu_count=1)
+    _tap = test_microvm.ssh_network_config(
+         network_config,
+         '1',
+         allow_mmds_requests=True
     )
+
+    test_microvm.start()
+    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+
+    response = test_microvm.mmds.put_config(json=config_data)
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+    cmd = 'ip route add 169.254.169.250 dev eth0'
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _assert_out(stdout, stderr, '')
+
+    pre = 'curl -s http://169.254.169.250/'
+
+    cmd = pre + 'latest'
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _assert_out(stdout, stderr, '{"meta-data":{"ami-id":\
+"ami-12345678","dummy_res":["res1","res2"],"local-hostname":\
+"ip-10-251-50-12.ec2.internal","public-hostname":\
+"ec2-203-0-113-25.compute-1.amazonaws.com","reservation-id":\
+"r-fea54097"}}')
+
+    cmd = pre + 'latest/meta-data/'
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _assert_out(stdout, stderr, '{"ami-id":\
+"ami-12345678","dummy_res":["res1","res2"],"local-hostname":\
+"ip-10-251-50-12.ec2.internal","public-hostname":\
+"ec2-203-0-113-25.compute-1.amazonaws.com","reservation-id":\
+"r-fea54097"}')
+
+    cmd = pre + 'latest/meta-data/ami-id/'
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _assert_out(stdout, stderr, '"ami-12345678"')
+
+    cmd = pre + 'latest/meta-data/dummy_res/0'
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _assert_out(stdout, stderr, '"res1"')
 
 
 def test_mmds(test_microvm_with_ssh, network_config):
@@ -220,37 +295,43 @@ def test_mmds(test_microvm_with_ssh, network_config):
 
     cmd = pre + 'latest/meta-data/ami-id'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'ami-12345678')
+    _assert_out(stdout, stderr, '"ami-12345678"')
 
     # The request is still valid if we append a trailing slash to a leaf node.
     cmd = pre + 'latest/meta-data/ami-id/'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'ami-12345678')
+    _assert_out(stdout, stderr, '"ami-12345678"')
 
     cmd = pre + 'latest/meta-data/network/interfaces/macs/'\
         '02:29:96:8f:6a:2d/subnet-id'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out(stdout, stderr, 'subnet-12345')
+    _assert_out(stdout, stderr, '"subnet-12345"')
 
     # Test reading a non-leaf node WITHOUT a trailing slash.
     cmd = pre + 'latest/meta-data'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out_multiple(
+    _assert_out(
         stdout,
         stderr,
-        ['ami-id', 'reservation-id', 'local-hostname', 'public-hostname',
-         'network/']
-    )
+        '{"ami-id":"ami-12345678","local-hostname":\
+"ip-10-251-50-12.ec2.internal","network":{"interfaces":\
+{"macs":{"02:29:96:8f:6a:2d":{"device-number":"13345342",\
+"local-hostname":"localhost","subnet-id":"subnet-12345"}}}},\
+"public-hostname":"ec2-203-0-113-25.compute-1.amazonaws.com",\
+"reservation-id":"r-fea54097"}')
 
     # Test reading a non-leaf node with a trailing slash.
     cmd = pre + 'latest/meta-data/'
     _, stdout, stderr = ssh_connection.execute_command(cmd)
-    _assert_out_multiple(
+    _assert_out(
         stdout,
         stderr,
-        ['ami-id', 'reservation-id', 'local-hostname', 'public-hostname',
-         'network/']
-    )
+        '{"ami-id":"ami-12345678","local-hostname":\
+"ip-10-251-50-12.ec2.internal","network":{"interfaces":\
+{"macs":{"02:29:96:8f:6a:2d":{"device-number":"13345342",\
+"local-hostname":"localhost","subnet-id":"subnet-12345"}}}},\
+"public-hostname":"ec2-203-0-113-25.compute-1.amazonaws.com",\
+"reservation-id":"r-fea54097"}')
 
 
 def test_mmds_dummy(test_microvm_with_ssh):


### PR DESCRIPTION
## Reason for This PR

 #1682

## Description of Changes

The changes comprised in this PR add JSON number support for MMDS information storage and retrieval. Currently, the MMDS data store scheme supports the following JSON data types: number, string, object and array.

Note: last three commits are relevant to this PR. It is best to be reviewed after #1772 gets merged.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
