### PR TITLE
jailer: fix test for sanitize_process

### DIFF
--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -353,7 +353,7 @@ fn main() {
 mod tests {
     use super::*;
     use std::fs::File;
-    use std::os::unix::io::AsRawFd;
+    use std::os::unix::io::IntoRawFd;
 
     use utils::arg_parser;
 
@@ -368,7 +368,7 @@ mod tests {
         for i in 0..n {
             let maybe_file = File::create(format!("{}/{}", tmp_dir_path, i));
             assert!(maybe_file.is_ok());
-            fds.push(maybe_file.unwrap().as_raw_fd());
+            fds.push(maybe_file.unwrap().into_raw_fd());
         }
 
         sanitize_process();


### PR DESCRIPTION
## Reason for This PR

#1804 

## Description of Changes

Change function used from `as_raw_fd` to `into_raw_fd` to ensure 100 fd's are created and held open for the sanitize_process function to close. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
