### PR TITLE
Use vmm_sys_util from utils everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "0.1.0"
 dependencies = [
  "kvm-bindings 0.2.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.2.0-2)",
  "kvm-ioctls 0.5.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.5.0-2)",
- "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utils 0.1.0",
 ]
 
 [[package]]
@@ -804,7 +804,6 @@ dependencies = [
  "versionize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
  "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 [dependencies]
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
-vmm-sys-util = ">=0.2.1"
+utils = { path = "../utils"}

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -12,7 +12,6 @@
 
 extern crate kvm_bindings;
 extern crate kvm_ioctls;
-extern crate vmm_sys_util;
 
 use kvm_bindings::CpuId;
 

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -138,7 +138,6 @@ pub fn use_host_cpuid_function(
 mod tests {
     use super::*;
     use common::tests::get_topoext_fn;
-    use kvm_bindings::kvm_cpuid_entry2;
     use transformer::VmSpec;
 
     #[test]
@@ -300,7 +299,7 @@ mod tests {
         // check that it returns Err when there are too many entriesentry.function == topoext_fn
         let mut cpuid = CpuId::new(kvm_bindings::KVM_MAX_CPUID_ENTRIES);
         match use_host_cpuid_function(&mut cpuid, topoext_fn, true) {
-            Err(Error::FamError(vmm_sys_util::fam::Error::SizeLimitExceeded)) => {}
+            Err(Error::FamError(utils::fam::Error::SizeLimitExceeded)) => {}
             _ => panic!("Wrong behavior"),
         }
     }

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -57,7 +57,7 @@ impl VmSpec {
 #[derive(Debug, Clone)]
 pub enum Error {
     /// A FamStructWrapper operation has failed
-    FamError(vmm_sys_util::fam::Error),
+    FamError(utils::fam::Error),
     /// A call to an internal helper method failed
     InternalError(super::common::Error),
     /// The maximum number of addressable logical CPUs cannot be stored in an `u8`.
@@ -97,7 +97,6 @@ pub trait CpuidTransformer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kvm_bindings::kvm_cpuid_entry2;
 
     #[test]
     fn test_vmspec() {

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -3,7 +3,13 @@
 
 extern crate vmm_sys_util;
 
-pub use vmm_sys_util::{epoll, errno, eventfd, ioctl, rand, syscall, tempdir, tempfile, terminal};
+// We use `utils` as a wrapper over `vmm_sys_util` to control the latter
+// dependency easier (i.e. update only in one place `vmm_sys_util` version).
+// More specifically, we are re-exporting modules from `vmm_sys_util` as part
+// of the `utils` crate.
+pub use vmm_sys_util::{
+    epoll, errno, eventfd, fam, ioctl, rand, syscall, tempdir, tempfile, terminal,
+};
 pub use vmm_sys_util::{ioctl_expr, ioctl_ioc_nr, ioctl_iow_nr};
 
 pub mod arg_parser;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -30,6 +30,3 @@ snapshot = { path = "../snapshot"}
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }
-
-[dev-dependencies]
-vmm-sys-util = ">=0.4.0"

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -9,7 +9,6 @@ extern crate snapshot;
 extern crate utils;
 extern crate vm_memory;
 extern crate vmm;
-extern crate vmm_sys_util;
 
 mod mock_devices;
 mod mock_resources;
@@ -27,6 +26,7 @@ use polly::event_manager::EventManager;
 use seccomp::{BpfProgram, SeccompLevel};
 #[cfg(target_arch = "x86_64")]
 use snapshot::Snapshot;
+use utils::tempfile::TempFile;
 #[cfg(target_arch = "x86_64")]
 use vmm::builder::build_microvm_from_snapshot;
 use vmm::builder::{build_microvm_for_boot, setup_serial_device};
@@ -42,7 +42,6 @@ use vmm::vmm_config::boot_source::BootSourceConfig;
 #[cfg(target_arch = "x86_64")]
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, SnapshotType};
 use vmm::Vmm;
-use vmm_sys_util::tempfile::TempFile;
 
 use mock_devices::MockSerialInput;
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## Reason for This PR

make it easier to update vmm_sys_util version.

## Description of Changes


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
