### PR TITLE
Add some infrastructure for snapshot integration test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ if os.geteuid() != 0:
     raise PermissionError("Test session needs to be run as root.")
 
 
-def test_images_s3_bucket():
+def _test_images_s3_bucket():
     """Auxiliary function for getting this session's bucket name."""
     return os.environ.get(
         ENV_TEST_IMAGES_S3_BUCKET,
@@ -125,7 +125,7 @@ def test_images_s3_bucket():
     )
 
 
-MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(test_images_s3_bucket())
+MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(_test_images_s3_bucket())
 
 
 def init_microvm(root_path, bin_cloner_path):

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -1,0 +1,135 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Define classes for interacting with CI artifacts in s3."""
+
+import os
+import platform
+import re
+
+from shutil import copyfile
+from typing import List
+from os import path
+from pathlib import Path
+
+import boto3
+import botocore.client
+
+
+MICROVM_CONFIG_EXTENSION = ".json"
+MICROVM_KERNEL_EXTENSION = ".bin"
+MICROVM_DISK_EXTENSION = ".ext4"
+
+
+class Artifact:
+    """A generic artifact manipulation class."""
+
+    bucket = None
+    key = None
+    local_folder = None
+
+    def __init__(self, bucket, key, type="misc"):
+        """Initialize bucket, key and type."""
+        self.bucket = bucket
+        self.key = key
+        self.type = type
+
+    def name(self):
+        """Return the artifact name."""
+        return self.key.rsplit("/", 1)[1]
+
+    def local_dir(self):
+        """Return the directory containing the downloaded artifact."""
+        return "{}/{}/{}".format(
+            self.local_folder,
+            self.type,
+            platform.machine(),
+        )
+
+    def download(self, target_folder, force=False):
+        """Save the artifact in the folder specified target_path."""
+        self.local_folder = target_folder
+        Path(self.local_dir()).mkdir(parents=True, exist_ok=True)
+        if force or not os.path.exists(self.local_path()):
+            self.bucket.download_file(self.key, self.local_path())
+
+    def local_path(self):
+        """Return the local path where the file was downloaded."""
+        # The file path format: <target_folder>/<type>/<platform>/<name>
+        return "{}/{}".format(
+            self.local_dir(),
+            self.name()
+        )
+
+
+class DiskArtifact(Artifact):
+    """Specializes the generic artifact."""
+
+    def ssh_key(self):
+        """Return a ssh key artifact."""
+        key_file_path = self.key.rsplit(".", 1)[0] + '.id_rsa'
+        return Artifact(self.bucket, key_file_path, type="ssh_key")
+
+
+class ArtifactCollection:
+    """Provides easy access to different artifact types."""
+
+    # S3 bucket structure.
+    ARTIFACTS_ROOT = 'ci-artifacts'
+    ARTIFACTS_DISKS = '/disks/' + platform.machine()
+    ARTIFACTS_KERNELS = '/kernels/' + platform.machine()
+    ARTIFACTS_MICROVMS = '/microvms'
+    ARTIFACTS_SNAPSHOTS = '/snapshots/' + platform.machine()
+
+    s3 = None
+    artifacts_bucket = None
+
+    def __init__(
+        self,
+        artifacts_bucket
+    ):
+        """Initialize S3 client."""
+        config = botocore.client.Config(signature_version=botocore.UNSIGNED)
+        self.s3 = boto3.resource('s3', config=config)
+        self.artifacts_bucket = artifacts_bucket
+
+    def microvms(self):
+        """Return all microvms artifacts for the current arch."""
+        bucket = self.s3.Bucket(self.artifacts_bucket)
+        microvm_artifacts = []
+        microvm_prefix = self.ARTIFACTS_ROOT + self.ARTIFACTS_MICROVMS
+        microvms = bucket.objects.filter(Prefix=microvm_prefix)
+        for microvm in microvms:
+            if microvm.key.endswith(MICROVM_CONFIG_EXTENSION):
+                microvm_artifacts.append(Artifact(bucket,
+                                                  microvm.key,
+                                                  type="microvm"))
+
+        return microvm_artifacts
+
+    def kernels(self):
+        """Return all microvms kernels for the current arch."""
+        bucket = self.s3.Bucket(self.artifacts_bucket)
+        kernel_artifacts = []
+        kernel_prefix = self.ARTIFACTS_ROOT + self.ARTIFACTS_KERNELS
+        kernels = bucket.objects.filter(Prefix=kernel_prefix)
+        for kernel in kernels:
+            if kernel.key.endswith(MICROVM_KERNEL_EXTENSION):
+                kernel_artifacts.append(Artifact(bucket,
+                                                 kernel.key,
+                                                 type="kernel"))
+
+        return kernel_artifacts
+
+    def disks(self):
+        """Return all disk artifacts for the current arch."""
+        bucket = self.s3.Bucket(self.artifacts_bucket)
+        disk_artifacts = []
+        disk_prefix = self.ARTIFACTS_ROOT + self.ARTIFACTS_DISKS
+        disks = bucket.objects.filter(Prefix=disk_prefix)
+        for disk in disks:
+            if disk.key.endswith(MICROVM_DISK_EXTENSION):
+                disk_artifacts.append(DiskArtifact(bucket,
+                                                   disk.key,
+                                                   type="disk"))
+
+        return disk_artifacts

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -3,11 +3,11 @@
 """Define some helpers methods to create microvms from artifacts."""
 
 import json
+import os
+import uuid
 from framework.microvm import Microvm
 import host_tools.cargo_build as build_tools
-import uuid
 from framework.artifacts import Artifact, DiskArtifact
-import os
 
 
 class MicrovmBuilder:
@@ -36,7 +36,7 @@ class MicrovmBuilder:
         vm.kernel_file = kernel.local_path()
         vm.rootfs_file = disks[0].local_path()
         ssh_key = disks[0].ssh_key()
-        
+
         # Download ssh key into microvm root.
         ssh_key.download(self.root_path)
         vm.ssh_config['ssh_key_path'] = ssh_key.local_path()
@@ -57,4 +57,3 @@ class MicrovmBuilder:
 
     def build_from_snapshot(self, snapshot: Artifact):
         """Build and start a microvm from a snapshot artifact."""
-        pass

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Define some helpers methods to create microvms from artifacts."""
+
+import json
+from framework.microvm import Microvm
+import host_tools.cargo_build as build_tools
+import uuid
+from framework.artifacts import Artifact, DiskArtifact
+import os
+
+
+class MicrovmBuilder:
+    """Build fresh microvms or restore from snapshot."""
+
+    def __init__(self, root_path, bin_cloner_path):
+        """Initialize microvm root and cloning binary."""
+        self.root_path = root_path
+        self.bin_cloner_path = bin_cloner_path
+
+    def build(self, kernel: Artifact, disks: [DiskArtifact], config: Artifact):
+        """Build and start a fresh microvm."""
+        microvm_id = str(uuid.uuid4())
+        fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+        vm = Microvm(
+            resource_path=self.root_path,
+            fc_binary_path=fc_binary,
+            jailer_binary_path=jailer_binary,
+            microvm_id=microvm_id,
+            bin_cloner_path=self.bin_cloner_path
+        )
+        vm.setup()
+
+        # Link the microvm to kernel, rootfs, ssh_key artifacts.
+        vm.kernel_file = kernel.local_path()
+        vm.rootfs_file = disks[0].local_path()
+        ssh_key = disks[0].ssh_key()
+        
+        # Download ssh key into microvm root.
+        ssh_key.download(self.root_path)
+        vm.ssh_config['ssh_key_path'] = ssh_key.local_path()
+        os.chmod(vm.ssh_config['ssh_key_path'], 0o400)
+
+        # Start firecracker.
+        vm.spawn()
+
+        # Apply the microvm artifact configuration and start microvm.
+        with open(config.local_path()) as microvm_config_file:
+            microvm_config = json.load(microvm_config_file)
+
+        vm.basic_config(vcpu_count=int(microvm_config['vcpu_count']),
+                        mem_size_mib=int(microvm_config['mem_size_mib']),
+                        ht_enabled=bool(microvm_config['ht_enabled']))
+
+        return vm
+
+    def build_from_snapshot(self, snapshot: Artifact):
+        """Build and start a microvm from a snapshot artifact."""
+        pass

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -13,6 +13,7 @@ from framework.microvm import Microvm
 import host_tools.cargo_build as build_tools
 import uuid
 
+
 ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
 
 
@@ -76,22 +77,7 @@ class TestMatrix:
         for microvm in self.microvms:
             microvm.download(self._cache_dir)
 
-    def configure_microvm(self, microvm_config, kernel, disk):
-        """Link the microvm to kernel, rootfs, ssh_key artifacts."""
-        self._microvm.kernel_file = kernel.local_path()
-        self._microvm.rootfs_file = disk.local_path()
-        ssh_key = disk.ssh_key()
-        ssh_key.download(self._cache_dir)
-        self._microvm.ssh_config['ssh_key_path'] = ssh_key.local_path()
-        os.chmod(self._microvm.ssh_config['ssh_key_path'], 0o400)
-
-        # Start firecracker.
-        self._microvm.spawn()
-
-        # Apply the microvm artifact configuration.
-        self._microvm.apply_microvm_config(microvm_config)
-
-    def run_test(self, test_fn, test_session_root_path, bin_cloner_path):
+    def run_test(self, test_fn):
         """Run a test function.
 
         The function will be called through the configuration matrix
@@ -106,43 +92,9 @@ class TestMatrix:
         for microvm_config in self.microvms:
             for kernel in self.kernels:
                 for disk in self.disks:
-                    self._microvm = init_microvm(test_session_root_path,
-                                                 bin_cloner_path)
-                    self.configure_microvm(microvm_config, kernel, disk)
                     self._context.update({
                         'microvm': microvm_config,
                         'kernel': kernel,
                         'disk': disk
                     })
                     test_fn(self._context, self._microvm)
-
-
-def init_microvm(root_path, bin_cloner_path):
-    """Auxiliary function for instantiating a microvm and setting it up."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
-    microvm_id = str(uuid.uuid4())
-    fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
-
-    vm = TestMicrovm(
-        resource_path=root_path,
-        fc_binary_path=fc_binary,
-        jailer_binary_path=jailer_binary,
-        microvm_id=microvm_id,
-        bin_cloner_path=bin_cloner_path
-    )
-    vm.setup()
-    return vm
-
-
-class TestMicrovm(Microvm):
-    """Specializes the configuration using a microvm artifact."""
-
-    def apply_microvm_config(self, microvm_artifact):
-        """Configure vCPUs, RAM and HT."""
-        with open(microvm_artifact.local_path()) as microvm_config_file:
-            microvm_config = json.load(microvm_config_file)
-
-        self.basic_config(vcpu_count=int(microvm_config['vcpu_count']),
-                          mem_size_mib=int(microvm_config['mem_size_mib']),
-                          ht_enabled=bool(microvm_config['ht_enabled']))

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -2,17 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Generate multiple microvm configurations and run tests.
 
-Implements a component that can run a specific test through a matrix of
-microvm kernel, disk, cpu and ram configurations.
-The matrix is computed as the cartesian product of all artifacts.
+Implements a component that calls a specific function in the context
+of the cartesian product of all artifact sets.
 """
 
-import json
 import os
-from framework.microvm import Microvm
-import host_tools.cargo_build as build_tools
-import uuid
-
 
 ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
 
@@ -24,140 +18,134 @@ class TestContext:
 
     def __init__(self):
         """Initialize the test context."""
-        self._kernel = None
-        self._disk = None
-        self._microvm = None
-        self._snapshot = None
-        # User defined context.
-        self._custom = None
+        self._context = {}
+
+    def set_any(self, key, value):
+        """Set any key value in the context."""
+        self._context[key] = value
 
     @property
     def kernel(self):
         """Return the kernel artifact."""
-        return self._kernel
+        return self._context.get('kernel', None)
 
     @kernel.setter
     def kernel(self, kernel):
         """Setter for kernel artifact."""
-        self._kernel = kernel
+        self._context['kernel'] = kernel
 
     @property
     def disk(self):
         """Return the disk artifact."""
-        return self._disk
+        return self._context.get('disk', None)
 
     @disk.setter
     def disk(self, disk):
         """Setter for disk artifact."""
-        self._disk = disk
+        self._context['disk'] = disk
 
     @property
     def microvm(self):
         """Return the microvm artifact."""
-        return self._microvm
+        return self._context.get('microvm', None)
 
     @microvm.setter
     def microvm(self, microvm):
         """Setter for kernel artifact."""
-        self._microvm = microvm
+        self._context['microvm'] = microvm
 
     @property
     def snapshot(self):
         """Return the snapshot artifact."""
-        return self._snapshot
+        return self._context.get('snapshot', None)
 
     @snapshot.setter
     def snapshot(self, snapshot):
         """Setter for snapshot artifact."""
-        self._snapshot = snapshot
+        self._context['snapshot'] = snapshot
 
     @property
     def custom(self):
         """Return the custom context."""
-        return self._custom
+        return self._context.get('custom', None)
 
     @custom.setter
     def custom(self, custom):
         """Setter for custom context."""
-        self._custom = custom
+        self._context['custom'] = custom
 
 
 class TestMatrix:
     """Computes the cartesian product of artifacts."""
 
     __test__ = False
-    _kernels = []
-    _disks = []
-    _microvms = []
-    _cache_dir = None
-    _microvm = None
-    _context = None
 
-    def __init__(self, context=TestContext(), cache_dir=ARTIFACTS_LOCAL_ROOT):
-        """Initialize the cache directory."""
-        self._cache_dir = cache_dir
+    def __init__(self,
+                 artifact_sets,
+                 context=TestContext(),
+                 cache_dir=ARTIFACTS_LOCAL_ROOT):
+        """Initialize context, cache dir, and artifact_sets."""
         self._context = context
-
+        # Stores the artifact sets array.
+        self._sets = artifact_sets
+        # ArtifactSet stack pointer.
+        self._set_index = 0
         if not os.path.exists(cache_dir):
             os.mkdir(cache_dir)
+        self._cache_dir = cache_dir
 
     @property
-    def disks(self):
-        """Return the disk artifacts."""
-        return self._disks
-
-    @disks.setter
-    def disks(self, disks):
-        """Setter for disk artifacts."""
-        self._disks = disks
-
-    @property
-    def kernels(self):
-        """Return the kernel artifacts."""
-        return self._kernels
-
-    @kernels.setter
-    def kernels(self, kernels):
-        """Setter for kernel artifacts."""
-        self._kernels = kernels
-
-    @property
-    def microvms(self):
-        """Return the microvm artifacts."""
-        return self._microvms
-
-    @microvms.setter
-    def microvms(self, microvms):
-        """Setter for microvm artifacts."""
-        self._microvms = microvms
+    def sets(self):
+        """Return the artifact sets."""
+        return self._sets
 
     def download_artifacts(self):
         """Download all configured artifacts."""
-        for disk in self.disks:
-            disk.download(self._cache_dir)
+        for artifact_set in self._sets:
+            for artifact in artifact_set.artifacts:
+                artifact.download(self._cache_dir)
 
-        for kernel in self.kernels:
-            kernel.download(self._cache_dir)
+    def _backtrack(self, test_fn, cartesian_product):
+        if len(self._sets) < self._set_index:
+            return
 
-        for microvm in self.microvms:
-            microvm.download(self._cache_dir)
+        # Validate solution: tuple element count is equal to
+        # set stack size.
+        if len(self._sets) == len(cartesian_product):
+            self._run_test_fn(cartesian_product, test_fn)
+            return
+
+        current_set = self._sets[self._set_index]
+        for _artifact in current_set.artifacts:
+            # Prepare for recursive call.
+            # Push the current Artifact in the solution.
+            cartesian_product.append(_artifact)
+            # Go 1 level up the ArtifactSet stack.
+            self._set_index += 1
+
+            self._backtrack(test_fn, cartesian_product)
+
+            # Pop the previous artifact from solution.
+            cartesian_product.pop()
+            # Walk down 1 level.
+            self._set_index -= 1
+
+    def _run_test_fn(self, artifacts, test_fn):
+        """Patch context and call test_fn."""
+        for artifact in artifacts:
+            self._context.set_any(artifact.type.value, artifact)
+        test_fn(self._context)
 
     def run_test(self, test_fn):
         """Run a test function.
 
-        The function will be called through the configuration matrix
-        in the context of a TestMicrovm
+        Iterates over the cartesian product of artifact sets and
+        calls `test_fn` for each element.
         """
         self.download_artifacts()
+        # Reset artifact stack pointer.
+        self._set_index = 0
 
-        assert len(self.microvms) > 0
-        assert len(self.kernels) > 0
-        assert len(self.disks) > 0
-
-        for microvm_config in self.microvms:
-            for kernel in self.kernels:
-                for disk in self.disks:
-                    self._context.kernel = kernel
-                    self._context.disk = disk
-                    self._context.microvm = microvm_config
-                    test_fn(self._context)
+        # Recursive backtracking will generate the cartesian product of
+        # the artifact sets.
+        self._backtrack(test_fn, [])

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -1,0 +1,148 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate multiple microvm configurations and run tests.
+
+Implements a component that can run a specific test through a matrix of
+microvm kernel, disk, cpu and ram configurations.
+The matrix is computed as the cartesian product of all artifacts.
+"""
+
+import json
+import os
+from framework.microvm import Microvm
+import host_tools.cargo_build as build_tools
+import uuid
+
+ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
+
+
+class TestMatrix:
+    """Computes the cartesian product of artifacts."""
+
+    __test__ = False
+    _kernels = []
+    _disks = []
+    _microvms = []
+    _cache_dir = None
+    _microvm = None
+    _context = None
+
+    def __init__(self, context=dict(), cache_dir=ARTIFACTS_LOCAL_ROOT):
+        """Initialize the cache directory."""
+        self._cache_dir = cache_dir
+        self._context = context
+
+        if not os.path.exists(cache_dir):
+            os.mkdir(cache_dir)
+
+    @property
+    def disks(self):
+        """Return the disk artifacts."""
+        return self._disks
+
+    @disks.setter
+    def disks(self, disks):
+        """Setter for disk artifacts."""
+        self._disks = disks
+
+    @property
+    def kernels(self):
+        """Return the kernel artifacts."""
+        return self._kernels
+
+    @kernels.setter
+    def kernels(self, kernels):
+        """Setter for kernel artifacts."""
+        self._kernels = kernels
+
+    @property
+    def microvms(self):
+        """Return the microvm artifacts."""
+        return self._microvms
+
+    @microvms.setter
+    def microvms(self, microvms):
+        """Setter for microvm artifacts."""
+        self._microvms = microvms
+
+    def download_artifacts(self):
+        """Download all configured artifacts."""
+        for disk in self.disks:
+            disk.download(self._cache_dir)
+
+        for kernel in self.kernels:
+            kernel.download(self._cache_dir)
+
+        for microvm in self.microvms:
+            microvm.download(self._cache_dir)
+
+    def configure_microvm(self, microvm_config, kernel, disk):
+        """Link the microvm to kernel, rootfs, ssh_key artifacts."""
+        self._microvm.kernel_file = kernel.local_path()
+        self._microvm.rootfs_file = disk.local_path()
+        ssh_key = disk.ssh_key()
+        ssh_key.download(self._cache_dir)
+        self._microvm.ssh_config['ssh_key_path'] = ssh_key.local_path()
+        os.chmod(self._microvm.ssh_config['ssh_key_path'], 0o400)
+
+        # Start firecracker.
+        self._microvm.spawn()
+
+        # Apply the microvm artifact configuration.
+        self._microvm.apply_microvm_config(microvm_config)
+
+    def run_test(self, test_fn, test_session_root_path, bin_cloner_path):
+        """Run a test function.
+
+        The function will be called through the configuration matrix
+        in the context of a TestMicrovm
+        """
+        self.download_artifacts()
+
+        assert len(self.microvms) > 0
+        assert len(self.kernels) > 0
+        assert len(self.disks) > 0
+
+        for microvm_config in self.microvms:
+            for kernel in self.kernels:
+                for disk in self.disks:
+                    self._microvm = init_microvm(test_session_root_path,
+                                                 bin_cloner_path)
+                    self.configure_microvm(microvm_config, kernel, disk)
+                    self._context.update({
+                        'microvm': microvm_config,
+                        'kernel': kernel,
+                        'disk': disk
+                    })
+                    test_fn(self._context, self._microvm)
+
+
+def init_microvm(root_path, bin_cloner_path):
+    """Auxiliary function for instantiating a microvm and setting it up."""
+    # pylint: disable=redefined-outer-name
+    # The fixture pattern causes a pylint false positive for that rule.
+    microvm_id = str(uuid.uuid4())
+    fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+    vm = TestMicrovm(
+        resource_path=root_path,
+        fc_binary_path=fc_binary,
+        jailer_binary_path=jailer_binary,
+        microvm_id=microvm_id,
+        bin_cloner_path=bin_cloner_path
+    )
+    vm.setup()
+    return vm
+
+
+class TestMicrovm(Microvm):
+    """Specializes the configuration using a microvm artifact."""
+
+    def apply_microvm_config(self, microvm_artifact):
+        """Configure vCPUs, RAM and HT."""
+        with open(microvm_artifact.local_path()) as microvm_config_file:
+            microvm_config = json.load(microvm_config_file)
+
+        self.basic_config(vcpu_count=int(microvm_config['vcpu_count']),
+                          mem_size_mib=int(microvm_config['mem_size_mib']),
+                          ht_enabled=bool(microvm_config['ht_enabled']))

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -17,6 +17,71 @@ import uuid
 ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
 
 
+class TestContext:
+    """Define a context for running test fns by TestMatrix."""
+
+    __test__ = False
+
+    def __init__(self):
+        """Initialize the test context."""
+        self._kernel = None
+        self._disk = None
+        self._microvm = None
+        self._snapshot = None
+        # User defined context.
+        self._custom = None
+
+    @property
+    def kernel(self):
+        """Return the kernel artifact."""
+        return self._kernel
+
+    @kernel.setter
+    def kernel(self, kernel):
+        """Setter for kernel artifact."""
+        self._kernel = kernel
+
+    @property
+    def disk(self):
+        """Return the disk artifact."""
+        return self._disk
+
+    @disk.setter
+    def disk(self, disk):
+        """Setter for disk artifact."""
+        self._disk = disk
+
+    @property
+    def microvm(self):
+        """Return the microvm artifact."""
+        return self._microvm
+
+    @microvm.setter
+    def microvm(self, microvm):
+        """Setter for kernel artifact."""
+        self._microvm = microvm
+
+    @property
+    def snapshot(self):
+        """Return the snapshot artifact."""
+        return self._snapshot
+
+    @snapshot.setter
+    def snapshot(self, snapshot):
+        """Setter for snapshot artifact."""
+        self._snapshot = snapshot
+
+    @property
+    def custom(self):
+        """Return the custom context."""
+        return self._custom
+
+    @custom.setter
+    def custom(self, custom):
+        """Setter for custom context."""
+        self._custom = custom
+
+
 class TestMatrix:
     """Computes the cartesian product of artifacts."""
 
@@ -28,7 +93,7 @@ class TestMatrix:
     _microvm = None
     _context = None
 
-    def __init__(self, context=dict(), cache_dir=ARTIFACTS_LOCAL_ROOT):
+    def __init__(self, context=TestContext(), cache_dir=ARTIFACTS_LOCAL_ROOT):
         """Initialize the cache directory."""
         self._cache_dir = cache_dir
         self._context = context
@@ -92,9 +157,7 @@ class TestMatrix:
         for microvm_config in self.microvms:
             for kernel in self.kernels:
                 for disk in self.disks:
-                    self._context.update({
-                        'microvm': microvm_config,
-                        'kernel': kernel,
-                        'disk': disk
-                    })
-                    test_fn(self._context, self._microvm)
+                    self._context.kernel = kernel
+                    self._context.disk = disk
+                    self._context.microvm = microvm_config
+                    test_fn(self._context)


### PR DESCRIPTION
## Reason for This PR
Fixes #1849.

## Description of Changes
Adds the flexibility required to generate a test matrix for save/restore tests using multiple snapshot images and firecracker binaries.

This PR introduces a new way for spinning up microvms in integration tests. Firstly, it does not rely on the hidden logic of fixtures to create and configure the microvms. Secondly, it defines a decoupled view of test resources, machine configurations, microvm configuration and implements  simple APIs that manage these. And thirdly, it allows a single test function to be run multiple times in a different setup (machine, disks, kernels, snapshots).

Layers and components:
- Resources layer components: **ArtifactCollection**, **Artifact**, **ArtifactSet**, **MicrovmBuilder**
- Test layer components: **TestContext**, **TestMatrix**

The resources exposed by these APIs are stored separately(`ci-artifacts` folder in S3 bucket) from the other resources used in integration tests.

The snapshot_pause_resume.py test was updated and now runs pause/resume on these 3 distinct microvm configurations: [2 vcpu 256MB](https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/microvms/2vcpu_256mb.json), [2 vcpu 512MB](https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/microvms/2vcpu_512mb.json), [2 vcpu 1024MB](https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/microvms/2vcpu_1024mb.json) in 8 seconds.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
