### PR TITLE
Use syscall.rs from vmm_sys_util

### DIFF
--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -8,3 +8,4 @@ libc = ">=0.2.39"
 regex = ">=1.0.0"
 
 utils = { path = "../utils" }
+vmm-sys-util = ">=0.5.1"

--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -9,7 +9,7 @@ use std::ptr::null;
 use libc;
 
 use super::{to_cstring, Error, Result};
-use utils::syscall::SyscallReturnCode;
+use vmm_sys_util::syscall::SyscallReturnCode;
 
 const OLD_ROOT_DIR_NAME_NUL_TERMINATED: &[u8] = b"old_root\0";
 const ROOT_DIR_NUL_TERMINATED: &[u8] = b"/\0";

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate vmm_sys_util;
+
 use std::ffi::{CStr, OsString};
 use std::fs::{self, canonicalize, File, Permissions};
 use std::os::unix::fs::PermissionsExt;
@@ -14,8 +16,8 @@ use libc;
 use cgroup::Cgroup;
 use chroot::chroot;
 use utils::arg_parser::Error::MissingValue;
-use utils::syscall::SyscallReturnCode;
 use utils::{arg_parser, validators};
+use vmm_sys_util::syscall::SyscallReturnCode;
 use {Error, Result};
 
 const STDIN_FILENO: libc::c_int = 0;

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -5,6 +5,7 @@ extern crate libc;
 extern crate regex;
 
 extern crate utils;
+extern crate vmm_sys_util;
 
 mod cgroup;
 mod chroot;


### PR DESCRIPTION
Currently syscall.rs from utils crate is used to use struct
SyscallReturnCode. This struct is now available in vmm_sys_util
and so we need to use that one instead of the one from utils crate.

Signed-off-by: Malhar Vora <mlvora.2010@gmail.com>

## Reason for This PR
It addresses issue #2001


## Description of Changes
In places where SyscallReturnCode is used from utils crate, this commit imports it from vmm_sys_util crate.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist


- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
