### PR TITLE
Fix boot time for AMD guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
   requests originating from guest.
 - Fixed folder permissions in the jail (#1802).
+- Boot time on AMD achieves the desired performance (i.e under 150ms).
 
 ### Changed
 - Updated CVE-2019-3016 mitigation information in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added metrics for the vsock device.
 
 ### Fixed
+
 - Added `--version` flag to both Firecracker and Jailer.
 - Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
   requests originating from guest.
@@ -34,6 +35,7 @@
 - Boot time on AMD achieves the desired performance (i.e under 150ms).
 
 ### Changed
+
 - Updated CVE-2019-3016 mitigation information in
   [Production Host Setup](docs/prod-host-setup.md)
 - In case of using an invalid JSON as a 'config-file' for Firecracker,
@@ -52,7 +54,7 @@
 - Allowed the MMDS data store to be initialized with all supported JSON types.
   Retrieval of these values within the guest, besides String, Array, and
   Dictionary, is only possible in JSON mode.
-- `PATCH` request on `/mmds` before the data store is initialized returns 
+- `PATCH` request on `/mmds` before the data store is initialized returns
   `403 BadRequest`.
 - Segregated MMDS documentation in MMDS design documentation and MMDS user
   guide documentation.
@@ -70,7 +72,7 @@
 - Fixed #1469 - Broken GitHub location for Firecracker release binary.
 - The jailer allows changing the default api socket path by using the extra
   arguments passed to firecracker.
-- Fixed #1456 - Occasional KVM_EXIT_SHUTDOWN and bad syscall (14) during 
+- Fixed #1456 - Occasional KVM_EXIT_SHUTDOWN and bad syscall (14) during
   VM shutdown.
 - Updated the production host setup guide with steps for addressing
   CVE-2019-18960.
@@ -79,7 +81,7 @@
   un-swapped.
 
 ### Changed
-  
+
 - Removed redundant `--seccomp-level` jailer parameter since it can be
   simply forwarded to the Firecracker executable using "end of command
   options" convention.
@@ -101,19 +103,19 @@
 
 ### Fixed
 
-- Fixed CVE-2019-18960 - Fixed a logical error in bounds checking performed 
+- Fixed CVE-2019-18960 - Fixed a logical error in bounds checking performed
   on vsock virtio descriptors.
 - Fixed #1283 - Can't start a VM in AARCH64 with vcpus number more than 16.
-- Fixed #1088 - The backtrace are printed on `panic`, no longer causing a 
+- Fixed #1088 - The backtrace are printed on `panic`, no longer causing a
   seccomp fault.
-- Fixed #1375 - Change logger options type from Value to Vec<LogOption> to
+- Fixed #1375 - Change logger options type from `Value` to `Vec<LogOption>` to
   prevent potential unwrap on None panics.
 - Fixed #1436 - Raise interrupt for TX queue used descriptors
-- Fixed #1439 - Prevent achieving 100% cpu load when the net device rx is 
+- Fixed #1439 - Prevent achieving 100% cpu load when the net device rx is
   throttled by the ratelimiter
-- Fixed #1437 - Invalid fields in rate limiter related API requests are 
+- Fixed #1437 - Invalid fields in rate limiter related API requests are
   now failing with a proper error message.
-- Fixed #1316 - correctly determine the size of a virtio device backed 
+- Fixed #1316 - correctly determine the size of a virtio device backed
   by a block device.
 - Fixed #1383 - Log failed api requests.
 

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -36,7 +36,10 @@ pub fn update_feature_info_entry(
     let max_cpus_per_package = u32::from(common::get_max_cpus_per_package(vm_spec.cpu_count)?);
 
     // X86 hypervisor feature
-    entry.ecx.write_bit(ecx::HYPERVISOR_BITINDEX, true);
+    entry
+        .ecx
+        .write_bit(ecx::TSC_DEADLINE_TIMER_BITINDEX, true)
+        .write_bit(ecx::HYPERVISOR_BITINDEX, true);
 
     entry
         .ebx
@@ -165,7 +168,8 @@ mod tests {
 
         assert!(update_feature_info_entry(&mut entry, &vm_spec).is_ok());
 
-        assert!(entry.edx.read_bit(edx::HTT_BITINDEX) == expected_htt)
+        assert_eq!(entry.edx.read_bit(edx::HTT_BITINDEX), expected_htt);
+        assert_eq!(entry.ecx.read_bit(ecx::TSC_DEADLINE_TIMER_BITINDEX), true);
     }
 
     fn check_update_cache_parameters_entry(


### PR DESCRIPTION
## Reason for This PR

Fixes #1017 

## Description of Changes

Newer processors (like the one we run the CI on, AMD EPYC)
have adopted the TSC_DEADLINE_TIMER cpu flag which used to be Intel
specific.

** Please review by commits. Thanks!

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
