### PR TITLE
Remove CPUID caching.

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -615,7 +615,6 @@ fn create_vcpus(
         let vcpu = Vcpu::new_x86_64(
             cpu_idx,
             vm.fd(),
-            vm.supported_cpuid().clone(),
             vm.supported_msrs().clone(),
             exit_evt,
             request_ts.clone(),
@@ -645,9 +644,14 @@ pub fn configure_system_for_boot(
     #[cfg(target_arch = "x86_64")]
     {
         for vcpu in vcpus.iter_mut() {
-            vcpu.configure_x86_64_for_boot(vmm.guest_memory(), entry_addr, &vcpu_config)
-                .map_err(Error::Vcpu)
-                .map_err(Internal)?;
+            vcpu.configure_x86_64_for_boot(
+                vmm.guest_memory(),
+                entry_addr,
+                &vcpu_config,
+                vmm.vm.supported_cpuid().clone(),
+            )
+            .map_err(Error::Vcpu)
+            .map_err(Internal)?;
         }
 
         // Write the kernel command line to guest memory. This is x86_64 specific, since on


### PR DESCRIPTION
## Reason for This PR

Fixes #1942

## Description of Changes

Use KVM_GET_CPUID2 in Vcpu::save_state().
    
Currently the CPUID is cached only at microvm boot time. The restore path
fails to cache the CPUID from the snapshot and will save a bogus value when
a new snapshot is created from the current state. When such a snapshot is loaded
it will cause the in-kernel KVM LAPIC emulation to setup incorrectly and
other undefined behaviour.

This commit removes CPUID caching from Vcpu and calls KVM_GET_CPUID2 on
the Vcpu::save_state() path.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
