### PR TITLE
jailer: ensure correct permissions on folders inside jail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### Added
 
-- Added a new API call, `PUT /metrics`, for configuring the metrics
-  system.
-- Added `app_name` field in InstanceInfo struct for storing the
-  application name.
+- Added a new API call, `PUT /metrics`, for configuring the metrics system.
+- Added `app_name` field in InstanceInfo struct for storing the application
+  name.
 - New command-line parameters for `firecracker`, named `--log-path`,
   `--level`, `--show-level` and `--show-log-origin` that can be used
   for configuring the Logger when starting the process. When using
@@ -30,6 +29,7 @@
 - Added `--version` flag to both Firecracker and Jailer.
 - Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
   requests originating from guest.
+- Fixed folder permissions in the jail (#1802).
 
 ### Changed
 - Updated CVE-2019-3016 mitigation information in
@@ -44,12 +44,12 @@
   updates to existing configurations.
 - `PATCH /network-interfaces/{id}` only allowed post-boot. Use `PUT` for
   pre-boot updates to existing configurations.
-- Changed returned status code from `500 Internal Server Error` to `501 Not Implemented`,
-  for queries on the MMDS endpoint in IMDS format, when the requested resource value type
-  is unsupported.
+- Changed returned status code from `500 Internal Server Error` to
+  `501 Not Implemented`, for queries on the MMDS endpoint in IMDS format, when
+  the requested resource value type is unsupported.
 - Allowed the MMDS data store to be initialized with all supported JSON types.
-  Retrieval of these values within the guest, besides String, Array, and Dictionary,
-  is only possible in JSON mode.
+  Retrieval of these values within the guest, besides String, Array, and
+  Dictionary, is only possible in JSON mode.
 - `PATCH` request on `/mmds` before the data store is initialized returns 
   `403 BadRequest`.
 - Segregated MMDS documentation in MMDS design documentation and MMDS user

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.31
+COVERAGE_TARGET_PCT = 84.4
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -8,7 +8,7 @@ import stat
 REG_PERMS = stat.S_IRUSR | stat.S_IWUSR | \
             stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | \
             stat.S_IROTH | stat.S_IXOTH
-DIR_STATS = stat.S_IFDIR | REG_PERMS
+DIR_STATS = stat.S_IFDIR | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
 FILE_STATS = stat.S_IFREG | REG_PERMS
 SOCK_STATS = stat.S_IFSOCK | REG_PERMS
 # These are the stats of the devices created by tha jailer.


### PR DESCRIPTION
## Reason for This PR

#1802  

## Description of Changes

The jailer enforces `0o755` (`rwx|r_x|r_x`)  permissions on the jail folder hierarchy, to make sure that the de-privileged firecracker can always access device nodes.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

rust-vmm doesn't have a jailing crate yet.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
