### PR TITLE
tests: enough to run rustfmt on single arch

### DIFF
--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -16,7 +16,7 @@ SUCCESS_CODE = 0
 @pytest.mark.timeout(120)
 @pytest.mark.skipif(
     platform.machine() != "x86_64",
-    reason="rustfmt is not available on Rust 1.38 on aarch64"
+    reason="no need to test it on multiple platforms"
 )
 def test_rust_style():
     """Fail if there's misbehaving Rust style in this repo."""


### PR DESCRIPTION
## Reason for This PR

Fixes #1322 

## Description of Changes

Updated comment to match reason for which we are not running `rustfmt` on `aarch64`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
