### PR TITLE
mmds: IPv4 address link-local check at config time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   this method for configuration, only `--log-path` is mandatory.
 - Added a [guide](docs/devctr-image.md) for updating the dev container image.
 - Added a new API call, `PUT /mmds/config`, for configuring the
-  `MMDS` with a custom IPv4 address.
+  `MMDS` with a custom valid link-local IPv4 address.
 
 ### Fixed
 - Added `--version` flag to both Firecracker and Jailer.

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -67,9 +67,10 @@ Users can set up a custom IPv4 address for MMDS. This can be achieved through a
 }
 ```
 
-The `ipv4_address` value must be a valid IPv4 address. The configured IPv4 address
-can be used from within the microVM to issue `GET` requests  to the MMDS. An
-example of MMDS request from within the guest might look like the following:
+The `ipv4_address` value must be a valid link-local IPv4 address. The
+configured IPv4 address can be used from within the microVM to issue `GET`
+requests to the MMDS. An example of MMDS request from within the guest
+might look like the following:
 
 ```bash
 curl -s "http://169.254.169.200/latest/meta-data/ami-id"

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -670,7 +670,7 @@ mod tests {
             .write_all(
                 b"PUT /mmds/config HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
-                Content-Length: 26\r\n\r\n{\"ipv4_address\":\"1.1.1.1\"}",
+                Content-Length: 32\r\n\r\n{\"ipv4_address\":\"169.254.170.2\"}",
             )
             .unwrap();
         assert!(connection.try_read().is_ok());

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::VmmAction;
 use micro_http::StatusCode;
 use request::{Body, Error, ParsedRequest};
+use vmm::rpc_interface::VmmAction::SetMmdsConfiguration;
 use vmm::vmm_config::mmds::MmdsConfig;
 
 pub fn parse_get_mmds() -> Result<ParsedRequest, Error> {
@@ -16,7 +16,7 @@ pub fn parse_put_mmds(
 ) -> Result<ParsedRequest, Error> {
     match path_second_token {
         Some(config_path) => match *config_path {
-            "config" => Ok(ParsedRequest::Sync(VmmAction::SetMmdsConfiguration(
+            "config" => Ok(ParsedRequest::Sync(SetMmdsConfiguration(
                 serde_json::from_slice::<MmdsConfig>(body.raw()).map_err(Error::SerdeJson)?,
             ))),
             _ => Err(Error::Generic(
@@ -55,7 +55,7 @@ mod tests {
         assert!(parse_put_mmds(&Body::new(invalid_body), None).is_err());
 
         let body = r#"{
-                "ipv4_address": "1.1.1.1"
+                "ipv4_address": "169.254.170.2"
               }"#;
         let path = "config";
         assert!(parse_put_mmds(&Body::new(body), Some(&path)).is_ok());

--- a/src/dumbo/src/ns.rs
+++ b/src/dumbo/src/ns.rs
@@ -106,8 +106,8 @@ impl MmdsNetworkStack {
         self.tcp_handler.set_local_ipv4_addr(ipv4_addr);
     }
 
-    pub fn set_default_ipv4_addr(&mut self) {
-        self.set_ipv4_addr(Ipv4Addr::from(DEFAULT_IPV4_ADDR));
+    pub fn default_ipv4_addr() -> Ipv4Addr {
+        Ipv4Addr::from(DEFAULT_IPV4_ADDR)
     }
 
     // This is the entry point into the MMDS network stack. The src slice should hold the contents
@@ -513,11 +513,9 @@ mod tests {
     }
 
     #[test]
-    fn test_set_default_ipv4_addr() {
-        let mut ns = MmdsNetworkStack::new_with_defaults(None);
-        ns.set_default_ipv4_addr();
-        let expected_ipv4_addr = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
-        assert_eq!(ns.ipv4_addr, expected_ipv4_addr);
-        assert_eq!(ns.tcp_handler.local_ipv4_addr(), expected_ipv4_addr);
+    fn test_default_ipv4_addr() {
+        let actual = MmdsNetworkStack::default_ipv4_addr();
+        let expected = Ipv4Addr::from(DEFAULT_IPV4_ADDR);
+        assert_eq!(actual, expected);
     }
 }

--- a/src/utils/src/net/ipv4addr.rs
+++ b/src/utils/src/net/ipv4addr.rs
@@ -1,0 +1,63 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::Ipv4Addr;
+
+/// Checks if an IPv4 address is RFC 3927 compliant.
+/// # Examples
+///
+/// ```
+/// use std::net::Ipv4Addr;
+/// use utils::net::ipv4addr::is_link_local_valid;
+///
+/// is_link_local_valid(Ipv4Addr::new(169, 254, 1, 1));
+///
+pub fn is_link_local_valid(ipv4_addr: Ipv4Addr) -> bool {
+    match ipv4_addr.octets() {
+        [169, 254, 0, _] => false,
+        [169, 254, 255, _] => false,
+        [169, 254, _, _] => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net::ipv4addr::is_link_local_valid;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_is_link_local_valid() {
+        // Outside link-local IPv4 address range (169.254.0.0/16 - 169.254.255.255/16).
+        let mut ipv4_addr = Ipv4Addr::new(1, 1, 1, 1);
+        assert!(!is_link_local_valid(ipv4_addr));
+
+        // First 256 addresses can not be used, per RFC 3927.
+        ipv4_addr = Ipv4Addr::new(169, 254, 0, 0);
+        assert!(!is_link_local_valid(ipv4_addr));
+        ipv4_addr = Ipv4Addr::new(169, 254, 0, 10);
+        assert!(!is_link_local_valid(ipv4_addr));
+        ipv4_addr = Ipv4Addr::new(169, 254, 0, 255);
+        assert!(!is_link_local_valid(ipv4_addr));
+
+        // Last 256 addresses can not be used, per RFC 3927.
+        ipv4_addr = Ipv4Addr::new(169, 254, 255, 0);
+        assert!(!is_link_local_valid(ipv4_addr));
+        ipv4_addr = Ipv4Addr::new(169, 254, 255, 194);
+        assert!(!is_link_local_valid(ipv4_addr));
+        ipv4_addr = Ipv4Addr::new(169, 254, 255, 255);
+        assert!(!is_link_local_valid(ipv4_addr));
+
+        // First valid IPv4 link-local address.
+        ipv4_addr = Ipv4Addr::new(169, 254, 1, 0);
+        assert!(is_link_local_valid(ipv4_addr));
+
+        // Last valid IPv4 link-local address.
+        ipv4_addr = Ipv4Addr::new(169, 254, 254, 255);
+        assert!(is_link_local_valid(ipv4_addr));
+
+        // In between valid IPv4 link-local address.
+        ipv4_addr = Ipv4Addr::new(169, 254, 170, 2);
+        assert!(is_link_local_valid(ipv4_addr));
+    }
+}

--- a/src/utils/src/net/mod.rs
+++ b/src/utils/src/net/mod.rs
@@ -12,4 +12,7 @@
 //! network interfaces.
 
 mod tap;
+
+/// Provides IPv4 address utility methods.
+pub mod ipv4addr;
 pub use self::tap::{Error as TapError, Tap};

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::export::Formatter;
+use std::fmt::{Display, Result};
 use std::net::Ipv4Addr;
 
 /// Keeps the MMDS configuration.
@@ -16,5 +18,22 @@ impl MmdsConfig {
     /// Otherwise returns None.
     pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
         self.ipv4_address
+    }
+}
+
+/// MMDS configuration related errors.
+#[derive(Debug)]
+pub enum MmdsConfigError {
+    /// The provided IPv4 address is not link-local valid.
+    InvalidIpv4Addr,
+}
+
+impl Display for MmdsConfigError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            MmdsConfigError::InvalidIpv4Addr => {
+                write!(f, "The MMDS IPv4 address is not link local.")
+            }
+        }
     }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.46
+COVERAGE_TARGET_PCT = 84.37
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -18,7 +18,7 @@ def _assert_out_multiple(stdout, stderr, lines):
     assert sorted(out.split('\n')) == sorted(lines)
 
 
-def test_custom_ipv4_support_config(test_microvm_with_ssh, network_config):
+def test_custom_ipv4(test_microvm_with_ssh, network_config):
     """Test the API for MMDS custom ipv4 support."""
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
@@ -57,6 +57,12 @@ def test_custom_ipv4_support_config(test_microvm_with_ssh, network_config):
 
     config_data = {
         'ipv4_address': ''
+    }
+    response = test_microvm.mmds.put_config(json=config_data)
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+    config_data = {
+        'ipv4_address': '1.1.1.1'
     }
     response = test_microvm.mmds.put_config(json=config_data)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)


### PR DESCRIPTION
# Reason for This PR

MMDS configuration `ipv4_address` field must be a valid link-local IPv4 address.

## Description of Changes

Added a link-local check for the IPv4 address which comes with MMDS configuration, returning an error if the provided IPv4 address is not link-local.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
