### PR TITLE
MMDS HTTP method check for guest requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
    
 ### Fixed
 - Added `--version` flag to both Firecracker and Jailer.
+- Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
+  requests originating from guest.
 
 ### Changed
 - Updated CVE-2019-3016 mitigation information in

--- a/src/micro_http/src/common/mod.rs
+++ b/src/micro_http/src/common/mod.rs
@@ -127,7 +127,7 @@ impl Body {
 }
 
 /// Supported HTTP Methods.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Method {
     /// GET Method.
     Get,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.89
+COVERAGE_TARGET_PCT = 83.93
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

#1819

## Description of Changes

Add a validation check to enforce MMDS HTTP requests to use only `GET`.
Documentation about MMDS guest requests failures can be found in #1800 .

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
