### PR TITLE
tests: add some assertions to metrics case

### DIFF
--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -3,6 +3,7 @@
 """Tests the metrics system."""
 
 import os
+import json
 import host_tools.logging as log_tools
 
 
@@ -22,5 +23,29 @@ def test_flush_metrics(test_microvm_with_api):
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     microvm.start()
+
+    res = metrics_fifo.sequential_reader(1)
+    metrics = json.loads(res[0])
+
+    exp_keys = [
+        'utc_timestamp_ms',
+        'api_server',
+        'block',
+        'get_api_requests',
+        'i8042',
+        'logger',
+        'mmds',
+        'net',
+        'patch_api_requests',
+        'put_api_requests',
+        'rtc',
+        'seccomp',
+        'vcpu',
+        'vmm',
+        'uart',
+        'signals',
+    ]
+
+    assert set(metrics.keys()) == set(exp_keys)
 
     microvm.flush_metrics(metrics_fifo)


### PR DESCRIPTION
Improve metrics test case, to read metrics back and assert 2 items
values inside result.

Values in these 2 items should be always equal to expected under normal case.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
