### PR TITLE
Add --cgroups parameter to jailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   from the API (user) perspective.
 - Added metric for measuring the duration of loading a snapshot, from the API
   (user) perspective.
+- Added new jailer command line argument `--cgroup` which allow the user to
+  specify the cgroups that are going to be set by the Jailer.
 
 ### Fixed
 
@@ -86,7 +88,8 @@
   `--boot-timer` dedicated cmdline parameter.
 - `firecracker/jailer --version` now gets updated on each devtool
   build to the output of `git describe --dirty`, if the git repo is available.
-
+- MicroVM process is only attached to the cgroups defined by using `--cgroups`
+  or the ones defined indirectly by using `--node`.
 
 ## [0.21.0]
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -162,7 +162,7 @@ process, immediately before the execution of the untrusted guest code starts.
 
 #### Cgroups and Quotas
 
-Each Firecracker microVM is further encapsulated into a cgroup. By setting the
+Each Firecracker microVM can be further encapsulated into a cgroup. By setting the
 affinity of the Firecracker microVM to a node via the cpuset subsystem, one
 can prevent the migration of said microVM from one node to another, something
 that would impair performance and cause unnecessary contention on shared

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -34,6 +34,7 @@ class JailerContext:
     daemonize = None
     extra_args = None
     api_socket_name = None
+    cgroups = None
 
     def __init__(
             self,
@@ -45,6 +46,7 @@ class JailerContext:
             chroot_base=DEFAULT_CHROOT_PATH,
             netns=None,
             daemonize=True,
+            cgroups=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -63,11 +65,16 @@ class JailerContext:
         self.daemonize = daemonize
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
+        self.cgroups = cgroups
 
     def __del__(self):
         """Cleanup this jailer context."""
         self.cleanup()
 
+    # Disabling 'too-many-branches' warning for this function as it needs to
+    # check every argument, so the number of branches will increase
+    # with every new argument.
+    # pylint: disable=too-many-branches
     def construct_param_list(self):
         """Create the list of parameters we want the jailer to start with.
 
@@ -96,6 +103,9 @@ class JailerContext:
             jailer_param_list.extend(['--netns', str(self.netns_file_path())])
         if self.daemonize:
             jailer_param_list.append('--daemonize')
+        if self.cgroups is not None:
+            for cgroup in self.cgroups:
+                jailer_param_list.extend(['--cgroup', str(cgroup)])
         # applying neccessory extra args if needed
         if len(self.extra_args) > 0:
             jailer_param_list.append('--')
@@ -106,6 +116,7 @@ class JailerContext:
                     if key == "api-sock":
                         self.api_socket_name = value
         return jailer_param_list
+    # pylint: enable=too-many-branches
 
     def chroot_base_with_id(self):
         """Return the MicroVM chroot base + MicroVM ID."""
@@ -193,39 +204,40 @@ class JailerContext:
         # because we can't remove it unless we're sure there's no other running
         # microVM.
 
-        # Firecracker is interested in these 3 cgroups for the moment.
-        controllers = ('cpu', 'cpuset', 'pids')
-        for controller in controllers:
-            # Obtain the tasks from each cgroup and wait on them before
-            # removing the microvm's associated cgroup folder.
-            try:
-                retry_call(
-                    f=self._kill_crgoup_tasks,
-                    fargs=[controller],
-                    exceptions=TimeoutError,
-                    max_delay=5
+        if self.cgroups:
+            controllers = set()
+
+            # Extract the controller for every cgroup that needs to be set.
+            for cgroup in self.cgroups:
+                controllers.add(cgroup.split('.')[0])
+
+            for controller in controllers:
+                # Obtain the tasks from each cgroup and wait on them before
+                # removing the microvm's associated cgroup folder.
+                try:
+                    retry_call(
+                        f=self._kill_cgroup_tasks,
+                        fargs=[controller],
+                        exceptions=TimeoutError,
+                        max_delay=5
+                    )
+                except TimeoutError:
+                    pass
+
+                # Remove cgroups and sub cgroups.
+                back_cmd = r'-depth -type d -exec rmdir {} \;'
+                cmd = 'find /sys/fs/cgroup/{}/{}/{} {}'.format(
+                    controller,
+                    FC_BINARY_NAME,
+                    self.jailer_id,
+                    back_cmd
                 )
-            except TimeoutError:
-                pass
+                # We do not need to know if it succeeded or not; afterall,
+                # we are trying to clean up resources created by the jailer
+                # itself not the testing system.
+                utils.run_cmd(cmd, ignore_return_code=True)
 
-            # As the files inside a cgroup aren't real, they can't need
-            # to be removed, that is why 'rm -rf' and 'rmdir' fail.
-            # We only need to remove the cgroup directories. The "-depth"
-            # argument tells find to do a depth first recursion, so that
-            # we remove any sub cgroups first if they are there.
-            back_cmd = r'-depth -type d -exec rmdir {} \;'
-            cmd = 'find /sys/fs/cgroup/{}/{}/{} {}'.format(
-                controller,
-                FC_BINARY_NAME,
-                self.jailer_id,
-                back_cmd
-            )
-            # We do not need to know if it succeeded or not; afterall, we are
-            # trying to clean up resources created by the jailer itself not
-            # the testing system.
-            utils.run_cmd(cmd, ignore_return_code=True)
-
-    def _kill_crgoup_tasks(self, controller):
+    def _kill_cgroup_tasks(self, controller):
         """Simulate wait on pid.
 
         Read the tasks file and stay there until /proc/{pid}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.70, "AMD": 84.68}
+COVERAGE_DICT = {"Intel": 85.08, "AMD": 85.00}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Increase cgroups integration flexibility for the Jailer. 
Fixes #1937
Fixes #1617

## Description of Changes

New `--cgroups` argument have been added to the Jailer. This argument takes care of setting the passed cgroups generically and check that the expected value is correctly written.

The `Cgroup` type have been modified in order to represent each of the cgroups passed by `--cgroups` command line argument.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
