### PR TITLE
Fix MAC spoofing metric

### DIFF
--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use dumbo::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState, MAC_ADDR_LEN};
+use dumbo::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState, MacAddr, MAC_ADDR_LEN};
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
@@ -102,6 +102,10 @@ impl Persist for Net {
         net.config_space = ConfigSpace {
             guest_mac: state.config_space.guest_mac,
         };
+
+        net.guest_mac = Some(MacAddr::from_bytes_unchecked(
+            &state.config_space.guest_mac[..MAC_ADDR_LEN],
+        ));
 
         if state.virtio_state.activated {
             net.device_state = DeviceState::Activated(constructor_args.mem);


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Fixes #1856 

## Description of Changes

Update the Mac address whenever there is a write to the config space.
This way, we update the spoofing metric for both cases: guest MAC provided by the user or
by the guest driver.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] No new added `unsafe` code.
- [x] No API changes.
- [x] No user-facing changes.
