### PR TITLE
block: added metrics for throttled events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added metric for throttled block device events.
 - Added a new API call, `PUT /metrics`, for configuring the metrics system.
 - Added `app_name` field in InstanceInfo struct for storing the application
   name.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -361,6 +361,8 @@ pub struct BlockDeviceMetrics {
     pub read_count: SharedMetric,
     /// Number of successful write operations.
     pub write_count: SharedMetric,
+    /// Number of rate limiter throttling events.
+    pub rate_limiter_throttled_events: SharedMetric,
 }
 
 /// Metrics specific to the i8042 device.


### PR DESCRIPTION
There are now two new metrics for throttled events in the block
device: `ops_rate_limiter_throttled` and
`transfer_rate_limiter_throttled`.

Signed-off-by: George Pisaltu <gpl@amazon.com>

## Reason for This PR

#1987 

## Description of Changes

Added `ops_rate_limiter_throttled` and `transfer_rate_limiter_throttled` metrics for a block device.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
