### PR TITLE
Remove dependency of `utils` crate on `dumbo` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,6 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dumbo 0.1.0",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,6 +10,3 @@ libc = ">=0.2.39"
 vmm-sys-util = ">=0.2.1"
 
 net_gen = { path = "../net_gen" }
-
-[dev-dependencies]
-dumbo = { path = "../dumbo" }


### PR DESCRIPTION
## Reason for This PR

Fixes  #1769. 
Remove the dependency of crate `utils` on crate `dumbo`. Dubmo was used to test sending IPv4 packets on the Tap interface. This refactor is for better testing for `utils` crate. Since now if the tests fail they only refer to problems in `utils` crate and not in `dumbo`.

## Description of Changes

*  Change `test_write` to write raw IPV4 UDP packet with a constant payload and assert that the same payload was received on the other end.
* Change `test_write` to parse the ARP request and respond without needing `dumbo`. And validating the payload read from the TAP device.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
