### PR TITLE
api_server: escape JSON meta characters

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -16,6 +16,7 @@ extern crate vmm;
 mod parsed_request;
 mod request;
 
+use serde_json::json;
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Mutex, RwLock};
 use std::{fmt, io};
@@ -251,17 +252,8 @@ impl ApiServer {
         response
     }
 
-    // Builds a string that looks like (where $ stands for substitution):
-    //  {
-    //    "$k": "$v"
-    //  }
-    // Mainly used for building fault message response json bodies.
-    fn basic_json_body<K: AsRef<str>, V: AsRef<str>>(k: K, v: V) -> String {
-        format!("{{\n  \"{}\": \"{}\"\n}}", k.as_ref(), v.as_ref())
-    }
-
-    fn json_fault_message<T: AsRef<str>>(msg: T) -> String {
-        ApiServer::basic_json_body("fault_message", msg)
+    fn json_fault_message<T: AsRef<str> + serde::Serialize>(msg: T) -> String {
+        json!({ "fault_message": msg }).to_string()
     }
 }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.43, "AMD": 84.32}
+COVERAGE_DICT = {"Intel": 84.37, "AMD": 84.32}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

devices::virtio::net::Error::TapOpen contains '"' in the string representation, which results an invalid JSON like below.

```
{
  "fault_message": "Could not create Network Device: TapOpen(CreateTap(Os { code
: 1, kind: PermissionDenied, message: "Operation not permitted" }))"
}
```

It is safer to use serde_json rather than format!().

## Description of Changes

- Use serde_json instead of using format!() to create a JSON object.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented: N/A No unsafe
- [x] Any API changes are reflected in `firecracker/swagger.yaml`: N/A No API changes
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`: N/A No user-facing changes
