### PR TITLE
 Use string for target version in CreateSnapshot API call

### DIFF
--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -754,10 +754,10 @@ mod tests {
             .write_all(
                 b"PUT /snapshot/create HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
-                Content-Length: 64\r\n\r\n{ \
+                Content-Length: 71\r\n\r\n{ \
                 \"snapshot_path\": \"foo\", \
                 \"mem_file_path\": \"bar\", \
-                \"version\": 2 \
+                \"version\": \"0.23.0\" \
             }",
             )
             .unwrap();

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -61,14 +61,14 @@ mod tests {
                 "snapshot_type": "Diff",
                 "snapshot_path": "foo",
                 "mem_file_path": "bar",
-                "version": 2
+                "version": "0.23.0"
               }"#;
 
         let mut expected_cfg = CreateSnapshotParams {
             snapshot_type: SnapshotType::Diff,
             snapshot_path: PathBuf::from("foo"),
             mem_file_path: PathBuf::from("bar"),
-            version: Some(2),
+            version: Some(String::from("0.23.0")),
         };
 
         match parse_put_snapshot(&Body::new(body), Some(&"create")) {

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -552,7 +552,9 @@ definitions:
           snapshot is created.
       version:
         type: string
-        description: The snapshot format version.
+        description:
+          The microVM version for which we want to create the snapshot.
+          It is optional and it defaults to the current version.
 
   Drive:
     type: object

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -543,7 +543,8 @@ definitions:
       snapshot_path:
         type: string
         description: Path to the file that will contain the microVM state.
-      snapshot_type: string
+      snapshot_type:
+        type: string
         enum:
           - Full
           - Diff
@@ -640,7 +641,7 @@ definitions:
       - snapshot_path
     properties:
       enable_diff_snapshots:
-        type: bool
+        type: boolean
         description:
           Enable support for incremental (diff) snapshots by tracking dirty guest pages.
       mem_file_path:

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -128,7 +128,7 @@ pub fn create_snapshot(
 fn snapshot_state_to_file(
     microvm_state: &MicrovmState,
     snapshot_path: &PathBuf,
-    version: Option<u16>,
+    version: Option<String>,
     version_map: VersionMap,
 ) -> std::result::Result<(), CreateSnapshotError> {
     let mut snapshot_file = OpenOptions::new()

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -9,18 +9,18 @@ use lazy_static::lazy_static;
 use versionize::VersionMap;
 
 lazy_static! {
-    // Note: this needs to be updated when the version changes.
+    // Note: until we have a better design, this needs to be updated when the version changes.
     /// Static instance used for handling microVM state versions.
     pub static ref VERSION_MAP: VersionMap = {
         VersionMap::new()
     };
 
-    /// Static instance used for mapping Firecracker release version to
-    /// snapshot data format version.
-    pub static ref FC_VERSION_TO_SNAP_VERSION: HashMap<u16, u16> = {
-        let mut hm = HashMap::new();
-        hm.insert(23, 1);
+    /// Static instance used for creating a 1:1 mapping between Firecracker release version
+    /// and snapshot data format version.
+    pub static ref FC_VERSION_TO_SNAP_VERSION: HashMap<String, u16> = {
+        let mut mapping = HashMap::new();
+        mapping.insert(String::from("0.23.0"), 1);
 
-        hm
+        mapping
     };
 }

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -33,9 +33,9 @@ pub struct CreateSnapshotParams {
     pub snapshot_path: PathBuf,
     /// Path to the file that will contain the guest memory.
     pub mem_file_path: PathBuf,
-    ///  Optional field for the snapshot format version. The default
-    /// value is the current app version.
-    pub version: Option<u16>,
+    /// Optional field for the microVM version. The default
+    /// value is the current version.
+    pub version: Option<String>,
 }
 
 /// Stores the configuration that will be used for loading a snapshot.

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -324,7 +324,7 @@ fn create_snapshot(is_diff: bool) {
                 snapshot_type,
                 snapshot_path: snapshot_file.as_path().to_path_buf(),
                 mem_file_path: memory_file.as_path().to_path_buf(),
-                version: Some(23),
+                version: Some(String::from("0.23.0")),
             };
 
             {


### PR DESCRIPTION

Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Fixes #1893 

Parsing the target version from the PUT /snapshot/create API call
params as a string allows for 1:1 mapping with the Firecracker version
that can be seen with the `./firecracker --version` command.

## Description of Changes

- modify the type of the `version` field from `CreateSnapshotParams` from `Option<u16>` to `Option<String>`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] No new `unsafe` code.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
