### PR TITLE
serial: handle HANG_UP

### DIFF
--- a/src/devices/tests/integration_tests.rs
+++ b/src/devices/tests/integration_tests.rs
@@ -1,0 +1,93 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod serial_utils;
+
+use std::io;
+use std::os::raw::{c_int, c_void};
+use std::sync::{Arc, Mutex};
+
+use devices::legacy::Serial;
+use devices::BusDevice;
+use polly::event_manager::EventManager;
+use serial_utils::MockSerialInput;
+use utils::epoll::{EpollEvent, EventSet};
+use utils::eventfd::EventFd;
+
+#[test]
+fn test_issue_serial_hangup_anon_pipe() {
+    let mut fds: [c_int; 2] = [0; 2];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert!(rc == 0);
+
+    // Serial input is the reading end of the pipe.
+    let serial_in = MockSerialInput(fds[0]);
+    let serial = Arc::new(Mutex::new(Serial::new_in_out(
+        EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+        Box::new(serial_in),
+        Box::new(io::stdout()),
+    )));
+
+    // Make reading fd non blocking to read just what is inflight.
+    let flags = unsafe { libc::fcntl(fds[0], libc::F_GETFL, 0) };
+    let mut rc = unsafe { libc::fcntl(fds[0], libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    assert!(rc == 0);
+
+    // Write some dummy data on the writing end of the pipe to handle it later on.
+    // 33 bytes are read in two rounds of serial input processing because
+    // it  is handled in batches of 32 bytes at maximum.
+    const BYTES_COUNT: usize = 33;
+    let mut dummy_data = [1u8; BYTES_COUNT];
+    rc = unsafe {
+        libc::write(
+            fds[1],
+            dummy_data.as_mut_ptr() as *const c_void,
+            dummy_data.len(),
+        ) as i32
+    };
+    assert!(dummy_data.len() == rc as usize);
+
+    // Register the reading end of the pipe to the event manager, to be processed later on.
+    let mut event_manager = EventManager::new().unwrap();
+    event_manager
+        .register(
+            fds[0],
+            EpollEvent::new(EventSet::IN, fds[0] as u64),
+            serial.clone(),
+        )
+        .unwrap();
+
+    let mut ev_count = 1;
+    while ev_count != 0 {
+        // `EventSet::IN` was received.
+        ev_count = event_manager.run_with_timeout(0).unwrap();
+    }
+
+    let mut data = [0u8; BYTES_COUNT];
+
+    // On the main thread, we will simulate guest "vCPU" thread serial reads.
+    let data_bus_offset = 0;
+    for i in 0..BYTES_COUNT {
+        serial
+            .lock()
+            .unwrap()
+            .read(data_bus_offset, &mut data[i..=i]);
+    }
+
+    // We need to assert on a maximum of 32 bytes slices, because this is the maximum
+    // rust can compare.
+    assert!(data[..31] == dummy_data[..31]);
+    assert!(data[32] == dummy_data[32]);
+
+    // Close the writing end (this sends an HANG_UP to the reading end).
+    rc = unsafe { libc::close(fds[1]) };
+    assert!(rc == 0);
+
+    // `EventSet::HANG_UP` was received.
+    let ev_count = event_manager.run().unwrap();
+    assert!(ev_count == 1);
+
+    // Serial input was unregistered.
+    let ev_count = event_manager.run_with_timeout(1).unwrap();
+    assert!(ev_count == 0);
+}

--- a/src/devices/tests/serial_utils/mod.rs
+++ b/src/devices/tests/serial_utils/mod.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use devices::legacy::ReadableFd;
+use std::io;
+use std::os::raw::c_void;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::RawFd;
+
+pub struct MockSerialInput(pub RawFd);
+
+impl io::Read for MockSerialInput {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let count = unsafe { libc::read(self.0, buf.as_mut_ptr() as *mut c_void, buf.len()) };
+        if count < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(count as usize)
+    }
+}
+
+impl AsRawFd for MockSerialInput {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+impl ReadableFd for MockSerialInput {}


### PR DESCRIPTION
## Reason for This PR

Firecracker serial device is emulated around the standard input of a Firecracker process. When the Firecracker standard input is set up as an end of a pipe and the other end of the pipe is closed, then this event will level-trigger an `EPOLLHUP` event on the Firecracker standard input, which is monitored for driving the serial device emulation.

`EPOLLHUP` is currently an unexpected event and when it arrives, it will issue a warning. This warning is logged continuously, raising the Firecracker emulation thread to 100% utilization, starving the emulation and the guest, if quotas are imposed on the Firecracker process as a whole.

Fixes: #1875 .

## Description of Changes

Added handling of `EPOLLHUP` event received on the serial device input. When it is received, consume any bytes which might be inflight, then unregister the serial input from monitoring.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- ~~[ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- ~~[ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
