### PR TITLE
Remove backtrace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,26 +57,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "backtrace"
-version = "0.3.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bincode"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,11 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -316,7 +291,6 @@ name = "firecracker"
 version = "0.21.0"
 dependencies = [
  "api_server 0.1.0",
- "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "mmds 0.1.0",
@@ -591,11 +565,6 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.6.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -942,15 +911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)" = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
-"checksum backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 "checksum bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum crc64 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
@@ -991,7 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 "checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.21.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]
-backtrace = {version = ">=0.3.35", features = ["libunwind", "libbacktrace", "std"], default-features = false}
 libc = ">=0.2.39"
 timerfd = ">=1.0"
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate api_server;
-extern crate backtrace;
 extern crate libc;
 #[macro_use]
 extern crate logger;
@@ -15,8 +14,6 @@ extern crate vmm;
 
 mod api_server_adapter;
 mod metrics;
-
-use backtrace::Backtrace;
 
 use std::fs;
 use std::io;
@@ -73,8 +70,6 @@ fn main() {
         }
 
         METRICS.vmm.panic_count.inc();
-        let bt = Backtrace::new();
-        error!("{:?}", bt);
 
         // Write the metrics before aborting.
         if let Err(e) = METRICS.write() {

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -40,12 +40,12 @@ def cargo_build(path, extra_args='', src_dir='', extra_env=''):
     utils.run_cmd(cmd)
 
 
-def cargo_test(path, extra_args='', extra_env=''):
+def cargo_test(path, extra_args=''):
     """Trigger unit tests depending on flags provided."""
     path = os.path.join(path, CARGO_UNITTEST_REL_PATH)
-    cmd = 'CARGO_TARGET_DIR={} {} RUST_TEST_THREADS=1 RUST_BACKTRACE=1 ' \
+    cmd = 'CARGO_TARGET_DIR={} RUST_TEST_THREADS=1 RUST_BACKTRACE=1 ' \
           'RUSTFLAGS="{}" cargo test {} --all --no-fail-fast'.format(
-            path, extra_env, get_rustflags(), extra_args)
+            path, get_rustflags(), extra_args)
     utils.run_cmd(cmd)
 
 
@@ -57,9 +57,9 @@ def get_firecracker_binaries():
     """
     target = DEFAULT_BUILD_TARGET
     cd_cmd = "cd {}".format(FC_WORKSPACE_DIR)
-    env_cmd = 'TARGET_CC=musl-gcc RUSTFLAGS="{}"'.format(get_rustflags())
+    flags = 'RUSTFLAGS="{}"'.format(get_rustflags())
     cargo_cmd = "cargo build --release --target {}".format(target)
-    cmd = "{} && {} {}".format(cd_cmd, env_cmd, cargo_cmd)
+    cmd = "{} && {} {}".format(cd_cmd, flags, cargo_cmd)
 
     utils.run_cmd(cmd)
 

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -11,13 +11,13 @@ import host_tools.cargo_build as host
 MACHINE = platform.machine()
 """ Platform definition used to select the correct size target"""
 
-FC_BINARY_SIZE_TARGET = 3124000 if MACHINE == "x86_64" else 3349336
+FC_BINARY_SIZE_TARGET = 3013464 if MACHINE == "x86_64" else 3251464
 """Firecracker target binary size in bytes"""
 
-FC_BINARY_SIZE_LIMIT = 3300000 if MACHINE == "x86_64" else 3500000
+FC_BINARY_SIZE_LIMIT = 32000000 if MACHINE == "x86_64" else 3400000
 """Firecracker maximum binary size in bytes"""
 
-JAILER_BINARY_SIZE_TARGET = 2483592 if MACHINE == "x86_64" else 2714528
+JAILER_BINARY_SIZE_TARGET = 2568384 if MACHINE == "x86_64" else 2792688
 """Jailer target binary size in bytes"""
 
 JAILER_BINARY_SIZE_LIMIT = 3000000

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -19,19 +19,14 @@ TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
 )
 def test_unittests(test_session_root_path, target):
     """Run unit and doc tests for all supported targets."""
-    extra_env = ''
     extra_args = "--release --target {} ".format(target)
 
-    if "musl" in target:
-        extra_env += "TARGET_CC=musl-gcc"
-
-        if MACHINE == "x86_64":
-            pytest.skip("On x86_64 with musl target unit tests"
-                        " are already run as part of testing"
-                        " code-coverage.")
+    if "musl" in target and MACHINE == "x86_64":
+        pytest.skip("On x86_64 with musl target unit tests"
+                    " are already run as part of testing"
+                    " code-coverage.")
 
     host.cargo_test(
         test_session_root_path,
-        extra_args=extra_args,
-        extra_env=extra_env
+        extra_args=extra_args
     )

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -16,7 +16,7 @@ ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
 ENV PATH="$PATH:$CARGO_HOME/bin"
 
-# Install system dependecies
+# Install system dependencies
 #
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
@@ -36,7 +36,6 @@ RUN apt-get update \
         libssl-dev \
         lsof \
         make \
-        musl-tools \
         net-tools \
         openssh-client \
         pkgconf \

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -16,7 +16,7 @@ ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
 ENV PATH="$PATH:$CARGO_HOME/bin"
 
-# Install system dependecies
+# Install system dependencies
 #
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
@@ -36,7 +36,6 @@ RUN apt-get update \
         libssl-dev \
         lsof \
         make \
-        musl-tools \
         net-tools \
         openssh-client \
         pkgconf \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v15"
+DEVCTR_IMAGE="fcuvm/dev:v16"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"

--- a/tools/devtool
+++ b/tools/devtool
@@ -480,13 +480,9 @@ cmd_build() {
     # Run the cargo build process inside the container.
     # We don't need any special privileges for the build phase, so we run the
     # container as the current user/group.
-    #
-    # Note: we need to pass an explicit TARGET_CC to cargo, because the `cc`
-    # crate gets confused for aarch64 musl.
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
-        --env TARGET_CC=musl-gcc \
         -- \
         cargo build \
             --target-dir "$CTR_CARGO_TARGET_DIR" \


### PR DESCRIPTION
## Reason for This PR

We've decided  to completely remove `backtrace` dependency because of the following reasons:
- the backtrace wasn't useful for us (Firecracker team) in the debugging process :(,
- requires `musl-gcc` to be installed (`musl-tools`),
- prints the stack only in `--release` mode,
- caused us some troubles; see: #1088 for details -> forces us to whitelist some syscalls, which we are trying to avoid as much as possible.


We are curious if someone from the community was actually helped by our backtrace or if someone has an idea of how can we improve the generated backtrace. Any feedback would be greatly appreciated :blush:.


As an example, for the following panic message:

```
2020-04-28T14:01:47.106739566 [anonymous-instance:ERROR:src/firecracker/src/main.rs:67] Firecracker panicked at 'Error creating the HTTP server: IOError(Os { code: 98, kind: AddrInUse, message: "Address in use" })', src/api_server/src/lib.rs:104:26
```

The backtrace stack would be:

```2020-04-28T14:21:37.051916121 [anonymous-instance:ERROR:src/firecracker/src/main.rs:77]    0: firecracker::main::{{closure}}
   1: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:474
   2: rust_begin_unwind
             at src/libstd/panicking.rs:378
   3: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
   4: core::option::expect_none_failed
             at src/libcore/option.rs:1211
   5: api_server::ApiServer::bind_and_run
   6: std::sys_common::backtrace::__rust_begin_short_backtrace
   7: core::ops::function::FnOnce::call_once{{vtable.shim}}
   8: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/4fb7144ed159f94491249e86d5bbd033b5d60550/src/liballoc/boxed.rs:1017
   9: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/4fb7144ed159f94491249e86d5bbd033b5d60550/src/liballoc/boxed.rs:1017
      std::sys_common::thread::start_thread
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread:🆕:thread_start
             at src/libstd/sys/unix/thread.rs:80

Aborted
```
The only line that seems to be relevant is:

`5: api_server::ApiServer::bind_and_run,`

but this would be the function that contains the line that is printed in the error message (by `error!`, not `backtrace`), so it's not really helpful.

Fixes: #1088.

## Description of Changes

At this moment, just removed the `backtrace` dependency. Needs some more investigation if we can simplify things in other places.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
