### PR TITLE
Prepare vmm/builder for building from snapshot

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -634,15 +634,9 @@ fn attach_mmio_device(
     id: String,
     device: MmioTransport,
 ) -> std::result::Result<(), device_manager::mmio::Error> {
-    let type_id = device
-        .device()
-        .lock()
-        .expect("Poisoned device lock")
-        .device_type();
-
     let (_mmio_base, _irq) =
         vmm.mmio_device_manager
-            .register_mmio_device(vmm.vm.fd(), device, type_id, id)?;
+            .register_mmio_device(vmm.vm.fd(), device, id)?;
     #[cfg(target_arch = "x86_64")]
     vmm.mmio_device_manager
         .add_device_to_cmdline(&mut vmm.kernel_cmdline, _mmio_base, _irq)?;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -563,7 +563,7 @@ fn attach_legacy_devices(
     }
 
     mmio_device_manager
-        .register_mmio_rtc(vm.fd())
+        .register_new_mmio_rtc(vm.fd())
         .map_err(Error::RegisterMMIODevice)
         .map_err(StartMicrovmError::Internal)?;
 
@@ -634,12 +634,12 @@ fn attach_mmio_device(
     id: String,
     device: MmioTransport,
 ) -> std::result::Result<(), device_manager::mmio::Error> {
-    let (_mmio_base, _irq) =
-        vmm.mmio_device_manager
-            .register_mmio_device(vmm.vm.fd(), device, id)?;
+    let mmio_slot = vmm.mmio_device_manager.allocate_new_slot()?;
+    vmm.mmio_device_manager
+        .register_virtio_mmio_device(vmm.vm.fd(), id, device, &mmio_slot)?;
     #[cfg(target_arch = "x86_64")]
     vmm.mmio_device_manager
-        .add_device_to_cmdline(&mut vmm.kernel_cmdline, _mmio_base, _irq)?;
+        .add_virtio_device_to_cmdline(&mut vmm.kernel_cmdline, &mmio_slot)?;
 
     Ok(())
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -91,6 +91,9 @@ impl MMIODeviceManager {
     /// Create a new DeviceManager handling mmio devices (virtio net, block).
     pub fn new(mmio_base: &mut u64, irq_interval: (u32, u32)) -> MMIODeviceManager {
         if cfg!(target_arch = "aarch64") {
+            // This hack is done to reserve the 'log boot time magic address'.
+            // TODO (issue #1865): we should create a simple mmio device for logging the boot time
+            // and use it on both x86_64 and aarch64, instead of this hacky thing we do right now.
             *mmio_base += MMIO_LEN;
         }
         MMIODeviceManager {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -68,7 +68,6 @@ use devices::virtio::{
     TYPE_NET, TYPE_VSOCK,
 };
 use devices::BusDevice;
-use kernel::cmdline::Cmdline as KernelCmdline;
 use logger::{LoggerError, MetricsError, METRICS};
 #[cfg(target_arch = "x86_64")]
 use persist::{
@@ -216,8 +215,6 @@ pub struct Vmm {
 
     // Guest VM core resources.
     guest_memory: GuestMemoryMmap,
-
-    kernel_cmdline: KernelCmdline,
 
     vcpus_handles: Vec<VcpuHandle>,
     exit_evt: EventFd,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -255,6 +255,8 @@ impl Vmm {
 
         for mut vcpu in vcpus.drain(..) {
             vcpu.set_mmio_bus(self.mmio_device_manager.bus.clone());
+            #[cfg(target_arch = "x86_64")]
+            vcpu.set_pio_bus(self.pio_device_manager.io_bus.clone());
 
             self.vcpus_handles.push(
                 vcpu.start_threaded(vcpu_seccomp_filter.to_vec())

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -94,8 +94,8 @@ pub struct MicrovmState {
 mod tests {
     use super::*;
     use crate::builder::tests::{
-        default_vmm, insert_block_devices, insert_net_device, insert_vsock_device,
-        CustomBlockConfig,
+        default_kernel_cmdline, default_vmm, insert_block_devices, insert_net_device,
+        insert_vsock_device, CustomBlockConfig,
     };
     use crate::vstate::tests::default_vcpu_state;
     use crate::Vmm;
@@ -178,11 +178,12 @@ mod tests {
 
     fn default_vmm_with_devices(event_manager: &mut EventManager) -> Vmm {
         let mut vmm = default_vmm();
+        let mut cmdline = default_kernel_cmdline();
 
         // Add a block device.
         let drive_id = String::from("root");
         let block_configs = vec![CustomBlockConfig::new(drive_id.clone(), true, None, true)];
-        insert_block_devices(&mut vmm, event_manager, block_configs);
+        insert_block_devices(&mut vmm, &mut cmdline, event_manager, block_configs);
 
         // Add net device.
         let network_interface = NetworkInterfaceConfig {
@@ -193,13 +194,13 @@ mod tests {
             tx_rate_limiter: None,
             allow_mmds_requests: true,
         };
-        insert_net_device(&mut vmm, event_manager, network_interface);
+        insert_net_device(&mut vmm, &mut cmdline, event_manager, network_interface);
 
         // Add vsock device.
         let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
         let vsock_config = default_config(&tmp_sock_file);
 
-        insert_vsock_device(&mut vmm, event_manager, vsock_config);
+        insert_vsock_device(&mut vmm, &mut cmdline, event_manager, vsock_config);
 
         vmm
     }

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -795,14 +795,14 @@ impl Vcpu {
     }
 
     #[cfg(target_arch = "x86_64")]
-    /// Configures a x86_64 specific vcpu and should be called once per vcpu.
+    /// Configures a x86_64 specific vcpu for booting Linux and should be called once per vcpu.
     ///
     /// # Arguments
     ///
     /// * `machine_config` - The machine configuration of this microvm needed for the CPUID configuration.
     /// * `guest_mem` - The guest memory used by this microvm.
     /// * `kernel_start_addr` - Offset from `guest_mem` at which the kernel starts.
-    pub fn configure_x86_64(
+    pub fn configure_x86_64_for_boot(
         &mut self,
         guest_mem: &GuestMemoryMmap,
         kernel_start_addr: GuestAddress,
@@ -842,14 +842,14 @@ impl Vcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    /// Configures an aarch64 specific vcpu.
+    /// Configures an aarch64 specific vcpu for booting Linux.
     ///
     /// # Arguments
     ///
     /// * `vm_fd` - The kvm `VmFd` for this microvm.
     /// * `guest_mem` - The guest memory used by this microvm.
     /// * `kernel_load_addr` - Offset from `guest_mem` at which the kernel is loaded.
-    pub fn configure_aarch64(
+    pub fn configure_aarch64_for_boot(
         &mut self,
         vm_fd: &VmFd,
         guest_mem: &GuestMemoryMmap,
@@ -1525,19 +1525,19 @@ pub(crate) mod tests {
         };
 
         assert!(vcpu
-            .configure_x86_64(&vm_mem, GuestAddress(0), &vcpu_config)
+            .configure_x86_64_for_boot(&vm_mem, GuestAddress(0), &vcpu_config)
             .is_ok());
 
         // Test configure while using the T2 template.
         vcpu_config.cpu_template = Some(CpuFeaturesTemplate::T2);
         assert!(vcpu
-            .configure_x86_64(&vm_mem, GuestAddress(0), &vcpu_config)
+            .configure_x86_64_for_boot(&vm_mem, GuestAddress(0), &vcpu_config)
             .is_ok());
 
         // Test configure while using the C3 template.
         vcpu_config.cpu_template = Some(CpuFeaturesTemplate::C3);
         assert!(vcpu
-            .configure_x86_64(&vm_mem, GuestAddress(0), &vcpu_config)
+            .configure_x86_64_for_boot(&vm_mem, GuestAddress(0), &vcpu_config)
             .is_ok());
     }
 
@@ -1559,7 +1559,7 @@ pub(crate) mod tests {
         .unwrap();
 
         assert!(vcpu
-            .configure_aarch64(vm.fd(), &gm, GuestAddress(0))
+            .configure_aarch64_for_boot(vm.fd(), &gm, GuestAddress(0))
             .is_ok());
 
         // Try it for when vcpu id is NOT 0.
@@ -1572,7 +1572,7 @@ pub(crate) mod tests {
         .unwrap();
 
         assert!(vcpu
-            .configure_aarch64(vm.fd(), &gm, GuestAddress(0))
+            .configure_aarch64_for_boot(vm.fd(), &gm, GuestAddress(0))
             .is_ok());
     }
 
@@ -1741,7 +1741,7 @@ pub(crate) mod tests {
             ht_enabled: false,
             cpu_template: None,
         };
-        vcpu.configure_x86_64(&vm_mem, entry_addr, &vcpu_config)
+        vcpu.configure_x86_64_for_boot(&vm_mem, entry_addr, &vcpu_config)
             .expect("failed to configure vcpu");
 
         let seccomp_filter = seccomp::SeccompFilter::empty().try_into().unwrap();

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -597,7 +597,6 @@ pub struct Vcpu {
     id: u8,
     create_ts: TimestampUs,
     mmio_bus: Option<devices::Bus>,
-    #[cfg_attr(all(test, target_arch = "aarch64"), allow(unused))]
     exit_evt: EventFd,
 
     #[cfg(target_arch = "x86_64")]
@@ -1244,6 +1243,7 @@ impl Vcpu {
     // All channels get closed on the other side while this Vcpu thread is still running.
     // This Vcpu thread should just do a clean finish without reporting back to the main thread.
     fn exit(&mut self, _: u8) -> StateMachine<Self> {
+        self.exit_evt.write(1).unwrap();
         // State machine reached its end.
         StateMachine::finish()
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.23
+COVERAGE_TARGET_PCT = 84.31
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Prerequisite for #1847 

## Description of Changes

Rearranges vmm creation code to differentiate between creating resources and configuring them for boot.

This is a prerequisite for building from snapshot in order to share logic between the two paths.

**Note**: should be much easier to review going one commit at a time.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
