### PR TITLE
Permission: Run tests as root with all cap. on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added user confirmation before running test container as root with all
+  capabilities.
 - Added a new API call, `PUT /metrics`, for configuring the metrics system.
 - Added `app_name` field in InstanceInfo struct for storing the application
   name.

--- a/tools/devtool
+++ b/tools/devtool
@@ -287,6 +287,30 @@ get_user_confirmation() {
     return 1
 }
 
+# Notify the user of what is about to happen: 
+# 1. Granting a container that is not theirs root access with all capabilities.
+# 2. Prompt the user for confirmation before proceeding.
+# 3. Log what they have agreed to - in case of inadvertent use of:
+#  
+#     ```bash
+#     yes | ./tools/devtool test
+#     ```
+#
+get_root_capall_permission() {
+  local questionanswer
+  echo 'Container docker.io/fcuvm/dev requires root with all root capabilities.'
+  read -p "Do you want to continue? (yes/no): " questionanswer
+  if [[ ${questionanswer} != [Yy] && ${questionanswer} != [Yy][Ee][Ss] ]]; then
+      die "Aborting because of input '${questionanswer}'."
+  fi
+  # Incase someone is inadvertently running $(yes | ./tools/devtool test):
+  echo '************************************************************************'
+  echo 'YOU AGREED TO RUN docker.io/fcuvm/dev AS ROOT WITH ALL CAPABILITIES.'
+  echo 'CTRL+C IF THIS IS NOT WHAT YOU INTENDED.'
+  echo '************************************************************************'
+  return 0
+}
+
 # Validate the user supplied version number.
 # It must be composed of 3 groups of integers separated by dot.
 #
@@ -593,6 +617,8 @@ cmd_test() {
     ensure_devctr
     ensure_build_dir
 
+    # Get user permission to run as root with all capabilities.
+    get_root_capall_permission
 
     # If we got to here, we've got all we need to continue.
     say "$(date -u +'%F %H:%M:%S %Z')"


### PR DESCRIPTION
## Reason for This PR

Closes issue #1980.

## Description of Changes

While Docker is often used with root access to all capabilities,
this can be a surprise to users coming from podman.

We don't immediately know the minimal set of capabilities the
root user needs to run the Firecracker test suite.

Until then the best we can do is:
1. Tell the user what is about to happen.
2. Get user agreement.
3. Log what they have agreed to.

The logging is generally useful. However it is primarily intended
to inform users who may have inadvertently done something like:

   $(yes | ./tools/devtool test)

This is a workaround until a we identify the minimal set of root
capabilities needed to run the Firecracker test suite.

Signed-off-by: Begley Brothers Inc <begleybrothers@gmail.com>

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- ~~[ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
