### PR TITLE
Use TempFile from vmm-sys-utils to cleanup test files

### DIFF
--- a/src/micro_http/src/server.rs
+++ b/src/micro_http/src/server.rs
@@ -536,7 +536,7 @@ mod tests {
     use common::Body;
     use utils::tempfile::TempFile;
 
-    fn get_path_to_socket() -> TempFile {
+    fn get_temp_socket_file() -> TempFile {
         let mut path_to_socket = TempFile::new().unwrap();
         path_to_socket.remove().unwrap();
         path_to_socket
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_wait_one_connection() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_wait_concurrent_connections() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_wait_expect_connection() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -701,7 +701,7 @@ mod tests {
 
     #[test]
     fn test_wait_many_connections() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_wait_parse_error() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();
@@ -754,7 +754,7 @@ mod tests {
 
     #[test]
     fn test_wait_in_flight_responses() {
-        let path_to_socket = get_path_to_socket();
+        let path_to_socket = get_temp_socket_file();
 
         let mut server = HttpServer::new(path_to_socket.as_path()).unwrap();
         server.start_server().unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -726,7 +726,7 @@ pub mod tests {
     use vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
     use vmm_config::drive::BlockDeviceConfig;
     use vmm_config::net::NetworkInterfaceConfig;
-    use vmm_config::vsock::tests::{default_config, TempSockFile};
+    use vmm_config::vsock::tests::default_config;
     use vmm_config::vsock::{VsockBuilder, VsockDeviceConfig};
 
     pub(crate) struct CustomBlockConfig {
@@ -1113,7 +1113,8 @@ pub mod tests {
         let mut event_manager = EventManager::new().expect("Unable to create EventManager");
         let mut vmm = default_vmm();
 
-        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let mut tmp_sock_file = TempFile::new().unwrap();
+        tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
 
         let mut cmdline = default_kernel_cmdline();

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -206,7 +206,7 @@ mod tests {
     use snapshot::Persist;
     use utils::tempfile::TempFile;
     use vmm_config::net::NetworkInterfaceConfig;
-    use vmm_config::vsock::tests::{default_config, TempSockFile};
+    use vmm_config::vsock::tests::default_config;
 
     fn default_vmm_with_devices(event_manager: &mut EventManager) -> Vmm {
         let mut vmm = default_vmm();
@@ -229,7 +229,8 @@ mod tests {
         insert_net_device(&mut vmm, &mut cmdline, event_manager, network_interface);
 
         // Add vsock device.
-        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let mut tmp_sock_file = TempFile::new().unwrap();
+        tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
 
         insert_vsock_device(&mut vmm, &mut cmdline, event_manager, vsock_config);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -306,7 +306,7 @@ mod tests {
     use vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
     use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
     use vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
-    use vmm_config::vsock::tests::{default_config, TempSockFile};
+    use vmm_config::vsock::tests::default_config;
     use vmm_config::RateLimiterConfig;
     use vstate::VcpuConfig;
 
@@ -821,7 +821,8 @@ mod tests {
     #[test]
     fn test_set_vsock_device() {
         let mut vm_resources = default_vm_resources();
-        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let mut tmp_sock_file = TempFile::new().unwrap();
+        tmp_sock_file.remove().unwrap();
         let new_vsock_cfg = default_config(&tmp_sock_file);
         assert!(vm_resources.vsock.get().is_none());
         vm_resources


### PR DESCRIPTION
## Reason for This PR

Fix #1803

## Description of Changes

- Renamed helper function for tests as mentioned in #1922
- Use `TempFile` in `src/api_server/src/lib.rs::test_bind_and_run()`
- Remove `src/vmm/src/vmm_config/vsock.rs::TempSockFile`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
