### PR TITLE
virtio-queue: use map_err for error handling

### DIFF
--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -77,14 +77,13 @@ impl<'a> DescriptorChain<'a> {
         mem.checked_offset(desc_head, 16)?;
 
         // These reads can't fail unless Guest memory is hopelessly broken.
-        let desc = match mem.read_obj::<Descriptor>(desc_head) {
-            Ok(ret) => ret,
-            Err(_) => {
+        let desc = mem
+            .read_obj::<Descriptor>(desc_head)
+            .map_err(|_| {
                 // TODO log address
                 error!("Failed to read from memory");
-                return None;
-            }
-        };
+            })
+            .unwrap();
         let chain = DescriptorChain {
             mem,
             desc_table,


### PR DESCRIPTION
Use `err_map` to handle error cases when getting desc variable, to
instead `match` statement.

I feel we need not the line:
```rust
            Err(_) => {
                ...
                return None;
            }
```
for check has been done, and if memory broken happens, just throw out error message.

Signed-off-by: keyangxie <keyang.xie@gmail.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
