### PR TITLE
devices: enforce data length validity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,9 +194,15 @@ def test_session_tmp_path(test_session_root_path):
 
 def _gcc_compile(src_file, output_file):
     """Build a source file with gcc."""
-    compile_cmd = 'gcc {} -o {} -static -O3'.format(
+    arch = ''
+    if platform.machine() == "x86_64":
+        arch = 'DX86_64'
+    elif platform.machine() == "aarch64":
+        arch = 'DAARCH64'
+    compile_cmd = 'gcc {} -o {} -static -O3 -{}'.format(
         src_file,
-        output_file
+        output_file,
+        arch
     )
     utils.run_cmd(compile_cmd)
 
@@ -232,6 +238,22 @@ def bin_vsock_path(test_session_root_path):
         vsock_helper_bin_path
     )
     yield vsock_helper_bin_path
+
+
+@pytest.fixture(scope='session')
+def mmio_config_update_bin(test_session_root_path):
+    """Build a binary that tries an invalid write to MMIO config space."""
+    # pylint: disable=redefined-outer-name
+    # The fixture pattern causes a pylint false positive for that rule.
+    mmio_write_bin_path = os.path.join(
+        test_session_root_path,
+        'mmio_write'
+    )
+    _gcc_compile(
+        'host_tools/mmio_write.c',
+        mmio_write_bin_path
+    )
+    yield mmio_write_bin_path
 
 
 @pytest.fixture(scope='session')

--- a/tests/host_tools/mmio_write.c
+++ b/tests/host_tools/mmio_write.c
@@ -1,0 +1,72 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a binary, used by the Firecracker integration tests,
+// to test that a MMIO config space rewrite with invalid data
+// (data length too small) will not update the config space.
+// It can be run inside the guest and we expect to not trigger
+// any panic.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+
+int main(int argc, char *argv[]) {
+    int fd;
+    unsigned char *p;
+    int ret = 0;
+    int config_start;
+    int64_t config_offset = 0x00000000;
+    int64_t mmio_start_address = 0x00000000;
+
+    fd = open("/dev/mem", O_RDWR);
+    if (fd < 0) {
+        perror("Failed to open /dev/mem.");
+        return 1;
+    }
+
+    #ifdef X86_64
+        mmio_start_address = 0xD0000000;
+        // The offset in MMIO space where the config space
+        // for the net device starts.
+        // Net device config space offset. From 0xD0000000
+        // to 0xD0001000 is the MMIO space for the root device
+        // (block device).
+        config_offset = 0x00001100;
+    #endif
+    #ifdef AARCH64
+        // From 0x40000000 to 0x40001000 is a space reserved
+        // for the boot time.
+        mmio_start_address = 0x40001000;
+        // The offset in MMIO space where the config space
+        // for the net device starts. It is different than
+        // the one for X86, because here the first MMIO device
+        // is the serial console (from 0x40000000 to 0x40001000).
+        config_offset = 0x00002100;
+    #endif
+
+    p = mmap(NULL, 0x3000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, mmio_start_address);
+    if (p == MAP_FAILED) {
+        perror("Failed to mmap /dev/mem.");
+        return 2;
+    }
+
+    // A MMIO device config space starts at the `config_offset` offset.
+    config_start = p[config_offset];
+    // This wil trigger a MMIO config space rewrite, but because it is
+    // an invalid (partial) write, the config space should not be modified.
+    p[config_offset] += 4;
+    sleep(0.5);
+
+    // Check if the MMIO config space was not updated.
+    if (p[config_offset] != config_start) {
+        perror("Unexpected MMIO config space update.");
+        return 1;
+    }
+
+    printf("Finished.\n");
+    return ret;
+}

--- a/tests/host_tools/vsock_helper.c
+++ b/tests/host_tools/vsock_helper.c
@@ -18,7 +18,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
 
 

--- a/tests/integration_tests/functional/test_mmio_access.py
+++ b/tests/integration_tests/functional/test_mmio_access.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests invalid writes to MMIO config space don't panic."""
+
+import host_tools.network as net_tools
+
+
+def test_mmio_invalid_write(test_microvm_with_ssh, network_config,
+                            mmio_config_update_bin):
+    """Test invalid write to MMIO config space.
+
+    If a write from within the guest to MMIO config space has
+    a length smaller than that space, we should not panic
+    (config space won't be updated).
+    """
+    microvm = test_microvm_with_ssh
+    microvm.spawn()
+
+    microvm.basic_config()
+    # Configure a network interface.
+    _tap, _, _ = microvm.ssh_network_config(network_config, '1')
+
+    microvm.start()
+
+    conn = net_tools.SSHConnection(microvm.ssh_config)
+
+    write_mmio_path = mmio_config_update_bin
+    conn.scp_file(write_mmio_path, 'mmio_write')
+    cmd = "chmod u+x mmio_write && ./mmio_write"
+    # This should be executed successfully.
+    _, stdout, stderr = conn.execute_command(cmd)
+
+    assert stderr.read() == ''
+    assert stdout.read() == 'Finished.\n'
+
+    # Validate the microVM is still up and running.
+    cmd = "ls"
+    _, stdout, stderr = conn.execute_command(cmd)
+    assert stderr.read() == ""
+    assert stdout.read().strip() == "mmio_write"


### PR DESCRIPTION
## Reason for This PR

Fixes: #1822 

## Description of Changes

detailed in the commit message.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
