### PR TITLE
rate-limiter: remove code-paths that divide by zero

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -427,7 +427,7 @@ pub(crate) mod tests {
     /// Create a default Block instance using file at the specified path to be used in tests.
     pub fn default_block_with_path(path: String) -> Block {
         // Rate limiting is enabled but with a high operation rate (10 million ops/s).
-        let rate_limiter = RateLimiter::new(0, None, 0, 100_000, None, 10).unwrap();
+        let rate_limiter = RateLimiter::new(0, 0, 0, 100_000, 0, 10).unwrap();
 
         let id = "test".to_string();
         // The default block device is read-write and non-root.
@@ -856,7 +856,7 @@ pub(crate) mod tests {
         let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evts[0].as_raw_fd() as u64);
 
         // Create bandwidth rate limiter that allows only 80 bytes/s with bucket size of 8 bytes.
-        let mut rl = RateLimiter::new(8, None, 100, 0, None, 0).unwrap();
+        let mut rl = RateLimiter::new(8, 0, 100, 0, 0, 0).unwrap();
         // Use up the budget.
         assert!(rl.consume(8, TokenType::Bytes));
 
@@ -921,7 +921,7 @@ pub(crate) mod tests {
         let queue_evt = EpollEvent::new(EventSet::IN, block.queue_evts[0].as_raw_fd() as u64);
 
         // Create ops rate limiter that allows only 10 ops/s with bucket size of 1 ops.
-        let mut rl = RateLimiter::new(0, None, 0, 1, None, 100).unwrap();
+        let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100).unwrap();
         // Use up the budget.
         assert!(rl.consume(1, TokenType::Ops));
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -1376,7 +1376,7 @@ pub(crate) mod tests {
         net.assign_queues(rxq.create_queue(), txq.create_queue());
         net.activate(mem.clone()).unwrap();
 
-        net.rx_rate_limiter = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
+        net.rx_rate_limiter = RateLimiter::new(0, 0, 0, 0, 0, 0).unwrap();
         let rate_limiter_event =
             EpollEvent::new(EventSet::IN, net.rx_rate_limiter.as_raw_fd() as u64);
         check_metric_after_block!(
@@ -1395,7 +1395,7 @@ pub(crate) mod tests {
         net.assign_queues(rxq.create_queue(), txq.create_queue());
         net.activate(mem.clone()).unwrap();
 
-        net.tx_rate_limiter = RateLimiter::new(0, None, 0, 0, None, 0).unwrap();
+        net.tx_rate_limiter = RateLimiter::new(0, 0, 0, 0, 0, 0).unwrap();
         let rate_limiter_event =
             EpollEvent::new(EventSet::IN, net.tx_rate_limiter.as_raw_fd() as u64);
         net.process(&rate_limiter_event, &mut event_manager);
@@ -1421,7 +1421,7 @@ pub(crate) mod tests {
         // Test TX bandwidth rate limiting
         {
             // create bandwidth rate limiter that allows 40960 bytes/s with bucket size 4096 bytes
-            let mut rl = RateLimiter::new(0x1000, None, 100, 0, None, 0).unwrap();
+            let mut rl = RateLimiter::new(0x1000, 0, 100, 0, 0, 0).unwrap();
             // use up the budget
             assert!(rl.consume(0x1000, TokenType::Bytes));
 
@@ -1471,7 +1471,7 @@ pub(crate) mod tests {
         // Test RX bandwidth rate limiting
         {
             // create bandwidth rate limiter that allows 40960 bytes/s with bucket size 4096 bytes
-            let mut rl = RateLimiter::new(0x1000, None, 100, 0, None, 0).unwrap();
+            let mut rl = RateLimiter::new(0x1000, 0, 100, 0, 0, 0).unwrap();
             // use up the budget
             assert!(rl.consume(0x1000, TokenType::Bytes));
 
@@ -1540,7 +1540,7 @@ pub(crate) mod tests {
         // Test TX ops rate limiting
         {
             // create ops rate limiter that allows 10 ops/s with bucket size 1 ops
-            let mut rl = RateLimiter::new(0, None, 0, 1, None, 100).unwrap();
+            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100).unwrap();
             // use up the budget
             assert!(rl.consume(1, TokenType::Ops));
 
@@ -1585,7 +1585,7 @@ pub(crate) mod tests {
         // Test RX ops rate limiting
         {
             // create ops rate limiter that allows 10 ops/s with bucket size 1 ops
-            let mut rl = RateLimiter::new(0, None, 0, 1, None, 100).unwrap();
+            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100).unwrap();
             // use up the budget
             assert!(rl.consume(0x800, TokenType::Ops));
 
@@ -1654,13 +1654,13 @@ pub(crate) mod tests {
         net.assign_queues(rxq.create_queue(), txq.create_queue());
         net.activate(mem.clone()).unwrap();
 
-        net.rx_rate_limiter = RateLimiter::new(10, None, 10, 2, None, 2).unwrap();
-        net.tx_rate_limiter = RateLimiter::new(10, None, 10, 2, None, 2).unwrap();
+        net.rx_rate_limiter = RateLimiter::new(10, 0, 10, 2, 0, 2).unwrap();
+        net.tx_rate_limiter = RateLimiter::new(10, 0, 10, 2, 0, 2).unwrap();
 
-        let rx_bytes = TokenBucket::new(1000, Some(1001), 1002).unwrap();
-        let rx_ops = TokenBucket::new(1003, Some(1004), 1005).unwrap();
-        let tx_bytes = TokenBucket::new(1006, Some(1007), 1008).unwrap();
-        let tx_ops = TokenBucket::new(1009, Some(1010), 1011).unwrap();
+        let rx_bytes = TokenBucket::new(1000, 1001, 1002).unwrap();
+        let rx_ops = TokenBucket::new(1003, 1004, 1005).unwrap();
+        let tx_bytes = TokenBucket::new(1006, 1007, 1008).unwrap();
+        let tx_ops = TokenBucket::new(1009, 1010, 1011).unwrap();
 
         net.patch_rate_limiters(
             BucketUpdate::Update(rx_bytes.clone()),

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -107,11 +107,23 @@ pub struct TokenBucket {
 }
 
 impl TokenBucket {
-    /// Creates a TokenBucket of `size` total capacity that takes `complete_refill_time_ms`
+    /// Creates a `TokenBucket` wrapped in an `Option`.
+    ///
+    /// TokenBucket created is of `size` total capacity and takes `complete_refill_time_ms`
     /// milliseconds to go from zero tokens to total capacity. The `one_time_burst` is initial
     /// extra credit on top of total capacity, that does not replenish and which can be used
     /// for an initial burst of data.
-    pub fn new(size: u64, one_time_burst: Option<u64>, complete_refill_time_ms: u64) -> Self {
+    ///
+    /// If the `size` or the `complete refill time` are zero, then `None` is returned.
+    pub fn new(
+        size: u64,
+        one_time_burst: Option<u64>,
+        complete_refill_time_ms: u64,
+    ) -> Option<Self> {
+        // If either token bucket capacity or refill time is 0, disable limiting.
+        if size == 0 || complete_refill_time_ms == 0 {
+            return None;
+        }
         // Formula for computing current refill amount:
         // refill_token_count = (delta_time * size) / (complete_refill_time_ms * 1_000_000)
         // In order to avoid overflows, simplify the fractions by computing greatest common divisor.
@@ -124,7 +136,7 @@ impl TokenBucket {
         // The division will be exact since `common_factor` is a factor of `complete_refill_time_ns`.
         let processed_refill_time: u64 = complete_refill_time_ns / common_factor;
 
-        TokenBucket {
+        Some(TokenBucket {
             size,
             one_time_burst,
             refill_time: complete_refill_time_ms,
@@ -134,7 +146,7 @@ impl TokenBucket {
             last_update: Instant::now(),
             processed_capacity,
             processed_refill_time,
-        }
+        })
     }
 
     /// Attempts to consume `tokens` from the bucket and returns whether the action succeeded.
@@ -237,6 +249,16 @@ pub enum TokenType {
     Ops,
 }
 
+/// Enum that describes the type of token bucket update.
+pub enum BucketUpdate {
+    /// No Update - same as before.
+    None,
+    /// Rate Limiting is disabled on this bucket.
+    Disabled,
+    /// Rate Limiting enabled with updated bucket.
+    Update(TokenBucket),
+}
+
 /// Rate Limiter that works on both bandwidth and ops/s limiting.
 ///
 /// Bandwidth (bytes/s) and ops/s limiting can be used at the same time or individually.
@@ -278,26 +300,6 @@ impl fmt::Debug for RateLimiter {
 }
 
 impl RateLimiter {
-    /// This function creates a `TokenBucket` wrapped in an `Option` with a given total capacity,
-    /// one time burst, and complete refill time (in miliseconds). If the total capacity or the
-    /// complete refill time are zero, then `None` is returned.
-    fn make_bucket(
-        total_capacity: u64,
-        one_time_burst: Option<u64>,
-        complete_refill_time_ms: u64,
-    ) -> Option<TokenBucket> {
-        // If either token bucket capacity or refill time is 0, disable limiting.
-        if total_capacity != 0 && complete_refill_time_ms != 0 {
-            Some(TokenBucket::new(
-                total_capacity,
-                one_time_burst,
-                complete_refill_time_ms,
-            ))
-        } else {
-            None
-        }
-    }
-
     /// Creates a new Rate Limiter that can limit on both bytes/s and ops/s.
     ///
     /// # Arguments
@@ -327,13 +329,13 @@ impl RateLimiter {
         ops_one_time_burst: Option<u64>,
         ops_complete_refill_time_ms: u64,
     ) -> io::Result<Self> {
-        let bytes_token_bucket = Self::make_bucket(
+        let bytes_token_bucket = TokenBucket::new(
             bytes_total_capacity,
             bytes_one_time_burst,
             bytes_complete_refill_time_ms,
         );
 
-        let ops_token_bucket = Self::make_bucket(
+        let ops_token_bucket = TokenBucket::new(
             ops_total_capacity,
             ops_one_time_burst,
             ops_complete_refill_time_ms,
@@ -426,23 +428,17 @@ impl RateLimiter {
 
     /// Updates the parameters of the token buckets associated with this RateLimiter.
     // TODO: Please note that, right now, the buckets become full after being updated.
-    pub fn update_buckets(&mut self, bytes: Option<TokenBucket>, ops: Option<TokenBucket>) {
-        // TODO: We should reconcile the create and update paths, such that they use the same data
-        // format. Currently, the TokenBucket config data is used for create, but the live
-        // TokenBucket objects are used for update.
-        // We have to call make_bucket instead of directly assigning the bytes and/or ops
-        // because the RateLimiter validates the TokenBucket config data (e.g. it nullifies
-        // an unusable bucket with size 0). This is needed, because passing a 0-sized bucket is
-        // the only method the user has to disable rate limiting. I.e. if the user passes `null`
-        // as the token bucket config, the old config is left unchanged.
-
-        if let Some(b) = bytes {
-            self.bandwidth = Self::make_bucket(b.size, b.one_time_burst, b.refill_time);
-        }
-
-        if let Some(b) = ops {
-            self.ops = Self::make_bucket(b.size, b.one_time_burst, b.refill_time);
-        }
+    pub fn update_buckets(&mut self, bytes: BucketUpdate, ops: BucketUpdate) {
+        match bytes {
+            BucketUpdate::Disabled => self.bandwidth = None,
+            BucketUpdate::Update(tb) => self.bandwidth = Some(tb),
+            BucketUpdate::None => (),
+        };
+        match ops {
+            BucketUpdate::Disabled => self.ops = None,
+            BucketUpdate::Update(tb) => self.ops = Some(tb),
+            BucketUpdate::None => (),
+        };
     }
 
     /// Returns an immutable view of the inner bandwidth token bucket.
@@ -522,7 +518,7 @@ pub(crate) mod tests {
     #[test]
     fn test_token_bucket_create() {
         let before = Instant::now();
-        let tb = TokenBucket::new(1000, None, 1000);
+        let tb = TokenBucket::new(1000, None, 1000).unwrap();
         assert_eq!(tb.capacity(), 1000);
         assert_eq!(tb.budget(), 1000);
         assert!(*tb.get_last_update() >= before);
@@ -530,16 +526,21 @@ pub(crate) mod tests {
         assert!(*tb.get_last_update() <= after);
         assert_eq!(tb.get_processed_capacity(), 1);
         assert_eq!(tb.get_processed_refill_time(), 1_000_000);
+
+        // Verify invalid bucket configurations result in `None`.
+        assert!(TokenBucket::new(0, Some(1234), 1000).is_none());
+        assert!(TokenBucket::new(100, Some(1234), 0).is_none());
+        assert!(TokenBucket::new(0, Some(1234), 0).is_none());
     }
 
     #[test]
     fn test_token_bucket_preprocess() {
-        let tb = TokenBucket::new(1000, None, 1000);
+        let tb = TokenBucket::new(1000, None, 1000).unwrap();
         assert_eq!(tb.get_processed_capacity(), 1);
         assert_eq!(tb.get_processed_refill_time(), NANOSEC_IN_ONE_MILLISEC);
 
         let thousand = 1000;
-        let tb = TokenBucket::new(3 * 7 * 11 * 19 * thousand, None, 7 * 11 * 13 * 17);
+        let tb = TokenBucket::new(3 * 7 * 11 * 19 * thousand, None, 7 * 11 * 13 * 17).unwrap();
         assert_eq!(tb.get_processed_capacity(), 3 * 19);
         assert_eq!(
             tb.get_processed_refill_time(),
@@ -553,7 +554,7 @@ pub(crate) mod tests {
         // allowing rate of 1 token/ms.
         let capacity = 1000;
         let refill_ms = 1000;
-        let mut tb = TokenBucket::new(capacity, None, refill_ms as u64);
+        let mut tb = TokenBucket::new(capacity, None, refill_ms as u64).unwrap();
 
         assert!(tb.reduce(123));
         assert_eq!(tb.budget(), capacity - 123);
@@ -565,7 +566,7 @@ pub(crate) mod tests {
         assert!(!tb.reduce(capacity));
 
         // token bucket with capacity 1000 and refill time of 1000 milliseconds
-        let mut tb = TokenBucket::new(1000, Some(1100), 1000);
+        let mut tb = TokenBucket::new(1000, Some(1100), 1000).unwrap();
         // safely assuming the thread can run these 3 commands in less than 500ms
         assert!(tb.reduce(1000));
         assert_eq!(tb.one_time_burst(), 100);
@@ -754,13 +755,16 @@ pub(crate) mod tests {
         let initial_bw = x.bandwidth.clone();
         let initial_ops = x.ops.clone();
 
-        x.update_buckets(None, None);
+        x.update_buckets(BucketUpdate::None, BucketUpdate::None);
         assert_eq!(x.bandwidth, initial_bw);
         assert_eq!(x.ops, initial_ops);
 
-        let new_bw = TokenBucket::new(123, None, 57);
-        let new_ops = TokenBucket::new(321, Some(12346), 89);
-        x.update_buckets(Some(new_bw.clone()), Some(new_ops.clone()));
+        let new_bw = TokenBucket::new(123, None, 57).unwrap();
+        let new_ops = TokenBucket::new(321, Some(12346), 89).unwrap();
+        x.update_buckets(
+            BucketUpdate::Update(new_bw.clone()),
+            BucketUpdate::Update(new_ops.clone()),
+        );
 
         // We have manually adjust the last_update field, because it changes when update_buckets()
         // constructs new buckets (and thus gets a different value for last_update). We do this so
@@ -770,6 +774,10 @@ pub(crate) mod tests {
 
         assert_eq!(x.bandwidth, Some(new_bw));
         assert_eq!(x.ops, Some(new_ops));
+
+        x.update_buckets(BucketUpdate::Disabled, BucketUpdate::Disabled);
+        assert_eq!(x.bandwidth, None);
+        assert_eq!(x.ops, None);
     }
 
     #[test]

--- a/src/rate_limiter/src/persist.rs
+++ b/src/rate_limiter/src/persist.rs
@@ -12,7 +12,7 @@ use versionize_derive::Versionize;
 #[derive(Versionize)]
 pub struct TokenBucketState {
     size: u64,
-    one_time_burst: Option<u64>,
+    one_time_burst: u64,
     refill_time: u64,
     budget: u64,
     elapsed_ns: u64,
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_token_bucket_persistence() {
-        let mut tb = TokenBucket::new(1000, Some(2000), 3000).unwrap();
+        let mut tb = TokenBucket::new(1000, 2000, 3000).unwrap();
 
         // Check that TokenBucket restores correctly if untouched.
         let restored_tb = TokenBucket::restore((), &tb.save()).unwrap();
@@ -128,8 +128,7 @@ mod tests {
     #[test]
     fn test_rate_limiter_persistence() {
         let refill_time = 100_000;
-        let mut rate_limiter =
-            RateLimiter::new(100, None, refill_time, 10, None, refill_time).unwrap();
+        let mut rate_limiter = RateLimiter::new(100, 0, refill_time, 10, 0, refill_time).unwrap();
 
         // Check that RateLimiter restores correctly if untouched.
         let restored_rate_limiter =

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -510,15 +510,6 @@ impl RuntimeApiController {
                 .expect("Unexpected BusDevice type")
                 .device();
 
-            macro_rules! get_handler_arg {
-                ($rate_limiter: ident, $metric: ident) => {{
-                    new_cfg
-                        .$rate_limiter
-                        .map(|rl| rl.$metric.map(vmm_config::TokenBucketConfig::into))
-                        .unwrap_or(None)
-                }};
-            }
-
             virtio_device
                 .lock()
                 .expect("Poisoned lock")
@@ -526,10 +517,10 @@ impl RuntimeApiController {
                 .downcast_mut::<Net>()
                 .unwrap()
                 .patch_rate_limiters(
-                    get_handler_arg!(rx_rate_limiter, bandwidth),
-                    get_handler_arg!(rx_rate_limiter, ops),
-                    get_handler_arg!(tx_rate_limiter, bandwidth),
-                    get_handler_arg!(tx_rate_limiter, ops),
+                    new_cfg.rx_bytes(),
+                    new_cfg.rx_ops(),
+                    new_cfg.tx_bytes(),
+                    new_cfg.tx_ops(),
                 );
         } else {
             return Err(VmmActionError::NetworkConfig(

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -72,10 +72,10 @@ impl TryInto<RateLimiter> for RateLimiterConfig {
         let ops = self.ops.unwrap_or_default();
         RateLimiter::new(
             bw.size,
-            bw.one_time_burst,
+            bw.one_time_burst.unwrap_or(0),
             bw.refill_time,
             ops.size,
-            ops.one_time_burst,
+            ops.one_time_burst.unwrap_or(0),
             ops.refill_time,
         )
     }

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -64,11 +64,15 @@ macro_rules! get_bucket_update {
             Some(rl_cfg) => match rl_cfg.$metric {
                 // There is data to update.
                 Some(tb_cfg) => {
-                    TokenBucket::new(tb_cfg.size, tb_cfg.one_time_burst, tb_cfg.refill_time)
-                        // Updated active rate-limiter.
-                        .map(BucketUpdate::Update)
-                        // Updated/deactivated rate-limiter
-                        .unwrap_or(BucketUpdate::Disabled)
+                    TokenBucket::new(
+                        tb_cfg.size,
+                        tb_cfg.one_time_burst.unwrap_or(0),
+                        tb_cfg.refill_time,
+                    )
+                    // Updated active rate-limiter.
+                    .map(BucketUpdate::Update)
+                    // Updated/deactivated rate-limiter
+                    .unwrap_or(BucketUpdate::Disabled)
                 }
                 // No update to the rate-limiter.
                 None => BucketUpdate::None,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,14 +17,14 @@ import pytest
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
-COVERAGE_TARGET_PCT = 84.41
+COVERAGE_TARGET_PCT = 84.32
 # This slight difference comes from
 # the brand string, On Intel, it contains
 # the frequency while on AMD it does not.
 # (the cpuid crate). In the future other
 # differences may appear.
 if "AMD" in platform.processor():
-    COVERAGE_TARGET_PCT = 84.35
+    COVERAGE_TARGET_PCT = 84.26
 
 COVERAGE_MAX_DELTA = 0.05
 


### PR DESCRIPTION
## Reason for This PR

Fixes #1918 

## Description of Changes

TokenBucket constructor now validates input and provides 'None' result meaning disabled when its 'size' or 'refill_time' are zero.

Simplify and slightly optimize code by changing 'one_time_burst' from 'Option<u64>' to simple 'u64'. Value of zero is equivalent to 'None'.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
