### PR TITLE
devices: support partial config space write

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,11 +192,12 @@ def test_session_tmp_path(test_session_root_path):
     shutil.rmtree(tmp_path)
 
 
-def _gcc_compile(src_file, output_file):
+def _gcc_compile(src_file, output_file, extra_flags="-static -O3"):
     """Build a source file with gcc."""
-    compile_cmd = 'gcc {} -o {} -static -O3'.format(
+    compile_cmd = 'gcc {} -o {} {}'.format(
         src_file,
-        output_file
+        output_file,
+        extra_flags
     )
     utils.run_cmd(compile_cmd)
 
@@ -232,6 +233,22 @@ def bin_vsock_path(test_session_root_path):
         vsock_helper_bin_path
     )
     yield vsock_helper_bin_path
+
+
+@pytest.fixture(scope='session')
+def change_net_config_space_bin(test_session_root_path):
+    """Build a binary that changes the MMIO config space."""
+    # pylint: disable=redefined-outer-name
+    change_net_config_space_bin = os.path.join(
+        test_session_root_path,
+        'change_net_config_space'
+    )
+    _gcc_compile(
+        'host_tools/change_net_config_space.c',
+        change_net_config_space_bin,
+        extra_flags=""
+    )
+    yield change_net_config_space_bin
 
 
 @pytest.fixture(scope='session')

--- a/tests/host_tools/change_net_config_space.c
+++ b/tests/host_tools/change_net_config_space.c
@@ -1,0 +1,88 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is used by the `test_net_config_space.py` integration test, which writes
+// into the microVM configured network device config space a new MAC address.
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int show_usage() {
+    printf("Usage: ./change_net_config_space.bin [dev_addr_start] [mac_addr]\n");
+    printf("Example:\n");
+    printf("> ./change_net_config_space.bin 0xd00001000 0x060504030201\n");
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    int fd, i, offset;
+    uint8_t *map_base;
+    volatile uint8_t *virt_addr;
+
+    uint64_t mapped_size, page_size, offset_in_page, target;
+    uint64_t width = 6;
+
+    uint64_t config_offset = 0x100;
+    uint64_t device_start_addr = 0x00000000;
+    uint64_t mac = 0;
+
+    if (argc != 3) {
+        return show_usage();
+    }
+
+    device_start_addr = strtoull(argv[1], NULL, 0);
+    mac = strtoull(argv[2], NULL, 0);
+
+    fd = open("/dev/mem", O_RDWR | O_SYNC);
+    if (fd < 0) {
+        perror("Failed to open '/dev/mem'.");
+        return 1;
+    }
+
+    target = device_start_addr + config_offset;
+    // Get the page size.
+    mapped_size = page_size = getpagesize();
+    // Get the target address physical frame page offset.
+    offset_in_page = (unsigned) target & (page_size - 1);
+    /* If the data length goes out of the current page,
+     * double the needed map size. */
+    if (offset_in_page + width > page_size) {
+        /* This access spans pages.
+         * Must map two pages to make it possible. */
+        mapped_size *= 2;
+    }
+
+    // Map the `/dev/mem` to virtual memory.
+    map_base = mmap(NULL,
+            mapped_size,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            fd,
+            target & ~(off_t)(page_size - 1));
+    if (map_base == MAP_FAILED) {
+            perror("Failed to mmap '/dev/mem'.");
+            return 2;
+    }
+
+    // Write in the network device config space a new MAC.
+    virt_addr = (volatile uint8_t*) (map_base + offset_in_page);
+    *virt_addr = (uint8_t) (mac >> 40);
+    printf("%02x", *virt_addr);
+
+    for (i = 1; i <= 5; i++) {
+        *(virt_addr + i) = (uint8_t) (mac >> (5 - i) * 8);
+        printf(":%02x", *(virt_addr + i));
+    }
+
+    // Deallocate resources.
+    munmap(map_base, mapped_size);
+    close(fd);
+
+    return 0;
+}

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -278,6 +278,14 @@ def mac_from_ip(ip_address):
     return "{}:{}:{}:{}:{}:{}".format(*mac_as_list)
 
 
+def get_guest_net_if_name(ssh_connection, guest_ip):
+    """Get network interface name based on its IPv4 address."""
+    cmd = "ip a s | grep '{}' | tr -s ' ' | cut -d' ' -f6".format(guest_ip)
+    _, guest_if_name, _ = ssh_connection.execute_command(cmd)
+    if_name = guest_if_name.read().strip()
+    return if_name if if_name != '' else None
+
+
 class Tap:
     """Functionality for creating a tap and cleaning up after it."""
 

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -23,12 +23,4 @@ def test_flush_metrics(test_microvm_with_api):
 
     microvm.start()
 
-    # Empty fifo before triggering `FlushMetrics` so that we get accurate data.
-    _ = metrics_fifo.sequential_reader(100)
-
-    how_many_flushes = 3
-    for _ in range(how_many_flushes):
-        response = microvm.actions.put(action_type='FlushMetrics')
-        assert microvm.api_session.is_status_no_content(response.status_code)
-    lines = metrics_fifo.sequential_reader(how_many_flushes)
-    assert len(lines) == how_many_flushes
+    microvm.flush_metrics(metrics_fifo)

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -1,0 +1,324 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests on devices config space."""
+
+import os
+import random
+import re
+import string
+from threading import Thread
+import subprocess
+import platform
+
+import host_tools.logging as log_tools
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+# pylint: disable=global-statement
+PAYLOAD_DATA_SIZE = 20
+
+
+def test_net_change_mac_address(test_microvm_with_ssh, network_config,
+                                change_net_config_space_bin):
+    """Test changing the MAC address of the network device."""
+    global PAYLOAD_DATA_SIZE
+
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+    test_microvm.basic_config(boot_args="ipv6.disable=1")
+
+    # Data exchange interface ('eth0' in guest).
+    iface_id = '1'
+    _tap1, host_ip1, guest_ip1 = test_microvm.ssh_network_config(
+        network_config,
+        iface_id
+    )
+
+    # Control interface ('eth1' in guest).
+    iface_id = '2'
+    _tap2, _, guest_ip2 = test_microvm.ssh_network_config(
+        network_config,
+        iface_id
+    )
+
+    # Configure metrics, to get later the `tx_spoofed_mac_count`.
+    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+    response = test_microvm.metrics.put(
+        metrics_path=test_microvm.create_jailed_resource(metrics_fifo.path)
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    test_microvm.start()
+
+    # Create the control ssh connection.
+    test_microvm.ssh_config['hostname'] = guest_ip2
+    ssh_connection_ctl = net_tools.SSHConnection(test_microvm.ssh_config)
+
+    # Start a server(host) - client(guest) communication with the following
+    # parameters.
+    host_port = 4444
+    iterations = 1
+    _exchange_data(
+        test_microvm.jailer,
+        ssh_connection_ctl,
+        host_ip1,
+        host_port,
+        iterations
+    )
+
+    fc_metrics = test_microvm.flush_metrics(metrics_fifo)
+    assert fc_metrics['net']['tx_spoofed_mac_count'] == 0
+
+    # Change the MAC address of the network data interface.
+    # This change will be propagated only inside the net device kernel struct
+    # and will be used for ethernet frames formation when data is exchanged
+    # on the network interface.
+    mac = "06:05:04:03:02:01"
+    mac_hex = "0x060504030201"
+    guest_if1_name = net_tools.get_guest_net_if_name(ssh_connection_ctl,
+                                                     guest_ip1)
+    assert guest_if1_name is not None
+    _change_guest_if_mac(ssh_connection_ctl, mac, guest_if1_name)
+
+    _exchange_data(
+        test_microvm.jailer,
+        ssh_connection_ctl,
+        host_ip1,
+        host_port,
+        iterations
+    )
+
+    # `tx_spoofed_mac_count` metric was incremented due to the MAC address
+    # change.
+    fc_metrics = test_microvm.flush_metrics(metrics_fifo)
+    assert fc_metrics['net']['tx_spoofed_mac_count'] > 0
+
+    net_addr_base = _get_net_mem_addr_base(ssh_connection_ctl,
+                                           guest_if1_name)
+    assert net_addr_base is not None
+
+    # Write into '/dev/mem' the same mac address, byte by byte.
+    # This changes the MAC address physically, in the network device registers.
+    # After this step, the net device kernel struct MAC address will be the
+    # same with the MAC address stored in the network device registers. The
+    # `tx_spoofed_mac_count` metric shouldn't be incremented later on.
+    ssh_connection_ctl.scp_file(change_net_config_space_bin,
+                                'change_net_config_space')
+    cmd = "chmod u+x change_net_config_space &&\
+          ./change_net_config_space {} {}"
+    cmd = cmd.format(net_addr_base, mac_hex)
+
+    # This should be executed successfully.
+    exit_code, stdout, _ = ssh_connection_ctl.execute_command(cmd)
+    assert exit_code == 0
+    assert stdout.read() == mac
+
+    # Discard any parasite data exchange which might've been
+    # happened on the emulation thread while the config space
+    # was changed on the vCPU thread.
+    test_microvm.flush_metrics(metrics_fifo)
+
+    _exchange_data(
+        test_microvm.jailer,
+        ssh_connection_ctl,
+        host_ip1,
+        host_port,
+        iterations
+    )
+    fc_metrics = test_microvm.flush_metrics(metrics_fifo)
+    assert fc_metrics['net']['tx_spoofed_mac_count'] == 0
+
+    # Try again, just to be extra sure.
+    _exchange_data(
+        test_microvm.jailer,
+        ssh_connection_ctl,
+        host_ip1,
+        host_port,
+        iterations
+    )
+    fc_metrics = test_microvm.flush_metrics(metrics_fifo)
+    assert fc_metrics['net']['tx_spoofed_mac_count'] == 0
+
+
+def _create_server(jailer, host_ip, port, iterations):
+    # Wait for `iterations` TCP segments, on one connection.
+    # This server has to run under the network namespace, initialized
+    # by the integration test microvm jailer.
+    # pylint: disable=global-statement
+    global PAYLOAD_DATA_SIZE
+    script =                                                        \
+        "import socket\n"                                           \
+        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"   \
+        "s.setsockopt(\n"                                           \
+        "    socket.SOL_SOCKET, socket.SO_REUSEADDR,\n"             \
+        "     s.getsockopt(socket.SOL_SOCKET,\n"                    \
+        "                 socket.SO_REUSEADDR) | 1\n"               \
+        ")\n"                                                       \
+        "s.bind(('{}', {}))\n"                                      \
+        "s.listen(1)\n"                                             \
+        "conn, addr = s.accept()\n"                                 \
+        "recv_iterations = {}\n"                                    \
+        "while recv_iterations > 0:\n"                              \
+        "    data = conn.recv({})\n"                                \
+        "    recv_iterations -= 1\n"                                \
+        "conn.close()\n"                                            \
+        "s.close()"
+
+    cmd = "python -c \"{}\"".format(
+        script.format(
+            host_ip,
+            port,
+            iterations,
+            PAYLOAD_DATA_SIZE
+        )
+    )
+    netns_cmd = jailer.netns_cmd_prefix() + cmd
+    exit_code = subprocess.call(netns_cmd, shell=True)
+    assert exit_code == 0
+
+
+def _send_data_g2h(ssh_connection, host_ip, host_port, iterations, data,
+                   retries):
+    script =                                                        \
+        "import socket\n"                                           \
+        "import time\n"                                             \
+        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"   \
+        "retries={}\n"                                              \
+        "while retries > 0:\n"                                      \
+        "   try:\n"                                                 \
+        "       s.connect(('{}',{}))\n"                             \
+        "       retries = 0\n"                                      \
+        "   except Exception as e:\n"                               \
+        "       retries -= 1\n"                                     \
+        "       time.sleep(1)\n"                                    \
+        "       if retries == 0:\n"                                 \
+        "           exit(1)\n"                                      \
+        "send_iterations={}\n"                                      \
+        "while send_iterations > 0:\n"                              \
+        "   s.sendall('{}')\n"                                      \
+        "   send_iterations -= 1\n"                                 \
+        "s.close()"
+
+    cmd = "python -c \"{}\"".format(
+        script.format(
+            retries,
+            host_ip,
+            str(host_port),
+            iterations,
+            data
+        )
+    )
+
+    # Wait server to initialize.
+    exit_code, _, stderr = ssh_connection.execute_command(cmd)
+    # If this assert fails, a connection refused happened.
+    assert exit_code == 0
+    assert stderr.read() == ''
+
+
+def _start_host_server_thread(jailer, host_ip, host_port, iterations):
+    thread = Thread(
+        target=_create_server,
+        args=(jailer, host_ip, host_port, iterations)
+    )
+
+    thread.start()
+    return thread
+
+
+def _exchange_data(
+        jailer,
+        ssh_control_connection,
+        host_ip,
+        host_port,
+        iterations
+):
+    server_thread = _start_host_server_thread(
+        jailer,
+        host_ip,
+        host_port,
+        iterations
+    )
+
+    # Generate random data.
+    letters = string.ascii_lowercase
+    data = ''.join(random.choice(letters) for i in range(PAYLOAD_DATA_SIZE))
+
+    # We need to synchronize host server with guest client. Server thread has
+    # to start listening for incoming connections before the client tries to
+    # connect. To synchronize, we implement a polling mechanism, retrying to
+    # establish a connection, on the client side, mechanism to retry guest
+    # client socket connection, in case the server had not started yet.
+    _send_data_g2h(
+        ssh_control_connection,
+        host_ip,
+        host_port,
+        iterations,
+        data,
+        retries=5
+    )
+
+    # Wait for host server to receive the data sent by the guest client.
+    server_thread.join()
+
+
+def _change_guest_if_mac(ssh_connection, guest_if_mac, guest_if_name):
+    cmd = "ip link set dev {} address ".format(guest_if_name) + guest_if_mac
+    # The connection will be down, because changing the mac will issue down/up
+    # on the interface.
+    ssh_connection.execute_command(cmd)
+
+
+def _get_net_mem_addr_base(ssh_connection, if_name):
+    """Get the net device memory start address."""
+    if platform.machine() == "x86_64":
+        sys_virtio_mmio_cmdline = "/sys/devices/virtio-mmio-cmdline/"
+        cmd = "ls {} | grep virtio-mmio. | sed 's/virtio-mmio.//'"
+        exit_code, stdout, _ = ssh_connection.execute_command(
+            cmd.format(sys_virtio_mmio_cmdline)
+        )
+        assert exit_code == 0
+        virtio_devs_idx = stdout.read().split()
+
+        cmd = "cat /proc/cmdline"
+        exit_code, cmd_line, _ = ssh_connection.execute_command(cmd)
+        assert exit_code == 0
+        pattern_dev = re.compile("(virtio_mmio.device=4K@0x[0-9a-f]+:[0-9]+)+")
+        pattern_addr = re.compile("virtio_mmio.device=4K@(0x[0-9a-f]+):[0-9]+")
+        devs_addr = []
+        for dev in re.findall(pattern_dev, cmd_line.read()):
+            matched_addr = pattern_addr.search(dev)
+            # The 1st group which matches this pattern
+            # is the device start address. `0` group is
+            # full match.
+            addr = matched_addr.group(1)
+            devs_addr.append(addr)
+
+        cmd = "ls {}/virtio-mmio.{}/virtio{}/net"
+        for idx in virtio_devs_idx:
+            _, guest_if_name, _ = ssh_connection.execute_command(
+                cmd.format(sys_virtio_mmio_cmdline, idx, idx)
+            )
+            if guest_if_name.read().strip() == if_name:
+                return devs_addr[int(idx)]
+    elif platform.machine() == "aarch64":
+        sys_virtio_mmio_cmdline = "/sys/devices/platform"
+        cmd = "ls {} | grep .virtio_mmio".format(sys_virtio_mmio_cmdline)
+        rc, stdout, _ = ssh_connection.execute_command(cmd)
+        assert rc == 0
+
+        virtio_devs = stdout.read().split()
+        devs_addr = list(map(lambda dev: dev.split(".")[0], virtio_devs))
+
+        cmd = "ls {}/{}/virtio{}/net"
+        # Device start addresses lack the hex prefix and are not interpreted
+        # accordingly when parsed inside `change_config_space.c`.
+        hex_prefix = '0x'
+        for (idx, dev) in enumerate(virtio_devs):
+            _, guest_if_name, _ = ssh_connection.execute_command(
+                cmd.format(sys_virtio_mmio_cmdline, dev, idx)
+            )
+            if guest_if_name.read().strip() == if_name:
+                return hex_prefix + devs_addr[int(idx)]
+
+    return None


### PR DESCRIPTION
## Reason for This PR

Fixes: #1822.

## Description of Changes

Support partial writes to network & block devices config space.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] Any newly added `unsafe` code is properly documented~~.
- ~~[ ] Any API changes are reflected in `firecracker/swagger.yaml`~~.
- ~~[ ] Any user-facing changes are mentioned in `CHANGELOG.md`~~.
