### PR TITLE
Improve command-line arguments

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.32, "AMD": 84.26}
+COVERAGE_DICT = {"Intel": 84.42, "AMD": 84.38}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

#1688

## Description of Changes

#1688, with the following additions:

* documented `--start-time-us` and `--start-time-cpu-us`, fixed `start-time-cpu-us` typo
* one unit test for jailed (#363) to counter imprecise kcov results preventing coverage test to pass
  * the most relevant issue for this behavior I've found is https://github.com/rust-lang/rust/issues/55352

...and with the exception for:

>Segregate mandatory and optional arguments properly.

See https://github.com/firecracker-microvm/firecracker/issues/1688#issuecomment-623550854.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
