### PR TITLE
Create event loop when one does not exist

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -148,7 +148,13 @@ def run_cmd_list_async(cmd_list):
     :param cmd_list: list of commands to execute
     :return: None
     """
-    loop = asyncio.get_event_loop()
+    loop = None
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # Create event loop when one is not available
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     cmds = []
     # Create a list of partial functions to run
@@ -172,7 +178,13 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
     :param noshell: don't run the command in a sub-shell
     :returns: tuple of (return code, stdout, stderr)
     """
-    loop = asyncio.get_event_loop()
+    loop = None
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # Create event loop when one is not available
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     return loop.run_until_complete(
         run_cmd_async(cmd=cmd,


### PR DESCRIPTION
## Reason for This PR

When executing a shell command from a thread, the event loop in the
thread may be missing, so we should create one when that happens.

## Description of Changes

When no event loop exists, we create one and set it.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
