### PR TITLE
tests: Fix pylint 2.5.2 errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -448,9 +448,9 @@ TEST_MICROVM_CAP_FIXTURE_TEMPLATE = (
 # provide a way to do that outright, but luckily all of python is just lists of
 # of lists and a cursor, so exec() works fine here.
 for capability in MICROVM_S3_FETCHER.enum_capabilities():
-    test_microvm_cap_fixture = (
+    TEST_MICROVM_CAP_FIXTURE = (
         TEST_MICROVM_CAP_FIXTURE_TEMPLATE.replace('CAP', capability)
     )
     # pylint: disable=exec-used
     # This is the most straightforward way to achieve this result.
-    exec(test_microvm_cap_fixture)
+    exec(TEST_MICROVM_CAP_FIXTURE)

--- a/tests/integration_tests/build/test_style.py
+++ b/tests/integration_tests/build/test_style.py
@@ -42,7 +42,7 @@ def test_python_style():
         '--output-format=colorized --attr-rgx="[a-z_][a-z0-9_]{1,30}$" ' \
         '--argument-rgx="[a-z_][a-z0-9_]{1,30}$" ' \
         '--variable-rgx="[a-z_][a-z0-9_]{1,30}$" --disable=' \
-        'bad-continuation,fixme,too-many-instance-attributes,' \
+        'bad-continuation,fixme,too-many-instance-attributes,import-error,' \
         'too-many-locals,too-many-arguments',
 
         # pycodestyle

--- a/tests/integration_tests/functional/test_initrd.py
+++ b/tests/integration_tests/functional/test_initrd.py
@@ -33,6 +33,6 @@ def test_microvm_initrd_with_serial(
 
     serial.rx(token='# ')
 
-    serial.tx(f"findmnt /")
+    serial.tx("findmnt /")
     serial.rx(
         token=f"/      {INITRD_FILESYSTEM} {INITRD_FILESYSTEM}")

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -6,7 +6,7 @@ from framework.microvm import Serial
 from framework.state_machine import TestState
 
 
-class WaitLogin(TestState):
+class WaitLogin(TestState):  # pylint: disable=too-few-public-methods
     """Initial state when we wait for the login prompt."""
 
     def handle_input(self, serial, input_char) -> TestState:
@@ -18,7 +18,7 @@ class WaitLogin(TestState):
         return self
 
 
-class WaitPasswordPrompt(TestState):
+class WaitPasswordPrompt(TestState):  # pylint: disable=too-few-public-methods
     """Wait for the password prompt to be shown."""
 
     def handle_input(self, serial, input_char) -> TestState:
@@ -32,7 +32,7 @@ class WaitPasswordPrompt(TestState):
         return self
 
 
-class WaitIDResult(TestState):
+class WaitIDResult(TestState):  # pylint: disable=too-few-public-methods
     """Wait for the console to show the result of the 'id' shell command."""
 
     def handle_input(self, unused_serial, input_char) -> TestState:
@@ -42,10 +42,10 @@ class WaitIDResult(TestState):
         return self
 
 
-class TestFinished(TestState):
+class TestFinished(TestState):  # pylint: disable=too-few-public-methods
     """Test complete and successful."""
 
-    def handle_input(self, unused_serial, input_char) -> TestState:
+    def handle_input(self, unused_serial, _) -> TestState:
         """Return self since the test is about to end."""
         return self
 


### PR DESCRIPTION
Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

## Reason for This PR

The latest pylint version throws a few new styling errors as mentioned in #1913 
This PR fixes those errors.

## Description of Changes

Fix styling errors.

The `import-error` error was added to the ignore list, because the import paths are implicitly verified when the tests are executed.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
