### PR TITLE
test: fix typo in utils.py

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -111,7 +111,7 @@ async def run_cmd_async(cmd, ignore_return_code=False, no_shell=False):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE)
 
-    # Capture stdin/stdout
+    # Capture stdout/stderr
     stdout, stderr = await proc.communicate()
 
     output_message = f"\n[{proc.pid}] Command:\n{cmd}"


### PR DESCRIPTION
## Reason for This PR
Fix typo inside utils.py: ```stdin``` instead of ```stdout``` and ```stdout``` instead of ```stderr```

## Description of Changes
Fix small typo inside utils.py

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
