### PR TITLE
net: add metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   when a TX frame missing the VNET header is encountered.
 - Added metrics for counting rate limiter throttling events.
 - Added metric for counting MAC address updates.
+- Added metrics for counting TAP read and write errors.
+- Added metrics for counting RX and TX partial writes.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   binaries.
 - Added the `tx_malformed_frames` metric for the virtio net device, emitted
   when a TX frame missing the VNET header is encountered.
+- Added metrics for counting rate limiter throttling events.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added the `tx_malformed_frames` metric for the virtio net device, emitted
   when a TX frame missing the VNET header is encountered.
 - Added metrics for counting rate limiter throttling events.
+- Added metric for counting MAC address updates.
 
 ### Fixed
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -760,6 +760,7 @@ impl VirtioDevice for Net {
         self.guest_mac = Some(MacAddr::from_bytes_unchecked(
             &self.config_space.guest_mac[..MAC_ADDR_LEN],
         ));
+        METRICS.net.mac_address_updates.inc();
     }
 
     fn is_activated(&self) -> bool {
@@ -1015,6 +1016,7 @@ pub(crate) mod tests {
         // Check that the guest MAC was updated.
         let expected_guest_mac = MacAddr::from_bytes_unchecked(&new_config);
         assert_eq!(expected_guest_mac, net.guest_mac.unwrap());
+        assert_eq!(METRICS.net.mac_address_updates.count(), 1);
 
         // Partial write (this is how the kernel sets a new mac address) - byte by byte.
         let new_config = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -383,7 +383,7 @@ impl Net {
             }
             Err(e) => {
                 error!("Failed to write to tap: {:?}", e);
-                METRICS.net.tx_fails.inc();
+                METRICS.net.tap_write_fails.inc();
             }
         };
         Ok(false)
@@ -541,9 +541,11 @@ impl Net {
                     }
                     Err(e) => {
                         error!("Failed to read slice: {:?}", e);
-                        METRICS.net.tx_fails.inc();
                         if let GuestMemoryError::PartialBuffer { completed, .. } = e {
                             read_count += completed;
+                            METRICS.net.tx_partial_reads.inc();
+                        } else {
+                            METRICS.net.tx_fails.inc();
                         }
                         break;
                     }

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -430,6 +430,8 @@ pub struct NetDeviceMetrics {
     pub rx_queue_event_count: SharedMetric,
     /// Number of events associated with the rate limiter installed on the receiving path.
     pub rx_event_rate_limiter_count: SharedMetric,
+    /// Number of RX partial writes to guest.
+    pub rx_partial_writes: SharedMetric,
     /// Number of RX rate limiter throttling events.
     pub rx_rate_limiter_throttled: SharedMetric,
     /// Number of events received on the associated tap.
@@ -442,6 +444,8 @@ pub struct NetDeviceMetrics {
     pub rx_fails: SharedMetric,
     /// Number of successful read operations while receiving data.
     pub rx_count: SharedMetric,
+    /// Number of times reading from TAP failed.
+    pub tap_read_fails: SharedMetric,
     /// Number of times writing to TAP failed.
     pub tap_write_fails: SharedMetric,
     /// Number of transmitted bytes.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -428,6 +428,8 @@ pub struct NetDeviceMetrics {
     pub rx_queue_event_count: SharedMetric,
     /// Number of events associated with the rate limiter installed on the receiving path.
     pub rx_event_rate_limiter_count: SharedMetric,
+    /// Number of RX rate limiter throttling events.
+    pub rx_rate_limiter_throttled: SharedMetric,
     /// Number of events received on the associated tap.
     pub rx_tap_event_count: SharedMetric,
     /// Number of bytes received.
@@ -452,6 +454,8 @@ pub struct NetDeviceMetrics {
     pub tx_queue_event_count: SharedMetric,
     /// Number of events associated with the rate limiter installed on the transmitting path.
     pub tx_rate_limiter_event_count: SharedMetric,
+    /// Number of RX rate limiter throttling events.
+    pub tx_rate_limiter_throttled: SharedMetric,
     /// Number of packets with a spoofed mac, sent by the guest.
     pub tx_spoofed_mac_count: SharedMetric,
 }

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -442,6 +442,8 @@ pub struct NetDeviceMetrics {
     pub rx_fails: SharedMetric,
     /// Number of successful read operations while receiving data.
     pub rx_count: SharedMetric,
+    /// Number of times writing to TAP failed.
+    pub tap_write_fails: SharedMetric,
     /// Number of transmitted bytes.
     pub tx_bytes_count: SharedMetric,
     /// Number of malformed TX frames.
@@ -452,6 +454,8 @@ pub struct NetDeviceMetrics {
     pub tx_count: SharedMetric,
     /// Number of transmitted packets.
     pub tx_packets_count: SharedMetric,
+    /// Number of TX partial reads from guest.
+    pub tx_partial_reads: SharedMetric,
     /// Number of events associated with the transmitting queue.
     pub tx_queue_event_count: SharedMetric,
     /// Number of events associated with the rate limiter installed on the transmitting path.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -418,6 +418,8 @@ pub struct NetDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of times when interacting with the space config of a network device failed.
     pub cfg_fails: SharedMetric,
+    //// Number of times the mac address was updated through the config space.
+    pub mac_address_updates: SharedMetric,
     /// No available buffer for the net device rx queue.
     pub no_rx_avail_buffer: SharedMetric,
     /// No available buffer for the net device tx queue.


### PR DESCRIPTION
## Reason for This PR

This PR aims to improve the virtio-net metrics by covering some missing cases:
- throttled events (fixes #1986)
- mac address updates (fixes #1867)
- 2 new cases are separated from **rx_fails**: tap_read_fails and rx_partial_write
- 2 new cases are separated from **tx_fails**: tap_write_fails and tx_partial_reads

## Description of Changes

See above.
- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
