### PR TITLE
micro-http: unsigned Content-Length + several checked arithmetic operations

### DIFF
--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -316,6 +316,16 @@ fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) ->
     match request {
         Ok(request) => callback(request),
         Err(e) => match e {
+            RequestError::BodyWithoutPendingRequest => build_response(
+                Version::default(),
+                StatusCode::BadRequest,
+                Body::new(e.to_string()),
+            ),
+            RequestError::HeadersWithoutPendingRequest => build_response(
+                Version::default(),
+                StatusCode::BadRequest,
+                Body::new(e.to_string()),
+            ),
             RequestError::InvalidHttpVersion(err_msg) => build_response(
                 Version::default(),
                 StatusCode::NotImplemented,

--- a/src/micro_http/src/common/headers.rs
+++ b/src/micro_http/src/common/headers.rs
@@ -74,7 +74,7 @@ impl Header {
 pub struct Headers {
     /// The `Content-Length` header field tells us how many bytes we need to receive
     /// from the source after the headers.
-    content_length: i32,
+    content_length: u32,
     /// The `Expect` header field is set when the headers contain the entry "Expect: 100-continue".
     /// This means that, per HTTP/1.1 specifications, we must send a response with the status code
     /// 100 after we have received the headers in order to receive the body of the request. This
@@ -134,7 +134,7 @@ impl Headers {
                 }
                 if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
                     match head {
-                        Header::ContentLength => match entry[1].trim().parse::<i32>() {
+                        Header::ContentLength => match entry[1].trim().parse::<u32>() {
                             Ok(content_length) => {
                                 self.content_length = content_length;
                                 Ok(())
@@ -180,7 +180,7 @@ impl Headers {
     }
 
     /// Returns the content length of the body.
-    pub fn content_length(&self) -> i32 {
+    pub fn content_length(&self) -> u32 {
         self.content_length
     }
 
@@ -318,7 +318,7 @@ mod tests {
     use super::*;
 
     impl Headers {
-        pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
+        pub fn new(content_length: u32, expect: bool, chunked: bool) -> Self {
             Self {
                 content_length,
                 expect,
@@ -471,6 +471,12 @@ mod tests {
         assert!(header
             .parse_header_line(b"Accept: application/json-patch")
             .is_err());
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: -1"),
+            Err(RequestError::InvalidHeader)
+        );
     }
 
     #[test]

--- a/src/micro_http/src/common/mod.rs
+++ b/src/micro_http/src/common/mod.rs
@@ -16,6 +16,10 @@ pub mod ascii {
 /// Errors associated with parsing the HTTP Request from a u8 slice.
 #[derive(Debug, PartialEq)]
 pub enum RequestError {
+    /// No request was pending while the request body was being parsed.
+    BodyWithoutPendingRequest,
+    /// No request was pending while the request headers were being parsed.
+    HeadersWithoutPendingRequest,
     /// The HTTP Method is not supported or it is invalid.
     InvalidHttpMethod(&'static str),
     /// Request URI is invalid.
@@ -37,6 +41,14 @@ pub enum RequestError {
 impl Display for RequestError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
+            Self::BodyWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request body was being parsed."
+            ),
+            Self::HeadersWithoutPendingRequest => write!(
+                f,
+                "No request was pending while the request headers were being parsed."
+            ),
             Self::InvalidHttpMethod(inner) => write!(f, "Invalid HTTP Method: {}", inner),
             Self::InvalidUri(inner) => write!(f, "Invalid URI: {}", inner),
             Self::InvalidHttpVersion(inner) => write!(f, "Invalid HTTP Version: {}", inner),
@@ -298,6 +310,14 @@ mod tests {
 
     #[test]
     fn test_display_request_error() {
+        assert_eq!(
+            format!("{}", RequestError::BodyWithoutPendingRequest),
+            "No request was pending while the request body was being parsed."
+        );
+        assert_eq!(
+            format!("{}", RequestError::HeadersWithoutPendingRequest),
+            "No request was pending while the request headers were being parsed."
+        );
         assert_eq!(
             format!("{}", RequestError::InvalidHeader),
             "Invalid header."


### PR DESCRIPTION
## Reason for This PR

Fixes #1977

## Description of Changes

* Changed `Content-Length` from `i32` to `u32`.
* Added a bunch of fixes for unchecked unsigned arithmetic in `connection.rs`. 
* Added more unit tests too that exercise failure cases for over/underflows in math operations.
* Replaced some `unwrap`s with error propagation, introducing new error variants.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
