### PR TITLE
CI: fix bug in getting AMD's coverage

### DIFF
--- a/tests/host_tools/proc.py
+++ b/tests/host_tools/proc.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utility functions for interacting with the processor."""
+import re
+import framework.utils as utils
+
+
+def proc_type():
+    """Obtain the model processor on a Linux system."""
+    cmd = "cat /proc/cpuinfo"
+    result = utils.run_cmd(cmd)
+    lines = result.stdout.strip().splitlines()
+    for line in lines:
+        if "model name" in line:
+            return re.sub(".*model name.*:", "", line, 1)
+    return ""

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -16,15 +16,15 @@ import pytest
 
 import framework.utils as utils
 import host_tools.cargo_build as host  # pylint: disable=import-error
+import host_tools.proc as proc
 
-COVERAGE_TARGET_PCT = 84.32
-# This slight difference comes from
-# the brand string, On Intel, it contains
-# the frequency while on AMD it does not.
-# (the cpuid crate). In the future other
+# AMD has a slightly different coverage due to
+# the appearance of the brand string. On Intel,
+# this contains the frequency while on AMD it does not.
+# Checkout the cpuid crate. In the future other
 # differences may appear.
-if "AMD" in platform.processor():
-    COVERAGE_TARGET_PCT = 84.26
+COVERAGE_DICT = {"Intel": 84.32, "AMD": 84.26}
+PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05
 
@@ -88,6 +88,9 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
     The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
     after a coverage run.
     """
+    proc_model = [item for item in COVERAGE_DICT if item in PROC_MODEL]
+    assert len(proc_model) == 1, "Could not get processor model!"
+    coverage_target_pct = COVERAGE_DICT[proc_model[0]]
     exclude_pattern = (
         '${CARGO_HOME:-$HOME/.cargo/},'
         'build/,'
@@ -130,22 +133,22 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
 
     coverage_low_msg = (
         'Current code coverage ({:.2f}%) is below the target ({}%).'
-        .format(coverage, COVERAGE_TARGET_PCT)
+        .format(coverage, coverage_target_pct)
     )
 
-    min_coverage = COVERAGE_TARGET_PCT - COVERAGE_MAX_DELTA
+    min_coverage = coverage_target_pct - COVERAGE_MAX_DELTA
     assert coverage >= min_coverage, coverage_low_msg
 
     # Get the name of the variable that needs updating.
     namespace = globals()
     cov_target_name = [name for name in namespace if namespace[name]
-                       is COVERAGE_TARGET_PCT][0]
+                       is COVERAGE_DICT][0]
 
     coverage_high_msg = (
         'Current code coverage ({:.2f}%) is above the target ({}%).\n'
         'Please update the value of {}.'
-        .format(coverage, COVERAGE_TARGET_PCT, cov_target_name)
+        .format(coverage, coverage_target_pct, cov_target_name)
     )
 
-    assert coverage - COVERAGE_TARGET_PCT <= COVERAGE_MAX_DELTA,\
+    assert coverage - coverage_target_pct <= COVERAGE_MAX_DELTA,\
         coverage_high_msg


### PR DESCRIPTION
## Reason for This PR

AMD CI would intermittently fail while checking against expected coverage.

## Description of Changes

Read value of processor model from `/proc/cpuinfo` rather than relying on python's "platform.processor()" function.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
