### PR TITLE
jailer: increase code coverage

### DIFF
--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -421,6 +421,13 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
+                Error::Chmod(path.clone(), io::Error::from_raw_os_error(2))
+            ),
+            "Failed to change permissions on \"/foo\": No such file or directory (os error 2)",
+        );
+        assert_eq!(
+            format!(
+                "{}",
                 Error::CgroupLineNotFound(proc_mounts.to_string(), controller.to_string())
             ),
             "sysfs configurations not found in /proc/mounts",
@@ -636,6 +643,18 @@ mod tests {
                 Error::Write(file_path, io::Error::from_raw_os_error(2))
             ),
             format!("Failed to write to /foo/bar: {}", err2_str),
+        );
+    }
+
+    #[test]
+    fn test_to_cstring() {
+        let path = Path::new("some_path");
+        let cstring_path = to_cstring(path).unwrap();
+        assert_eq!(cstring_path, CString::new("some_path").unwrap());
+        let path_with_nul = Path::new("some_path\0");
+        assert_eq!(
+            format!("{}", to_cstring(path_with_nul).unwrap_err()),
+            "Encountered interior \\0 while parsing a string"
         );
     }
 }

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -14,7 +14,7 @@ MACHINE = platform.machine()
 FC_BINARY_SIZE_TARGET = 3013464 if MACHINE == "x86_64" else 3251464
 """Firecracker target binary size in bytes"""
 
-FC_BINARY_SIZE_LIMIT = 32000000 if MACHINE == "x86_64" else 3400000
+FC_BINARY_SIZE_LIMIT = 3200000 if MACHINE == "x86_64" else 3400000
 """Firecracker maximum binary size in bytes"""
 
 JAILER_BINARY_SIZE_TARGET = 2568384 if MACHINE == "x86_64" else 2792688

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.42, "AMD": 84.38}
+COVERAGE_DICT = {"Intel": 84.63, "AMD": 84.60}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

A step forward for #363.

## Description of Changes

With the recently merged #1862, realized the coverage for jailer can be quite easily increased.
Split `run()` in two in order to be able to unit-test some part of it.
Added a few unit tests and made a small cleanup in jailer env tests.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
