### PR TITLE
whitelist getpid and tgkill syscalls for gnu libc

### DIFF
--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -60,6 +60,8 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     )?],
                 ],
             ),
+            #[cfg(target_env = "gnu")]
+            allow_syscall(libc::SYS_getpid),
             allow_syscall(libc::SYS_getrandom),
             allow_syscall_if(libc::SYS_ioctl, super::create_ioctl_seccomp_rule()?),
             allow_syscall(libc::SYS_lseek),
@@ -105,6 +107,8 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     (sigrtmin() + super::super::vstate::VCPU_RTSIG_OFFSET) as u64
                 )?]],
             ),
+            #[cfg(target_env = "gnu")]
+            allow_syscall(libc::SYS_tgkill),
             allow_syscall(libc::SYS_timerfd_create),
             allow_syscall(libc::SYS_timerfd_settime),
             allow_syscall(libc::SYS_write),


### PR DESCRIPTION
## Reason for This PR

Fix for issue [#1960](https://github.com/firecracker-microvm/firecracker/issues/1960)

## Description of Changes

Whitelisted getpid and tgkill syscalls in seccomp filter for GNU.
Glibc is using these syscalls in the `pthread_kill()` implementation

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
