### PR TITLE
Gracefully handle cmd line logger errors

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -191,7 +191,8 @@ fn main() {
         // It's safe to unwrap here because the field's been provided with a default value.
         let level = arguments.value_as_string("level").unwrap();
         let logger_level = LoggerLevel::from_string(level).unwrap_or_else(|err| {
-            panic!("Invalid value for logger level: {}. Possible values: [Error, Warning, Info, Debug]", err);
+            error!("Invalid value for logger level: {}. Possible values: [Error, Warning, Info, Debug]", err);
+            process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
         });
         let show_level = arguments.value_as_bool("show-level").unwrap_or(false);
         let show_log_origin = arguments.value_as_bool("show-log-origin").unwrap_or(false);
@@ -202,7 +203,10 @@ fn main() {
             show_level,
             show_log_origin,
         );
-        init_logger(logger_config, &instance_info).expect("Could not initialize logger.");
+        init_logger(logger_config, &instance_info).unwrap_or_else(|err| {
+            error!("Could not initialize logger: {}", err);
+            process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
+        });
     }
 
     // It's safe to unwrap here because the field's been provided with a default value.


### PR DESCRIPTION
## Reason for This PR

If the logger initialization from command line
arguments failed, the process aborted with a coredump.

## Description of Changes


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
