### PR TITLE
Fix script checking firecracker requirements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,27 +37,8 @@ The generic requirements are explained below:
      If you need help setting up access to `/dev/kvm`, you should check out
      [Appendix A](#appendix-a-setting-up-kvm-access).
 
-<details>
-
-<summary>Click here to see a BASH script that will check if your system meets
-the basic requirements to run Firecracker.</summary>
-
-```bash
-    err="";
-    [ "$(uname) $(uname -m)" = "Linux x86_64" ]  \
-      || [ "$(uname) $(uname -m)" = "Linux aarch64" ] \
-      || err="ERROR: your system is not Linux x86_64 or Linux aarch64."; \
-    [ -r /dev/kvm ] && [ -w /dev/kvm ] \
-      || err="$err\nERROR: /dev/kvm is innaccessible."; \
-    (( $(uname -r | cut -d. -f1)*1000 + $(uname -r | cut -d. -f2) >= 4014 )) \
-      || err="$err\nERROR: your kernel version ($(uname -r)) is too old."; \
-    dmesg | grep -i "hypervisor detected" \
-      && echo "WARNING: you are running in a virtual machine." \
-      && echo "Firecracker is not well tested under nested virtualization."; \
-    [ -z "$err" ] && echo "Your system looks ready for Firecracker!" || echo -e "$err"
-```
-
-</details>
+To check if your system meets the requirements to run Firecracker, clone
+the repository and execute `tools/devtool checkenv`.
 
 ## Getting the Firecracker Binary
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,11 +68,12 @@ just download the latest binary from our
 and run it on your x86_64 or aarch64 Linux machine.
 
 On the EC2 instance, this binary can be downloaded as:
-```
-latest=$(basename $(curl -fsSLI -o /dev/null -w  %{url_effective}  https://github.com/firecracker-microvm/firecracker/releases/latest))
+
+```wrap
+latest=$(basename $(curl -fsSLI -o /dev/null -w  %{url_effective} https://github.com/firecracker-microvm/firecracker/releases/latest))
 ```
 
-```
+```wrap
 curl -LOJ https://github.com/firecracker-microvm/firecracker/releases/download/${latest}/firecracker-${latest}-$(uname -m)
 ```
 
@@ -163,7 +164,8 @@ In your **second shell** prompt:
     echo "Saved kernel file to $dest_kernel and root block device to $dest_rootfs."
   ```
 
-- set the guest kernel (assuming you are in the same directory as the above script was run):
+- set the guest kernel (assuming you are in the same directory as the
+  above script was run):
 
   ```bash
     arch=`uname -m`
@@ -245,28 +247,28 @@ curl --unix-socket /tmp/firecracker.socket -i  \
     }'
 ```
 
-#### Configuring the microVM without sending API requests
+### Configuring the microVM without sending API requests
 
-If you'd like to boot up a guest machine without using the API socket, you can do that
-by passing the parameter `--config-file` to the Firecracker process. The command for
-starting Firecracker with this option will look like this:
+If you'd like to boot up a guest machine without using the API socket, you can
+do that by passing the parameter `--config-file` to the Firecracker process.
+The command for starting Firecracker with this option will look like this:
 
-```bash
-./firecracker --api-sock /tmp/firecracker.socket --config-file
-<path_to_the_configuration_file>
+```wrap
+./firecracker --api-sock /tmp/firecracker.socket --config-file <path_to_the_configuration_file>
 ```
 
-`path_to_the_configuration_file` should represent the path to a file that contains a
-JSON which stores the entire configuration for all of the microVM's resources. The
-JSON **must** contain the configuration for the guest kernel and rootfs, as these
-are mandatory, but all of the other resources are optional, so it's your choice
-if you want to configure them or not. Because using this configuration method will
-also start the microVM, you need to specify all desired pre-boot configurable resources
-in that JSON. The names of the resources are the ones from the `firecracker.yaml` file
-and the names of their fields are the same that are used in API requests.
-You can find an example of configuration file at `tests/framework/vm_config.json`.
-After the machine is booted, you can still use the socket to send API requests
-for post-boot operations.
+`path_to_the_configuration_file` should represent the path to a file that
+contains a JSON which stores the entire configuration for all of the microVM's
+resources. The JSON **must** contain the configuration for the guest kernel and
+rootfs, as these are mandatory, but all of the other resources are optional,
+so it's your choice if you want to configure them or not. Because using this
+configuration method will also start the microVM, you need to specify all
+desired pre-boot configurable resources in that JSON. The names of the
+resources are the ones from the `firecracker.yaml` file and the names of
+their fields are the same that are used in API requests. You can find an
+example of configuration file at `tests/framework/vm_config.json`.
+After the machine is booted, you can still use the socket to send
+API requests for post-boot operations.
 
 ## Building From Source
 
@@ -298,9 +300,10 @@ git checkout tags/v0.10.1
 Within the Firecracker repository root directory:
 
 1. with the default musl target: ```tools/devtool build```
-2. using the gnu target: ```tools/devtool build -l gnu```
+1. using the gnu target: ```tools/devtool build -l gnu```
 
 This will build and place the two Firecracker binaries at:
+
 - `build/cargo_target/${toolchain}/debug/firecracker` and
 - `build/cargo_target/${toolchain}/debug/jailer`.
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -836,6 +836,13 @@ check_swap () {
 	say_warn "WARNING: SWAP enabled"
 }
 
+check_vm() {
+    if [ $(dmesg | grep -c -i "hypervisor detected") -gt 0 ]; then
+        say_warn "WARNING: you are running in a virtual machine." \
+	"Firecracker is not well tested under nested virtualization."
+    fi
+}
+
 cmd_checkenv() {
     # Parse any command line args.
     while [ $# -gt 0 ]; do
@@ -853,6 +860,7 @@ cmd_checkenv() {
     say "Please check $QUICKSTART in case of any error."
     ensure_kvm_rw
     check_kernver
+    check_vm
     say "Checking Host Security Configuration."
     say "Please check $PROD_DOC in case of any error."
     check_KSM


### PR DESCRIPTION
## Reason for This PR

The script in the getting started guide supposed to let to know the user whether firecracker would run on their machine or not, is broken when checking the kernel version when using Zsh.

## Description of Changes

Fixed the arithmetic and evaluation expression.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
