### PR TITLE
Fix spelling error in SPECIFICATION.md

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -46,7 +46,7 @@ enough RAM, etc.), customers can rely on the following:
      of the host CPU core for emulation. _`[integration test pending]`_
    - the guest achieves up to `25 Gbps` network throughput by using `100%`
      of the host CPU core for emulation. _`[integration test pending]`_
-   - the virtualization layer adds on averadge `0.06ms` of latency.
+   - the virtualization layer adds on average `0.06ms` of latency.
      _`[integration test pending]`_
      [See further details on network performance](docs/network-performance.md)
    - the guest achieves up to `1 GiB/s` storage throughput by using `<= 70%`


### PR DESCRIPTION
Minor spelling fix

## Reason for This PR

The word `average` was misspelled in the specification document.

## Description of Changes

I changed the spelling of the word `averadge` to `average`.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
