### PR TITLE
vmm: fix rust integration tests

### DIFF
--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -13,6 +13,7 @@ extern crate vmm_sys_util;
 mod mock_devices;
 mod mock_resources;
 mod mock_seccomp;
+mod test_utils;
 
 use std::io;
 use std::thread;
@@ -20,7 +21,6 @@ use std::time::Duration;
 
 use polly::event_manager::EventManager;
 use seccomp::{BpfProgram, SeccompLevel};
-use utils::signal::register_signal_handler;
 use vmm::builder::{build_microvm, setup_serial_device};
 use vmm::default_syscalls::get_seccomp_filter;
 use vmm::resources::VmResources;
@@ -29,7 +29,8 @@ use vmm_sys_util::tempfile::TempFile;
 
 use mock_devices::MockSerialInput;
 use mock_resources::{MockBootSourceConfig, MockVmResources};
-use mock_seccomp::{mock_sigsys_handler, MockSeccomp, SIGSYS_RECEIVED};
+use mock_seccomp::MockSeccomp;
+use test_utils::{restore_stdin, set_panic_hook};
 
 #[test]
 fn test_setup_serial_device() {
@@ -47,48 +48,88 @@ fn test_setup_serial_device() {
 
 #[test]
 fn test_build_microvm() {
-    {
-        // Error case: no boot source configured.
-        let resources: VmResources = MockVmResources::new().into();
-        let mut event_manager = EventManager::new().unwrap();
-        let empty_seccomp_filter = get_seccomp_filter(SeccompLevel::None).unwrap();
+    // Error case: no boot source configured.
+    let resources: VmResources = MockVmResources::new().into();
+    let mut event_manager = EventManager::new().unwrap();
+    let empty_seccomp_filter = get_seccomp_filter(SeccompLevel::None).unwrap();
 
-        let vmm_ret = build_microvm(&resources, &mut event_manager, &empty_seccomp_filter);
-        assert_eq!(format!("{:?}", vmm_ret.err()), "Some(MissingKernelConfig)");
-    }
+    let vmm_ret = build_microvm(&resources, &mut event_manager, &empty_seccomp_filter);
+    assert_eq!(format!("{:?}", vmm_ret.err()), "Some(MissingKernelConfig)");
 
-    {
-        // Success case.
-        let boot_source_cfg: BootSourceConfig = MockBootSourceConfig::new().with_boot_args().into();
-        let resources: VmResources = MockVmResources::new()
-            .with_boot_source(boot_source_cfg)
-            .into();
-        let mut event_manager = EventManager::new().unwrap();
-        let empty_seccomp_filter = get_seccomp_filter(SeccompLevel::None).unwrap();
+    // Success case.
+    // Child process will run the vmm and exit.
+    // Parent will wait for child to exit and assert on exit status 0.
+    let pid = unsafe { libc::fork() };
+    match pid {
+        0 => {
+            // Child process: build and run vmm.
+            // If the vmm thread panics, the `wait()` in the parent doesn't exit.
+            // Force the child to exit on panic to unblock the waiting parent.
+            set_panic_hook();
 
-        let vmm = build_microvm(&resources, &mut event_manager, &empty_seccomp_filter).unwrap();
-        // This exits the process, so we won't get the output from cargo.
-        vmm.lock().unwrap().stop(0);
+            let boot_source_cfg: BootSourceConfig =
+                MockBootSourceConfig::new().with_default_boot_args().into();
+            let resources: VmResources = MockVmResources::new()
+                .with_boot_source(boot_source_cfg)
+                .into();
+            let mut event_manager = EventManager::new().unwrap();
+            let empty_seccomp_filter = get_seccomp_filter(SeccompLevel::None).unwrap();
+
+            let vmm = build_microvm(&resources, &mut event_manager, &empty_seccomp_filter).unwrap();
+
+            // On x86_64, the vmm should exit once its workload completes and signals the exit event.
+            // On aarch64, the test kernel doesn't exit, so the vmm is force-stopped.
+            let _ = event_manager.run_with_timeout(500).unwrap();
+
+            #[cfg(target_arch = "x86_64")]
+            vmm.lock().unwrap().stop(-1); // If we got here, something went wrong.
+            #[cfg(target_arch = "aarch64")]
+            vmm.lock().unwrap().stop(0);
+        }
+        vmm_pid => {
+            // Parent process: wait for the vmm to exit.
+            let mut vmm_status: i32 = -1;
+            let pid_done = unsafe { libc::waitpid(vmm_pid, &mut vmm_status, 0) };
+            assert_eq!(pid_done, vmm_pid);
+            restore_stdin();
+            // If any panics occurred, its exit status will be != 0.
+            assert!(unsafe { libc::WIFEXITED(vmm_status) });
+            assert_eq!(unsafe { libc::WEXITSTATUS(vmm_status) }, 0);
+        }
     }
 }
 
 #[test]
 fn test_vmm_seccomp() {
     // Tests the behavior of a customized seccomp filter on the VMM.
-    let boot_source_cfg: BootSourceConfig = MockBootSourceConfig::new().with_boot_args().into();
-    let resources: VmResources = MockVmResources::new()
-        .with_boot_source(boot_source_cfg)
-        .into();
-    let mut event_manager = EventManager::new().unwrap();
+    let pid = unsafe { libc::fork() };
+    match pid {
+        0 => {
+            // Child process: build vmm and (try to) run it.
+            let boot_source_cfg: BootSourceConfig =
+                MockBootSourceConfig::new().with_default_boot_args().into();
+            let resources: VmResources = MockVmResources::new()
+                .with_boot_source(boot_source_cfg)
+                .into();
+            let mut event_manager = EventManager::new().unwrap();
 
-    register_signal_handler(libc::SIGSYS, mock_sigsys_handler).unwrap();
-    // The customer "forgot" to whitelist the KVM_RUN ioctl.
-    let filter: BpfProgram = MockSeccomp::new().without_kvm_run().into();
-
-    let vmm = build_microvm(&resources, &mut event_manager, &filter).unwrap();
-    // Give the signal handler some time to complete.
-    thread::sleep(Duration::from_millis(30));
-    assert!(unsafe { SIGSYS_RECEIVED });
-    // This exits the process, so we won't get the output from cargo.
-    vmm.lock().unwrap().stop(0);
+            // The customer "forgot" to whitelist the KVM_RUN ioctl.
+            let filter: BpfProgram = MockSeccomp::new().without_kvm_run().into();
+            let vmm = build_microvm(&resources, &mut event_manager, &filter).unwrap();
+            // Give the vCPUs a chance to attempt KVM_RUN.
+            thread::sleep(Duration::from_millis(200));
+            // Should never get here.
+            vmm.lock().unwrap().stop(-1);
+        }
+        vmm_pid => {
+            // Parent process: wait for the vmm to exit.
+            let mut vmm_status: i32 = -1;
+            let pid_done = unsafe { libc::waitpid(vmm_pid, &mut vmm_status, 0) };
+            assert_eq!(pid_done, vmm_pid);
+            restore_stdin();
+            // The seccomp fault should have caused death by SIGSYS.
+            assert!(unsafe { libc::WIFSIGNALED(vmm_status) });
+            assert_eq!(unsafe { libc::WTERMSIG(vmm_status) }, libc::SIGSYS);
+        }
+    }
 }

--- a/src/vmm/tests/mock_resources/mod.rs
+++ b/src/vmm/tests/mock_resources/mod.rs
@@ -38,7 +38,7 @@ impl MockBootSourceConfig {
         })
     }
 
-    pub fn with_boot_args(mut self) -> Self {
+    pub fn with_default_boot_args(mut self) -> Self {
         self.0.boot_args = Some(DEFAULT_BOOT_ARGS.to_string());
         self
     }

--- a/src/vmm/tests/test_utils/mod.rs
+++ b/src/vmm/tests/test_utils/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::panic;
+
+use utils::terminal::Terminal;
+
+const VMM_ERR_EXIT: i32 = 42;
+
+pub fn restore_stdin() {
+    let stdin = io::stdin();
+    stdin.lock().set_canon_mode().unwrap();
+}
+
+pub fn set_panic_hook() {
+    panic::set_hook(Box::new(move |_| {
+        restore_stdin();
+        unsafe {
+            libc::exit(VMM_ERR_EXIT);
+        }
+    }));
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.07
+COVERAGE_TARGET_PCT = 84.23
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

#1834 

## Description of Changes

* the tests that run a vmm now `fork`. The vmm itself runs in the child process and terminates either with `vmm.stop()` (exit code 0) or `libc::exit(errcode)` in case of panic. The parent waits on the vmm process and asserts on its exit status.
* signal handling doesn't work under `kcov` => changed the default action in the test seccomp filter to `Kill` instead of `Trap`. `Trap`ping doesn't work either under `kcov` (!!) and, now that the vmm runs in a forked child, we can assert on its `SIGSYS`-marked exit code.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
