### PR TITLE
Versionize arrays where the size is a constant

### DIFF
--- a/src/versionize_derive/src/fields/union_field.rs
+++ b/src/versionize_derive/src/fields/union_field.rs
@@ -83,7 +83,6 @@ impl UnionField {
             // deserialize a Vec<T> and then copy the elements to the target array.
             syn::Type::Array(array) => {
                 let array_type_token;
-                let array_len: usize;
 
                 match *array.elem.clone() {
                     syn::Type::Path(token) => {
@@ -94,22 +93,16 @@ impl UnionField {
 
                 match &array.len {
                     syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
-                        syn::Lit::Int(lit_int) => array_len = lit_int.base10_parse().unwrap(),
+                        syn::Lit::Int(lit_int) => {
+                            let array_len: usize = lit_int.base10_parse().unwrap();
+                            self.generate_array_deserializer(array_type_token, array_len)
+                        }
                         _ => panic!("Unsupported array len literal."),
                     },
-                    _ => panic!("Unsupported array len expression."),
-                }
-
-                quote! {
-                    unsafe {
-                        object.#field_ident = {
-                            let mut array = [#array_type_token::default() ; #array_len];
-                            for i in 0..#array_len {
-                                array[i] = <#array_type_token as Versionize>::deserialize(&mut reader, version_map, app_version)?;
-                            }
-                            array
-                        }
+                    syn::Expr::Path(expr_path) => {
+                        self.generate_array_deserializer(array_type_token, &expr_path.path)
                     }
+                    _ => panic!("Unsupported array len expression."),
                 }
             }
             syn::Type::Path(_) => quote! {
@@ -119,6 +112,26 @@ impl UnionField {
                 unsafe { object.#field_ident = <#ty as Versionize>::deserialize(&mut reader, version_map, app_version)?; }
             },
             _ => panic!("Unsupported field type {:?}", self.ty),
+        }
+    }
+
+    fn generate_array_deserializer<T: quote::ToTokens>(
+        &self,
+        array_type_token: syn::TypePath,
+        array_len: T,
+    ) -> proc_macro2::TokenStream {
+        let field_ident = format_ident!("{}", self.name);
+
+        quote! {
+            unsafe {
+                object.#field_ident = {
+                    let mut array = [#array_type_token::default() ; #array_len];
+                    for i in 0..#array_len {
+                        array[i] = <#array_type_token as Versionize>::deserialize(&mut reader, version_map, app_version)?;
+                    }
+                    array
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Fixes #1810

## Description of Changes

Support constants as sizes for arrays when generating deserializers.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
