### PR TITLE
virtio/block: improve match block statement

### DIFF
--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -71,9 +71,9 @@ impl Subscriber for Block {
 
             // Looks better than C style if/else if/else.
             match source {
-                _ if queue_evt == source => self.process_queue_event(),
-                _ if rate_limiter_evt == source => self.process_rate_limiter_event(),
-                _ if activate_fd == source => self.process_activate_event(evmgr),
+                queue_evt => self.process_queue_event(),
+                rate_limiter_evt => self.process_rate_limiter_event(),
+                activate_fd => self.process_activate_event(evmgr),
                 _ => warn!("Block: Spurious event received: {:?}", source),
             }
         } else {


### PR DESCRIPTION
The `if` languages inside `match` block should be removed.

Signed-off-by: keyangxie <keyang.xie@gmail.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
