### PR TITLE
Add micrvom state serialization benchmark report.

### DIFF
--- a/docs/benchmarks/state-serialize.md
+++ b/docs/benchmarks/state-serialize.md
@@ -1,5 +1,7 @@
-### Snapshot save/load benchmarks
-Snapshot contains 100 structs and a 10k array.  
+
+### MicroVM state serialization benchmarks
+The benchmarks have been performed using a synthetic state snapshot that contains 100 structs and a 10k element array.
+Source code: [src/snapshot/benches/basic.rs](../../src/snapshot/benches/basic.rs).
 Snapshot size: 83886 bytes.  
 
 ### Host configuration
@@ -29,7 +31,12 @@ Snapshot size: 83886 bytes.
 - Flags:               `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d`
 
 ### Current baseline
-Serialize: **356.42 us**                     
-Deserialize: **74.710 us**  
-Serialize + crc64: **402.89 us**  
-Deserialize + crc64: **248.62 us**
+
+| Test                |      Mean     |
+|---------------------|---------------|
+| Serialize           |    354.18 us  |
+| Serialize + crc64   |    406.08 us  |
+| Deserialize         |    61.412 us  |
+| Deserialize + crc64 |    258.27 us  |
+
+Detailed criterion benchmarks available [here](https://s3.amazonaws.com/spec.ccfc.min/perf/snapshot-0.23/report/index.html).

--- a/src/snapshot/benches/basic.rs
+++ b/src/snapshot/benches/basic.rs
@@ -185,7 +185,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(50);
+    config = Criterion::default().sample_size(200);
     targets = criterion_benchmark
 }
 


### PR DESCRIPTION
## Reason for This PR

This PR is publishing basic synthetic state serialization benchmarks. As snapshot functionality becomes available we will publish the a full breakdown of microvm save/restore for various configurations:
- state serialization/deserialization
- kvm state save/restore
- device save/restore
- overall save/restore latency.

## Description of Changes

In commit messages.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
