### PR TITLE
snapshot load: open memory file in O_RDONLY mode

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -277,11 +277,7 @@ fn guest_memory_from_file(
     mem_state: &GuestMemoryState,
 ) -> std::result::Result<GuestMemoryMmap, LoadSnapshotError> {
     use self::LoadSnapshotError::{DeserializeMemory, MemoryBackingFile};
-    let mem_file = OpenOptions::new()
-        .write(true)
-        .read(true)
-        .open(mem_file_path)
-        .map_err(MemoryBackingFile)?;
+    let mem_file = File::open(mem_file_path).map_err(MemoryBackingFile)?;
     GuestMemoryMmap::restore(&mem_file, mem_state).map_err(DeserializeMemory)
 }
 


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Since we are mmaping the memory file with MAP_PRIVATE, we don't need to open the file with write permission.

## Description of Changes


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
