### PR TITLE
(de)serialiaze devices through device manager

### DIFF
--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -33,7 +33,7 @@ pub struct BlockConstructorArgs {
     pub mem: GuestMemoryMmap,
 }
 
-impl Persist for Block {
+impl Persist<'_> for Block {
     type State = BlockState;
     type ConstructorArgs = BlockConstructorArgs;
     type Error = io::Error;

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -45,7 +45,7 @@ pub enum Error {
     CreateRateLimiter(io::Error),
 }
 
-impl Persist for Net {
+impl Persist<'_> for Net {
     type State = NetState;
     type ConstructorArgs = NetConstructorArgs;
     type Error = Error;

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -40,7 +40,7 @@ pub struct QueueState {
     next_used: Wrapping<u16>,
 }
 
-impl Persist for Queue {
+impl Persist<'_> for Queue {
     type State = QueueState;
     type ConstructorArgs = ();
     type Error = ();
@@ -115,7 +115,7 @@ pub struct MmioTransportConstructorArgs {
     pub device: Arc<Mutex<dyn VirtioDevice>>,
 }
 
-impl Persist for MmioTransport {
+impl Persist<'_> for MmioTransport {
     type State = MmioTransportState;
     type ConstructorArgs = MmioTransportConstructorArgs;
     type Error = ();

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -53,7 +53,7 @@ pub struct VsockUdsConstructorArgs {
     pub cid: u64,
 }
 
-impl Persist for VsockUnixBackend {
+impl Persist<'_> for VsockUnixBackend {
     type State = VsockBackendState;
     type ConstructorArgs = VsockUdsConstructorArgs;
     type Error = VsockUnixBackendError;
@@ -77,7 +77,7 @@ impl Persist for VsockUnixBackend {
     }
 }
 
-impl<B> Persist for Vsock<B>
+impl<B> Persist<'_> for Vsock<B>
 where
     B: VsockBackend + 'static,
 {
@@ -130,7 +130,7 @@ pub(crate) mod tests {
     use crate::virtio::vsock::defs::uapi;
     use utils::byte_order;
 
-    impl Persist for TestBackend {
+    impl Persist<'_> for TestBackend {
         type State = VsockBackendState;
         type ConstructorArgs = VsockUdsConstructorArgs;
         type Error = VsockUnixBackendError;

--- a/src/dumbo/src/persist.rs
+++ b/src/dumbo/src/persist.rs
@@ -22,7 +22,7 @@ pub struct MmdsNetworkStackState {
     max_pending_resets: usize,
 }
 
-impl Persist for MmdsNetworkStack {
+impl Persist<'_> for MmdsNetworkStack {
     type State = MmdsNetworkStackState;
     type ConstructorArgs = ();
     type Error = ();

--- a/src/rate_limiter/src/persist.rs
+++ b/src/rate_limiter/src/persist.rs
@@ -18,7 +18,7 @@ pub struct TokenBucketState {
     elapsed_ns: u64,
 }
 
-impl Persist for TokenBucket {
+impl Persist<'_> for TokenBucket {
     type State = TokenBucketState;
     type ConstructorArgs = ();
     type Error = ();
@@ -56,7 +56,7 @@ pub struct RateLimiterState {
     bandwidth: Option<TokenBucketState>,
 }
 
-impl Persist for RateLimiter {
+impl Persist<'_> for RateLimiter {
     type State = RateLimiterState;
     type ConstructorArgs = ();
     type Error = io::Error;

--- a/src/snapshot/src/persist.rs
+++ b/src/snapshot/src/persist.rs
@@ -4,7 +4,7 @@
 //! Defines an abstract interface for saving/restoring a component from state.
 
 /// An abstract interface for saving/restoring a component using a specific state.
-pub trait Persist
+pub trait Persist<'a>
 where
     Self: Sized,
 {
@@ -21,5 +21,5 @@ where
     fn restore(
         constructor_args: Self::ConstructorArgs,
         state: &Self::State,
-    ) -> Result<Self, Self::Error>;
+    ) -> std::result::Result<Self, Self::Error>;
 }

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -9,3 +9,5 @@
 pub mod legacy;
 /// Memory Mapped I/O Manager.
 pub mod mmio;
+/// Device managers (de)serialization support.
+pub mod persist;

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -1,0 +1,439 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides functionality for saving/restoring the MMIO device manager and its devices.
+
+// Currently only supports x86_64.
+#![cfg(target_arch = "x86_64")]
+
+// TODO: remove once serialization is used.
+#![allow(unused)]
+
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use super::mmio::*;
+
+use devices::virtio::block::persist::{BlockConstructorArgs, BlockState};
+use devices::virtio::block::Block;
+use devices::virtio::net::persist::{Error as NetError, NetConstructorArgs, NetState};
+use devices::virtio::net::Net;
+use devices::virtio::persist::{MmioTransportConstructorArgs, MmioTransportState};
+use devices::virtio::vsock::persist::{VsockConstructorArgs, VsockState, VsockUdsConstructorArgs};
+use devices::virtio::vsock::{Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError};
+use devices::virtio::{MmioTransport, TYPE_BLOCK, TYPE_NET, TYPE_VSOCK};
+use kvm_ioctls::VmFd;
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use vm_memory::GuestMemoryMmap;
+
+/// Errors for (de)serialization of the MMIO device manager.
+#[derive(Debug)]
+pub enum Error {
+    Block(io::Error),
+    DeviceManager(super::mmio::Error),
+    MmioTransport,
+    Net(NetError),
+    Vsock(VsockError),
+    VsockUnixBackend(VsockUnixBackendError),
+}
+
+#[derive(Versionize)]
+/// Holds the state of a block device connected to the MMIO space.
+pub struct ConnectedBlockState {
+    /// Device identifier.
+    pub device_id: String,
+    /// Device state.
+    pub device_state: BlockState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub mmio_slot: MMIODeviceInfo,
+}
+
+#[derive(Versionize)]
+/// Holds the state of a net device connected to the MMIO space.
+pub struct ConnectedNetState {
+    /// Device identifier.
+    pub device_id: String,
+    /// Device state.
+    pub device_state: NetState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub mmio_slot: MMIODeviceInfo,
+}
+
+#[derive(Versionize)]
+/// Holds the state of a vsock device connected to the MMIO space.
+pub struct ConnectedVsockState {
+    /// Device identifier.
+    pub device_id: String,
+    /// Device state.
+    pub device_state: VsockState,
+    /// Mmio transport state.
+    pub transport_state: MmioTransportState,
+    /// VmmResources.
+    pub mmio_slot: MMIODeviceInfo,
+}
+
+#[derive(Versionize)]
+/// Holds the device states.
+pub struct DeviceStates {
+    /// Block device states.
+    pub block_devices: Vec<ConnectedBlockState>,
+    /// Net device states.
+    pub net_devices: Vec<ConnectedNetState>,
+    /// Vsock device tests.
+    pub vsock_device: Option<ConnectedVsockState>,
+}
+
+pub struct MMIODevManagerConstructorArgs<'a> {
+    pub mem: GuestMemoryMmap,
+    pub vm: &'a VmFd,
+}
+
+// Cannot implement actual 'trait Persist' without adding a lifetime parameter
+// to the Persist trait.
+impl MMIODeviceManager {
+    pub fn save(&self) -> DeviceStates {
+        let mut states = DeviceStates {
+            block_devices: Vec::new(),
+            net_devices: Vec::new(),
+            vsock_device: None,
+        };
+        for ((device_type, device_id), device_info) in self.get_device_info().iter() {
+            let bus_device = self
+                .get_device(*device_type, device_id)
+                // Safe to unwrap() because we know the device exists.
+                .unwrap()
+                .lock()
+                .expect("Poisoned device lock");
+
+            let mmio_transport = bus_device
+                .as_any()
+                // Only MmioTransport implements BusDevice on x86_64 at this point.
+                .downcast_ref::<MmioTransport>()
+                .expect("Unexpected BusDevice type");
+
+            let transport_state = mmio_transport.save();
+
+            let locked_device = mmio_transport.locked_device();
+            match locked_device.device_type() {
+                TYPE_BLOCK => {
+                    let block_state = locked_device
+                        .as_any()
+                        .downcast_ref::<Block>()
+                        .unwrap()
+                        .save();
+                    states.block_devices.push(ConnectedBlockState {
+                        device_id: device_id.clone(),
+                        device_state: block_state,
+                        transport_state,
+                        mmio_slot: device_info.clone(),
+                    });
+                }
+                TYPE_NET => {
+                    let net_state = locked_device.as_any().downcast_ref::<Net>().unwrap().save();
+                    states.net_devices.push(ConnectedNetState {
+                        device_id: device_id.clone(),
+                        device_state: net_state,
+                        transport_state,
+                        mmio_slot: device_info.clone(),
+                    });
+                }
+                TYPE_VSOCK => {
+                    let vsock = locked_device
+                        .as_any()
+                        // Currently, VsockUnixBackend is the only implementation of VsockBackend.
+                        .downcast_ref::<Vsock<VsockUnixBackend>>()
+                        .unwrap();
+                    let vsock_state = VsockState {
+                        backend: vsock.backend().save(),
+                        frontend: vsock.save(),
+                    };
+                    states.vsock_device = Some(ConnectedVsockState {
+                        device_id: device_id.clone(),
+                        device_state: vsock_state,
+                        transport_state,
+                        mmio_slot: device_info.clone(),
+                    });
+                }
+                _ => unreachable!(),
+            };
+        }
+        states
+    }
+
+    pub fn restore(
+        constructor_args: MMIODevManagerConstructorArgs,
+        state: &DeviceStates,
+    ) -> std::result::Result<Self, io::Error> {
+        // These are only used during initial registration.
+        let mut dummy_mmio_base = 0;
+        let dummy_irq_range = (0, 0);
+        let mut dev_manager = MMIODeviceManager::new(&mut dummy_mmio_base, dummy_irq_range);
+        let mem = &constructor_args.mem;
+        let vm = constructor_args.vm;
+
+        for block_state in &state.block_devices {
+            let device = Arc::new(Mutex::new(
+                Block::restore(
+                    BlockConstructorArgs { mem: mem.clone() },
+                    &block_state.device_state,
+                )
+                .map_err(Error::Block)?,
+            ));
+
+            let device_id = block_state.device_id.clone();
+            let transport_state = &block_state.transport_state;
+            let mmio_slot = &block_state.mmio_slot;
+
+            let restore_args = MmioTransportConstructorArgs {
+                mem: mem.clone(),
+                device,
+            };
+            let mmio_transport = MmioTransport::restore(restore_args, transport_state)
+                .map_err(|()| Error::MmioTransport)?;
+            dev_manager
+                .register_virtio_mmio_device(vm, device_id, mmio_transport, &mmio_slot)
+                .map_err(Error::DeviceManager);
+        }
+        for net_state in &state.net_devices {
+            let device = Arc::new(Mutex::new(
+                Net::restore(
+                    NetConstructorArgs { mem: mem.clone() },
+                    &net_state.device_state,
+                )
+                .map_err(Error::Net)?,
+            ));
+
+            let device_id = net_state.device_id.clone();
+            let transport_state = &net_state.transport_state;
+            let mmio_slot = &net_state.mmio_slot;
+
+            let restore_args = MmioTransportConstructorArgs {
+                mem: mem.clone(),
+                device,
+            };
+            let mmio_transport = MmioTransport::restore(restore_args, transport_state)
+                .map_err(|()| Error::MmioTransport)?;
+            dev_manager
+                .register_virtio_mmio_device(vm, device_id, mmio_transport, &mmio_slot)
+                .map_err(Error::DeviceManager);
+        }
+        if let Some(vsock_state) = &state.vsock_device {
+            let ctor_args = VsockUdsConstructorArgs {
+                cid: vsock_state.device_state.frontend.cid,
+            };
+            let backend = VsockUnixBackend::restore(ctor_args, &vsock_state.device_state.backend)
+                .map_err(Error::VsockUnixBackend)?;
+            let device = Arc::new(Mutex::new(
+                Vsock::restore(
+                    VsockConstructorArgs {
+                        mem: mem.clone(),
+                        backend,
+                    },
+                    &vsock_state.device_state.frontend,
+                )
+                .map_err(Error::Vsock)?,
+            ));
+
+            let device_id = vsock_state.device_id.clone();
+            let transport_state = &vsock_state.transport_state;
+            let mmio_slot = &vsock_state.mmio_slot;
+
+            let restore_args = MmioTransportConstructorArgs {
+                mem: mem.clone(),
+                device,
+            };
+            let mmio_transport = MmioTransport::restore(restore_args, transport_state)
+                .map_err(|()| Error::MmioTransport)?;
+            dev_manager
+                .register_virtio_mmio_device(vm, device_id, mmio_transport, &mmio_slot)
+                .map_err(Error::DeviceManager);
+        }
+
+        Ok(dev_manager)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use builder::tests::*;
+    use utils::tempfile::TempFile;
+    use vmm_config::net::NetworkInterfaceConfig;
+    use vmm_config::vsock::tests::TempSockFile;
+    use vmm_config::vsock::VsockDeviceConfig;
+
+    use polly::event_manager::EventManager;
+
+    impl PartialEq for ConnectedBlockState {
+        fn eq(&self, other: &ConnectedBlockState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state && self.mmio_slot == other.mmio_slot
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedBlockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedBlockDevice {{ transport_state: {:?}, mmio_slot: {:?} }}",
+                self.transport_state, self.mmio_slot
+            )
+        }
+    }
+
+    impl PartialEq for ConnectedNetState {
+        fn eq(&self, other: &ConnectedNetState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state && self.mmio_slot == other.mmio_slot
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedNetState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedNetDevice {{ transport_state: {:?}, mmio_slot: {:?} }}",
+                self.transport_state, self.mmio_slot
+            )
+        }
+    }
+
+    impl PartialEq for ConnectedVsockState {
+        fn eq(&self, other: &ConnectedVsockState) -> bool {
+            // Actual device state equality is checked by the device's tests.
+            self.transport_state == other.transport_state && self.mmio_slot == other.mmio_slot
+        }
+    }
+
+    impl std::fmt::Debug for ConnectedVsockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "ConnectedVsockDevice {{ transport_state: {:?}, mmio_slot: {:?} }}",
+                self.transport_state, self.mmio_slot
+            )
+        }
+    }
+
+    impl PartialEq for DeviceStates {
+        fn eq(&self, other: &DeviceStates) -> bool {
+            self.block_devices == other.block_devices
+                && self.net_devices == other.net_devices
+                && self.vsock_device == other.vsock_device
+        }
+    }
+
+    impl std::fmt::Debug for DeviceStates {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(
+                f,
+                "DevicesStates {{ block_devices: {:?}, net_devices: {:?}, vsock_device: {:?} }}",
+                self.block_devices, self.net_devices, self.vsock_device
+            )
+        }
+    }
+
+    impl Clone for MMIODeviceManager {
+        fn clone(&self) -> Self {
+            let mut dummy_mmio_base = 0;
+            let dummy_irq_range = (0, 0);
+            let mut clone = MMIODeviceManager::new(&mut dummy_mmio_base, dummy_irq_range);
+            // We only care about the device hashmap.
+            clone.id_to_dev_info = self.id_to_dev_info.clone();
+            clone
+        }
+    }
+
+    impl PartialEq for MMIODeviceManager {
+        fn eq(&self, other: &MMIODeviceManager) -> bool {
+            // We only care about the device hashmap.
+            if self.id_to_dev_info.len() != other.id_to_dev_info.len() {
+                return false;
+            }
+            for (key, val) in &self.id_to_dev_info {
+                match other.id_to_dev_info.get(key) {
+                    Some(other_val) if val == other_val => continue,
+                    _ => return false,
+                };
+            }
+            true
+        }
+    }
+
+    impl std::fmt::Debug for MMIODeviceManager {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{:?}", self.id_to_dev_info)
+        }
+    }
+
+    #[test]
+    fn test_device_manager_persistence() {
+        let mut buf = vec![0; 16384];
+        let version_map = VersionMap::new();
+        // These need to survive so the restored blocks find them.
+        let _block_files;
+        let _tmp_sock_file;
+        // Set up a vmm with one of each device, and get the serialized DeviceStates.
+        let original_mmio_device_manager = {
+            let mut event_manager = EventManager::new().expect("Unable to create EventManager");
+            let mut vmm = default_vmm();
+            let mut cmdline = default_kernel_cmdline();
+
+            // Add a block device.
+            let drive_id = String::from("root");
+            let block_configs = vec![CustomBlockConfig::new(drive_id.clone(), true, None, true)];
+            _block_files =
+                insert_block_devices(&mut vmm, &mut cmdline, &mut event_manager, block_configs);
+            // Add a net device.
+            let network_interface = NetworkInterfaceConfig {
+                iface_id: String::from("netif"),
+                host_dev_name: String::from("hostname"),
+                guest_mac: None,
+                rx_rate_limiter: None,
+                tx_rate_limiter: None,
+                allow_mmds_requests: true,
+            };
+            insert_net_device(
+                &mut vmm,
+                &mut cmdline,
+                &mut event_manager,
+                network_interface,
+            );
+            // Add a vsock device.
+            let orig_tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+            let vsock_dev_id = "vsock";
+            let vsock_config = VsockDeviceConfig {
+                vsock_id: vsock_dev_id.to_string(),
+                guest_cid: 3,
+                uds_path: orig_tmp_sock_file.path().clone(),
+            };
+            insert_vsock_device(&mut vmm, &mut cmdline, &mut event_manager, vsock_config);
+            // This will be used by the restored device and will cleanup the UDS when test ends.
+            _tmp_sock_file = orig_tmp_sock_file.clone();
+
+            vmm.mmio_device_manager
+                .save()
+                .serialize(&mut buf.as_mut_slice(), &version_map, 1)
+                .unwrap();
+            vmm.mmio_device_manager.clone()
+        };
+
+        let vmm = default_vmm();
+        let device_states: DeviceStates =
+            DeviceStates::deserialize(&mut buf.as_slice(), &version_map, 1).unwrap();
+        let restore_args = MMIODevManagerConstructorArgs {
+            mem: vmm.guest_memory().clone(),
+            vm: vmm.vm.fd(),
+        };
+        let restored_dev_manager =
+            MMIODeviceManager::restore(restore_args, &device_states).unwrap();
+
+        assert_eq!(restored_dev_manager, original_mmio_device_manager);
+    }
+}

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -94,10 +94,12 @@ pub struct MMIODevManagerConstructorArgs<'a> {
     pub vm: &'a VmFd,
 }
 
-// Cannot implement actual 'trait Persist' without adding a lifetime parameter
-// to the Persist trait.
-impl MMIODeviceManager {
-    pub fn save(&self) -> DeviceStates {
+impl<'a> Persist<'a> for MMIODeviceManager {
+    type State = DeviceStates;
+    type ConstructorArgs = MMIODevManagerConstructorArgs<'a>;
+    type Error = Error;
+
+    fn save(&self) -> Self::State {
         let mut states = DeviceStates {
             block_devices: Vec::new(),
             net_devices: Vec::new(),
@@ -166,10 +168,10 @@ impl MMIODeviceManager {
         states
     }
 
-    pub fn restore(
-        constructor_args: MMIODevManagerConstructorArgs,
-        state: &DeviceStates,
-    ) -> std::result::Result<Self, io::Error> {
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error> {
         // These are only used during initial registration.
         let mut dummy_mmio_base = 0;
         let dummy_irq_range = (0, 0);

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -62,21 +62,10 @@ use arch::DeviceType;
 #[cfg(target_arch = "x86_64")]
 use device_manager::legacy::PortIODeviceManager;
 use device_manager::mmio::MMIODeviceManager;
-#[cfg(target_arch = "x86_64")]
-use devices::virtio::{
-    vsock::persist::VsockState, Block, MmioTransport, Net, Vsock, VsockUnixBackend, TYPE_BLOCK,
-    TYPE_NET, TYPE_VSOCK,
-};
 use devices::BusDevice;
 use logger::{LoggerError, MetricsError, METRICS};
-#[cfg(target_arch = "x86_64")]
-use persist::{
-    ConnectedBlockState, ConnectedNetState, ConnectedVsockState, DeviceStates, VmmResourcesState,
-};
 use polly::event_manager::{self, EventManager, Subscriber};
 use seccomp::{BpfProgram, BpfProgramRef, SeccompFilter};
-#[cfg(target_arch = "x86_64")]
-use snapshot::Persist;
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;
 use utils::time::TimestampUs;
@@ -369,81 +358,6 @@ impl Vmm {
     /// Returns a reference to the inner KVM Vm object.
     pub fn kvm_vm(&self) -> &Vm {
         &self.vm
-    }
-
-    /// Saves the device states.
-    #[cfg(target_arch = "x86_64")]
-    pub fn save_mmio_device_states(&mut self) -> DeviceStates {
-        let mut states = DeviceStates {
-            block_devices: Vec::new(),
-            net_devices: Vec::new(),
-            vsock_device: None,
-        };
-        let device_manager = &mut self.mmio_device_manager;
-
-        for ((device_type, device_id), device_info) in device_manager.get_device_info().iter() {
-            let bus_device = device_manager
-                .get_device(*device_type, device_id)
-                // Safe to unwrap() because we know the device exists.
-                .unwrap()
-                .lock()
-                .expect("Poisoned device lock");
-
-            let mmio_transport = bus_device
-                .as_any()
-                // Only MmioTransport implements BusDevice at this point.
-                .downcast_ref::<MmioTransport>()
-                .expect("Unexpected BusDevice type");
-
-            let transport_state = mmio_transport.save();
-            let vmm_resources = VmmResourcesState {
-                mmio_base: device_info.addr,
-                len: device_info.len,
-                irqs: vec![device_info.irq],
-            };
-
-            let locked_device = mmio_transport.locked_device();
-            match locked_device.device_type() {
-                TYPE_BLOCK => {
-                    let block_state = locked_device
-                        .as_any()
-                        .downcast_ref::<Block>()
-                        .unwrap()
-                        .save();
-                    states.block_devices.push(ConnectedBlockState {
-                        device_state: block_state,
-                        transport_state,
-                        vmm_resources,
-                    });
-                }
-                TYPE_NET => {
-                    let net_state = locked_device.as_any().downcast_ref::<Net>().unwrap().save();
-                    states.net_devices.push(ConnectedNetState {
-                        device_state: net_state,
-                        transport_state,
-                        vmm_resources,
-                    });
-                }
-                TYPE_VSOCK => {
-                    let vsock = locked_device
-                        .as_any()
-                        // Currently, VsockUnixBackend is the only implementation of VsockBackend.
-                        .downcast_ref::<Vsock<VsockUnixBackend>>()
-                        .unwrap();
-                    let vsock_state = VsockState {
-                        backend: vsock.backend().save(),
-                        frontend: vsock.save(),
-                    };
-                    states.vsock_device = Some(ConnectedVsockState {
-                        device_state: vsock_state,
-                        transport_state,
-                        vmm_resources,
-                    });
-                }
-                _ => unreachable!(),
-            };
-        }
-        states
     }
 }
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -42,6 +42,7 @@ mod tests {
     use crate::vstate::tests::default_vcpu_state;
     use crate::Vmm;
     use polly::event_manager::EventManager;
+    use snapshot::Persist;
     use utils::tempfile::TempFile;
     use vmm_config::net::NetworkInterfaceConfig;
     use vmm_config::vsock::tests::{default_config, TempSockFile};

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -99,6 +99,7 @@ pub(crate) mod tests {
 
     // Placeholder for the path where a socket file will be created.
     // The socket file will be removed when the scope ends.
+    #[derive(Clone)]
     pub(crate) struct TempSockFile {
         path: String,
     }


### PR DESCRIPTION
## Reason for This PR

Part of #1847 

## Description of Changes

Move device map crawling and serialization from Vmm to the device manager.

The device manager implements 'save()' which creates the previously defined 'DeviceStates' containing the devices' states plus mmio bus and irq attributes.

The device manager implements 'restore()' which takes a 'DeviceStates' structure, restores the devices and registers them using the original mmio bus and irq settings.

Ideally the device-manager would be device implementation agnostic, but Persist and Versionize don't allow dynamic dispatch.
The current organization of serialized data does however allow such a design, so the present state is a two-way-door and if in the future we invest here, we might be able to get the implementation there with no disruption to the user.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
