### PR TITLE
aarch64: fix confusion in IRQ allocation

### DIFF
--- a/src/arch/src/aarch64/gic.rs
+++ b/src/arch/src/aarch64/gic.rs
@@ -92,10 +92,13 @@ pub trait GICDevice {
     where
         Self: Sized,
     {
-        /* We need to tell the kernel how many irqs to support with this vgic.
-         * See the `layout` module for details.
+        /* On arm there are 3 types of interrupts: SGI (0-15), PPI (16-31), SPI (32-1020).
+         * SPIs are used to signal interrupts from various peripherals accessible across
+         * the whole system so these are the ones that we increment when adding a new virtio device.
+         * KVM_DEV_ARM_VGIC_GRP_NR_IRQS sets the highest SPI number. Consequently, we will have a total
+         * of `super::layout::IRQ_MAX - 32` usable SPIs in our microVM.
          */
-        let nr_irqs: u32 = super::layout::IRQ_MAX - super::layout::IRQ_BASE + 1;
+        let nr_irqs: u32 = super::layout::IRQ_MAX;
         let nr_irqs_ptr = &nr_irqs as *const u32;
         Self::set_device_attribute(
             gic_device.device_fd(),

--- a/src/arch/src/aarch64/layout.rs
+++ b/src/arch/src/aarch64/layout.rs
@@ -66,12 +66,11 @@ pub const FDT_MAX_SIZE: usize = 0x20_0000;
 // * bigger than 32
 // * less than 1023 and
 // * a multiple of 32.
-// We are setting up our interrupt controller to support a maximum of 128 interrupts.
+/// The highest usable SPI on aarch64.
+pub const IRQ_MAX: u32 = 128;
+
 /// First usable interrupt on aarch64.
 pub const IRQ_BASE: u32 = 32;
-
-/// Last usable interrupt on aarch64.
-pub const IRQ_MAX: u32 = 159;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 1 << 30; // 1 GB


### PR DESCRIPTION
We previously stated that we have a total of
128 usable interrupts when in fact we have a total
of 96 (128-32) since KVM_DEV_ARM_VGIC_GRP_NR_IRQS will
set the highest SPI number not the number of
usable SPIs.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
