### PR TITLE
CI: adjust coverage on AMD

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -18,6 +18,14 @@ import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
 
 COVERAGE_TARGET_PCT = 84.71
+# This slight difference comes from
+# the brand string, On Intel, it contains
+# the frequency while on AMD it does not.
+# (the cpuid crate). In the future other
+# differences may appear.
+if "AMD" in platform.processor():
+    COVERAGE_TARGET_PCT = 84.68
+
 COVERAGE_MAX_DELTA = 0.05
 
 CARGO_KCOV_REL_PATH = os.path.join(host.CARGO_BUILD_REL_PATH, 'kcov')


### PR DESCRIPTION
## Reason for This PR

The cpuid crate introduces a slight
difference in the coverage value.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
