### PR TITLE
api_server: normalize ParsedRequest enum size

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -171,9 +171,9 @@ impl ApiServer {
         }
     }
 
-    fn serve_vmm_action_request(&self, vmm_action: VmmAction) -> Response {
+    fn serve_vmm_action_request(&self, vmm_action: Box<VmmAction>) -> Response {
         self.api_request_sender
-            .send(Box::new(vmm_action))
+            .send(vmm_action)
             .expect("Failed to send VMM message");
         self.to_vmm_fd.write(1).expect("Cannot update send VMM fd");
         let vmm_outcome = *(self.vmm_response_receiver.recv().expect("VMM disconnected"));
@@ -340,7 +340,7 @@ mod tests {
                 StartMicrovmError::MicroVMAlreadyRunning,
             ))))
             .unwrap();
-        let response = api_server.serve_vmm_action_request(VmmAction::StartMicroVm);
+        let response = api_server.serve_vmm_action_request(Box::new(VmmAction::StartMicroVm));
         assert_eq!(response.status(), StatusCode::BadRequest);
     }
 

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -24,13 +24,12 @@ use ApiServer;
 
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 
-#[allow(clippy::large_enum_variant)]
 pub enum ParsedRequest {
     GetInstanceInfo,
     GetMMDS,
     PatchMMDS(Value),
     PutMMDS(Value),
-    Sync(VmmAction),
+    Sync(Box<VmmAction>),
 }
 
 impl ParsedRequest {
@@ -114,6 +113,11 @@ impl ParsedRequest {
                 response
             }
         }
+    }
+
+    /// Helper function to avoid boiler-plate code.
+    pub fn new_sync(vmm_action: VmmAction) -> ParsedRequest {
+        ParsedRequest::Sync(Box::new(vmm_action))
     }
 }
 
@@ -232,7 +236,7 @@ pub fn checked_id(id: &str) -> Result<&str, Error> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use std::io::Write;
@@ -260,6 +264,13 @@ mod tests {
                 }
                 _ => false,
             }
+        }
+    }
+
+    pub(crate) fn vmm_action_from_request(req: ParsedRequest) -> VmmAction {
+        match req {
+            ParsedRequest::Sync(vmm_action) => *vmm_action,
+            _ => panic!("Invalid request"),
         }
     }
 

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -3,9 +3,10 @@
 
 use super::super::VmmAction;
 use logger::{Metric, METRICS};
+use parsed_request::{Error, ParsedRequest};
+use request::Body;
 #[cfg(target_arch = "aarch64")]
 use request::StatusCode;
-use request::{Body, Error, ParsedRequest};
 
 // The names of the members from this enum must precisely correspond (as a string) to the possible
 // values of "action_type" from the json request body. This is useful to get a strongly typed
@@ -33,8 +34,8 @@ pub fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
     })?;
 
     match action_body.action_type {
-        ActionType::FlushMetrics => Ok(ParsedRequest::Sync(VmmAction::FlushMetrics)),
-        ActionType::InstanceStart => Ok(ParsedRequest::Sync(VmmAction::StartMicroVm)),
+        ActionType::FlushMetrics => Ok(ParsedRequest::new_sync(VmmAction::FlushMetrics)),
+        ActionType::InstanceStart => Ok(ParsedRequest::new_sync(VmmAction::StartMicroVm)),
         ActionType::SendCtrlAltDel => {
             // SendCtrlAltDel not supported on aarch64.
             #[cfg(target_arch = "aarch64")]
@@ -44,7 +45,7 @@ pub fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
             ));
 
             #[cfg(target_arch = "x86_64")]
-            Ok(ParsedRequest::Sync(VmmAction::SendCtrlAltDel))
+            Ok(ParsedRequest::new_sync(VmmAction::SendCtrlAltDel))
         }
     }
 }
@@ -62,7 +63,7 @@ mod tests {
                 "action_type": "InstanceStart"
             }"#;
 
-            let req: ParsedRequest = ParsedRequest::Sync(VmmAction::StartMicroVm);
+            let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::StartMicroVm);
             let result = parse_put_actions(&Body::new(json));
             assert!(result.is_ok());
             assert!(result.unwrap().eq(&req));
@@ -74,7 +75,7 @@ mod tests {
                 "action_type": "SendCtrlAltDel"
             }"#;
 
-            let req: ParsedRequest = ParsedRequest::Sync(VmmAction::SendCtrlAltDel);
+            let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::SendCtrlAltDel);
             let result = parse_put_actions(&Body::new(json));
             assert!(result.is_ok());
             assert!(result.unwrap().eq(&req));
@@ -95,7 +96,7 @@ mod tests {
                 "action_type": "FlushMetrics"
             }"#;
 
-            let req: ParsedRequest = ParsedRequest::Sync(VmmAction::FlushMetrics);
+            let req: ParsedRequest = ParsedRequest::new_sync(VmmAction::FlushMetrics);
             let result = parse_put_actions(&Body::new(json));
             assert!(result.is_ok());
             assert!(result.unwrap().eq(&req));

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -3,12 +3,13 @@
 
 use super::super::VmmAction;
 use logger::{Metric, METRICS};
-use request::{Body, Error, ParsedRequest};
+use parsed_request::{Error, ParsedRequest};
+use request::Body;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 
 pub fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.boot_source_count.inc();
-    Ok(ParsedRequest::Sync(VmmAction::ConfigureBootSource(
+    Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
         serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|e| {
             METRICS.put_api_requests.boot_source_fails.inc();
             Error::SerdeJson(e)
@@ -38,6 +39,6 @@ mod tests {
         assert!(result.is_ok());
         let parsed_req = result.unwrap_or_else(|_e| panic!("Failed test."));
 
-        assert!(parsed_req == ParsedRequest::Sync(VmmAction::ConfigureBootSource(same_body)));
+        assert!(parsed_req == ParsedRequest::new_sync(VmmAction::ConfigureBootSource(same_body)));
     }
 }

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use logger::{Metric, METRICS};
-use request::{Error, ParsedRequest};
+use parsed_request::{Error, ParsedRequest};
 
 pub fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.instance_info_count.inc();

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -3,12 +3,13 @@
 
 use super::super::VmmAction;
 use logger::{Metric, METRICS};
-use request::{Body, Error, ParsedRequest};
+use parsed_request::{Error, ParsedRequest};
+use request::Body;
 use vmm::vmm_config::metrics::MetricsConfig;
 
 pub fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.metrics_count.inc();
-    Ok(ParsedRequest::Sync(VmmAction::ConfigureMetrics(
+    Ok(ParsedRequest::new_sync(VmmAction::ConfigureMetrics(
         serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|e| {
             METRICS.put_api_requests.metrics_fails.inc();
             Error::SerdeJson(e)
@@ -21,6 +22,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::parsed_request::tests::vmm_action_from_request;
 
     #[test]
     fn test_parse_put_metrics_request() {
@@ -31,10 +33,8 @@ mod tests {
         let expected_cfg = MetricsConfig {
             metrics_path: PathBuf::from("metrics"),
         };
-        match parse_put_metrics(&Body::new(body)) {
-            Ok(ParsedRequest::Sync(VmmAction::ConfigureMetrics(cfg))) => {
-                assert_eq!(cfg, expected_cfg)
-            }
+        match vmm_action_from_request(parse_put_metrics(&Body::new(body)).unwrap()) {
+            VmmAction::ConfigureMetrics(cfg) => assert_eq!(cfg, expected_cfg),
             _ => panic!("Test failed."),
         }
 

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use micro_http::StatusCode;
-use request::{Body, Error, ParsedRequest};
+use parsed_request::{Error, ParsedRequest};
+use request::Body;
 use vmm::rpc_interface::VmmAction::SetMmdsConfiguration;
 use vmm::vmm_config::mmds::MmdsConfig;
 
@@ -16,7 +17,7 @@ pub fn parse_put_mmds(
 ) -> Result<ParsedRequest, Error> {
     match path_second_token {
         Some(config_path) => match *config_path {
-            "config" => Ok(ParsedRequest::Sync(SetMmdsConfiguration(
+            "config" => Ok(ParsedRequest::new_sync(SetMmdsConfiguration(
                 serde_json::from_slice::<MmdsConfig>(body.raw()).map_err(Error::SerdeJson)?,
             ))),
             _ => Err(Error::Generic(

--- a/src/api_server/src/request/mod.rs
+++ b/src/api_server/src/request/mod.rs
@@ -15,4 +15,3 @@ pub mod vsock;
 pub use micro_http::{
     Body, HttpServer, Method, Request, RequestError, Response, StatusCode, Version,
 };
-use parsed_request::{checked_id, method_to_error, Error, ParsedRequest};

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -3,7 +3,8 @@
 
 use super::super::VmmAction;
 use logger::{Metric, METRICS};
-use request::{checked_id, Body, Error, ParsedRequest, StatusCode};
+use parsed_request::{checked_id, Error, ParsedRequest};
+use request::{Body, StatusCode};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 
 pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
@@ -26,7 +27,9 @@ pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedR
             "The id from the path does not match the id from the body!".to_string(),
         ));
     }
-    Ok(ParsedRequest::Sync(VmmAction::InsertNetworkDevice(netif)))
+    Ok(ParsedRequest::new_sync(VmmAction::InsertNetworkDevice(
+        netif,
+    )))
 }
 
 pub fn parse_patch_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
@@ -50,7 +53,7 @@ pub fn parse_patch_net(body: &Body, id_from_path: Option<&&str>) -> Result<Parse
             "The id from the path does not match the id from the body!".to_string(),
         ));
     }
-    Ok(ParsedRequest::Sync(VmmAction::UpdateNetworkInterface(
+    Ok(ParsedRequest::new_sync(VmmAction::UpdateNetworkInterface(
         netif,
     )))
 }
@@ -60,6 +63,7 @@ mod tests {
     use serde_json;
 
     use super::*;
+    use crate::parsed_request::tests::vmm_action_from_request;
 
     #[test]
     fn test_parse_put_net_request() {
@@ -76,10 +80,8 @@ mod tests {
 
         // 3. Success case.
         let netif_clone = serde_json::from_str::<NetworkInterfaceConfig>(body).unwrap();
-        match parse_put_net(&Body::new(body), Some(&"foo")) {
-            Ok(ParsedRequest::Sync(VmmAction::InsertNetworkDevice(netif))) => {
-                assert_eq!(netif, netif_clone)
-            }
+        match vmm_action_from_request(parse_put_net(&Body::new(body), Some(&"foo")).unwrap()) {
+            VmmAction::InsertNetworkDevice(netif) => assert_eq!(netif, netif_clone),
             _ => panic!("Test failed."),
         }
 
@@ -120,10 +122,8 @@ mod tests {
 
         // 3. Success case.
         let netif_clone = serde_json::from_str::<NetworkInterfaceUpdateConfig>(body).unwrap();
-        match parse_patch_net(&Body::new(body), Some(&"foo")) {
-            Ok(ParsedRequest::Sync(VmmAction::UpdateNetworkInterface(netif))) => {
-                assert_eq!(netif, netif_clone)
-            }
+        match vmm_action_from_request(parse_patch_net(&Body::new(body), Some(&"foo")).unwrap()) {
+            VmmAction::UpdateNetworkInterface(netif) => assert_eq!(netif, netif_clone),
             _ => panic!("Test failed."),
         }
 

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
-use request::{Body, Error, ParsedRequest};
+use parsed_request::{Error, ParsedRequest};
+use request::Body;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 pub fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
-    Ok(ParsedRequest::Sync(VmmAction::SetVsockDevice(
+    Ok(ParsedRequest::new_sync(VmmAction::SetVsockDevice(
         serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(Error::SerdeJson)?,
     )))
 }


### PR DESCRIPTION
## Reason for This PR

Fixes #1142 

## Description of Changes

Box `VmmAction` in `ParsedRequest::Sync` to keep enum variants around the same size.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
