### PR TITLE
devtool: support for new parameter

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -239,7 +239,7 @@ ensure_build_dir() {
 # owned by root. This fixes that by recursively changing the ownership of build/
 # to the current user.
 #
-fix_build_dir_perms() {
+cmd_fix_perms() {
     # Yes, running Docker to get elevated privileges, just to chown some files
     # is a dirty hack.
     run_devctr \
@@ -415,6 +415,8 @@ cmd_help() {
     echo ""
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
+    echo "    fix_perms"
+    echo "        Fixes permissions when devtool dies in the middle of a privileged session."
     echo ""
 }
 
@@ -546,7 +548,7 @@ cmd_test() {
 
     # Running as root would have created some root-owned files under the build
     # dir. Let's fix that.
-    fix_build_dir_perms
+    cmd_fix_perms
 
     return $ret
 }
@@ -594,7 +596,7 @@ cmd_shell() {
         # Running as root may have created some root-owned files under the build
         # dir. Let's fix that.
         #
-        fix_build_dir_perms
+        cmd_fix_perms
     else
         say "Dropping to shell prompt as user $(whoami) ..."
         say "Note: $FC_ROOT_DIR is bind-mounted under $CTR_FC_ROOT_DIR"


### PR DESCRIPTION
## Reason for This PR

Add a new parameter to devtool that fixes
permissions for the build directory (the one that can
get modified by the container).
This way unprivileged users can regain rights
(i.e delete build session) when devtool dies in
the middle of a privileged session.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
