### PR TITLE
Improve `--help` content in both firecracker and jailer

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -100,21 +100,19 @@ fn main() {
                 .takes_value(true)
                 .default_value("2")
                 .help(
-                    "Level of seccomp filtering that will be passed to executed path as \
-                    argument.\n
-                        - Level 0: No filtering.\n
-                        - Level 1: Seccomp filtering by syscall number.\n
-                        - Level 2: Seccomp filtering by syscall number and argument values.\n
-                    ",
+                    "Level of seccomp filtering (0: no filter | 1: filter by syscall number | 2: filter by syscall \
+                     number and argument values) that will be passed to executed path as argument."
                 ),
         )
         .arg(
             Argument::new("start-time-us")
-                .takes_value(true),
+                .takes_value(true)
+                .help("Process start time (wall clock, microseconds)."),
         )
         .arg(
             Argument::new("start-time-cpu-us")
-                .takes_value(true),
+                .takes_value(true)
+                .help("Process start CPU time (wall clock, microseconds)."),
         )
         .arg(
             Argument::new("config-file")
@@ -236,7 +234,7 @@ fn main() {
 
         let start_time_cpu_us = arguments.value_as_string("start-time-cpu-us").map(|s| {
             s.parse::<u64>()
-                .expect("'start-time-cpu_us' parameter expected to be of 'u64' type.")
+                .expect("'start-time-cpu-us' parameter expected to be of 'u64' type.")
         });
         let instance_info = InstanceInfo {
             id: instance_id,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.53
+COVERAGE_TARGET_PCT = 84.59
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
Signed-off-by: Shion Yamashita <shioyama1118@gmail.com>

## Reason for This PR

Fix: #1688

## Description of Changes

Improve the following in `--help` content
- Display default values along with the description
- Segregate required and optional arguments
- Sort and align arguments

```
Jailer v0.21.0

required arguments:
  --exec-file <exec-file>   File path to exec into.
  --gid <gid>               The group identifier the jailer switches to after exec.
  --id <id>                 Jail ID.
  --node <node>             NUMA node to assign this microVM to.
  --uid <uid>               The user identifier the jailer switches to after exec.

optional arguments:
  --chroot-base-dir <chroot-base-dir>   The base folder where chroot jails are located. [default: "/srv/jailer"]
  --daemonize                           Daemonize the jailer before exec, by invoking setsid(), and redirecting the standard I/O file descriptors to /dev/null.
  --extra-args <extra-args>             Arguments that will be passed verbatim to the exec file.
  --help                                Show the help message.
  --netns <netns>                       Path to the network namespace this microVM should join.
```

```
Firecracker v0.21.0

optional arguments:
  --api-sock <api-sock>                     Path to unix domain socket used by the API. [default: "/run/firecracker.socket"]
  --config-file <config-file>               Path to a file that contains the microVM configuration in JSON format.
  --help                                    Show the help message.
  --id <id>                                 MicroVM unique identifier. [default: "anonymous-instance"]
  --level <level>                           Set the logger level. [default: "Warning"]
  --log-path <log-path>                     Path to a fifo or a file used for configuring the logger on startup.
  --no-api                                  Optional parameter which allows starting and using a microVM without an active API socket.
  --seccomp-level <seccomp-level>           Level of seccomp filtering (0: no filter | 1: filter by syscall number | 2: filter by syscall number and argument values) that will be passed to executed path as argument. [default: "2"]
  --show-level                              Whether or not to output the level in the logs.
  --show-log-origin                         Whether or not to include the file path and line number of the log's origin.
  --start-time-cpu-us <start-time-cpu-us>   Process start CPU time (wall clock, microseconds).
  --start-time-us <start-time-us>           Process start time (wall clock, microseconds).
```

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
