### PR TITLE
[RFC] tools: add support for environment shielding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
   from the API (user) perspective.
 - Added metric for measuring the duration of loading a snapshot, from the API
   (user) perspective.
+- Added devtool -s|--shield flag.
 
 ### Fixed
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -57,6 +57,12 @@
 #
 #
 # TODO:
+#   - Transform `devtool` with dependency injection in mind. `devtool` commands
+#     can be seen as individual entries/dependencies for `devtool`, which is a
+#     thin layer over them. Keep in mind that some commands, and thus `devtool`,
+#     may require different host dependencies. The ideal objective would be to have
+#     zero host dependencies and offload dependencies to the development docker container,
+#     where is possible.
 #   - Cache test binaries, preserving them across `./devtool test` invocations.
 #     At the moment, Firecracker is rebuilt everytime a test is run.
 #   - List tests by parsing the `pytest --collect-only` output.
@@ -118,36 +124,60 @@ CTR_MICROVM_IMAGES_DIR="$CTR_FC_BUILD_DIR/img"
 # These options are not command-specific, so we store them as global vars
 OPT_UNATTENDED=false
 
+# Shield relevant mountpoints.
+SYSFS_MOUNTPOINT=$(cat /proc/mounts | grep "^sysfs \/.\+ sysfs .*$" | cut -d' ' -f2 | head -n 1)
+CPUSET_MOUNTPOINT=$(cat /proc/mounts | grep -P "^[^ ]+ (/.+) (?:cpuset |cgroup (?:[^ ]*,)?cpuset[, ])"\
+                                               | cut -d' ' -f2 | head -n 1)
+
+# Shield relevant exit codes.
+ESKIP=12
+ESINGLENUMANODE=13
 
 # Send a decorated message to stdout, followed by a new line
 #
 say() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
-        || echo "[$MY_NAME] $*"
+    run_devctr \
+    --user "$(id -u):$(id -g)" \
+    --workdir "$CTR_FC_ROOT_DIR" \
+    -- \
+    python3 -c "
+import tools.log_utils as lu
+lu.say_info(\"$1\")"
 }
 
 # Send a decorated message to stdout, without a trailing new line
 #
 say_noln() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo -n "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
-        || echo "[$MY_NAME] $*"
+    run_devctr \
+    --user "$(id -u):$(id -g)" \
+    --workdir "$CTR_FC_ROOT_DIR" \
+    -- \
+    python3 -c "
+import tools.log_utils as lu
+lu.say_info(\"$1\", False)"
 }
 
 # Send a text message to stderr
 #
 say_err() {
-    [ -t 2 ] && [ -n "$TERM" ] \
-        && echo -e "$(tput setaf 1)[$MY_NAME] $*$(tput sgr0)" 1>&2 \
-        || echo -e "[$MY_NAME] $*" 1>&2
+    run_devctr \
+    --user "$(id -u):$(id -g)" \
+    --workdir "$CTR_FC_ROOT_DIR" \
+    -- \
+    python3 -c "
+import tools.log_utils as lu
+lu.say_err(\"$1\")"
 }
 
 # Send a warning-highlighted text to stdout
 say_warn() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo "$(tput setaf 3)[$MY_NAME] $*$(tput sgr0)" \
-        || echo "[$MY_NAME] $*"
+    run_devctr \
+    --user "$(id -u):$(id -g)" \
+    --workdir "$CTR_FC_ROOT_DIR" \
+    -- \
+    python3 -c "
+import tools.log_utils as lu
+lu.say_warn(\"$1\")"
 }
 
 # Exit with an error message and (optional) code
@@ -159,7 +189,8 @@ die() {
         code="$2"
         shift 2
     }
-    say_err "$@"
+
+    [ ! -z "$@" ] && say_err "$@"
     exit $code
 }
 
@@ -168,6 +199,69 @@ die() {
 ok_or_die() {
     code=$?
     [[ $code -eq 0 ]] || die -c $code "$@"
+}
+
+validate_shield() {
+    local shield=$1
+
+    run_devctr \
+    --user "$(id -u):$(id -g)" \
+    --workdir "$CTR_FC_ROOT_DIR" \
+    --mount type=bind,source="$SYSFS_MOUNTPOINT",target="/host_sys" \
+    --mount type=bind,source="$CPUSET_MOUNTPOINT",target="/host_cpuset" \
+    -- \
+    python3 -c "
+import tools.shield_utils as su
+su.validate(\"$shield\")"
+    ok_or_die
+}
+
+shield_environment() {
+    local numa_node_id=$1
+    local cpus_count=$2
+    if [ ! -z $numa_node_id ] && [ ! -z $cpus_count ]; then
+        # Get available cpuset cpus list.
+        local cpuset_cpus=$(run_devctr \
+        --user "$(id -u):$(id -g)" \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        --mount type=bind,source="$SYSFS_MOUNTPOINT",target="/host_sys" \
+        --mount type=bind,source="$CPUSET_MOUNTPOINT",target="/host_cpuset" \
+        -- \
+        python3 -c "import tools.shield_utils as su
+print(su.ensure_environment($numa_node_id, $cpus_count, return_to_stdout=True))")
+        ok_or_die "Failed to ensure the shielded environment ($?)."
+
+        # Create system cpuset.
+        run_devctr \
+        --privileged \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        --mount type=bind,source="$SYSFS_MOUNTPOINT",target="/host_sys" \
+        --mount type=bind,source="$CPUSET_MOUNTPOINT",target="/host_cpuset" \
+        -- \
+        python3 -c "import tools.shield_utils as su
+su.create_system_cpuset($numa_node_id)" || ENVIRONMENT_SHIELDED=$? > /dev/null
+
+        # Verify exit codes.
+        [[ -z $ENVIRONMENT_SHIELDED ]] && ENVIRONMENT_SHIELDED=0
+        [[ $ENVIRONMENT_SHIELDED -eq $ESINGLENUMANODE ]] || [[ $ENVIRONMENT_SHIELDED -eq $ESKIP ]] || [[ $ENVIRONMENT_SHIELDED -eq 0 ]]
+        ok_or_die "Failed to create the system cpuset ($ENVIRONMENT_SHIELDED)."
+
+        retval=$cpuset_cpus
+    fi
+}
+
+cleanup_shield() {
+    # Teardown the created 'system' cpuset.
+    [[ -z $ENVIRONMENT_SHIELDED ]] || \
+    [[ $ENVIRONMENT_SHIELDED -eq $ESINGLENUMANODE ]] || \
+    run_devctr \
+        --user "$(id -u):$(id -g)" \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        --mount type=bind,source="$SYSFS_MOUNTPOINT",target="/host_sys" \
+        --mount type=bind,source="$CPUSET_MOUNTPOINT",target="/host_cpuset" \
+        -- \
+        python3 -c "import tools.shield_utils as su
+su.teardown_system_cpuset()" || die
 }
 
 # Check if Docker is available and exit if it's not.
@@ -194,7 +288,6 @@ ensure_docker() {
 # available on this system.
 #
 ensure_devctr() {
-
     # We depend on having Docker present.
     ensure_docker
 
@@ -430,10 +523,18 @@ cmd_help() {
     echo "        the contents of CHANGELOG.md enclosed between the header corresponding to "
     echo "        the specified version and the one corresponding to the previous version."
     echo ""
-    echo "    test [-- [<pytest args>]]"
+    echo "    test [-s|--shield <shield>] -- [<pytest args>]]"
     echo "        Run the Firecracker integration tests."
     echo "        The Firecracker testing system is based on pytest. All arguments after --"
     echo "        will be passed through to pytest."
+    echo "        -s, --shield <shield>    Specify a shield pattern: NUMA_NODE_ID;CPUS_COUNT. The shield"
+    echo "                                 consists from a docker container with cpuset.cpus and cpuset.mems."
+    echo "                                 The cpuset.cpus and cpuset.mems correspond to NUMA_NODE_ID. CPUS_COUNT"
+    echo "                                 are selected as CPU cores which are not used by cpuset other than '/'"
+    echo "                                 (root) and 'docker'. It also creates a new cpuset called 'system'."
+    echo "                                 By default, this cpuset is bound to other node than the one used by the shield,"
+    echo "                                 if possible. If the system cpuset can not be created, due to a lack of available"
+    echo "                                 NUMA nodes, the creation is skipped and the shield is ignored."
     echo ""
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
@@ -575,11 +676,22 @@ cmd_strip() {
 # Please see `$0 help` for more information.
 #
 cmd_test() {
+    # Inherited from `shield.py`.
+    trap cleanup_shield EXIT
 
     # Parse any command line args.
     while [ $# -gt 0 ]; do
         case "$1" in
             "-h"|"--help")      { cmd_help; exit 1; } ;;
+            "-s"|"--shield")
+                shift
+                validate_shield $1
+
+                # Pattern match on the shield: {TESTS_NUMA_NODE_ID};{CPUS_COUNT}.
+                [[ "$1" =~ ^(0|[1-9][0-9]*)\;([1-9][0-9]*)$ ]] && \
+                local tests_numa_node_id=${BASH_REMATCH[1]} && \
+                local cpus_count=${BASH_REMATCH[2]}
+                ;;
             "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
@@ -593,10 +705,13 @@ cmd_test() {
     ensure_devctr
     ensure_build_dir
 
-
     # If we got to here, we've got all we need to continue.
     say "$(date -u +'%F %H:%M:%S %Z')"
     say "Starting test run ..."
+
+    # Produce `$CPUSET_CPUS`.
+    shield_environment $tests_numa_node_id $cpus_count
+    local cpuset_cpus=$retval
 
     # Testing (running Firecracker via the jailer) needs root access,
     # in order to set-up the Firecracker jail (manipulating cgroups, net
@@ -608,6 +723,8 @@ cmd_test() {
         --ulimit core=0 \
         --ulimit nofile=4096:4096 \
         --workdir "$CTR_FC_ROOT_DIR/tests" \
+        --cpuset-cpus="$cpuset_cpus" \
+        --cpuset-mems="$tests_numa_node_id" \
         -- \
         pytest "$@"
 

--- a/tools/log_utils.py
+++ b/tools/log_utils.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""This script is intended to be an entry point for `devtool` script.
+
+It provides the needed primitives for logging to standard output and error.
+"""
+
+import sys
+from enum import Enum
+
+
+MY_NAME = "[Firecracker tooling]"
+
+
+class Colors(Enum):
+    """Helper class for colored output encoding."""
+
+    HEADER = '\033[95m'
+    OKGREEN = '\033[32m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def _say(msg, msg_color, tag, tag_color, file, newline=True):
+    if not file.isatty():
+        return
+    if msg_color is None:
+        msg_color = ""
+    if tag_color is None:
+        tag_color = ""
+    print(f"{tag_color}{tag}{Colors.ENDC.value} "
+          f"{msg_color}{msg}{msg_color}{Colors.ENDC.value}",
+          file=file, end="\n" if newline else "")
+
+
+def say_info(msg, newline=True):
+    """Send a decorated message to stdout, followed by a new line."""
+    _say(msg, None, MY_NAME, Colors.OKGREEN.value, sys.stdout, newline)
+
+
+def say_err(msg, newline=True):
+    """Send a text message to stderr."""
+    _say(msg, Colors.FAIL.value, MY_NAME, Colors.FAIL.value,
+         sys.stderr, newline)
+
+
+def say_warn(msg, newline=True):
+    """Send a warning-highlighted text to stdout."""
+    _say(msg, Colors.ENDC.value, MY_NAME, Colors.WARNING.value,
+         sys.stdout, newline)
+
+
+def die(msg, code=-1):
+    """Exit with an error message and (optional) code."""
+    say_err(msg)
+    sys.exit(code)
+
+
+def ok_or_die(msg, code):
+    """Exit with an error message if the last exit code is not 0."""
+    if code != 0:
+        die(msg, code)

--- a/tools/shield_utils.py
+++ b/tools/shield_utils.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""This script is intended to be an entry point for `devtool test`.
+
+It provides the needed primitives for creation of a "shielded" environment.
+Shielding is based entirely on cgroup cpuset. The idea behind the environment
+setup is to isolate and shield workloads started by the testing framework. To
+this end, we will be interested in three high-level cpusets:
+* root - the root cpuset hierarchy.
+* system - where existing tasks will run.
+* docker - where tests workloads will run.
+
+Docker shares all the available cpus and memory nodes with root, but when
+containers start, they can receive a slice of the available cpus and memory,
+depending on what is requested by the "caller". The slice must be contained by
+an isolated NUMA node. Shielding this slice of the NUMA node is done by moving
+all the existing tasks inside system cpuset, letting the "shielded" and free
+slice available for a new docker container.
+"""
+
+
+import os
+import re
+import io
+import functools
+import random
+import sys
+from enum import IntEnum
+import tools.log_utils as log
+
+
+class ExitCode(IntEnum):
+    """Exit codes used across the script."""
+
+    OKSUCCESS = 0
+    EINVPATTERN = 1
+    EINVSYSFS = 2
+    ENOAVAILCPU = 3
+    ECONFLICTCPUSET = 4
+    EINVARG = 5
+    ENOAVAILMEM = 6
+    EOFFNODE = 7
+    EDIRTYENV = 8
+    ESHARENODE = 9
+    ETEARDOWN = 10
+    EEXCEPT = 11
+    ESKIP = 12
+    ESINGLENUMANODE = 13
+    ERANGEPARSE = 14
+
+
+# Patterns.
+RANGE_PATTERN = "([0-9][1-9]*)-([0-9][1-9]*)"
+
+
+# Hardcoded sysfs information.
+SYSFS_MOUNTPOINT = "/host_sys"
+CPUSET_MOUNTPOINT = "/host_cpuset"
+
+
+def _is_range(content):
+    """Return true if `content` is a range.
+
+    Args:
+        * content (str).
+    Returns:
+        * boolean: True if `content` is a range and False otherwise.
+    """
+    match = re.search(RANGE_PATTERN, content)
+    # group is a singular value.
+    return match is not None
+
+
+def _range(content):
+    """Return a range of integers based on the `content`.
+
+    The `content` respects the LIST FORMAT defined in the
+    cpuset documentation.
+    See: https://man7.org/linux/man-pages/man7/cpuset.7.html.
+
+    Args:
+        * content (str).
+    Returns:
+        * list of ints: a list with ints corresponding to a range
+                        of CPU cores IDs.
+    """
+    content = content.strip()
+    ends = content.split("-")
+    if len(ends) != 2:
+        log.die("Range parse error.")
+        sys.exit(ExitCode.ERANGEPARSE)
+    return list(range(int(ends[0]), int(ends[1]) + 1))
+
+
+def _parse_list_format(content):
+    """Parse list formats for cpuset and mems.
+
+    See LIST FORMAT here: https://man7.org/linux/man-pages/man7/cpuset.7.html.
+
+    Args:
+        * content (str).
+    Returns:
+        * list of ints: ints corresponding to elements of a LIST FORMAT, as
+                        described into `cpuset` documentation.
+    """
+    content = content.strip()
+    if len(content) == 0:
+        return []
+
+    groups = content.split(",")
+    arr = set()
+
+    def func(acc, cpu):
+        if _is_range(cpu):
+            acc.update(_range(cpu))
+        else:
+            acc.add(int(cpu))
+        return acc
+
+    return list(functools.reduce(func, groups, arr))
+
+
+def _is_node_online(numa_node_id):
+    """Check whether a NUMA node is online.
+
+    Args:
+        * numa_node_id (int).
+    Returns:
+        * boolean.
+    """
+    online_numa_nodes_path = SYSFS_MOUNTPOINT + "/devices/system/node/online"
+    with open(online_numa_nodes_path) as fp:
+        content = fp.readline()
+        online_numa_nodes = _parse_list_format(content)
+        return len(list(filter(lambda cpu: cpu == numa_node_id,
+                               online_numa_nodes))) > 0
+
+
+def _get_cpulist(numa_node_id, raw=False):
+    """Get the cpulist of a NUMA node.
+
+    Args:
+        * numa_node_id (int).
+        * raw (boolean): Default is False. If set to True, will return
+                         the content found in the cpulist information
+                         present in sysfs.
+     Returns:
+        * str: the content found in the NUMA node cpulist file.
+        * list of ints: ints corresponding to elements of a LIST FORMAT, as
+                        described into `cpuset` documentation.
+    """
+    cpulist_path = SYSFS_MOUNTPOINT + "/devices/system/node/node{}/cpulist"\
+        .format(numa_node_id)
+    with open(cpulist_path) as fp:
+        if raw:
+            return fp.readline().strip()
+        return _parse_list_format(fp.readline())
+
+
+def _is_memory_node_available(numa_node_id):
+    """Check if the memory node is used by an explicit cpuset.
+
+    By explicit cpusets we mean cpusets different than root and '/docker'
+
+    Args:
+        * numa_node_id (int).
+    Returns:
+        * boolean.
+    """
+    (root, dirnames, _) = next(os.walk(CPUSET_MOUNTPOINT))
+    for dirname in dirnames:
+        if dirname == "docker":
+            continue
+
+        with open(root + "/" + dirname + "/cpuset.mems") as fp:
+            log.say(root + "/" + dirname + "/cpuset.mems")
+            mems = _parse_list_format(fp.readline())
+            if not len(list(filter(lambda m: m == numa_node_id, mems))) == 0:
+                return False
+
+    return True
+
+
+def _get_unavailable_cpus():
+    """Return a set unavailable CPU cores.
+
+    An unavailable CPU core is a cpu id which is used by
+    others cpuset than `/` (root) and `/docker`.
+
+    Returns:
+        * list of ints: a list of CPU core IDs used by other cpusets than `/`
+                        (root) and `/docker`.
+    """
+    (root, dirnames, _) = next(os.walk(CPUSET_MOUNTPOINT))
+    unavail_cpus = set()
+    for dirname in dirnames:
+        if dirname == "docker":
+            continue
+
+        with open(root + "/" + dirname + "/cpuset.cpus") as fp:
+            unavail_cpus |= set(_parse_list_format(fp.readline()))
+
+    return list(unavail_cpus)
+
+
+def _get_available_cpus(numa_node_id):
+    """Determine NUMA node CPUs which are not assigned to an explicit cpuset.
+
+    By explicit cpusets we mean cpusets different than root and '/docker'.
+
+    Args:
+        * numa_node_id (int).
+    Returns:
+        * list of ints: a list of CPU core IDs free for use by docker
+                        containers.
+    """
+    cpulist = _get_cpulist(numa_node_id)
+    unavail_cpus = _get_unavailable_cpus()
+    avail_cpus = [cpu for cpu in cpulist if cpu not in unavail_cpus]
+    return avail_cpus
+
+
+def validate(shield):
+    """Validate that the shield pattern is respected.
+
+    It also validates that the shield pattern can be satisfied.
+    Exit if the shield is not valid. Shield pattern:
+    {NUMA_NODE_ID};{CPUS_COUNT}.
+
+    Args:
+        * shield (str): Respects the shield pattern.
+    """
+    match = re.search("^(0|[1-9][0-9]*);([1-9][0-9]*)$", shield)
+    if match is None:
+        log.die("Invalid shield: '{}'. Please stick with the pattern:"
+                " '{{NUMA_NODE_ID}};{{CPUS_COUNT}}'.".format(shield),
+                ExitCode.EINVPATTERN)
+
+    numa_node_id = int(match.group(1))
+    cpus_count = int(match.group(2))
+    if not _is_node_online(numa_node_id):
+        log.die("NUMA node {} is not online.".format(numa_node_id),
+                ExitCode.EOFFNODE)
+
+    if len(_get_available_cpus(numa_node_id)) < cpus_count:
+        log.die("Can not provide {} CPUs for NUMA node {}."
+                .format(cpus_count, numa_node_id), ExitCode.ENOAVAILCPU)
+
+    if not _is_memory_node_available(numa_node_id):
+        log.die("NUMA node {} memory is assigned to an existing cpuset,"
+                " other than '/' and 'docker'.".format(numa_node_id),
+                ExitCode.ENOAVAILMEM)
+
+
+def ensure_environment(numa_node_id, cpus_count, return_to_stdout=False):
+    """Exit if NUMA node id or cpus count CPU cores are not free.
+
+    It verifies if the environment can be satisfied by using the
+    specified numa node id and cpus count of the same numa node.
+    Exits if it can not produce a list of cpus count CPU cores, of the
+    numa node id.
+
+    Args:
+        * numa_node_id (positive int).
+        * cpus_count (positive int).
+        * return_to_stdout (boolean): False by default. If set to True,
+        it changes the format of the return type.
+
+    Returns:
+        * list: A list of positive ints with all the CPUs cores that can
+                be used to set up an isolated enviornment for numa node id,
+                which is not used by other cpusets.
+        * str: Returns a cpuset list formatted set of CPUs cores which can be
+               written directly into the `cpuset.cpus` file of a cpuset.
+    """
+    if numa_node_id < 0:
+        log.die("Invalid NUMA node id: {}.".format(numa_node_id),
+                ExitCode.EINVARG)
+
+    if cpus_count < 1:
+        log.die("Invalid cpus count: {}.".format(cpus_count), ExitCode.EINVARG)
+
+    if not _is_node_online(numa_node_id):
+        log.die("NUMA node is not online: {}.".format(numa_node_id),
+                ExitCode.EOFFNODE)
+
+    if not _is_memory_node_available(numa_node_id):
+        log.die("NUMA node {} memory is assigned to other cpuset."
+                .format(numa_node_id), ExitCode.ENOAVAILMEM)
+
+    cpu_list = _get_cpulist(numa_node_id)
+    avail_cpus = _get_available_cpus(numa_node_id)
+
+    cpu_list_len = functools.reduce(lambda acc, cpu: acc + cpu, cpu_list, 0)
+
+    if cpu_list_len < cpus_count or len(avail_cpus) < cpus_count:
+        log.die("Can not provide {} CPUs for NUMA node {}.".
+                format(cpus_count, numa_node_id), ExitCode.ENOAVAILCPU)
+
+    if return_to_stdout:
+        return ','.join(map(str, avail_cpus))
+
+    return avail_cpus
+
+
+def create_system_cpuset(excluded_numa_node_id):
+    """Create a 'system' cpuset based on resources which can not be used.
+
+    Chooses the first found online numa node that can be used and bound its
+    resources to the 'system' cpuset.
+
+    Args:
+        excluded_numa_node_id (positive int).
+    """
+    cpuset_system_path = CPUSET_MOUNTPOINT + "/system"
+    system_exists = os.path.isdir(cpuset_system_path)
+    if system_exists:
+        log.say_warn("'system' cpuset already exists.")
+        sys.exit(ExitCode.ESKIP)
+
+    online_numa_nodes_path = SYSFS_MOUNTPOINT + "/devices/system/node/online"
+    with open(online_numa_nodes_path) as fp:
+        online_numa_nodes = _parse_list_format(fp.readline())
+        avail_nodes = list(filter(lambda node: node != excluded_numa_node_id,
+                                  online_numa_nodes))
+        if len(avail_nodes) == 0:
+            log.say_warn("There is a single NUMA node on the system, where"
+                         " tests can run. Skipping creation of the system"
+                         " tasks cpuset...")
+            sys.exit(ExitCode.ESINGLENUMANODE)
+
+    # Create a 'system' cpuset if only there is a separate NUMA node which
+    # can host it.
+    system_node = random.choice(avail_nodes)
+    try:
+        os.mkdir(cpuset_system_path)
+    except IOError as err:
+        if str(err).find("Permission denied") != -1:
+            log.die("Please run as a privileged user if you want to create"
+                    " 'system' cpuset.", ExitCode.EEXCEPT)
+        else:
+            log.die(str(err), ExitCode.EEXCEPT)
+
+    # Impose the isolation for the entire CPULIST of the system node.
+    with open(cpuset_system_path + "/cpuset.cpus", "r+") as fp:
+        fp.write(_get_cpulist(system_node, raw=True))
+
+    with open(cpuset_system_path + "/cpuset.mems", "r+") as fp:
+        fp.write(str(system_node))
+
+    # Move root existing tasks to "system" cpuset.
+    with open(CPUSET_MOUNTPOINT + "/tasks", "r+") as root_tasks:
+        pids = root_tasks.readlines()
+
+        def move_pid(pid):
+            try:
+                system_tasks = io.open(cpuset_system_path + "/tasks",
+                                       'w', encoding="iso8859-1")
+                system_tasks.write(pid)
+                system_tasks.close()
+                return None
+            except IOError:
+                return pid
+
+        unmovable = list(filter(lambda pid: pid is not None,
+                                map(move_pid, pids)))
+        if len(unmovable) != 0:
+            log.say("Unmovable tasks: {}.".format(len(unmovable)))
+
+        log.say("'system' cpuset was succesfully created.")
+
+
+def teardown_system_cpuset():
+    """Delete a cpuset called 'system'.
+
+    Before deleting the 'system' cpuset, all the tasks bound to the cpuset are
+    moved to '/' (root) cpuset.
+    """
+    cpuset_system_path = CPUSET_MOUNTPOINT + "/system"
+
+    dir_exists = os.path.isdir(cpuset_system_path)
+    if not dir_exists:
+        log.say_warn("System tasks cpuset does not exist.")
+        sys.exit(ExitCode.OKSUCCESS)
+
+    # Move existing tasks to "root" cpuset.
+    with open(cpuset_system_path + "/tasks") as system_tasks:
+        pids = system_tasks.readlines()
+        for pid in pids:
+            try:
+                root_tasks = io.open(CPUSET_MOUNTPOINT + "/tasks", 'w',
+                                     encoding="iso8859-1")
+                root_tasks.write(pid)
+                root_tasks.close()
+            except IOError as err:
+                # Warn unknown exception. It is not fatal.
+                log.say_warn(str(err))
+
+    try:
+        os.rmdir(cpuset_system_path)
+    except IOError as err:
+        if str(err).find("Device or resource busy"):
+            log.die(str(err), ExitCode.EEXCEPT)
+        else:
+            log.say_warn(str(err))
+
+    dir_exists = os.path.isdir(cpuset_system_path)
+    if dir_exists:
+        log.die("'system' cpuset could not be removed.", ExitCode.ETEARDOWN)
+
+    log.say("'system' cpuset was succesfully removed.")


### PR DESCRIPTION
## Reason for This PR

When running performance tests, one might want to run them in a shielded and isolated environment, where there is as little as possible system tasks interference. It can be done with external tools, but this would imply adding specific dependencies on the host. To avoid this, but to also offer the bare minimum for setting up a shielded and isolated environment, `devtool` was augmented with the needed support.

## Description of Changes

Added `devtool test` flag: -s|--shield {NUMA_NODE_ID};{CPUS_COUNT}

The flag computes the available CPUs and memory specified through the pattern. It will bind the tests docker container
to those. It also isolates the docker container from outside tasks interference, by trying to move all exisiting running tasks
to a separate cpuset, which will use other resources compared to the shield. However, if there is only a single NUMA node online on the platform, the system cpuset can not be created and the tests will run as if there is no shield present.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~[] Any newly added `unsafe` code is properly documented.~~
~~[] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
~~[] All added/changed functionality is tested.~~
