### PR TITLE
Update Rust toolchain to 1.43.1

### DIFF
--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -201,6 +201,7 @@ mod tests {
                 "drive_id": "foo",
                 "path_on_host": "dummy"
               }"#;
+        #[allow(clippy::match_wild_err_arm)]
         match parse_patch_drive(&Body::new(body), Some(&"foo")) {
             Ok(ParsedRequest::Sync(VmmAction::UpdateBlockDevicePath(a, b))) => {
                 assert_eq!(a, "foo".to_string());

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -89,7 +89,7 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
     device_info: &HashMap<(DeviceType, String), T>,
     gic_device: &Box<dyn GICDevice>,
     initrd: &Option<InitrdConfig>,
-) -> Result<(Vec<u8>)> {
+) -> Result<Vec<u8>> {
     // Alocate stuff necessary for the holding the blob.
     let mut fdt = vec![0; FDT_MAX_SIZE];
 

--- a/src/arch/src/aarch64/layout.rs
+++ b/src/arch/src/aarch64/layout.rs
@@ -76,4 +76,4 @@ pub const IRQ_BASE: u32 = 32;
 pub const IRQ_MAX: u32 = 159;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
-pub const MAPPED_IO_START: u64 = (1 << 30); // 1 GB
+pub const MAPPED_IO_START: u64 = 1 << 30; // 1 GB

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -38,7 +38,7 @@ const PSR_I_BIT: u64 = 0x0000_0080;
 const PSR_A_BIT: u64 = 0x0000_0100;
 const PSR_D_BIT: u64 = 0x0000_0200;
 // Taken from arch/arm64/kvm/inject_fault.c.
-const PSTATE_FAULT_BITS_64: u64 = (PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT);
+const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
 
 // Following are macros that help with getting the ID of a aarch64 core register.
 // The core register are represented by the user_pt_regs structure. Look for it in

--- a/src/arch/src/x86_64/gdt.rs
+++ b/src/arch/src/x86_64/gdt.rs
@@ -11,17 +11,17 @@ use kvm_bindings::kvm_segment;
 
 /// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
 pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {
-    (((u64::from(base) & 0xff00_0000u64) << (56 - 24))
+    ((u64::from(base) & 0xff00_0000u64) << (56 - 24))
         | ((u64::from(flags) & 0x0000_f0ffu64) << 40)
         | ((u64::from(limit) & 0x000f_0000u64) << (48 - 16))
         | ((u64::from(base) & 0x00ff_ffffu64) << 16)
-        | (u64::from(limit) & 0x0000_ffffu64))
+        | (u64::from(limit) & 0x0000_ffffu64)
 }
 
 fn get_base(entry: u64) -> u64 {
-    ((((entry) & 0xFF00_0000_0000_0000) >> 32)
+    (((entry) & 0xFF00_0000_0000_0000) >> 32)
         | (((entry) & 0x0000_00FF_0000_0000) >> 16)
-        | (((entry) & 0x0000_0000_FFFF_0000) >> 16))
+        | (((entry) & 0x0000_0000_FFFF_0000) >> 16)
 }
 
 fn get_limit(entry: u64) -> u32 {

--- a/src/arch/src/x86_64/interrupts.rs
+++ b/src/arch/src/x86_64/interrupts.rs
@@ -37,7 +37,7 @@ fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
 }
 
 fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {
-    (((reg) & !0x700) | ((mode) << 8))
+    ((reg) & !0x700) | ((mode) << 8)
 }
 
 /// Configures LAPICs.  LAPIC0 is set for external interrupts, LAPIC1 is set for NMI.

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -48,8 +48,8 @@ pub enum Error {
 
 // Where BIOS/VGA magic would live on a real PC.
 const EBDA_START: u64 = 0x9fc00;
-const FIRST_ADDR_PAST_32BITS: u64 = (1 << 32);
-const MEM_32BIT_GAP_SIZE: u64 = (768 << 20);
+const FIRST_ADDR_PAST_32BITS: u64 = 1 << 32;
+const MEM_32BIT_GAP_SIZE: u64 = 768 << 20;
 /// The start of the memory area reserved for MMIO devices.
 pub const MMIO_MEM_START: u64 = FIRST_ADDR_PAST_32BITS - MEM_32BIT_GAP_SIZE;
 

--- a/src/devices/src/bus.rs
+++ b/src/devices/src/bus.rs
@@ -218,14 +218,14 @@ mod tests {
         assert!(bus.insert(dummy.clone(), 0x0, 0x20).is_err());
         assert!(bus.insert(dummy.clone(), 0x20, 0x05).is_ok());
         assert!(bus.insert(dummy.clone(), 0x25, 0x05).is_ok());
-        assert!(bus.insert(dummy.clone(), 0x0, 0x10).is_ok());
+        assert!(bus.insert(dummy, 0x0, 0x10).is_ok());
     }
 
     #[test]
     fn bus_read_write() {
         let mut bus = Bus::new();
         let dummy = Arc::new(Mutex::new(DummyDevice));
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
+        assert!(bus.insert(dummy, 0x10, 0x10).is_ok());
         assert!(bus.read(0x10, &mut [0, 0, 0, 0]));
         assert!(bus.write(0x10, &[0, 0, 0, 0]));
         assert!(bus.read(0x11, &mut [0, 0, 0, 0]));
@@ -242,7 +242,7 @@ mod tests {
     fn bus_read_write_values() {
         let mut bus = Bus::new();
         let dummy = Arc::new(Mutex::new(ConstantDevice));
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
+        assert!(bus.insert(dummy, 0x10, 0x10).is_ok());
 
         let mut values = [0, 1, 2, 3];
         assert!(bus.read(0x10, &mut values));

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -379,7 +379,7 @@ mod tests {
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let serial_out = SharedBuffer::new();
 
-        let mut serial = Serial::new_out(intr_evt, Box::new(serial_out.clone()));
+        let mut serial = Serial::new_out(intr_evt, Box::new(serial_out));
         // A serial without in does not have any events in the list.
         assert!(serial.interest_list().is_empty());
         // Even though there is no in, process should not panic. Call it to validate this.
@@ -397,7 +397,7 @@ mod tests {
         let mut serial = Serial::new_in_out(
             intr_evt.try_clone().unwrap(),
             Box::new(serial_in_out.clone()),
-            Box::new(serial_in_out.clone()),
+            Box::new(serial_in_out),
         );
         // Check that the interest list contains the EPOLL_IN event.
         assert_eq!(serial.interest_list().len(), 1);

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -56,8 +56,7 @@ fn build_device_id(disk_image: &File) -> result::Result<String, Error> {
         blk_metadata.st_dev(),
         blk_metadata.st_rdev(),
         blk_metadata.st_ino()
-    )
-    .to_owned();
+    );
     Ok(device_id)
 }
 
@@ -141,7 +140,7 @@ impl Block {
             partuuid,
             disk_image_id: build_disk_image_id(&disk_image),
             disk_image,
-            disk_image_path: disk_image_path.clone(),
+            disk_image_path,
             disk_nsectors: disk_size / SECTOR_SIZE,
             avail_features,
             acked_features: 0u64,

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -122,9 +122,7 @@ mod tests {
 
         // Restore the block device.
         let restored_block = Block::restore(
-            BlockConstructorArgs {
-                mem: guest_mem.clone(),
-            },
+            BlockConstructorArgs { mem: guest_mem },
             &BlockState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
         )
         .unwrap();

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 //! Implements virtio devices, queues, and transport mechanisms.
-use std;
 use std::any::Any;
 use std::io::Error as IOError;
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -817,7 +817,7 @@ pub(crate) mod tests {
 
             let mut net = Net::new_with_tap(
                 format!("net-device{}", next_tap),
-                tap_dev_name.clone(),
+                tap_dev_name,
                 Some(&guest_mac),
                 RateLimiter::default(),
                 RateLimiter::default(),

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -154,9 +154,7 @@ mod tests {
         // Deserialize and restore the net device.
         {
             let restored_net = Net::restore(
-                NetConstructorArgs {
-                    mem: guest_mem.clone(),
-                },
+                NetConstructorArgs { mem: guest_mem },
                 &NetState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
             )
             .unwrap();

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -43,7 +43,7 @@ impl ApiServerAdapter {
             controller: RuntimeApiController::new(vm_config, vmm),
         }));
         event_manager
-            .add_subscriber(api_adapter.clone())
+            .add_subscriber(api_adapter)
             .expect("Cannot register the api event to the event manager.");
         loop {
             event_manager

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -151,7 +151,7 @@ impl Cgroup {
                     {
                         return Err(Error::CgroupLineNotUnique(
                             PROC_MOUNTS.to_string(),
-                            controller.to_string(),
+                            (*controller).to_string(),
                         ));
                     }
                 }
@@ -166,7 +166,7 @@ impl Cgroup {
                 if !found_controllers.contains_key(controller) {
                     return Err(Error::CgroupLineNotFound(
                         PROC_MOUNTS.to_string(),
-                        controller.to_string(),
+                        (*controller).to_string(),
                     ));
                 }
             }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -472,7 +472,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::CreateDir(path.clone(), io::Error::from_raw_os_error(2))
+                Error::CreateDir(path, io::Error::from_raw_os_error(2))
             ),
             format!("Failed to create directory /foo: {}", err2_str)
         );

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -499,10 +499,7 @@ mod tests {
 
     fn log_channel() -> (LogWriter, LogReader) {
         let buf = Arc::new(Mutex::new(vec![]));
-        (
-            LogWriter { buf: buf.clone() },
-            LogReader { buf: buf.clone() },
-        )
+        (LogWriter { buf: buf.clone() }, LogReader { buf })
     }
 
     impl Logger {

--- a/src/micro_http/src/server.rs
+++ b/src/micro_http/src/server.rs
@@ -129,13 +129,10 @@ impl<T: Read + Write> ClientConnection<T> {
 
                 // Send an error response for the request that gave us the error.
                 let mut error_response = Response::new(Version::Http11, StatusCode::BadRequest);
-                error_response.set_body(Body::new(
-                    format!(
-                        "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
-                        inner.to_string()
-                    )
-                    .to_string(),
-                ));
+                error_response.set_body(Body::new(format!(
+                    "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
+                    inner.to_string()
+                )));
                 self.connection.enqueue_response(error_response);
             }
             Err(ConnectionError::InvalidWrite) => {

--- a/src/polly/src/event_manager.rs
+++ b/src/polly/src/event_manager.rs
@@ -459,9 +459,7 @@ mod tests {
             .add_subscriber(dummy_subscriber.clone())
             .unwrap();
 
-        assert!(event_manager
-            .add_subscriber(dummy_subscriber.clone())
-            .is_err())
+        assert!(event_manager.add_subscriber(dummy_subscriber).is_err())
     }
 
     #[test]

--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -1278,7 +1278,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0);
             },
@@ -1303,7 +1303,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0, 0);
             },
@@ -1332,7 +1332,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, (KVM_GET_PIT2 - 1) as IoctlRequest);
             },
@@ -1358,7 +1358,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, 1);
             },
@@ -1386,7 +1386,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, KVM_GET_PIT2 as IoctlRequest);
             },
@@ -1417,7 +1417,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, u64::from(std::u32::MAX) + 10);
             },
@@ -1446,7 +1446,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, (KVM_GET_PIT2 + 1) as IoctlRequest);
             },
@@ -1478,7 +1478,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, u64::from(std::u32::MAX) + 11);
             },
@@ -1506,7 +1506,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, KVM_GET_PIT2 as IoctlRequest);
             },
@@ -1537,7 +1537,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, u64::from(std::u32::MAX) + 10);
             },
@@ -1572,7 +1572,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, KVM_GET_PIT2_LSB as IoctlRequest);
             },
@@ -1604,7 +1604,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, 0);
             },
@@ -1632,7 +1632,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, KVM_GET_PIT2 as IoctlRequest);
             },
@@ -1657,7 +1657,7 @@ mod tests {
         );
         // check syscalls that are not supposed to work
         validate_seccomp_filter(
-            rules.clone(),
+            rules,
             || unsafe {
                 libc::ioctl(0, 0 as IoctlRequest, std::u64::MAX);
             },
@@ -1795,7 +1795,7 @@ mod tests {
                 allow_syscall_if(
                     9,
                     vec![SeccompRule::new(
-                        vec![Cond::new(1, arg_len.clone(), MaskedEq(0b100), 36).unwrap()],
+                        vec![Cond::new(1, arg_len, MaskedEq(0b100), 36).unwrap()],
                         SeccompAction::Allow,
                     )],
                 ),

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
         // serialization.
         snapshot_mem.truncate(10);
         let restored_state_result: Result<Test, Error> =
-            Snapshot::load(&mut snapshot_mem.as_slice(), vm.clone());
+            Snapshot::load(&mut snapshot_mem.as_slice(), vm);
 
         assert_eq!(
             restored_state_result.unwrap_err(),
@@ -461,7 +461,7 @@ mod tests {
             .save(&mut snapshot_mem.as_mut_slice(), &state)
             .unwrap();
 
-        restored_state = Snapshot::load(&mut snapshot_mem.as_slice(), vm.clone()).unwrap();
+        restored_state = Snapshot::load(&mut snapshot_mem.as_slice(), vm).unwrap();
         assert_eq!(restored_state.field1, state.field1);
         assert_eq!(restored_state.field2, 2);
         assert_eq!(restored_state.field3, "test");
@@ -484,7 +484,7 @@ mod tests {
             .save_with_crc64(&mut snapshot_mem.as_mut_slice(), &state_1)
             .unwrap();
 
-        let _: Test1 = Snapshot::load_with_crc64(&mut snapshot_mem.as_slice(), vm.clone()).unwrap();
+        let _: Test1 = Snapshot::load_with_crc64(&mut snapshot_mem.as_slice(), vm).unwrap();
     }
 
     #[test]
@@ -511,7 +511,7 @@ mod tests {
         let expected_err = Error::Crc64(0x103F_8F52_8F51_20B1);
 
         let load_result: Result<Test1, Error> =
-            Snapshot::load_with_crc64(&mut snapshot_mem.as_slice(), vm.clone());
+            Snapshot::load_with_crc64(&mut snapshot_mem.as_slice(), vm);
         assert_eq!(load_result.unwrap_err(), expected_err);
     }
 
@@ -541,7 +541,7 @@ mod tests {
             .unwrap();
 
         let restored_state: kvm_pit_config =
-            Snapshot::load(&mut snapshot_mem.as_slice(), vm.clone()).unwrap();
+            Snapshot::load(&mut snapshot_mem.as_slice(), vm).unwrap();
         assert_eq!(restored_state, state);
     }
 }

--- a/src/utils/src/net/tap.rs
+++ b/src/utils/src/net/tap.rs
@@ -5,8 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use libc;
-use net_gen;
 use std::fs::File;
 use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::net::UdpSocket;

--- a/src/utils/src/structs.rs
+++ b/src/utils/src/structs.rs
@@ -5,7 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std;
 use std::fmt;
 use std::io::{self, Read};
 use std::mem;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -533,7 +533,7 @@ mod tests {
         );
         assert_eq!(
             arch::IRQ_BASE,
-            device_manager.id_to_dev_info[&(DeviceType::Virtio(type_id), id.clone())].irqs[0]
+            device_manager.id_to_dev_info[&(DeviceType::Virtio(type_id), id)].irqs[0]
         );
 
         let id = "bar";

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -400,7 +400,7 @@ mod tests {
 
             // Add a block device.
             let drive_id = String::from("root");
-            let block_configs = vec![CustomBlockConfig::new(drive_id.clone(), true, None, true)];
+            let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
             _block_files =
                 insert_block_devices(&mut vmm, &mut cmdline, &mut event_manager, block_configs);
             // Add a net device.
@@ -431,7 +431,7 @@ mod tests {
                 .save()
                 .serialize(&mut buf.as_mut_slice(), &version_map, 1)
                 .unwrap();
-            vmm.mmio_device_manager.clone()
+            vmm.mmio_device_manager
         };
         tmp_sock_file.remove().unwrap();
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -351,8 +351,8 @@ mod tests {
         }
     }
 
-    impl Clone for MMIODeviceManager {
-        fn clone(&self) -> Self {
+    impl MMIODeviceManager {
+        fn soft_clone(&self) -> Self {
             let mut dummy_mmio_base = 0;
             let dummy_irq_range = (0, 0);
             let mut clone = MMIODeviceManager::new(&mut dummy_mmio_base, dummy_irq_range);
@@ -431,7 +431,9 @@ mod tests {
                 .save()
                 .serialize(&mut buf.as_mut_slice(), &version_map, 1)
                 .unwrap();
-            vmm.mmio_device_manager
+
+            // We only want to keep the device map from the original MmioDeviceManager.
+            vmm.mmio_device_manager.soft_clone()
         };
         tmp_sock_file.remove().unwrap();
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -214,7 +214,7 @@ mod tests {
 
         // Add a block device.
         let drive_id = String::from("root");
-        let block_configs = vec![CustomBlockConfig::new(drive_id.clone(), true, None, true)];
+        let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
         insert_block_devices(&mut vmm, &mut cmdline, event_manager, block_configs);
 
         // Add net device.

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -160,7 +160,7 @@ impl Display for VmmActionError {
                         .to_string()
                 }
                 StartMicrovm(err) => err.to_string(),
-                /// The action `SetVsockDevice` failed because of bad user input.
+                // The action `SetVsockDevice` failed because of bad user input.
                 VsockConfig(err) => err.to_string(),
             }
         )

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -221,7 +221,7 @@ mod tests {
         let dummy_path = dummy_file.as_path().to_str().unwrap().to_string();
         let dummy_id = String::from("1");
         let dummy_block_device = BlockDeviceConfig {
-            path_on_host: dummy_path.clone(),
+            path_on_host: dummy_path,
             is_root_device: false,
             partuuid: None,
             is_read_only: false,
@@ -367,7 +367,7 @@ mod tests {
         let dummy_file_1 = TempFile::new().unwrap();
         let dummy_path_1 = dummy_file_1.as_path().to_str().unwrap().to_string();
         let root_block_device = BlockDeviceConfig {
-            path_on_host: dummy_path_1.clone(),
+            path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
             is_read_only: false,
@@ -448,7 +448,7 @@ mod tests {
         let mut block_devs = BlockBuilder::new();
 
         // Add 2 block devices.
-        assert!(block_devs.insert(root_block_device.clone()).is_ok());
+        assert!(block_devs.insert(root_block_device).is_ok());
         assert!(block_devs.insert(dummy_block_device_2.clone()).is_ok());
 
         // Get index zero.
@@ -490,12 +490,12 @@ mod tests {
         dummy_block_device_2.path_on_host = dummy_path_2.clone();
         dummy_block_device_2.is_root_device = true;
         assert_eq!(
-            block_devs.insert(dummy_block_device_2.clone()),
+            block_devs.insert(dummy_block_device_2),
             Err(DriveError::RootBlockDeviceAlreadyAdded)
         );
 
         let root_block_device = BlockDeviceConfig {
-            path_on_host: dummy_path_1.clone(),
+            path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
             is_read_only: false,

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -246,13 +246,13 @@ mod tests {
         guest_mac_1 = "01:23:45:67:89:0b";
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
 
-        assert!(net_builder.build(netif_1.clone()).is_ok());
+        assert!(net_builder.build(netif_1).is_ok());
         assert_eq!(net_builder.net_devices.len(), 1);
 
         // Test update host_dev_name (the tap will be updated).
         host_dev_name_1 = "dev2";
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
-        assert!(net_builder.build(netif_1.clone()).is_ok());
+        assert!(net_builder.build(netif_1).is_ok());
         assert_eq!(net_builder.net_devices.len(), 1);
     }
 
@@ -266,7 +266,7 @@ mod tests {
 
         // Adding the first valid network config.
         let netif_1 = create_netif(id_1, host_dev_name_1, guest_mac_1);
-        assert!(net_builder.build(netif_1.clone()).is_ok());
+        assert!(net_builder.build(netif_1).is_ok());
 
         // Error Cases for CREATE
         // Error Case: Add new network config with the same mac as netif_1.
@@ -280,11 +280,7 @@ mod tests {
             guest_mac_1.to_string()
         );
         assert_eq!(
-            net_builder
-                .build(netif_2.clone())
-                .err()
-                .unwrap()
-                .to_string(),
+            net_builder.build(netif_2).err().unwrap().to_string(),
             expected_error
         );
         assert_eq!(net_builder.net_devices.len(), 1);
@@ -292,11 +288,7 @@ mod tests {
         // Error Case: Add new network config with the same dev_host_name as netif_1.
         let netif_2 = create_netif(id_2, host_dev_name_1, guest_mac_2);
         assert_eq!(
-            net_builder
-                .build(netif_2.clone())
-                .err()
-                .unwrap()
-                .to_string(),
+            net_builder.build(netif_2).err().unwrap().to_string(),
             NetworkInterfaceError::CreateNetworkDevice(devices::virtio::net::Error::TapOpen(
                 TapError::CreateTap(std::io::Error::from_raw_os_error(16))
             ))
@@ -306,7 +298,7 @@ mod tests {
 
         // Adding the second valid network config.
         let netif_2 = create_netif(id_2, host_dev_name_2, guest_mac_2);
-        assert!(net_builder.build(netif_2.clone()).is_ok());
+        assert!(net_builder.build(netif_2).is_ok());
 
         // Error Cases for UPDATE
         // Error Case: Update netif_2 mac using the same mac as netif_1.
@@ -316,22 +308,14 @@ mod tests {
             guest_mac_1.to_string()
         );
         assert_eq!(
-            net_builder
-                .build(netif_2.clone())
-                .err()
-                .unwrap()
-                .to_string(),
+            net_builder.build(netif_2).err().unwrap().to_string(),
             expected_error
         );
 
         // Error Case: Update netif_2 dev_host_name using the same dev_host_name as netif_1.
         let netif_2 = create_netif(id_2, host_dev_name_1, guest_mac_2);
         assert_eq!(
-            net_builder
-                .build(netif_2.clone())
-                .err()
-                .unwrap()
-                .to_string(),
+            net_builder.build(netif_2).err().unwrap().to_string(),
             NetworkInterfaceError::CreateNetworkDevice(devices::virtio::net::Error::TapOpen(
                 TapError::CreateTap(std::io::Error::from_raw_os_error(16))
             ))

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -11,10 +11,10 @@ import host_tools.cargo_build as host
 MACHINE = platform.machine()
 """ Platform definition used to select the correct size target"""
 
-FC_BINARY_SIZE_TARGET = 2930992 if MACHINE == "x86_64" else 3132008
+FC_BINARY_SIZE_TARGET = 3124000 if MACHINE == "x86_64" else 3349336
 """Firecracker target binary size in bytes"""
 
-FC_BINARY_SIZE_LIMIT = 3100000 if MACHINE == "x86_64" else 3500000
+FC_BINARY_SIZE_LIMIT = 3300000 if MACHINE == "x86_64" else 3500000
 """Firecracker maximum binary size in bytes"""
 
 JAILER_BINARY_SIZE_TARGET = 2483592 if MACHINE == "x86_64" else 2714528

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,14 +17,14 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.71
+COVERAGE_TARGET_PCT = 84.41
 # This slight difference comes from
 # the brand string, On Intel, it contains
 # the frequency while on AMD it does not.
 # (the cpuid crate). In the future other
 # differences may appear.
 if "AMD" in platform.processor():
-    COVERAGE_TARGET_PCT = 84.68
+    COVERAGE_TARGET_PCT = 84.35
 
 COVERAGE_MAX_DELTA = 0.05
 

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.39.0"
+ARG RUST_TOOLCHAIN="1.43.1"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.39.0"
+ARG RUST_TOOLCHAIN="1.43.1"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v14"
+DEVCTR_IMAGE="fcuvm/dev:v15"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

The latest cargo-audit used in the Docker images requires Rust >=1.40. The current image still uses Rust 1.39.

Blocked by #1913

Fixes #1904

## Description of Changes

The Dockerfiles have been changed to use Rust 1.43.1, the latest stable Rust version.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
