### PR TITLE
Use BufReader to load snapshots.

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -268,8 +268,9 @@ fn snapshot_state_from_file(
     version_map: VersionMap,
 ) -> std::result::Result<MicrovmState, LoadSnapshotError> {
     use self::LoadSnapshotError::{DeserializeMicrovmState, SnapshotBackingFile};
-    let mut snapshot_file = File::open(snapshot_path).map_err(SnapshotBackingFile)?;
-    Snapshot::load(&mut snapshot_file, version_map).map_err(DeserializeMicrovmState)
+    let mut snapshot_reader =
+        std::io::BufReader::new(File::open(snapshot_path).map_err(SnapshotBackingFile)?);
+    Snapshot::load(&mut snapshot_reader, version_map).map_err(DeserializeMicrovmState)
 }
 
 fn guest_memory_from_file(


### PR DESCRIPTION
## Reason for This PR

Fixes #2027.

## Description of Changes

Currently we directly use a plain [Read](https://doc.rust-lang.org/std/io/trait.Read.html) object to read from the snapshot file which is not efficient. This PR switches to a [BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html) which fits perfectly with how deserialization works.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
