### PR TITLE
Remove dumbo's dependency on mmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "dumbo 0.1.0",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
+ "mmds 0.1.0",
  "net_gen 0.1.0",
  "polly 0.0.1",
  "rate_limiter 0.1.0",
@@ -253,13 +254,10 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
- "mmds 0.1.0",
+ "micro_http 0.1.0",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "snapshot 0.1.0",
  "utils 0.1.0",
- "versionize 0.1.0 (git+https://github.com/firecracker-microvm/versionize?tag=v0.1.0)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
 ]
 
 [[package]]
@@ -442,9 +440,15 @@ dependencies = [
 name = "mmds"
 version = "0.1.0"
 dependencies = [
+ "dumbo 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.1.0",
  "micro_http 0.1.0",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snapshot 0.1.0",
+ "utils 0.1.0",
+ "versionize 0.1.0 (git+https://github.com/firecracker-microvm/versionize?tag=v0.1.0)",
+ "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
 ]
 
 [[package]]

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -17,3 +17,4 @@ snapshot = { path = "../snapshot" }
 versionize = { git = "https://github.com/firecracker-microvm/versionize", tag = "v0.1.0" }
 versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
 virtio_gen = { path = "../virtio_gen" }
+mmds = { path = "../mmds" }

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -12,10 +12,11 @@ use crate::virtio::{
     ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_NET, VIRTIO_MMIO_INT_VRING,
 };
 use crate::{report_net_event_fail, Error as DeviceError};
-use dumbo::ns::MmdsNetworkStack;
-use dumbo::{EthernetFrame, MacAddr, MAC_ADDR_LEN};
+use dumbo::pdu::ethernet::EthernetFrame;
+use dumbo::{MacAddr, MAC_ADDR_LEN};
 use libc::EAGAIN;
 use logger::{Metric, METRICS};
+use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use std::io::Write;
 #[cfg(not(test))]
@@ -791,9 +792,8 @@ pub(crate) mod tests {
         Net, Queue, VirtioDevice, MAX_BUFFER_SIZE, RX_INDEX, TX_INDEX, TYPE_NET,
         VIRTIO_MMIO_INT_VRING, VIRTQ_DESC_F_WRITE,
     };
-    use dumbo::{
-        EthIPv4ArpFrame, EthernetFrame, MacAddr, ETHERTYPE_ARP, ETH_IPV4_FRAME_LEN, MAC_ADDR_LEN,
-    };
+    use dumbo::pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
+    use dumbo::pdu::ethernet::ETHERTYPE_ARP;
     use logger::{Metric, METRICS};
     use polly::event_manager::{EventManager, Subscriber};
     use rate_limiter::{RateLimiter, TokenBucket, TokenType};

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -7,7 +7,8 @@ use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use dumbo::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState, MacAddr, MAC_ADDR_LEN};
+use dumbo::{MacAddr, MAC_ADDR_LEN};
+use mmds::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState};
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -9,10 +9,7 @@ serde = ">=1.0.27"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }
-mmds = { path = "../mmds" }
-snapshot = { path = "../snapshot" }
-versionize = { git = "https://github.com/firecracker-microvm/versionize", tag = "v0.1.0" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
+micro_http = { path = "../micro_http" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -9,26 +9,15 @@
 extern crate bitflags;
 
 extern crate logger;
-extern crate mmds;
+extern crate micro_http;
 extern crate serde;
-extern crate snapshot;
 extern crate utils;
-extern crate versionize;
-extern crate versionize_derive;
 
 mod mac;
-pub mod ns;
-mod pdu;
-pub mod persist;
-mod tcp;
+pub mod pdu;
+pub mod tcp;
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};
-pub use pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
-pub use pdu::ethernet::{
-    EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4, PAYLOAD_OFFSET as ETHERNET_PAYLOAD_OFFSET,
-};
-pub use pdu::ipv4::{IPv4Packet, PROTOCOL_TCP, PROTOCOL_UDP};
-pub use pdu::udp::{UdpDatagram, UDP_HEADER_SIZE};
 use std::ops::Index;
 
 /// Represents a generalization of a borrowed `[u8]` slice.

--- a/src/dumbo/src/pdu/udp.rs
+++ b/src/dumbo/src/pdu/udp.rs
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_checksum() {
-        let mut bytes = [0u8; (2 + UDP_HEADER_SIZE)]; // 2-byte payload
+        let mut bytes = [0u8; 2 + UDP_HEADER_SIZE]; // 2-byte payload
         let correct_checksum: u16 = 0x14de;
         let payload_bytes = b"bb";
         let src_ip = Ipv4Addr::new(152, 1, 51, 27);

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -14,7 +14,7 @@
 use std::num::{NonZeroU16, NonZeroU64, Wrapping};
 
 use logger::{Metric, METRICS};
-use mmds::parse_request;
+use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
 use pdu::bytes::NetworkBytes;
 use pdu::tcp::TcpSegment;
 use pdu::Incomplete;
@@ -123,7 +123,11 @@ impl Endpoint {
         )
     }
 
-    pub fn receive_segment<T: NetworkBytes>(&mut self, s: &TcpSegment<T>) {
+    pub fn receive_segment<T: NetworkBytes>(
+        &mut self,
+        s: &TcpSegment<T>,
+        callback: fn(Request) -> Response,
+    ) {
         if self.stop_receiving {
             return;
         }
@@ -181,7 +185,7 @@ impl Endpoint {
             // available in self.receive_buf.
 
             // The following is some ugly but workable code that attempts to find the end of an
-            // HTTP 1.x request in receive_buf. We need to do this for now because parse_request()
+            // HTTP 1.x request in receive_buf. We need to do this for now because parse_request_bytes()
             // expects the entire request contents as parameter.
             if self.receive_buf_left > 2 {
                 let b = self.receive_buf.as_mut();
@@ -198,7 +202,8 @@ impl Endpoint {
                         };
 
                         // We found a potential request, let's parse it.
-                        let response = parse_request(&b[..end]);
+                        let response = parse_request_bytes(&b[..end], callback);
+
                         // The unwrap is safe because a Vec will allocate more space until all the
                         // writes succeed.
                         response.write_all(&mut self.response_buf).unwrap();
@@ -299,6 +304,51 @@ impl Endpoint {
     }
 }
 
+fn build_response(http_version: Version, status_code: StatusCode, body: Body) -> Response {
+    let mut response = Response::new(http_version, status_code);
+    response.set_body(body);
+    response
+}
+
+/// Parses the request bytes and builds a `micro_http::Response` by the given callback function.
+fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) -> Response {
+    let request = Request::try_from(byte_stream);
+    match request {
+        Ok(request) => callback(request),
+        Err(e) => match e {
+            RequestError::InvalidHttpVersion(err_msg) => build_response(
+                Version::default(),
+                StatusCode::NotImplemented,
+                Body::new(err_msg.to_string()),
+            ),
+            RequestError::InvalidUri(err_msg) => build_response(
+                Version::default(),
+                StatusCode::BadRequest,
+                Body::new(err_msg.to_string()),
+            ),
+            RequestError::InvalidHttpMethod(err_msg) => build_response(
+                Version::default(),
+                StatusCode::NotImplemented,
+                Body::new(err_msg.to_string()),
+            ),
+            RequestError::InvalidRequest => build_response(
+                Version::default(),
+                StatusCode::BadRequest,
+                Body::new("Invalid request.".to_string()),
+            ),
+            RequestError::InvalidHeader => build_response(
+                Version::default(),
+                StatusCode::BadRequest,
+                Body::new("Invalid headers.".to_string()),
+            ),
+            // `micro-http` supports a predefined list of HTTP headers.
+            // It shouldn't reach this point, because it ignores the
+            // HTTP unsupported headers.
+            RequestError::UnsupportedHeader => unreachable!(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -308,6 +358,7 @@ mod tests {
 
     use pdu::tcp::Flags as TcpFlags;
     use tcp::connection::tests::ConnectionTester;
+    use tcp::tests::mock_callback;
 
     impl Endpoint {
         pub fn set_eviction_threshold(&mut self, value: u64) {
@@ -372,7 +423,7 @@ mod tests {
         ctrl.set_flags_after_ns(TcpFlags::ACK);
         ctrl.set_ack_number(endpoint_isn.wrapping_add(1));
         assert!(!e.connection.is_established());
-        e.receive_segment(&ctrl);
+        e.receive_segment(&ctrl, mock_callback);
         assert!(e.connection.is_established());
 
         // Also, there should be nothing to send now anymore, nor any timeout pending.
@@ -385,7 +436,7 @@ mod tests {
             data.set_flags_after_ns(TcpFlags::ACK);
             data.set_sequence_number(remote_isn.wrapping_add(1));
             data.set_ack_number(endpoint_isn.wrapping_add(1));
-            e.receive_segment(&data);
+            e.receive_segment(&data, mock_callback);
         }
 
         assert_eq!(e.receive_buf_left, incomplete_request.len());
@@ -414,7 +465,7 @@ mod tests {
             data.set_flags_after_ns(TcpFlags::ACK);
             data.set_sequence_number(remote_first_not_sent);
             data.set_ack_number(endpoint_isn + 1);
-            e.receive_segment(&data);
+            e.receive_segment(&data, mock_callback);
         }
 
         remote_first_not_sent =
@@ -432,8 +483,8 @@ mod tests {
             assert_eq!(s.inner().ack_number(), remote_first_not_sent);
 
             let response = from_utf8(s.inner().payload()).unwrap();
-            // The response should contain "404" because the MMDS is empty.
-            assert!(response.contains("404"));
+            // The response should contain "200" because the HTTP request is correct.
+            assert!(response.contains("200"));
 
             endpoint_first_not_sent = s
                 .inner()
@@ -466,7 +517,7 @@ mod tests {
                 data.set_flags_after_ns(TcpFlags::ACK);
                 data.set_sequence_number(remote_first_not_sent);
                 data.set_ack_number(endpoint_first_not_sent);
-                e.receive_segment(&data);
+                e.receive_segment(&data, mock_callback);
             }
 
             remote_first_not_sent = remote_first_not_sent.wrapping_add(request.len() as u32);
@@ -480,7 +531,7 @@ mod tests {
                 assert_eq!(s.inner().ack_number(), remote_first_not_sent);
 
                 let response = from_utf8(s.inner().payload()).unwrap();
-                assert!(response.contains("404"));
+                assert!(response.contains("200"));
 
                 endpoint_first_not_sent =
                     endpoint_first_not_sent.wrapping_add(s.inner().payload_len() as u32);
@@ -512,7 +563,7 @@ mod tests {
             data.set_flags_after_ns(TcpFlags::ACK);
             data.set_sequence_number(remote_first_not_sent);
             data.set_ack_number(endpoint_first_not_sent);
-            e.receive_segment(&data);
+            e.receive_segment(&data, mock_callback);
         }
 
         {
@@ -521,5 +572,58 @@ mod tests {
                 .unwrap();
             assert_eq!(s.inner().flags_after_ns(), TcpFlags::RST);
         }
+    }
+
+    #[test]
+    fn test_parse_request_bytes_error() {
+        // Test unsupported HTTP version.
+        let request_bytes = b"GET http://169.254.169.255/ HTTP/2.0\r\n\r\n";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
+        expected_response.set_body(Body::new("Unsupported HTTP version.".to_string()));
+        let actual_response = parse_request_bytes(request_bytes, mock_callback);
+        assert_eq!(actual_response, expected_response);
+
+        // Test invalid URI (empty URI).
+        let request_bytes = b"GET   HTTP/1.0\r\n\r\n";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::BadRequest);
+        expected_response.set_body(Body::new("Empty URI not allowed.".to_string()));
+        let actual_response = parse_request_bytes(request_bytes, mock_callback);
+        assert_eq!(actual_response, expected_response);
+
+        // Test invalid HTTP methods.
+        let invalid_methods = ["POST", "HEAD", "DELETE", "CONNECT", "OPTIONS", "TRACE"];
+        for method in invalid_methods.iter() {
+            let request_bytes = format!("{} http://169.254.169.255/ HTTP/1.0\r\n\r\n", method);
+            let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
+            expected_response.set_body(Body::new("Unsupported HTTP method.".to_string()));
+            let actual_response = parse_request_bytes(request_bytes.as_bytes(), mock_callback);
+            assert_eq!(actual_response, expected_response);
+        }
+
+        // Test valid methods.
+        let valid_methods = ["PUT", "PATCH", "GET"];
+        for method in valid_methods.iter() {
+            let request_bytes = format!("{} http://169.254.169.255/ HTTP/1.0\r\n\r\n", method);
+            let expected_response = Response::new(Version::Http11, StatusCode::OK);
+            let actual_response = parse_request_bytes(request_bytes.as_bytes(), mock_callback);
+            assert_eq!(actual_response, expected_response);
+        }
+
+        // Test invalid HTTP format.
+        let request_bytes = b"GET / HTTP/1.1\r\n";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::BadRequest);
+        expected_response.set_body(Body::new("Invalid request.".to_string()));
+        let actual_response = parse_request_bytes(request_bytes, mock_callback);
+        assert_eq!(actual_response, expected_response);
+
+        // Test invalid HTTP headers.
+        let request_bytes = b"PATCH http://localhost/home HTTP/1.1\r\n\
+                                 Expect: 100-continue\r\n\
+                                 Transfer-Encoding: identity; q=0\r\n\
+                                 Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody";
+        let mut expected_response = Response::new(Version::Http11, StatusCode::BadRequest);
+        expected_response.set_body(Body::new("Invalid headers.".to_string()));
+        let actual_response = parse_request_bytes(request_bytes, mock_callback);
+        assert_eq!(actual_response, expected_response);
     }
 }

--- a/src/dumbo/src/tcp/mod.rs
+++ b/src/dumbo/src/tcp/mod.rs
@@ -92,6 +92,13 @@ pub fn seq_at_or_after(a: Wrapping<u32>, b: Wrapping<u32>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use micro_http::{Request, Response, StatusCode, Version};
+
+    /// In tcp tests, some of the functions require a callback parameter. Since we do not care,
+    /// for the purpose of those tests, what that callback does, we need to provide a dummy one.
+    pub fn mock_callback(_request: Request) -> Response {
+        Response::new(Version::Http11, StatusCode::OK)
+    }
 
     #[test]
     fn test_rst_config() {

--- a/src/micro_http/src/response.rs
+++ b/src/micro_http/src/response.rs
@@ -49,6 +49,7 @@ impl StatusCode {
     }
 }
 
+#[derive(Debug, PartialEq)]
 struct StatusLine {
     http_version: Version,
     status_code: StatusCode,
@@ -75,6 +76,7 @@ impl StatusLine {
 /// Wrapper over the list of headers associated with a HTTP Response.
 /// When creating a ResponseHeaders object, the content type is initialized to `text/plain`.
 /// The content type can be updated with a call to `set_content_type`.
+#[derive(Debug, PartialEq)]
 pub struct ResponseHeaders {
     content_length: i32,
     content_type: MediaType,
@@ -163,6 +165,7 @@ impl ResponseHeaders {
 /// the body is initialized to `None` and the header is initialized with the `default` value. The body
 /// can be updated with a call to `set_body`. The header can be updated with `set_content_type` and
 /// `set_server`.
+#[derive(Debug, PartialEq)]
 pub struct Response {
     status_line: StatusLine,
     headers: ResponseHeaders,

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -8,3 +8,9 @@ lazy_static = ">=1.1.0"
 serde_json = ">=1.0.9"
 
 micro_http = { path = "../micro_http" }
+utils = { path = "../utils" }
+logger = { path = "../logger" }
+dumbo = { path = "../dumbo" }
+snapshot = { path = "../snapshot" }
+versionize = { git = "https://github.com/firecracker-microvm/versionize", tag = "v0.1.0" }
+versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -5,15 +5,23 @@
 extern crate lazy_static;
 extern crate serde_json;
 
+extern crate dumbo;
+extern crate logger;
 extern crate micro_http;
+extern crate snapshot;
+extern crate utils;
+extern crate versionize;
+extern crate versionize_derive;
 
 pub mod data_store;
+pub mod ns;
+pub mod persist;
 
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
 
 use data_store::{Error as MmdsError, Mmds, OutputFormat};
-use micro_http::{Body, MediaType, Method, Request, RequestError, Response, StatusCode, Version};
+use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
 
 lazy_static! {
     // A static reference to a global Mmds instance. We currently use this for ease of access during
@@ -29,6 +37,13 @@ impl Into<OutputFormat> for MediaType {
             MediaType::PlainText => OutputFormat::Imds,
         }
     }
+}
+
+/// Builds the `micro_http::Response` with a given HTTP version, status code, and body.
+fn build_response(http_version: Version, status_code: StatusCode, body: Body) -> Response {
+    let mut response = Response::new(http_version, status_code);
+    response.set_body(body);
+    response
 }
 
 /// Patch provided JSON document (given as `serde_json::Value`) in-place with JSON Merge Patch
@@ -59,12 +74,6 @@ pub fn json_patch(target: &mut Value, patch: &Value) {
     }
 }
 
-fn build_response(http_version: Version, status_code: StatusCode, body: Body) -> Response {
-    let mut response = Response::new(http_version, status_code);
-    response.set_body(body);
-    response
-}
-
 // Make the URI a correct JSON pointer value.
 fn sanitize_uri(mut uri: String) -> String {
     let mut len = u32::MAX as usize;
@@ -78,94 +87,58 @@ fn sanitize_uri(mut uri: String) -> String {
     uri
 }
 
-pub fn parse_request(request_bytes: &[u8]) -> Response {
-    let request = Request::try_from(request_bytes);
-    match request {
-        Ok(request) => {
-            let uri = request.uri().get_abs_path();
-            if uri.is_empty() {
-                return build_response(
-                    request.http_version(),
-                    StatusCode::BadRequest,
-                    Body::new("Invalid URI.".to_string()),
-                );
-            }
+fn convert_to_response(request: Request) -> Response {
+    let uri = request.uri().get_abs_path();
+    if uri.is_empty() {
+        return build_response(
+            request.http_version(),
+            StatusCode::BadRequest,
+            Body::new("Invalid URI.".to_string()),
+        );
+    }
 
-            if request.method() != Method::Get {
-                let mut response = build_response(
-                    request.http_version(),
-                    StatusCode::MethodNotAllowed,
-                    Body::new("Not allowed HTTP method."),
-                );
-                response.allow_method(Method::Get);
-                return response;
-            }
+    if request.method() != Method::Get {
+        let mut response = build_response(
+            request.http_version(),
+            StatusCode::MethodNotAllowed,
+            Body::new("Not allowed HTTP method."),
+        );
+        response.allow_method(Method::Get);
+        return response;
+    }
 
-            // The data store expects a strict json path, so we need to
-            // sanitize the URI.
-            let json_pointer = sanitize_uri(uri.to_string());
+    // The data store expects a strict json path, so we need to
+    // sanitize the URI.
+    let json_pointer = sanitize_uri(uri.to_string());
 
-            // The lock can be held by one thread only, so it is safe to unwrap.
-            // If another thread poisoned the lock, we abort the execution.
-            let response = MMDS
-                .lock()
-                .expect("Poisoned lock")
-                .get_value(json_pointer, request.headers.accept().into());
+    // The lock can be held by one thread only, so it is safe to unwrap.
+    // If another thread poisoned the lock, we abort the execution.
+    let response = MMDS
+        .lock()
+        .expect("Poisoned lock")
+        .get_value(json_pointer, request.headers.accept().into());
 
-            match response {
-                Ok(response_body) => build_response(
-                    request.http_version(),
-                    StatusCode::OK,
-                    Body::new(response_body),
-                ),
-                Err(e) => match e {
-                    MmdsError::NotFound => {
-                        let error_msg = format!("Resource not found: {}.", uri);
-                        build_response(
-                            request.http_version(),
-                            StatusCode::NotFound,
-                            Body::new(error_msg),
-                        )
-                    }
-                    MmdsError::UnsupportedValueType => build_response(
-                        request.http_version(),
-                        StatusCode::NotImplemented,
-                        Body::new(e.to_string()),
-                    ),
-                    MmdsError::NotInitialized => unreachable!(),
-                },
-            }
-        }
+    match response {
+        Ok(response_body) => build_response(
+            request.http_version(),
+            StatusCode::OK,
+            Body::new(response_body),
+        ),
         Err(e) => match e {
-            RequestError::InvalidHttpVersion(err_msg) => build_response(
-                Version::default(),
+            MmdsError::NotFound => {
+                let error_msg = format!("Resource not found: {}.", uri);
+                build_response(
+                    request.http_version(),
+                    StatusCode::NotFound,
+                    Body::new(error_msg),
+                )
+            }
+            MmdsError::UnsupportedValueType => build_response(
+                request.http_version(),
                 StatusCode::NotImplemented,
-                Body::new(err_msg.to_string()),
+                Body::new(e.to_string()),
             ),
-            RequestError::InvalidUri(err_msg) => build_response(
-                Version::default(),
-                StatusCode::BadRequest,
-                Body::new(err_msg.to_string()),
-            ),
-            RequestError::InvalidHttpMethod(err_msg) => build_response(
-                Version::default(),
-                StatusCode::NotImplemented,
-                Body::new(err_msg.to_string()),
-            ),
-            RequestError::InvalidRequest => build_response(
-                Version::default(),
-                StatusCode::BadRequest,
-                Body::new("Invalid request.".to_string()),
-            ),
-            RequestError::InvalidHeader => build_response(
-                Version::default(),
-                StatusCode::BadRequest,
-                Body::new("Invalid headers.".to_string()),
-            ),
-            // `micro-http` supports a predefined list of HTTP headers.
-            // It shouldn't reach this point, because it ignores the
-            // HTTP unsupported headers.
-            RequestError::UnsupportedHeader => unreachable!(),
+            MmdsError::NotInitialized => unreachable!(),
         },
     }
 }
@@ -173,16 +146,8 @@ pub fn parse_request(request_bytes: &[u8]) -> Response {
 #[cfg(test)]
 mod tests {
     extern crate serde_json;
-    use super::*;
 
-    fn check_http_method_failure(method: String, status: StatusCode, err_msg: String) {
-        let request = format!("{} http://169.254.169.254/ HTTP/1.1\r\n\r\n", method);
-        let mut expected_response = Response::new(Version::Http11, status);
-        expected_response.set_body(Body::new(err_msg));
-        let actual_response = parse_request(request.as_bytes());
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-    }
+    use super::*;
 
     #[test]
     fn test_sanitize_uri() {
@@ -204,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_request() {
+    fn test_convert_to_response() {
         let data = r#"{
             "name": {
                 "first": "John",
@@ -224,54 +189,48 @@ mod tests {
             .put_data(serde_json::from_str(data).unwrap())
             .unwrap();
 
-        // Test invalid request.
-        let request = b"HTTP/1.1";
-        let dummy_response = Response::new(Version::Http11, StatusCode::BadRequest);
-        assert!(parse_request(request).status() == dummy_response.status());
-
-        // Test unsupported HTTP version.
-        let request = b"GET http://169.254.169.255/ HTTP/2.0\r\n\r\n";
-        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
-        expected_response.set_body(Body::new("Unsupported HTTP version.".to_string()));
-        let actual_response = parse_request(request);
-
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
-
-        // Test invalid (empty absolute path) URI.
-        let request = b"GET http:// HTTP/1.0\r\n\r\n";
-        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
-        expected_response.set_body(Body::new("Invalid URI.".to_string()));
-        let actual_response = parse_request(request);
-
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
-
-        // Test invalid HTTP format.
-        let request = b"GET / HTTP/1.1\r\n";
-        let mut expected_response = Response::new(Version::Http11, StatusCode::BadRequest);
-        expected_response.set_body(Body::new("Invalid request.".to_string()));
-        let actual_response = parse_request(request);
-
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
-
         // Test resource not found.
-        let request = b"GET http://169.254.169.254/invalid HTTP/1.0\r\n\r\n";
+        let request_bytes = b"GET http://169.254.169.254/invalid HTTP/1.0\r\n\r\n";
+        let request = Request::try_from(request_bytes).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::NotFound);
         expected_response.set_body(Body::new("Resource not found: /invalid.".to_string()));
-        let actual_response = parse_request(request);
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
 
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
+        // Test NotImplemented.
+        let request_bytes = b"GET /age HTTP/1.1\r\n\r\n";
+        let request = Request::try_from(request_bytes).unwrap();
+        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
+        let body = "Cannot retrieve value. The value has an unsupported type.".to_string();
+        expected_response.set_body(Body::new(body));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
+        // Test not allowed HTTP Method.
+        let not_allowed_methods = ["PUT", "PATCH"];
+        for method in not_allowed_methods.iter() {
+            let request_bytes = format!("{} http://169.254.169.255/ HTTP/1.0\r\n\r\n", method);
+            let request = Request::try_from(request_bytes.as_bytes()).unwrap();
+            let mut expected_response =
+                Response::new(Version::Http10, StatusCode::MethodNotAllowed);
+            expected_response.set_body(Body::new("Not allowed HTTP method.".to_string()));
+            expected_response.allow_method(Method::Get);
+            let actual_response = convert_to_response(request);
+            assert_eq!(actual_response, expected_response);
+        }
+
+        // Test invalid (empty absolute path) URI.
+        let request_bytes = b"GET http:// HTTP/1.0\r\n\r\n";
+        let request = Request::try_from(request_bytes).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        expected_response.set_body(Body::new("Invalid URI.".to_string()));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
 
         // Test Ok path.
-        let request = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
+        let request_bytes = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
                                     Accept: application/json\r\n\r\n";
+        let request = Request::try_from(request_bytes).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
         let mut body = r#"{
                 "age": 43,
@@ -290,75 +249,8 @@ mod tests {
         .to_string();
         body.retain(|c| !c.is_whitespace());
         expected_response.set_body(Body::new(body));
-        let actual_response = parse_request(request);
-
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
-
-        let request = b"GET /age HTTP/1.1\r\n\r\n";
-        let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
-        let body = "Cannot retrieve value. The value has an unsupported type.".to_string();
-        expected_response.set_body(Body::new(body));
-        let actual_response = parse_request(request);
-
-        assert!(expected_response.status() == actual_response.status());
-        assert!(expected_response.body().unwrap() == actual_response.body().unwrap());
-        assert!(expected_response.http_version() == actual_response.http_version());
-    }
-
-    #[test]
-    fn test_unsupported_http_method() {
-        check_http_method_failure(
-            "PUT".to_string(),
-            StatusCode::MethodNotAllowed,
-            "Not allowed HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "PATCH".to_string(),
-            StatusCode::MethodNotAllowed,
-            "Not allowed HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "POST".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "DELETE".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "POST".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "HEAD".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "CONNECT".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "OPTIONS".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "TRACE".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
-        check_http_method_failure(
-            "NOMETHOD".to_string(),
-            StatusCode::NotImplemented,
-            "Unsupported HTTP method.".to_string(),
-        );
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
     }
 
     #[test]

--- a/src/mmds/src/persist.rs
+++ b/src/mmds/src/persist.rs
@@ -5,6 +5,7 @@
 
 use std::net::Ipv4Addr;
 
+use dumbo::{MacAddr, MAC_ADDR_LEN};
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
@@ -34,9 +35,9 @@ impl Persist<'_> for MmdsNetworkStack {
         MmdsNetworkStackState {
             mac_addr,
             ipv4_addr: self.ipv4_addr.into(),
-            tcp_port: self.tcp_handler.local_port,
-            max_connections: self.tcp_handler.max_connections,
-            max_pending_resets: self.tcp_handler.max_pending_resets,
+            tcp_port: self.tcp_handler.local_port(),
+            max_connections: self.tcp_handler.max_connections(),
+            max_pending_resets: self.tcp_handler.max_pending_resets(),
         }
     }
 
@@ -78,16 +79,16 @@ mod tests {
         assert_eq!(restored_ns.mac_addr, ns.mac_addr);
         assert_eq!(restored_ns.ipv4_addr, ns.ipv4_addr);
         assert_eq!(
-            restored_ns.tcp_handler.local_port,
-            ns.tcp_handler.local_port
+            restored_ns.tcp_handler.local_port(),
+            ns.tcp_handler.local_port()
         );
         assert_eq!(
-            restored_ns.tcp_handler.max_connections,
-            ns.tcp_handler.max_connections
+            restored_ns.tcp_handler.max_connections(),
+            ns.tcp_handler.max_connections()
         );
         assert_eq!(
-            restored_ns.tcp_handler.max_pending_resets,
-            ns.tcp_handler.max_pending_resets
+            restored_ns.tcp_handler.max_pending_resets(),
+            ns.tcp_handler.max_pending_resets()
         );
     }
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -29,6 +29,7 @@ extern crate kernel;
 #[macro_use]
 extern crate logger;
 extern crate dumbo;
+extern crate mmds;
 extern crate rate_limiter;
 extern crate seccomp;
 extern crate snapshot;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -5,7 +5,7 @@
 
 use std::fs::File;
 
-use dumbo::ns::MmdsNetworkStack;
+use mmds::ns::MmdsNetworkStack;
 use utils::net::ipv4addr::is_link_local_valid;
 use vmm_config::boot_source::{
     BootConfig, BootSourceConfig, BootSourceConfigError, DEFAULT_KERNEL_CMDLINE,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.42, "AMD": 84.4}
+COVERAGE_DICT = {"Intel": 84.52, "AMD": 84.51}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
Signed-off-by: moricho <ikeda.morito@gmail.com>

## Reason for This PR

Fix: https://github.com/firecracker-microvm/firecracker/issues/1770

## Description of Changes

This PR 
・moves `dumbo::ns` to `mmds` crate.
・implements response retrieval callback passed to dumbo's tcp::handler
to remove the dumbo's dependency on `mmds`.


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
