### PR TITLE
Add MicroVMState structure

### DIFF
--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -30,7 +30,7 @@ pub struct BlockState {
 }
 
 pub struct BlockConstructorArgs {
-    pub(crate) mem: GuestMemoryMmap,
+    pub mem: GuestMemoryMmap,
 }
 
 impl Persist for Block {

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -36,7 +36,7 @@ pub struct NetState {
 }
 
 pub struct NetConstructorArgs {
-    mem: GuestMemoryMmap,
+    pub mem: GuestMemoryMmap,
 }
 
 #[derive(Debug)]

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -17,14 +17,14 @@ use crate::virtio::{DeviceState, Queue};
 
 #[derive(Versionize)]
 pub struct VsockState {
-    pub(crate) backend: VsockBackendState,
-    pub(crate) frontend: VsockFrontendState,
+    pub backend: VsockBackendState,
+    pub frontend: VsockFrontendState,
 }
 
 /// The Vsock serializable state.
 #[derive(Versionize)]
 pub struct VsockFrontendState {
-    pub(crate) cid: u64,
+    pub cid: u64,
     virtio_state: VirtioDeviceState,
 }
 
@@ -43,14 +43,14 @@ pub struct VsockUdsState {
 
 /// A helper structure that holds the constructor arguments for VsockUnixBackend
 pub struct VsockConstructorArgs<B> {
-    pub(crate) mem: GuestMemoryMmap,
-    pub(crate) backend: B,
+    pub mem: GuestMemoryMmap,
+    pub backend: B,
 }
 
 /// A helper structure that holds the constructor arguments for VsockUnixBackend
 pub struct VsockUdsConstructorArgs {
     // cid available in VsockFrontendState.
-    cid: u64,
+    pub cid: u64,
 }
 
 impl Persist for VsockUnixBackend {

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -234,7 +234,6 @@ impl MMIODeviceManager {
         Ok(())
     }
 
-    #[cfg(target_arch = "aarch64")]
     /// Gets the information of the devices registered up to some point in time.
     pub fn get_device_info(&self) -> &HashMap<(DeviceType, String), MMIODeviceInfo> {
         &self.id_to_dev_info
@@ -261,9 +260,9 @@ impl MMIODeviceManager {
 /// Private structure for storing information about the MMIO device registered at some address on the bus.
 #[derive(Clone, Debug)]
 pub struct MMIODeviceInfo {
-    addr: u64,
-    irq: u32,
-    len: u64,
+    pub addr: u64,
+    pub irq: u32,
+    pub len: u64,
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -1,0 +1,242 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines state structures for saving/restoring a Firecracker microVM.
+
+// Currently only supports x86_64.
+#![cfg(target_arch = "x86_64")]
+
+use devices::virtio::{
+    block::persist::BlockState, net::persist::NetState, persist::MmioTransportState,
+    vsock::persist::VsockState,
+};
+
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use vstate::{VcpuState, VmState};
+
+#[derive(Debug, PartialEq, Versionize)]
+/// Holds information related to how a device is registered in the mmio space.
+pub struct VmmResourcesState {
+    /// Mmio base address at which the device is registered.
+    pub mmio_base: u64,
+    /// Mmio addr range length.
+    pub len: u64,
+    /// Used Irq line(s) for the device.
+    pub irqs: Vec<u32>,
+}
+
+#[derive(Versionize)]
+/// Holds the state of a block device connected to the MMIO space.
+pub struct ConnectedBlockState {
+    /// Device state.
+    pub device_state: BlockState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub vmm_resources: VmmResourcesState,
+}
+
+#[derive(Versionize)]
+/// Holds the state of a net device connected to the MMIO space.
+pub struct ConnectedNetState {
+    /// Device state.
+    pub device_state: NetState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub vmm_resources: VmmResourcesState,
+}
+
+#[derive(Versionize)]
+/// Holds the state of a vsock device connected to the MMIO space.
+pub struct ConnectedVsockState {
+    /// Device state.
+    pub device_state: VsockState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub vmm_resources: VmmResourcesState,
+}
+
+#[derive(Versionize)]
+/// Holds the device states.
+pub struct DeviceStates {
+    /// Block device states.
+    pub block_devices: Vec<ConnectedBlockState>,
+    /// Net device states.
+    pub net_devices: Vec<ConnectedNetState>,
+    /// Vsock device tests.
+    pub vsock_device: Option<ConnectedVsockState>,
+}
+
+/// Holds information related to the VM that is not part of VmState.
+#[derive(Debug, PartialEq, Versionize)]
+pub struct VmInfo {
+    /// Guest memory size.
+    pub mem_size_mib: u64,
+}
+
+/// Contains the necesary state for saving/restoring a microVM.
+#[derive(Versionize)]
+pub struct MicrovmState {
+    /// Miscellaneous VM info.
+    pub vm_info: VmInfo,
+    /// VM KVM state.
+    pub vm_state: VmState,
+    /// Vcpu states.
+    pub vcpu_states: Vec<VcpuState>,
+    /// Device states.
+    pub device_states: DeviceStates,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::tests::{
+        default_vmm, insert_block_devices, insert_net_device, insert_vsock_device,
+        CustomBlockConfig,
+    };
+    use crate::vstate::tests::default_vcpu_state;
+    use crate::Vmm;
+    use polly::event_manager::EventManager;
+    use utils::tempfile::TempFile;
+    use vmm_config::net::NetworkInterfaceConfig;
+    use vmm_config::vsock::tests::{default_config, TempSockFile};
+
+    impl PartialEq for ConnectedBlockState {
+        fn eq(&self, other: &ConnectedBlockState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state
+                && self.vmm_resources == other.vmm_resources
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedBlockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedBlockDevice {{ transport_state: {:?}, vmm_resources: {:?} }}",
+                self.transport_state, self.vmm_resources
+            )
+        }
+    }
+
+    impl PartialEq for ConnectedNetState {
+        fn eq(&self, other: &ConnectedNetState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state
+                && self.vmm_resources == other.vmm_resources
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedNetState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedNetDevice {{ transport_state: {:?}, vmm_resources: {:?} }}",
+                self.transport_state, self.vmm_resources
+            )
+        }
+    }
+
+    impl PartialEq for ConnectedVsockState {
+        fn eq(&self, other: &ConnectedVsockState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state
+                && self.vmm_resources == other.vmm_resources
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedVsockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedVsockDevice {{ transport_state: {:?}, vmm_resources: {:?} }}",
+                self.transport_state, self.vmm_resources
+            )
+        }
+    }
+
+    impl PartialEq for DeviceStates {
+        fn eq(&self, other: &DeviceStates) -> bool {
+            self.block_devices == other.block_devices
+                && self.net_devices == other.net_devices
+                && self.vsock_device == other.vsock_device
+        }
+    }
+
+    impl std::fmt::Debug for DeviceStates {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "DevicesStates {{ block_devices: {:?}, net_devices: {:?}, vsock_device: {:?} }}",
+                self.block_devices, self.net_devices, self.vsock_device
+            )
+        }
+    }
+
+    fn default_vmm_with_devices(event_manager: &mut EventManager) -> Vmm {
+        let mut vmm = default_vmm();
+
+        // Add a block device.
+        let drive_id = String::from("root");
+        let block_configs = vec![CustomBlockConfig::new(drive_id.clone(), true, None, true)];
+        insert_block_devices(&mut vmm, event_manager, block_configs);
+
+        // Add net device.
+        let network_interface = NetworkInterfaceConfig {
+            iface_id: String::from("netif"),
+            host_dev_name: String::from("hostname"),
+            guest_mac: None,
+            rx_rate_limiter: None,
+            tx_rate_limiter: None,
+            allow_mmds_requests: true,
+        };
+        insert_net_device(&mut vmm, event_manager, network_interface);
+
+        // Add vsock device.
+        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let vsock_config = default_config(&tmp_sock_file);
+
+        insert_vsock_device(&mut vmm, event_manager, vsock_config);
+
+        vmm
+    }
+
+    #[test]
+    fn test_microvmstate_versionize() {
+        let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+        let mut vmm = default_vmm_with_devices(&mut event_manager);
+        let states = vmm.save_mmio_device_states();
+
+        // Only checking that all devices are saved, actual device state
+        // is tested by that device's tests.
+        assert_eq!(states.block_devices.len(), 1);
+        assert_eq!(states.net_devices.len(), 1);
+        assert!(states.vsock_device.is_some());
+
+        let microvm_state = MicrovmState {
+            vm_info: VmInfo { mem_size_mib: 1u64 },
+            vm_state: vmm.vm.save_state().unwrap(),
+            vcpu_states: vec![default_vcpu_state()],
+            device_states: states,
+        };
+
+        let mut buf = vec![0; 10000];
+        let version_map = VersionMap::new();
+
+        microvm_state
+            .serialize(&mut buf.as_mut_slice(), &version_map, 1)
+            .unwrap();
+
+        let restored_microvm_state =
+            MicrovmState::deserialize(&mut buf.as_slice(), &version_map, 1).unwrap();
+
+        assert_eq!(restored_microvm_state.vm_info, microvm_state.vm_info);
+        assert_eq!(
+            restored_microvm_state.device_states,
+            microvm_state.device_states
+        )
+    }
+}

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -1331,7 +1331,7 @@ enum VcpuEmulation {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     #[cfg(target_arch = "x86_64")]
     use std::convert::TryInto;
     use std::fs::File;
@@ -1395,6 +1395,22 @@ mod tests {
         }
 
         (vm, vcpu, gm)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn default_vcpu_state() -> VcpuState {
+        VcpuState {
+            cpuid: CpuId::new(1),
+            msrs: Msrs::new(1),
+            debug_regs: Default::default(),
+            lapic: Default::default(),
+            mp_state: Default::default(),
+            regs: Default::default(),
+            sregs: Default::default(),
+            vcpu_events: Default::default(),
+            xcrs: Default::default(),
+            xsave: Default::default(),
+        }
     }
 
     #[test]
@@ -1796,18 +1812,7 @@ mod tests {
         assert!(vcpu.restore_state(state.unwrap()).is_ok());
 
         unsafe { libc::close(vcpu.fd.as_raw_fd()) };
-        let state = VcpuState {
-            cpuid: CpuId::new(1),
-            msrs: Msrs::new(1),
-            debug_regs: Default::default(),
-            lapic: Default::default(),
-            mp_state: Default::default(),
-            regs: Default::default(),
-            sregs: Default::default(),
-            vcpu_events: Default::default(),
-            xcrs: Default::default(),
-            xsave: Default::default(),
-        };
+        let state = default_vcpu_state();
         // Setting default state should always fail.
         assert!(vcpu.restore_state(state).is_err());
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 83.87
+COVERAGE_TARGET_PCT = 84.00
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Part of #1779

## Description of Changes

This PR is the first step towards saving/restoring the full Firecracker microVM.
It defines the MicrovmState structure and introduces functionality for saving the mmio device states.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] No new added `unsafe` code.
- [x] No API changes.
- [X] No user-facing changes.
