### PR TITLE
Fix unit test coverage for the cpuid crate

### DIFF
--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -151,7 +151,7 @@ impl CpuidTransformer for AmdCpuidTransformer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -132,7 +132,7 @@ pub fn use_host_cpuid_function(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use common::tests::get_topoext_fn;
     use kvm_bindings::kvm_cpuid_entry2;

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -153,7 +153,7 @@ impl CpuidTransformer for IntelCpuidTransformer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use cpu_leaf::leaf_0xb::LEVEL_TYPE_CORE;
     use cpu_leaf::leaf_0xb::LEVEL_TYPE_INVALID;

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -88,7 +88,7 @@ pub trait CpuidTransformer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use kvm_bindings::kvm_cpuid_entry2;
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.42
+COVERAGE_TARGET_PCT = 84.08
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR
Solve issue #1705 

## Description of Changes
Set the mod block to `mod tests` instead of `mod test` in the `cpuid` crate. This will make the test code in `cpuid` crate get excluded by kcov. If it's not excluded kcov counts the test code as code and then the test coverage result gets messed up.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
