### PR TITLE
dumbo: add support for TCP payloads larger than MSS

### DIFF
--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -1548,18 +1548,23 @@ pub(crate) mod tests {
         let remote_isn = t.remote_isn;
         let mss = u32::from(t.mss);
 
+        let (payload_buf, mut response_seq) = payload_src.unwrap();
+        let mut payload_offset = 0;
         for i in 0..max {
             // Using the expects to get the value of i if there's an error.
             let s = t
-                .write_next_segment(&mut c, payload_src)
+                .write_next_segment(&mut c, Some((&payload_buf[payload_offset..], response_seq)))
                 .unwrap_or_else(|_| panic!("{}", i))
                 .unwrap_or_else(|| panic!("{}", i));
+
+            payload_offset += s.payload_len();
+            response_seq += Wrapping(s.payload_len() as u32);
 
             // Again, the 1 accounts for the sequence number taken up by the SYN.
             assert_eq!(s.sequence_number(), conn_isn.wrapping_add(1 + i * mss));
             assert_eq!(s.ack_number(), remote_isn.wrapping_add(1));
             assert_eq!(s.flags_after_ns(), TcpFlags::ACK);
-            assert_eq!(s.payload_len(), mss as usize);
+            assert_eq!(s.payload_len() as u32, mss);
         }
 
         // No more new data can be sent until the window advances, even though data_buf

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.94
+COVERAGE_TARGET_PCT = 83.89
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

#1836 

## Description of Changes

Using the Ethernet/IP/TCP stack for sending TCP payloads larger than MSS (Maximum Segment Size) established at connection handshake results in incorrect payload at the receiving endpoint.

This PR adds support for accounting of TCP payloads larger than MSS, sent with multiple segments.

Signed-off-by: Iulian Barbu <iul@amazon.com>

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
