### PR TITLE
Support (de)ser for MmioTransport

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -422,20 +422,17 @@ pub(crate) mod tests {
         let f = TempFile::new().unwrap();
         f.as_file().set_len(0x1000).unwrap();
 
+        default_block_with_path(f.as_path().to_str().unwrap().to_string())
+    }
+
+    /// Create a default Block instance using file at the specified path to be used in tests.
+    pub fn default_block_with_path(path: String) -> Block {
         // Rate limiting is enabled but with a high operation rate (10 million ops/s).
         let rate_limiter = RateLimiter::new(0, None, 0, 100_000, None, 10).unwrap();
 
         let id = "test".to_string();
         // The default block device is read-write and non-root.
-        Block::new(
-            id,
-            None,
-            f.as_path().to_str().unwrap().to_string(),
-            false,
-            false,
-            rate_limiter,
-        )
-        .unwrap()
+        Block::new(id, None, path, false, false, rate_limiter).unwrap()
     }
 
     pub fn default_mem() -> GuestMemoryMmap {

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -8,7 +8,6 @@ pub mod request;
 
 pub use self::device::Block;
 pub use self::event_handler::*;
-pub use self::persist::*;
 pub use self::request::*;
 
 use vm_memory::GuestMemoryError;

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -30,7 +30,7 @@ pub struct BlockState {
 }
 
 pub struct BlockConstructorArgs {
-    mem: GuestMemoryMmap,
+    pub(crate) mem: GuestMemoryMmap,
 }
 
 impl Persist for Block {

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -109,3 +109,9 @@ pub trait VirtioDevice: AsAny + Send {
         None
     }
 }
+
+impl std::fmt::Debug for dyn VirtioDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "VirtioDevice type {}", self.device_type())
+    }
+}

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -38,17 +38,18 @@ const MMIO_VERSION: u32 = 2;
 ///
 /// Typically one page (4096 bytes) of MMIO address space is sufficient to handle this transport
 /// and inner virtio device.
+#[derive(Debug)]
 pub struct MmioTransport {
     device: Arc<Mutex<dyn VirtioDevice>>,
     // The register where feature bits are stored.
-    features_select: u32,
+    pub(crate) features_select: u32,
     // The register where features page is selected.
-    acked_features_select: u32,
-    queue_select: u32,
-    device_status: u32,
-    config_generation: u32,
+    pub(crate) acked_features_select: u32,
+    pub(crate) queue_select: u32,
+    pub(crate) device_status: u32,
+    pub(crate) config_generation: u32,
     mem: GuestMemoryMmap,
-    interrupt_status: Arc<AtomicUsize>,
+    pub(crate) interrupt_status: Arc<AtomicUsize>,
 }
 
 impl MmioTransport {

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -787,18 +787,8 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) trait TestUtil {
-        fn default_net(test_mutators: TestMutators) -> Net;
-        fn default_guest_mac() -> MacAddr;
-        fn default_guest_memory() -> GuestMemoryMmap;
-        fn rx_single_frame_no_irq_coalescing(&mut self) -> bool;
-        fn virtqueues(mem: &GuestMemoryMmap) -> (VirtQueue, VirtQueue);
-        fn assign_queues(&mut self, rxq: Queue, txq: Queue);
-        fn set_mac(&mut self, mac: MacAddr);
-    }
-
-    impl TestUtil for Net {
-        fn default_net(test_mutators: TestMutators) -> Net {
+    impl Net {
+        pub fn default_net(test_mutators: TestMutators) -> Net {
             let next_tap = NEXT_INDEX.fetch_add(1, Ordering::SeqCst);
             let tap = Tap::open_named(&format!("net-device{}", next_tap)).unwrap();
             tap.enable().unwrap();
@@ -819,15 +809,15 @@ pub(crate) mod tests {
             net
         }
 
-        fn default_guest_mac() -> MacAddr {
+        pub fn default_guest_mac() -> MacAddr {
             MacAddr::parse_str("11:22:33:44:55:66").unwrap()
         }
 
-        fn default_guest_memory() -> GuestMemoryMmap {
+        pub fn default_guest_memory() -> GuestMemoryMmap {
             GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap()
         }
 
-        fn rx_single_frame_no_irq_coalescing(&mut self) -> bool {
+        pub fn rx_single_frame_no_irq_coalescing(&mut self) -> bool {
             let ret = self.rx_single_frame();
             if self.rx_deferred_irqs {
                 self.rx_deferred_irqs = false;
@@ -837,7 +827,7 @@ pub(crate) mod tests {
         }
 
         // Returns handles to virtio queues creation/activation and manipulation.
-        fn virtqueues(mem: &GuestMemoryMmap) -> (VirtQueue, VirtQueue) {
+        pub fn virtqueues(mem: &GuestMemoryMmap) -> (VirtQueue, VirtQueue) {
             let rxq = VirtQueue::new(GuestAddress(0), mem, 16);
             let txq = VirtQueue::new(GuestAddress(0x1000), mem, 16);
             assert!(rxq.end().0 < txq.start().0);
@@ -845,7 +835,7 @@ pub(crate) mod tests {
             (rxq, txq)
         }
 
-        fn set_mac(&mut self, mac: MacAddr) {
+        pub fn set_mac(&mut self, mac: MacAddr) {
             self.guest_mac = Some(mac);
             let mut config_space;
             config_space = vec![0; MAC_ADDR_LEN];
@@ -854,7 +844,7 @@ pub(crate) mod tests {
         }
 
         // Assigns "guest virtio driver" activated queues to the net device.
-        fn assign_queues(&mut self, rxq: Queue, txq: Queue) {
+        pub fn assign_queues(&mut self, rxq: Queue, txq: Queue) {
             self.queues.clear();
             self.queues.push(rxq);
             self.queues.push(txq);

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -243,6 +243,15 @@ mod tests {
     }
 
     #[test]
+    fn test_net_over_mmiotransport_persistance() {
+        use crate::virtio::net::device::{tests::TestMutators, Net};
+        let mem = default_mem();
+        let net = Arc::new(Mutex::new(Net::default_net(TestMutators::default())));
+        let mmio_transport = MmioTransport::new(mem.clone(), net.clone());
+        generic_mmiotransport_persistance_test(mmio_transport, mem, net);
+    }
+
+    #[test]
     fn test_vsock_over_mmiotransport_persistance() {
         use crate::virtio::vsock::{Vsock, VsockUnixBackend};
         let mem = default_mem();

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -9,7 +9,7 @@ mod csm;
 mod device;
 mod event_handler;
 mod packet;
-mod persist;
+pub mod persist;
 mod unix;
 
 use std::os::unix::io::AsRawFd;
@@ -156,7 +156,7 @@ pub trait VsockChannel {
 pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::device::{Vsock, RXQ_INDEX, TXQ_INDEX};
     use super::packet::VSOCK_PKT_HDR_SIZE;
     use super::*;


### PR DESCRIPTION
## Reason for This PR

Fixes #1714 

## Description of Changes

Defines `MmioTransportState` and implements (de)serialization for `MmioTransport` primitives.
    
Creates (de)serialization framework and and hooks in the `Block` and `Vsock` devices (de)serialization to the `MmioTransport` devices that hold block or vsock devices. This allows (de)serialization of the inner device state along with `MmioTransport` primitives.

- [x] Block device hooked in.
- [x] Vsock device hooked in.
- [ ] Net device hooked in - **not done** - depends on #1773 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
