### PR TITLE
Reregister devices with event-manager on restore

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -85,8 +85,12 @@ impl Serial {
         out: Option<Box<dyn io::Write + Send>>,
         input: Option<Box<dyn ReadableFd + Send>>,
     ) -> Serial {
+        let interrupt_enable = match out {
+            Some(_) => IER_RECV_BIT,
+            None => 0,
+        };
         Serial {
-            interrupt_enable: 0,
+            interrupt_enable,
             interrupt_identification: DEFAULT_INTERRUPT_IDENTIFICATION,
             interrupt_evt,
             line_control: DEFAULT_LINE_CONTROL,

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -1306,10 +1306,11 @@ pub(crate) mod tests {
         let mem = Net::default_guest_memory();
         let (rxq, txq) = Net::virtqueues(&mem);
         net.assign_queues(rxq.create_queue(), txq.create_queue());
-        net.activate(mem.clone()).unwrap();
 
         let net = Arc::new(Mutex::new(net));
         event_manager.add_subscriber(net.clone()).unwrap();
+
+        net.lock().unwrap().activate(mem.clone()).unwrap();
 
         // Process the activate event.
         let ev_count = event_manager.run_with_timeout(50).unwrap();

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -225,13 +225,17 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
             let restore_args = MmioTransportConstructorArgs {
                 mem: mem.clone(),
-                device,
+                device: device.clone(),
             };
             let mmio_transport = MmioTransport::restore(restore_args, transport_state)
                 .map_err(|()| Error::MmioTransport)?;
             dev_manager
                 .register_virtio_mmio_device(vm, device_id, mmio_transport, &mmio_slot)
                 .map_err(Error::DeviceManager);
+
+            event_manager
+                .add_subscriber(device)
+                .map_err(Error::EventManager);
         }
         if let Some(vsock_state) = &state.vsock_device {
             let ctor_args = VsockUdsConstructorArgs {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.59
+COVERAGE_TARGET_PCT = 84.71
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

Part of #1847 

## Description of Changes

Small reworking of devices event registering logic. Devices now own reporting their `interest-list` depending on their `activate` state. The mechanism to register events now becomes context independent and can be used and is used when restoring devices from snapshot.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
