### PR TITLE
Update vsock logic to address stalling problems

### DIFF
--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -749,6 +749,16 @@ mod tests {
         }
     }
 
+    impl<S> VsockConnection<S>
+    where
+        S: Read + Write + AsRawFd,
+    {
+        /// Get the fwd_cnt value from the connection.
+        pub(crate) fn fwd_cnt(&self) -> Wrapping<u32> {
+            self.fwd_cnt
+        }
+    }
+
     fn init_pkt(pkt: &mut VsockPacket, op: u16, len: u32) -> &mut VsockPacket {
         for b in pkt.hdr_mut() {
             *b = 0;

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -757,6 +757,11 @@ mod tests {
         pub(crate) fn fwd_cnt(&self) -> Wrapping<u32> {
             self.fwd_cnt
         }
+
+        /// Forcefully insert a credit update flag.
+        pub(crate) fn insert_credit_update(&mut self) {
+            self.pending_rx.insert(PendingRx::CreditUpdate);
+        }
     }
 
     fn init_pkt(pkt: &mut VsockPacket, op: u16, len: u32) -> &mut VsockPacket {

--- a/src/devices/src/virtio/vsock/csm/mod.rs
+++ b/src/devices/src/virtio/vsock/csm/mod.rs
@@ -10,11 +10,11 @@ pub use connection::VsockConnection;
 
 pub mod defs {
     /// Vsock connection TX buffer capacity.
-    pub const CONN_TX_BUF_SIZE: usize = 64 * 1024;
+    pub const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
 
-    /// After the guest thinks it has filled our TX buffer up to this limit (in bytes), we'll send
-    /// them a credit update packet, to let them know we can handle more.
-    pub const CONN_CREDIT_UPDATE_THRESHOLD: usize = CONN_TX_BUF_SIZE - 4 * 4 * 1024;
+    /// When the guest thinks we have less than this amount of free buffer space,
+    /// we will send them a credit update packet.
+    pub const CONN_CREDIT_UPDATE_THRESHOLD: u32 = 4 * 1024;
 
     /// Connection request timeout, in millis.
     pub const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;

--- a/src/devices/src/virtio/vsock/csm/txbuf.rs
+++ b/src/devices/src/virtio/vsock/csm/txbuf.rs
@@ -22,7 +22,7 @@ pub struct TxBuf {
 
 impl TxBuf {
     /// Total buffer size, in bytes.
-    const SIZE: usize = defs::CONN_TX_BUF_SIZE;
+    const SIZE: usize = defs::CONN_TX_BUF_SIZE as usize;
 
     /// Ring-buffer constructor.
     pub fn new() -> Self {

--- a/src/devices/src/virtio/vsock/csm/txbuf.rs
+++ b/src/devices/src/virtio/vsock/csm/txbuf.rs
@@ -122,7 +122,11 @@ impl TxBuf {
         // Attempt our second write. This will return immediately if a second write isn't
         // needed, since checking for an empty buffer is the first thing we do in this
         // function.
-        Ok(written + self.flush_to(sink)?)
+        //
+        // Interesting corner case: if we've already written some data in the first pass,
+        // and then the second write fails, we will consider the flush action a success
+        // and return the number of bytes written in the first pass.
+        Ok(written + self.flush_to(sink).unwrap_or(0))
     }
 
     /// Check if the buffer holds any data that hasn't yet been flushed out.

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -1320,4 +1320,26 @@ mod tests {
 
         assert!(!ctx.muxer.has_pending_rx());
     }
+
+    #[test]
+    fn test_regression_handshake() {
+        // Address one of the issues found while fixing the following issue:
+        // https://github.com/firecracker-microvm/firecracker/issues/1751
+        // This test checks that the handshake message is not accounted for
+        let mut ctx = MuxerTestContext::new("regression_handshake");
+        let peer_port = 1025;
+
+        // Create a local connection.
+        let (_, local_port) = ctx.local_connect(peer_port);
+
+        // Get the connection from the connection map.
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn = ctx.muxer.conn_map.get_mut(&key).unwrap();
+
+        // Check that fwd_cnt is 0 - "OK ..." was not accounted for.
+        assert_eq!(conn.fwd_cnt().0, 0);
+    }
 }

--- a/src/devices/src/virtio/vsock/unix/muxer_rxq.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer_rxq.rs
@@ -102,6 +102,11 @@ impl MuxerRxQ {
         false
     }
 
+    /// Peek into the front of the queue.
+    pub fn peek(&self) -> Option<MuxerRx> {
+        self.q.front().copied()
+    }
+
     /// Pop an RX item from the front of the queue.
     pub fn pop(&mut self) -> Option<MuxerRx> {
         self.q.pop_front()


### PR DESCRIPTION
## Reason for This PR

Addresses #1751 

## Description of Changes

This PR changes some of the internal mechanisms in the vsock device, that were causing the problems described in #1751.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
