### PR TITLE
micro-http: Add more flexibility when parsing the headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Added metrics for the vsock device.
 - Added devtool strip command which removes debug symbols from the release
   binaries.
+- Any number of whitespace characters are accepted after ":" when parsing HTTP
+  headers.
 
 ### Fixed
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.37, "AMD": 84.32}
+COVERAGE_DICT = {"Intel": 84.37, "AMD": 84.38}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Partially addresses #1975 and #1976 

## Description of Changes

Any number of whitespace characters are accepted after ":" when parsing HTTP headers.

- [ ] This functionality can be added in [`micro-http`](https://github.com/firecracker-microvm/firecracker/tree/master/src/micro_http).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
