### PR TITLE
vmm: implement Pause and Resume

### DIFF
--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -466,8 +466,8 @@ paths:
           schema:
             $ref: "#/definitions/Vm"
       responses:
-        501:
-          description: Not implemented yet
+        204:
+          description: Vm state updated
         400:
           description: Vm state cannot be updated due to bad input
           schema:

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -29,7 +29,7 @@ from framework.defs import MICROVM_KERNEL_RELPATH, MICROVM_FSFILES_RELPATH
 from framework.http import Session
 from framework.jailer import JailerContext
 from framework.resources import Actions, BootSource, Drive, Logger, MMDS, \
-    MachineConfigure, Metrics, Network, Vsock
+    MachineConfigure, Metrics, Network, Vm, Vsock
 
 LOG = logging.getLogger("microvm")
 
@@ -102,6 +102,7 @@ class Microvm:
         self.mmds = None
         self.network = None
         self.machine_cfg = None
+        self.vm = None
         self.vsock = None
 
         # Initialize the logging subsystem.
@@ -297,6 +298,7 @@ class Microvm:
         self.metrics = Metrics(self._api_socket, self._api_session)
         self.mmds = MMDS(self._api_socket, self._api_session)
         self.network = Network(self._api_socket, self._api_session)
+        self.vm = Vm(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
 
         if create_logger:

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -428,6 +428,38 @@ class Network():
         return datax
 
 
+class Vm():
+    """Facility for handling the state for a microvm."""
+
+    VM_CFG_RESOURCE = 'vm'
+
+    def __init__(self, api_usocket_full_name, api_session):
+        """Specify the information needed for sending API requests."""
+        url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
+        api_url = API_USOCKET_URL_PREFIX + url_encoded_path + '/'
+
+        self._vm_cfg_url = api_url + self.VM_CFG_RESOURCE
+        self._api_session = api_session
+
+    def patch(self, **args):
+        """Apply an update to the microvm state."""
+        datax = self.create_json(**args)
+
+        return self._api_session.patch(
+            self._vm_cfg_url,
+            json=datax
+        )
+
+    @staticmethod
+    def create_json(state):
+        """Create the json for the vm specific API request."""
+        datax = {
+            'state': state
+        }
+
+        return datax
+
+
 class Vsock():
     """Facility for handling vsock configuration for a microvm."""
 

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests scenarios for pausing/resuming a microVM."""
+
+import host_tools.network as net_tools
+
+
+def test_pause_resume(test_microvm_with_ssh, network_config):
+    """Test pausing and resuming the vCPUs."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+
+    # Set up the microVM with 2 vCPUs, 256 MiB of RAM and a root file
+    # system with the rw permission.
+    test_microvm.basic_config()
+
+    # Create tap before configuring interface.
+    _tap1, _, _ = test_microvm.ssh_network_config(network_config, '1')
+
+    # Pausing the microVM before being started is not allowed.
+    response = test_microvm.vm.patch(state='Paused')
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+    # Resuming the microVM before being started is also not allowed.
+    response = test_microvm.vm.patch(state='Resumed')
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+    # Start microVM.
+    test_microvm.start()
+
+    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+
+    # Verify guest is active.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code == 0
+
+    # Pausing the microVM after it's been started is successful.
+    response = test_microvm.vm.patch(state='Paused')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Verify guest is no longer active.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code != 0
+
+    # Pausing the microVM when it is already `Paused` is allowed
+    # (microVM remains in `Paused` state).
+    response = test_microvm.vm.patch(state='Paused')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Resuming the microVM is successful.
+    response = test_microvm.vm.patch(state='Resumed')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Verify guest is active again.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code == 0
+
+    # Resuming the microVM when it is already `Resumed` is allowed
+    # (microVM remains in the running state).
+    response = test_microvm.vm.patch(state='Resumed')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Verify guest is still active.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code == 0


### PR DESCRIPTION
## Reason for This PR

Fixes #1845

## Description of Changes

Implement pause/resume for microvm.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
