### PR TITLE
snapshot memory dump: make sure to write all bytes

### DIFF
--- a/src/vmm/src/memory_snapshot.rs
+++ b/src/vmm/src/memory_snapshot.rs
@@ -103,9 +103,7 @@ impl SnapshotMemory for GuestMemoryMmap {
     /// Dumps all contents of GuestMemoryMmap to a writer.
     fn dump<T: std::io::Write>(&self, writer: &mut T) -> std::result::Result<(), Error> {
         self.with_regions_mut(|_, region| {
-            region
-                .write_to(MemoryRegionAddress(0), writer, region.len() as usize)
-                .map(|_| ())
+            region.write_all_to(MemoryRegionAddress(0), writer, region.len() as usize)
         })
         .map_err(Error::WriteMemory)
     }
@@ -140,18 +138,18 @@ impl SnapshotMemory for GuestMemoryMmap {
                         write_size += page_size;
                     } else if write_size > 0 {
                         // We are at the end of a batch of dirty pages.
-                        region
-                            .write_to(MemoryRegionAddress(dirty_batch_start), writer, write_size)
-                            .map(|_| ())?;
+                        region.write_all_to(
+                            MemoryRegionAddress(dirty_batch_start),
+                            writer,
+                            write_size,
+                        )?;
                         write_size = 0;
                     }
                 }
             }
 
             if write_size > 0 {
-                region
-                    .write_to(MemoryRegionAddress(dirty_batch_start), writer, write_size)
-                    .map(|_| ())?;
+                region.write_all_to(MemoryRegionAddress(dirty_batch_start), writer, write_size)?;
             }
 
             writer_offset += region.len();


### PR DESCRIPTION

Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Replace the call to the `write_to` method from `vm_memory` with `write_all_to`. This one will use the [`Write::write_all`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all) method that makes sure to keep writing in a loop until done.

This fix ensures we are writing all the guest memory to file.


## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
