### PR TITLE
Fix mmds config type in swagger

### DIFF
--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -328,7 +328,7 @@ paths:
           description: The MMDS configuration as JSON.
           required: true
           schema:
-            type: "#/definitions/MmdsConfig"
+            $ref: "#/definitions/MmdsConfig"
       responses:
         204:
           description: MMDS configuration was created/updated.


### PR DESCRIPTION
Fixed the type definition for the MMDS config parameter by changing it from a `type` to a `$ref`.

## Reason for This PR

#1843 Change the type param so that it no longer resolves as an invalid built-in and instead
uses a ref.

## Description of Changes

Updated the Swagger API YAML file to change it as described.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.