### PR TITLE
Add metrics for vsock virtio device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added a new API call, `PUT /snapshot/create`, for creating a full or diff
   snapshot.
 - Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
+- Added metrics for the vsock device.
 
 ### Fixed
 - Added `--version` flag to both Firecracker and Jailer.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -524,6 +524,51 @@ pub struct SignalMetrics {
     pub sigsegv: SharedMetric,
 }
 
+/// Vsock-related metrics.
+#[derive(Default, Serialize)]
+pub struct VsockDeviceMetrics {
+    /// Number of times when activate failed on a vsock device.
+    pub activate_fails: SharedMetric,
+    /// Number of times when interacting with the space config of a vsock device failed.
+    pub cfg_fails: SharedMetric,
+    /// Number of times when handling RX queue events on a vsock device failed.
+    pub rx_queue_event_fails: SharedMetric,
+    /// Number of times when handling TX queue events on a vsock device failed.
+    pub tx_queue_event_fails: SharedMetric,
+    /// Number of times when handling event queue events on a vsock device failed.
+    pub ev_queue_event_fails: SharedMetric,
+    /// Number of times when handling muxer events on a vsock device failed.
+    pub muxer_event_fails: SharedMetric,
+    /// Number of times when handling connection events on a vsock device failed.
+    pub conn_event_fails: SharedMetric,
+    /// Number of events associated with the receiving queue.
+    pub rx_queue_event_count: SharedMetric,
+    /// Number of events associated with the transmitting queue.
+    pub tx_queue_event_count: SharedMetric,
+    /// Number of bytes received.
+    pub rx_bytes_count: SharedMetric,
+    /// Number of transmitted bytes.
+    pub tx_bytes_count: SharedMetric,
+    /// Number of packets received.
+    pub rx_packets_count: SharedMetric,
+    /// Number of transmitted packets.
+    pub tx_packets_count: SharedMetric,
+    /// Number of added connections.
+    pub conns_added: SharedMetric,
+    /// Number of killed connections.
+    pub conns_killed: SharedMetric,
+    /// Number of removed connections.
+    pub conns_removed: SharedMetric,
+    /// How many times the killq has been resynced.
+    pub killq_resync: SharedMetric,
+    /// How many flush fails have been seen.
+    pub tx_flush_fails: SharedMetric,
+    /// How many write fails have been seen.
+    pub tx_write_fails: SharedMetric,
+    /// Number of times read() has failed.
+    pub rx_read_fails: SharedMetric,
+}
+
 // The sole purpose of this struct is to produce an UTC timestamp when an instance is serialized.
 #[derive(Default)]
 struct SerializeToUtcTimestampMs;
@@ -570,6 +615,8 @@ pub struct FirecrackerMetrics {
     pub uart: SerialDeviceMetrics,
     /// Metrics related to signals.
     pub signals: SignalMetrics,
+    /// Metrics related to virtio-vsockets.
+    pub vsock: VsockDeviceMetrics,
 }
 
 #[cfg(test)]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.43, "AMD": 84.39}
+COVERAGE_DICT = {"Intel": 84.43, "AMD": 84.32}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -44,6 +44,7 @@ def test_flush_metrics(test_microvm_with_api):
         'vmm',
         'uart',
         'signals',
+        'vsock'
     ]
 
     assert set(metrics.keys()) == set(exp_keys)


### PR DESCRIPTION
Add metrics tracking for the vsock devive similar to the network virtio
device.

Signed-off-by: Joshua Abraham <sinisterpatrician@gmail.com>

I'm not sure if you have additional metrics you'd want to capture in the vsock module, or if the CHANGELOG needs to be updated :)

## Reason for This PR

Closes #1210.

## Description of Changes

This patch adds metrics tracking for the vsock virtio device TX and RX code paths.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist


`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
