### PR TITLE
logger: add support for case-insensitive level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
   `403 BadRequest`.
 - Segregated MMDS documentation in MMDS design documentation and MMDS user
   guide documentation.
+- The logger `level` field is now case-insensitive.
 
 ## [0.21.0]
 

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -27,16 +27,34 @@ mod tests {
 
     #[test]
     fn test_parse_put_logger_request() {
-        let body = r#"{
+        let mut body = r#"{
                 "log_path": "log",
                 "level": "Warning",
                 "show_level": false,
                 "show_log_origin": false
               }"#;
 
-        let expected_cfg = LoggerConfig {
+        let mut expected_cfg = LoggerConfig {
             log_path: PathBuf::from("log"),
             level: LoggerLevel::Warning,
+            show_level: false,
+            show_log_origin: false,
+        };
+        match vmm_action_from_request(parse_put_logger(&Body::new(body)).unwrap()) {
+            VmmAction::ConfigureLogger(cfg) => assert_eq!(cfg, expected_cfg),
+            _ => panic!("Test failed."),
+        }
+
+        body = r#"{
+                "log_path": "log",
+                "level": "DEBUG",
+                "show_level": false,
+                "show_log_origin": false
+              }"#;
+
+        expected_cfg = LoggerConfig {
+            log_path: PathBuf::from("log"),
+            level: LoggerLevel::Debug,
             show_level: false,
             show_log_origin: false,
         };

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -617,7 +617,7 @@ definitions:
     properties:
       level:
         type: string
-        description: Set the level.
+        description: Set the level. The possible values are case-insensitive.
         enum: [Error, Warning, Info, Debug]
         default: Warning
       log_path:


### PR DESCRIPTION
## Reason for This PR

For more flexibility, logger level should be case-insensitive.

## Description of Changes

Added support for configuring the logger with a case-insensitive level.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
