### PR TITLE
snapshot: add metrics for load and create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@
   from the VMM perspective.
 - Added metric for measuring the duration of loading a snapshot, from the VMM
   perspective.
+- Added metrics that measure the duration of pausing and resuming the microVM,
+  from the API (user) perspective.
+- Added metric for measuring the duration of the last full/diff snapshot created,
+  from the API (user) perspective.
+- Added metric for measuring the duration of loading a snapshot, from the API
+  (user) perspective.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
 - Added metric for counting MAC address updates.
 - Added metrics for counting TAP read and write errors.
 - Added metrics for counting RX and TX partial writes.
+- Added metrics that measure the duration of pausing and resuming the microVM,
+  from the VMM perspective.
+- Added metric for measuring the duration of the last full/diff snapshot created,
+  from the VMM perspective.
+- Added metric for measuring the duration of loading a snapshot, from the VMM
+  perspective.
 
 ### Fixed
 

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -105,8 +105,7 @@ impl ApiServer {
         let mut server = HttpServer::new(path).expect("Error creating the HTTP server");
 
         if let Some(start_time) = start_time_us {
-            let delta_us =
-                (utils::time::get_time(utils::time::ClockType::Monotonic) / 1000) - start_time;
+            let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
             METRICS
                 .api_server
                 .process_startup_time_us
@@ -115,7 +114,7 @@ impl ApiServer {
 
         if let Some(cpu_start_time) = start_time_cpu_us {
             let delta_us =
-                utils::time::get_time(utils::time::ClockType::ProcessCpu) / 1000 - cpu_start_time;
+                utils::time::get_time_us(utils::time::ClockType::ProcessCpu) - cpu_start_time;
             METRICS
                 .api_server
                 .process_startup_time_cpu_us

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -151,6 +151,9 @@ impl ApiServer {
                                 error!("API Server encountered an error on response: {}", e);
                                 Ok(())
                             })?;
+                        let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic)
+                            - request_processing_start_us;
+                        debug!("Total previous API call duration: {} us.", delta_us);
                     }
                 }
                 Err(e) => {

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -110,7 +110,7 @@ impl ApiServer {
             METRICS
                 .api_server
                 .process_startup_time_us
-                .add(delta_us as usize);
+                .store(delta_us as usize);
         }
 
         if let Some(cpu_start_time) = start_time_cpu_us {
@@ -119,7 +119,7 @@ impl ApiServer {
             METRICS
                 .api_server
                 .process_startup_time_cpu_us
-                .add(delta_us as usize);
+                .store(delta_us as usize);
         }
 
         // Load seccomp filters on the API thread.

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -81,7 +81,7 @@ impl ParsedRequest {
     }
 
     pub fn convert_to_response(
-        request_outcome: std::result::Result<VmmData, VmmActionError>,
+        request_outcome: &std::result::Result<VmmData, VmmActionError>,
     ) -> Response {
         match request_outcome {
             Ok(vmm_data) => match vmm_data {
@@ -469,7 +469,7 @@ pub(crate) mod tests {
     fn test_convert_to_response() {
         // Empty Vmm data.
         let mut buf = Cursor::new(vec![0]);
-        let response = ParsedRequest::convert_to_response(Ok(VmmData::Empty));
+        let response = ParsedRequest::convert_to_response(&Ok(VmmData::Empty));
         assert!(response.write_all(&mut buf).is_ok());
         let expected_response = "HTTP/1.1 204 \r\n\
                                  Server: Firecracker API\r\n\
@@ -479,7 +479,7 @@ pub(crate) mod tests {
 
         // With Vmm data.
         let mut buf = Cursor::new(vec![0]);
-        let response = ParsedRequest::convert_to_response(Ok(VmmData::MachineConfiguration(
+        let response = ParsedRequest::convert_to_response(&Ok(VmmData::MachineConfiguration(
             VmConfig::default(),
         )));
         assert!(response.write_all(&mut buf).is_ok());
@@ -497,7 +497,7 @@ pub(crate) mod tests {
         let error = VmmActionError::StartMicrovm(StartMicrovmError::MissingKernelConfig);
         let mut buf = Cursor::new(vec![0]);
         let json = ApiServer::json_fault_message(error.to_string());
-        let response = ParsedRequest::convert_to_response(Err(error));
+        let response = ParsedRequest::convert_to_response(&Err(error));
         response.write_all(&mut buf).unwrap();
 
         let expected_response = format!(

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -76,7 +76,7 @@ impl RTC {
         RTC {
             // This is used only for duration measuring purposes.
             previous_now: Instant::now(),
-            tick_offset: utils::time::get_time(utils::time::ClockType::Real) as i64,
+            tick_offset: utils::time::get_time_ns(utils::time::ClockType::Real) as i64,
             match_value: 0,
             load: 0,
             imsc: 0,
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(v, 123);
 
         // Read and write to the LR register.
-        let v = utils::time::get_time(utils::time::ClockType::Real);
+        let v = utils::time::get_time_ns(utils::time::ClockType::Real);
         byte_order::write_le_u32(&mut data, (v / utils::time::NANOS_PER_SECOND) as u32);
         let previous_now_before = rtc.previous_now;
         rtc.write(RTCLR, &data);

--- a/src/dumbo/src/tcp/mod.rs
+++ b/src/dumbo/src/tcp/mod.rs
@@ -94,8 +94,8 @@ mod tests {
     use super::*;
     use micro_http::{Request, Response, StatusCode, Version};
 
-    /// In tcp tests, some of the functions require a callback parameter. Since we do not care,
-    /// for the purpose of those tests, what that callback does, we need to provide a dummy one.
+    // In tcp tests, some of the functions require a callback parameter. Since we do not care,
+    // for the purpose of those tests, what that callback does, we need to provide a dummy one.
     pub fn mock_callback(_request: Request) -> Response {
         Response::new(Version::Http11, StatusCode::OK)
     }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -342,8 +342,8 @@ fn main() {
 
     Env::new(
         arg_parser.arguments(),
-        utils::time::get_time(utils::time::ClockType::Monotonic) / 1000,
-        utils::time::get_time(utils::time::ClockType::ProcessCpu) / 1000,
+        utils::time::get_time_us(utils::time::ClockType::Monotonic),
+        utils::time::get_time_us(utils::time::ClockType::ProcessCpu),
     )
     .and_then(|env| {
         fs::create_dir_all(env.chroot_dir())

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -20,7 +20,7 @@ mod metrics;
 pub use log::Level::*;
 pub use log::*;
 pub use logger::{LoggerError, LOGGER};
-pub use metrics::{Metric, MetricsError, METRICS};
+pub use metrics::{Metric, MetricsError, SharedMetric, METRICS};
 
 use std::sync::LockResult;
 
@@ -31,4 +31,10 @@ fn extract_guard<G>(lock_result: LockResult<G>) -> G {
         // (we might get an incomplete log line or something like that).
         Err(poisoned) => poisoned.into_inner(),
     }
+}
+
+pub fn update_metric_with_elapsed_time(metric: &SharedMetric, start_time_us: u64) -> u64 {
+    let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time_us;
+    metric.store(delta_us as usize);
+    delta_us
 }

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -479,6 +479,31 @@ pub struct NetDeviceMetrics {
     pub tx_spoofed_mac_count: SharedMetric,
 }
 
+/// Performance metrics related for the moment only to snapshots.
+// These store the duration of creating/loading a snapshot and of
+// pausing/resuming the microVM.
+// If there are more than one `/snapshot/create` request in a minute
+// (until the metrics are flushed), only the duration of the last
+// snapshot creation is stored in the metric. If the user is interested
+// in all the durations, a `FlushMetrics` request should be sent after
+// each `create` request.
+#[derive(Default, Serialize)]
+pub struct PerformanceMetrics {
+    #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot full create time, at the VMM level, in microseconds.
+    pub vmm_full_create_snapshot: SharedMetric,
+    #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot diff create time, at the VMM level, in microseconds.
+    pub vmm_diff_create_snapshot: SharedMetric,
+    #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot load time, at the VMM level, in microseconds.
+    pub vmm_load_snapshot: SharedMetric,
+    /// Measures the microVM pausing duration, at the VMM level, in microseconds.
+    pub vmm_pause_vm: SharedMetric,
+    /// Measures the microVM resuming duration, at the VMM level, in microseconds.
+    pub vmm_resume_vm: SharedMetric,
+}
+
 /// Metrics specific to the i8042 device.
 #[derive(Default, Serialize)]
 pub struct RTCDeviceMetrics {
@@ -514,6 +539,15 @@ pub struct SerialDeviceMetrics {
     pub write_count: SharedMetric,
 }
 
+/// Metrics related to signals.
+#[derive(Default, Serialize)]
+pub struct SignalMetrics {
+    /// Number of times that SIGBUS was handled.
+    pub sigbus: SharedMetric,
+    /// Number of times that SIGSEGV was handled.
+    pub sigsegv: SharedMetric,
+}
+
 /// Metrics specific to VCPUs' mode of functioning.
 #[derive(Default, Serialize)]
 pub struct VcpuMetrics {
@@ -538,15 +572,6 @@ pub struct VmmMetrics {
     pub device_events: SharedMetric,
     /// Metric for signaling a panic has occurred.
     pub panic_count: SharedMetric,
-}
-
-/// Metrics related to signals.
-#[derive(Default, Serialize)]
-pub struct SignalMetrics {
-    /// Number of times that SIGBUS was handled.
-    pub sigbus: SharedMetric,
-    /// Number of times that SIGSEGV was handled.
-    pub sigsegv: SharedMetric,
 }
 
 /// Vsock-related metrics.
@@ -618,6 +643,8 @@ pub struct FirecrackerMetrics {
     pub get_api_requests: GetRequestsMetrics,
     /// Metrics related to the i8042 device.
     pub i8042: I8042DeviceMetrics,
+    /// Metrics related to performance measurements.
+    pub latencies_us: PerformanceMetrics,
     /// Logging related metrics.
     pub logger: LoggerSystemMetrics,
     /// Metrics specific to MMDS functionality.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -490,6 +490,19 @@ pub struct NetDeviceMetrics {
 #[derive(Default, Serialize)]
 pub struct PerformanceMetrics {
     #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot full create time, at the API (user) level, in microseconds.
+    pub full_create_snapshot: SharedMetric,
+    #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot diff create time, at the API (user) level, in microseconds.
+    pub diff_create_snapshot: SharedMetric,
+    #[cfg(target_arch = "x86_64")]
+    /// Measures the snapshot load time, at the API (user) level, in microseconds.
+    pub load_snapshot: SharedMetric,
+    /// Measures the microVM pausing duration, at the API (user) level, in microseconds.
+    pub pause_vm: SharedMetric,
+    /// Measures the microVM resuming duration, at the API (user) level, in microseconds.
+    pub resume_vm: SharedMetric,
+    #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot full create time, at the VMM level, in microseconds.
     pub vmm_full_create_snapshot: SharedMetric,
     #[cfg(target_arch = "x86_64")]

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -601,7 +601,7 @@ struct SerializeToUtcTimestampMs;
 impl Serialize for SerializeToUtcTimestampMs {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_i64(
-            utils::time::get_time(utils::time::ClockType::Monotonic) as i64 / 1_000_000,
+            utils::time::get_time_ns(utils::time::ClockType::Monotonic) as i64 / 1_000_000,
         )
     }
 }

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -39,7 +39,7 @@ impl Into<OutputFormat> for MediaType {
     }
 }
 
-/// Builds the `micro_http::Response` with a given HTTP version, status code, and body.
+// Builds the `micro_http::Response` with a given HTTP version, status code, and body.
 fn build_response(http_version: Version, status_code: StatusCode, body: Body) -> Response {
     let mut response = Response::new(http_version, status_code);
     response.set_body(body);

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -160,19 +160,19 @@ impl Display for LoadSnapshotError {
 /// Creates a Microvm snapshot.
 pub fn create_snapshot(
     vmm: &mut Vmm,
-    params: CreateSnapshotParams,
+    params: &CreateSnapshotParams,
     version_map: VersionMap,
 ) -> std::result::Result<(), CreateSnapshotError> {
     let microvm_state = vmm
         .save_state()
         .map_err(CreateSnapshotError::MicrovmState)?;
 
-    snapshot_memory_to_file(vmm, &params.mem_file_path, params.snapshot_type)?;
+    snapshot_memory_to_file(vmm, &params.mem_file_path, &params.snapshot_type)?;
 
     snapshot_state_to_file(
         &microvm_state,
         &params.snapshot_path,
-        params.version,
+        &params.version,
         version_map,
     )?;
 
@@ -182,7 +182,7 @@ pub fn create_snapshot(
 fn snapshot_state_to_file(
     microvm_state: &MicrovmState,
     snapshot_path: &PathBuf,
-    version: Option<String>,
+    version: &Option<String>,
     version_map: VersionMap,
 ) -> std::result::Result<(), CreateSnapshotError> {
     use self::CreateSnapshotError::*;
@@ -194,7 +194,7 @@ fn snapshot_state_to_file(
 
     // Translate the microVM version to its corresponding snapshot data format.
     let snapshot_data_version = match version {
-        Some(version) => match FC_VERSION_TO_SNAP_VERSION.get(&version) {
+        Some(version) => match FC_VERSION_TO_SNAP_VERSION.get(version) {
             Some(data_version) => Ok(*data_version),
             _ => Err(InvalidVersion),
         },
@@ -212,7 +212,7 @@ fn snapshot_state_to_file(
 fn snapshot_memory_to_file(
     vmm: &Vmm,
     mem_file_path: &PathBuf,
-    snapshot_type: SnapshotType,
+    snapshot_type: &SnapshotType,
 ) -> std::result::Result<(), CreateSnapshotError> {
     use self::CreateSnapshotError::*;
     let mut file = OpenOptions::new()
@@ -246,7 +246,7 @@ pub(crate) fn mem_size_mib(guest_memory: &GuestMemoryMmap) -> u64 {
 pub fn load_snapshot(
     event_manager: &mut EventManager,
     seccomp_filter: BpfProgramRef,
-    params: LoadSnapshotParams,
+    params: &LoadSnapshotParams,
     version_map: VersionMap,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, LoadSnapshotError> {
     use self::LoadSnapshotError::*;

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -282,7 +282,7 @@ impl<'a> PrebootApiController<'a> {
             LoadSnapshot(snapshot_load_cfg) => persist::load_snapshot(
                 &mut self.event_manager,
                 &self.seccomp_filter,
-                snapshot_load_cfg,
+                &snapshot_load_cfg,
                 VERSION_MAP.clone(),
             )
             .map(|vmm| {
@@ -347,7 +347,7 @@ impl RuntimeApiController {
             // Supported operations allowed post-boot.
             #[cfg(target_arch = "x86_64")]
             CreateSnapshot(snapshot_create_cfg) => self
-                .create_snapshot(snapshot_create_cfg)
+                .create_snapshot(&snapshot_create_cfg)
                 .map(|_| VmmData::Empty),
             FlushMetrics => self.flush_metrics().map(|_| VmmData::Empty),
             GetVmConfiguration => Ok(VmmData::MachineConfiguration(self.vm_config.clone())),
@@ -427,7 +427,7 @@ impl RuntimeApiController {
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn create_snapshot(&mut self, params: CreateSnapshotParams) -> ActionResult {
+    fn create_snapshot(&mut self, params: &CreateSnapshotParams) -> ActionResult {
         let mut locked_vmm = self.vmm.lock().unwrap();
         persist::create_snapshot(&mut locked_vmm, params, VERSION_MAP.clone())
             .map_err(VmmActionError::CreateSnapshot)

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -309,7 +309,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
 
             {
                 let mut locked_vmm = vmm.lock().unwrap();
-                persist::create_snapshot(&mut locked_vmm, snapshot_params, VERSION_MAP.clone())
+                persist::create_snapshot(&mut locked_vmm, &snapshot_params, VERSION_MAP.clone())
                     .unwrap();
             }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.44, "AMD": 84.45}
+COVERAGE_DICT = {"Intel": 84.30, "AMD": 84.25}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -33,6 +33,7 @@ def test_flush_metrics(test_microvm_with_api):
         'block',
         'get_api_requests',
         'i8042',
+        'latencies_us',
         'logger',
         'mmds',
         'net',


### PR DESCRIPTION
## Reason for This PR

#1848

## Description of Changes

Added metrics that measure the duration of creating a full or diff snapshot and of loading from a snapshot.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
