### PR TITLE
Switch to Rust 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,6 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
@@ -621,6 +620,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "api_server"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 serde = ">=1.0.27"

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Mutex, RwLock};
 use std::{fmt, io};
 
+use crate::parsed_request::ParsedRequest;
 use logger::{update_metric_with_elapsed_time, Metric, METRICS};
 pub use micro_http::{
     Body, HttpServer, Method, Request, RequestError, Response, ServerError, ServerRequest,
@@ -28,7 +29,6 @@ pub use micro_http::{
 };
 use mmds::data_store;
 use mmds::data_store::Mmds;
-use parsed_request::ParsedRequest;
 use seccomp::{BpfProgram, SeccompFilter};
 use utils::eventfd::EventFd;
 use vmm::rpc_interface::{VmmAction, VmmActionError, VmmData};

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -4,23 +4,23 @@
 use serde_json::Value;
 
 use super::VmmData;
-use micro_http::{Body, Method, Request, Response, StatusCode, Version};
-use request::actions::parse_put_actions;
-use request::boot_source::parse_put_boot_source;
-use request::drive::{parse_patch_drive, parse_put_drive};
-use request::instance_info::parse_get_instance_info;
-use request::logger::parse_put_logger;
-use request::machine_configuration::{
+use crate::request::actions::parse_put_actions;
+use crate::request::boot_source::parse_put_boot_source;
+use crate::request::drive::{parse_patch_drive, parse_put_drive};
+use crate::request::instance_info::parse_get_instance_info;
+use crate::request::logger::parse_put_logger;
+use crate::request::machine_configuration::{
     parse_get_machine_config, parse_patch_machine_config, parse_put_machine_config,
 };
-use request::metrics::parse_put_metrics;
-use request::mmds::{parse_get_mmds, parse_patch_mmds, parse_put_mmds};
-use request::net::{parse_patch_net, parse_put_net};
-use request::snapshot::parse_patch_vm_state;
+use crate::request::metrics::parse_put_metrics;
+use crate::request::mmds::{parse_get_mmds, parse_patch_mmds, parse_put_mmds};
+use crate::request::net::{parse_patch_net, parse_put_net};
+use crate::request::snapshot::parse_patch_vm_state;
 #[cfg(target_arch = "x86_64")]
-use request::snapshot::parse_put_snapshot;
-use request::vsock::parse_put_vsock;
-use ApiServer;
+use crate::request::snapshot::parse_put_snapshot;
+use crate::request::vsock::parse_put_vsock;
+use crate::ApiServer;
+use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
-use logger::{Metric, METRICS};
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 #[cfg(target_arch = "aarch64")]
-use request::StatusCode;
+use crate::request::StatusCode;
+use logger::{Metric, METRICS};
 
 // The names of the members from this enum must precisely correspond (as a string) to the possible
 // values of "action_type" from the json request body. This is useful to get a strongly typed

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 use logger::{Metric, METRICS};
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
 use vmm::vmm_config::boot_source::BootSourceConfig;
 
 pub fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -4,9 +4,9 @@
 use serde_json::{Map, Value};
 
 use super::super::VmmAction;
+use crate::parsed_request::{checked_id, Error, ParsedRequest};
+use crate::request::{Body, StatusCode};
 use logger::{Metric, METRICS};
-use parsed_request::{checked_id, Error, ParsedRequest};
-use request::{Body, StatusCode};
 use vmm::vmm_config::drive::BlockDeviceConfig;
 
 struct PatchDrivePayload {

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::parsed_request::{Error, ParsedRequest};
 use logger::{Metric, METRICS};
-use parsed_request::{Error, ParsedRequest};
 
 pub fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.instance_info_count.inc();

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 use logger::{Metric, METRICS};
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
 use vmm::vmm_config::logger::LoggerConfig;
 
 pub fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0<Paste>
 
 use super::super::VmmAction;
+use crate::parsed_request::{method_to_error, Error, ParsedRequest};
+use crate::request::{Body, Method, StatusCode};
 use logger::{Metric, METRICS};
-use parsed_request::{method_to_error, Error, ParsedRequest};
-use request::{Body, Method, StatusCode};
 use vmm::vmm_config::machine_config::VmConfig;
 
 pub fn parse_get_machine_config() -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 use logger::{Metric, METRICS};
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
 use vmm::vmm_config::metrics::MetricsConfig;
 
 pub fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 use micro_http::StatusCode;
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
 use vmm::rpc_interface::VmmAction::SetMmdsConfiguration;
 use vmm::vmm_config::mmds::MmdsConfig;
 

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
+use crate::parsed_request::{checked_id, Error, ParsedRequest};
+use crate::request::{Body, StatusCode};
 use logger::{Metric, METRICS};
-use parsed_request::{checked_id, Error, ParsedRequest};
-use request::{Body, StatusCode};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 
 pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
@@ -60,8 +60,6 @@ pub fn parse_patch_net(body: &Body, id_from_path: Option<&&str>) -> Result<Parse
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
-
     use super::*;
     use crate::parsed_request::tests::vmm_action_from_request;
 

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 #[cfg(target_arch = "x86_64")]
-use request::{Method, StatusCode};
+use crate::request::{Method, StatusCode};
 #[cfg(target_arch = "x86_64")]
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams};
 use vmm::vmm_config::snapshot::{Vm, VmState};

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::VmmAction;
-use parsed_request::{Error, ParsedRequest};
-use request::Body;
+use crate::parsed_request::{Error, ParsedRequest};
+use crate::request::Body;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 pub fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -2,6 +2,7 @@
 name = "arch"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
+edition = "2018"
 
 [dependencies]
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -17,7 +17,7 @@ use super::super::InitrdConfig;
 use super::get_fdt_addr;
 use super::gic::GICDevice;
 use super::layout::FDT_MAX_SIZE;
-use aarch64::fdt::Error::CstringFDTTransform;
+use crate::aarch64::fdt::Error::CstringFDTTransform;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 
 // This is a value for uniquely identifying the FDT node declaring the interrupt controller.
@@ -530,8 +530,8 @@ fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildH
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aarch64::gic::create_gic;
-    use aarch64::{arch_memory_regions, layout};
+    use crate::aarch64::gic::create_gic;
+    use crate::aarch64::{arch_memory_regions, layout};
     use kvm_ioctls::Kvm;
 
     const LEN: u64 = 4096;

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -16,7 +16,9 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
 
+pub use self::fdt::DeviceInfoForFDT;
 use self::gic::GICDevice;
+use crate::DeviceType;
 use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 /// Errors thrown while configuring aarch64 system.
@@ -30,9 +32,6 @@ pub enum Error {
 
 /// The start of the memory area reserved for MMIO devices.
 pub const MMIO_MEM_START: u64 = layout::MAPPED_IO_START;
-
-pub use self::fdt::DeviceInfoForFDT;
-use DeviceType;
 
 /// Returns a Vec of the valid memory addresses for aarch64.
 /// See [`layout`](layout) module for a drawing of the specific memory model for this platform.

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -179,7 +179,7 @@ pub fn read_mpidr(vcpu: &VcpuFd) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aarch64::{arch_memory_regions, layout};
+    use crate::aarch64::{arch_memory_regions, layout};
     use kvm_ioctls::Kvm;
 
     #[test]

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -30,7 +30,7 @@ pub use aarch64::{
 pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
-pub use x86_64::{
+pub use crate::x86_64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
 };

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -16,11 +16,11 @@ pub mod msr;
 /// Logic for configuring x86_64 registers.
 pub mod regs;
 
+use crate::InitrdConfig;
 use arch_gen::x86::bootparam::{boot_params, E820_RAM};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion,
 };
-use InitrdConfig;
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `ByteValued`) where:

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -2,5 +2,6 @@
 name = "arch_gen"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cpuid"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }

--- a/src/cpuid/src/bit_helper.rs
+++ b/src/cpuid/src/bit_helper.rs
@@ -188,7 +188,7 @@ impl BitHelper for u32 {
 
 #[cfg(test)]
 mod tests {
-    use bit_helper::*;
+    use crate::bit_helper::*;
 
     #[test]
     #[should_panic]

--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use common::{VENDOR_ID_AMD, VENDOR_ID_INTEL};
+use crate::common::{VENDOR_ID_AMD, VENDOR_ID_INTEL};
 use std::arch::x86_64::__cpuid as host_cpuid;
 use std::slice;
 

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -6,7 +6,7 @@ use std::arch::x86::{CpuidResult, __cpuid_count, __get_cpuid_max};
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
 
-use cpu_leaf::*;
+use crate::cpu_leaf::*;
 
 pub const VENDOR_ID_INTEL: &[u8; 12] = b"GenuineIntel";
 pub const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
@@ -71,7 +71,7 @@ pub fn get_vendor_id() -> Result<[u8; 12], Error> {
 
 #[cfg(test)]
 pub mod tests {
-    use common::*;
+    use crate::common::*;
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn get_topoext_fn() -> u32 {

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -6,7 +6,7 @@ pub mod leaf_0x1 {
     pub const LEAF_NUM: u32 = 0x1;
 
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         pub const EXTENDED_FAMILY_ID_BITRANGE: BitRange = bit_range!(27, 20);
         pub const EXTENDED_PROCESSOR_MODEL_BITRANGE: BitRange = bit_range!(19, 16);
@@ -17,7 +17,7 @@ pub mod leaf_0x1 {
     }
 
     pub mod ebx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The bit-range containing the (fixed) default APIC ID.
         pub const APICID_BITRANGE: BitRange = bit_range!(31, 24);
@@ -69,7 +69,7 @@ pub mod leaf_0x1 {
 
 pub mod leaf_cache_parameters {
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         pub const CACHE_LEVEL_BITRANGE: BitRange = bit_range!(7, 5);
         pub const MAX_CPUS_PER_CORE_BITRANGE: BitRange = bit_range!(25, 14);
@@ -81,10 +81,10 @@ pub mod leaf_0x4 {
     pub const LEAF_NUM: u32 = 0x4;
 
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // inherit eax from leaf_cache_parameters
-        pub use cpu_leaf::leaf_cache_parameters::eax::*;
+        pub use crate::cpu_leaf::leaf_cache_parameters::eax::*;
 
         pub const MAX_CORES_PER_PACKAGE_BITRANGE: BitRange = bit_range!(31, 26);
     }
@@ -207,7 +207,7 @@ pub mod leaf_0xb {
     pub const LEVEL_TYPE_CORE: u32 = 2;
 
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The bit-range containing the number of bits to shift right the APIC ID in order to get
         // the next level APIC ID
@@ -215,7 +215,7 @@ pub mod leaf_0xb {
     }
 
     pub mod ebx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The bit-range containing the number of factory-configured logical processors
         // at the current cache level
@@ -223,7 +223,7 @@ pub mod leaf_0xb {
     }
 
     pub mod ecx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         pub const LEVEL_TYPE_BITRANGE: BitRange = bit_range!(15, 8);
         pub const LEVEL_NUMBER_BITRANGE: BitRange = bit_range!(7, 0);
@@ -236,7 +236,7 @@ pub mod leaf_0xd {
 
     pub mod index0 {
         pub mod eax {
-            use bit_helper::BitRange;
+            use crate::bit_helper::BitRange;
 
             pub const MPX_STATE_BITRANGE: BitRange = bit_range!(4, 3);
             pub const AVX512_STATE_BITRANGE: BitRange = bit_range!(7, 5);
@@ -256,7 +256,7 @@ pub mod leaf_0x80000000 {
     pub const LEAF_NUM: u32 = 0x8000_0000;
 
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         pub const LARGEST_EXTENDED_FN_BITRANGE: BitRange = bit_range!(31, 0);
     }
@@ -280,7 +280,7 @@ pub mod leaf_0x80000008 {
     pub const LEAF_NUM: u32 = 0x8000_0008;
 
     pub mod ecx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The number of bits in the initial ApicId value that indicate thread ID within a package
         // Possible values:
@@ -298,7 +298,7 @@ pub mod leaf_0x8000001d {
     pub const LEAF_NUM: u32 = 0x8000_001d;
 
     // inherit eax from leaf_cache_parameters
-    pub use cpu_leaf::leaf_cache_parameters::eax;
+    pub use crate::cpu_leaf::leaf_cache_parameters::eax;
 }
 
 // Extended APIC ID Leaf
@@ -306,13 +306,13 @@ pub mod leaf_0x8000001e {
     pub const LEAF_NUM: u32 = 0x8000_001e;
 
     pub mod eax {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         pub const EXTENDED_APIC_ID_BITRANGE: BitRange = bit_range!(31, 0);
     }
 
     pub mod ebx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The number of threads per core - 1
         pub const THREADS_PER_CORE_BITRANGE: BitRange = bit_range!(15, 8);
@@ -320,7 +320,7 @@ pub mod leaf_0x8000001e {
     }
 
     pub mod ecx {
-        use bit_helper::BitRange;
+        use crate::bit_helper::BitRange;
 
         // The number of nodes per processor. Possible values:
         // 0 -> 1 node per processor

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -16,20 +16,20 @@ extern crate kvm_ioctls;
 use kvm_bindings::CpuId;
 
 mod common;
-use common::*;
+use crate::common::*;
 
 /// Contains helper methods for bit operations.
 pub mod bit_helper;
 
 mod template;
-pub use template::c3;
-pub use template::t2;
+pub use crate::template::c3;
+pub use crate::template::t2;
 
 mod cpu_leaf;
 
 mod transformer;
-use transformer::*;
-pub use transformer::{Error, VmSpec};
+use crate::transformer::*;
+pub use crate::transformer::{Error, VmSpec};
 
 mod brand_string;
 

--- a/src/cpuid/src/template/c3.rs
+++ b/src/cpuid/src/template/c3.rs
@@ -1,13 +1,13 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use bit_helper::BitHelper;
-use cpu_leaf::*;
+use crate::bit_helper::BitHelper;
+use crate::cpu_leaf::*;
+use crate::transformer::*;
 use kvm_bindings::{kvm_cpuid_entry2, CpuId};
-use transformer::*;
 
 fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x1::*;
+    use crate::cpu_leaf::leaf_0x1::*;
 
     entry
         .eax
@@ -55,7 +55,7 @@ fn update_structured_extended_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x7::index0::*;
+    use crate::cpu_leaf::leaf_0x7::index0::*;
 
     if entry.index == 0 {
         entry
@@ -108,7 +108,7 @@ fn update_xsave_features_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0xd::*;
+    use crate::cpu_leaf::leaf_0xd::*;
 
     if entry.index == 0 {
         // MPX is masked out with the current template so the size in bytes of the save
@@ -139,7 +139,7 @@ fn update_extended_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x80000001::*;
+    use crate::cpu_leaf::leaf_0x80000001::*;
 
     entry
         .ecx

--- a/src/cpuid/src/template/t2.rs
+++ b/src/cpuid/src/template/t2.rs
@@ -1,13 +1,13 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use bit_helper::BitHelper;
-use cpu_leaf::*;
+use crate::bit_helper::BitHelper;
+use crate::cpu_leaf::*;
+use crate::transformer::*;
 use kvm_bindings::{kvm_cpuid_entry2, CpuId};
-use transformer::*;
 
 fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x1::*;
+    use crate::cpu_leaf::leaf_0x1::*;
 
     entry
         .eax
@@ -53,7 +53,7 @@ fn update_structured_extended_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x7::index0::*;
+    use crate::cpu_leaf::leaf_0x7::index0::*;
 
     if entry.index == 0 {
         entry
@@ -102,7 +102,7 @@ fn update_xsave_features_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0xd::*;
+    use crate::cpu_leaf::leaf_0xd::*;
 
     if entry.index == 0 {
         // MPX is masked out with the current template so the size in bytes of the save
@@ -133,7 +133,7 @@ fn update_extended_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x80000001::*;
+    use crate::cpu_leaf::leaf_0x80000001::*;
 
     entry.ecx.write_bit(ecx::PREFETCH_BITINDEX, false);
 

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -5,9 +5,9 @@ use super::*;
 
 use kvm_bindings::{CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX};
 
-use bit_helper::BitHelper;
-use cpu_leaf::*;
-use transformer::common::use_host_cpuid_function;
+use crate::bit_helper::BitHelper;
+use crate::cpu_leaf::*;
+use crate::transformer::common::use_host_cpuid_function;
 
 // Largest extended function. It has to be larger then 0x8000001d (Extended Cache Topology).
 const LARGEST_EXTENDED_FN: u32 = 0x8000_001f;
@@ -22,7 +22,7 @@ pub fn update_structured_extended_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x7::index0::*;
+    use crate::cpu_leaf::leaf_0x7::index0::*;
 
     // according to the EPYC PPR, only the leaf 0x7 with index 0 contains the
     // structured extended feature identifiers
@@ -38,7 +38,7 @@ pub fn update_largest_extended_fn_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x80000000::*;
+    use crate::cpu_leaf::leaf_0x80000000::*;
 
     // KVM sets the largest extended function to 0x80000000. Change it to 0x8000001f
     // Since we also use the leaf 0x8000001d (Extended Cache Topology).
@@ -53,7 +53,7 @@ pub fn update_extended_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x80000001::*;
+    use crate::cpu_leaf::leaf_0x80000001::*;
 
     // set the Topology Extension bit since we use the Extended Cache Topology leaf
     entry.ecx.write_bit(ecx::TOPOEXT_INDEX, true);
@@ -65,7 +65,7 @@ pub fn update_amd_features_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x80000008::*;
+    use crate::cpu_leaf::leaf_0x80000008::*;
 
     // We don't support more then 128 threads right now.
     // It's safe to put them all on the same processor.
@@ -90,7 +90,7 @@ pub fn update_extended_apic_id_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x8000001e::*;
+    use crate::cpu_leaf::leaf_0x8000001e::*;
 
     // When hyper-threading is enabled each pair of 2 consecutive logical CPUs
     // will have the same core id since they represent 2 threads in the same core.
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_update_structured_extended_entry() {
-        use cpu_leaf::leaf_0x7::index0::*;
+        use crate::cpu_leaf::leaf_0x7::index0::*;
 
         // Check that if index == 0 the entry is processed
         let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_update_largest_extended_fn_entry() {
-        use cpu_leaf::leaf_0x80000000::*;
+        use crate::cpu_leaf::leaf_0x80000000::*;
 
         let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_update_extended_feature_info_entry() {
-        use cpu_leaf::leaf_0x80000001::*;
+        use crate::cpu_leaf::leaf_0x80000001::*;
 
         let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -228,7 +228,7 @@ mod tests {
     }
 
     fn check_update_amd_features_entry(cpu_count: u8, ht_enabled: bool) {
-        use cpu_leaf::leaf_0x80000008::*;
+        use crate::cpu_leaf::leaf_0x80000008::*;
 
         let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -261,7 +261,7 @@ mod tests {
         expected_core_id: u32,
         expected_threads_per_core: u32,
     ) {
-        use cpu_leaf::leaf_0x8000001e::*;
+        use crate::cpu_leaf::leaf_0x8000001e::*;
 
         let vm_spec = VmSpec::new(cpu_id, cpu_count, ht_enabled).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bit_helper::BitHelper;
-use common::get_cpuid;
+use crate::bit_helper::BitHelper;
+use crate::common::get_cpuid;
 
+use crate::transformer::Error::FamError;
 use kvm_bindings::{kvm_cpuid_entry2, CpuId};
-use transformer::Error::FamError;
 
 // constants for setting the fields of kvm_cpuid2 structures
 // CPUID bits in ebx, ecx, and edx.
@@ -31,7 +31,7 @@ pub fn update_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x1::*;
+    use crate::cpu_leaf::leaf_0x1::*;
 
     let max_cpus_per_package = u32::from(common::get_max_cpus_per_package(vm_spec.cpu_count)?);
 
@@ -74,7 +74,7 @@ pub fn update_cache_parameters_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_cache_parameters::*;
+    use crate::cpu_leaf::leaf_cache_parameters::*;
 
     match entry.eax.read_bits_in_range(&eax::CACHE_LEVEL_BITRANGE) {
         // L1 & L2 Cache
@@ -137,8 +137,9 @@ pub fn use_host_cpuid_function(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::tests::get_topoext_fn;
-    use transformer::VmSpec;
+    use crate::common::tests::get_topoext_fn;
+    use crate::transformer::VmSpec;
+    use kvm_bindings::kvm_cpuid_entry2;
 
     #[test]
     fn test_get_max_cpus_per_package() {
@@ -151,7 +152,7 @@ mod tests {
     }
 
     fn check_update_feature_info_entry(cpu_count: u8, expected_htt: bool) {
-        use cpu_leaf::leaf_0x1::*;
+        use crate::cpu_leaf::leaf_0x1::*;
 
         let vm_spec = VmSpec::new(0, cpu_count, false).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -177,7 +178,7 @@ mod tests {
         cache_level: u32,
         expected_max_cpus_per_core: u32,
     ) {
-        use cpu_leaf::leaf_cache_parameters::*;
+        use crate::cpu_leaf::leaf_cache_parameters::*;
 
         let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -275,7 +276,7 @@ mod tests {
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn test_use_host_cpuid_function_without_count() {
-        use cpu_leaf::leaf_0x1::*;
+        use crate::cpu_leaf::leaf_0x1::*;
         // try to emulate the extended cache topology leaves
         let feature_info_fn = LEAF_NUM;
 

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bit_helper::BitHelper;
-use cpu_leaf::*;
+use crate::bit_helper::BitHelper;
+use crate::cpu_leaf::*;
 
 // The APIC ID shift in leaf 0xBh specifies the number of bits to shit the x2APIC ID to get a
 // unique topology of the next level. This allows 128 logical processors/package.
@@ -13,7 +13,7 @@ fn update_deterministic_cache_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x4::*;
+    use crate::cpu_leaf::leaf_0x4::*;
 
     common::update_cache_parameters_entry(entry, vm_spec)?;
 
@@ -30,7 +30,7 @@ fn update_power_management_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0x6::*;
+    use crate::cpu_leaf::leaf_0x6::*;
 
     entry.eax.write_bit(eax::TURBO_BOOST_BITINDEX, false);
     // Clear X86 EPB feature. No frequency selection in the hypervisor.
@@ -54,7 +54,7 @@ fn update_extended_topology_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,
 ) -> Result<(), Error> {
-    use cpu_leaf::leaf_0xb::*;
+    use crate::cpu_leaf::leaf_0xb::*;
 
     //reset eax, ebx, ecx
     entry.eax = 0 as u32;
@@ -134,10 +134,9 @@ impl CpuidTransformer for IntelCpuidTransformer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cpu_leaf::leaf_0xb::LEVEL_TYPE_CORE;
-    use cpu_leaf::leaf_0xb::LEVEL_TYPE_THREAD;
+    use crate::cpu_leaf::leaf_0xb::{LEVEL_TYPE_CORE, LEVEL_TYPE_THREAD};
+    use crate::transformer::VmSpec;
     use kvm_bindings::kvm_cpuid_entry2;
-    use transformer::VmSpec;
 
     #[test]
     fn test_update_perf_mon_entry() {
@@ -167,7 +166,7 @@ mod tests {
         cache_level: u32,
         expected_max_cores_per_package: u32,
     ) {
-        use cpu_leaf::leaf_0x4::*;
+        use crate::cpu_leaf::leaf_0x4::*;
 
         let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
@@ -199,7 +198,7 @@ mod tests {
         expected_num_logical_processors: u32,
         expected_level_type: u32,
     ) {
-        use cpu_leaf::leaf_0xb::*;
+        use crate::cpu_leaf::leaf_0xb::*;
 
         let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -7,9 +7,9 @@ pub mod intel;
 
 pub use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 
-use brand_string::BrandString;
-use brand_string::Reg as BsReg;
-use common::get_vendor_id;
+use crate::brand_string::BrandString;
+use crate::brand_string::Reg as BsReg;
+use crate::common::get_vendor_id;
 
 /// Structure containing the specifications of the VM
 pub struct VmSpec {

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dumbo"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 bitflags = ">=1.0.4"

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -17,7 +17,14 @@ mod mac;
 pub mod pdu;
 pub mod tcp;
 
-pub use mac::{MacAddr, MAC_ADDR_LEN};
+pub use crate::mac::{MacAddr, MAC_ADDR_LEN};
+pub use crate::pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
+pub use crate::pdu::ethernet::{
+    EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4, PAYLOAD_OFFSET as ETHERNET_PAYLOAD_OFFSET,
+};
+pub use crate::pdu::ipv4::{IPv4Packet, PROTOCOL_TCP, PROTOCOL_UDP};
+pub use crate::pdu::udp::{UdpDatagram, UDP_HEADER_SIZE};
+
 use std::ops::Index;
 
 /// Represents a generalization of a borrowed `[u8]` slice.

--- a/src/dumbo/src/pdu/arp.rs
+++ b/src/dumbo/src/pdu/arp.rs
@@ -514,7 +514,8 @@ mod tests {
         {
             let mac = MacAddr::from_bytes_unchecked(&[0; 6]);
             let mut eth =
-                ::pdu::ethernet::EthernetFrame::write_incomplete(a.as_mut(), mac, mac, 0).unwrap();
+                crate::pdu::ethernet::EthernetFrame::write_incomplete(a.as_mut(), mac, mac, 0)
+                    .unwrap();
             let mut arp = EthIPv4ArpFrame::from_bytes_unchecked(eth.inner_mut().payload_mut());
             arp.set_tpa(addr);
         }

--- a/src/dumbo/src/pdu/ipv4.rs
+++ b/src/dumbo/src/pdu/ipv4.rs
@@ -11,9 +11,9 @@ use std::convert::From;
 use std::net::Ipv4Addr;
 use std::result::Result;
 
-use pdu::bytes::{InnerBytes, NetworkBytes, NetworkBytesMut};
-use pdu::ethernet;
-use pdu::Incomplete;
+use crate::pdu::bytes::{InnerBytes, NetworkBytes, NetworkBytesMut};
+use crate::pdu::ethernet;
+use crate::pdu::Incomplete;
 
 const VERSION_AND_IHL_OFFSET: usize = 0;
 const DSCP_AND_ECN_OFFSET: usize = 1;
@@ -680,7 +680,7 @@ mod tests {
 
         {
             let mut eth =
-                ::pdu::ethernet::EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, 0)
+                crate::pdu::ethernet::EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, 0)
                     .unwrap();
             IPv4Packet::from_bytes_unchecked(eth.inner_mut().payload_mut())
                 .set_destination_address(ip);
@@ -689,7 +689,7 @@ mod tests {
 
         {
             let mut eth =
-                ::pdu::ethernet::EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, 0)
+                crate::pdu::ethernet::EthernetFrame::write_incomplete(buf.as_mut(), mac, mac, 0)
                     .unwrap();
             IPv4Packet::from_bytes_unchecked(eth.inner_mut().payload_mut())
                 .set_destination_address(other_ip);

--- a/src/dumbo/src/pdu/mod.rs
+++ b/src/dumbo/src/pdu/mod.rs
@@ -9,8 +9,8 @@
 
 use std::net::Ipv4Addr;
 
-use pdu::bytes::NetworkBytes;
-use pdu::ipv4::{PROTOCOL_TCP, PROTOCOL_UDP};
+use crate::pdu::bytes::NetworkBytes;
+use crate::pdu::ipv4::{PROTOCOL_TCP, PROTOCOL_UDP};
 
 pub mod arp;
 pub mod bytes;

--- a/src/dumbo/src/pdu/tcp.rs
+++ b/src/dumbo/src/pdu/tcp.rs
@@ -14,8 +14,8 @@ use std::result::Result;
 
 use super::bytes::{InnerBytes, NetworkBytes, NetworkBytesMut};
 use super::Incomplete;
-use pdu::ChecksumProto;
-use ByteBuffer;
+use crate::pdu::ChecksumProto;
+use crate::ByteBuffer;
 
 const SOURCE_PORT_OFFSET: usize = 0;
 const DESTINATION_PORT_OFFSET: usize = 2;

--- a/src/dumbo/src/pdu/udp.rs
+++ b/src/dumbo/src/pdu/udp.rs
@@ -11,8 +11,8 @@
 
 use std::net::Ipv4Addr;
 
-use pdu::bytes::NetworkBytesMut;
-use pdu::{ChecksumProto, Incomplete};
+use crate::pdu::bytes::NetworkBytesMut;
+use crate::pdu::{ChecksumProto, Incomplete};
 
 use super::bytes::{InnerBytes, NetworkBytes};
 
@@ -209,7 +209,7 @@ impl<'a, T: NetworkBytesMut> Incomplete<UdpDatagram<'a, T>> {
 mod tests {
     use std::fmt;
 
-    use pdu::udp::UdpDatagram;
+    use crate::pdu::udp::UdpDatagram;
 
     use super::*;
 

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -8,12 +8,14 @@
 
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize, Wrapping};
 
-use pdu::bytes::NetworkBytes;
-use pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
-use pdu::Incomplete;
-use tcp::{seq_after, seq_at_or_after, NextSegmentStatus, RstConfig, MAX_WINDOW_SIZE, MSS_DEFAULT};
+use crate::pdu::bytes::NetworkBytes;
+use crate::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
+use crate::pdu::Incomplete;
+use crate::tcp::{
+    seq_after, seq_at_or_after, NextSegmentStatus, RstConfig, MAX_WINDOW_SIZE, MSS_DEFAULT,
+};
+use crate::ByteBuffer;
 use utils::rand::xor_psuedo_rng_u32;
-use ByteBuffer;
 
 bitflags! {
     // We use a set of flags, instead of a state machine, to represent the connection status. Some

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -13,13 +13,13 @@
 
 use std::num::{NonZeroU16, NonZeroU64, Wrapping};
 
+use crate::micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
+use crate::pdu::{bytes::NetworkBytes, tcp::TcpSegment, Incomplete};
+use crate::tcp::{
+    connection::{Connection, PassiveOpenError, RecvStatusFlags},
+    seq_after, NextSegmentStatus, MAX_WINDOW_SIZE,
+};
 use logger::{Metric, METRICS};
-use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
-use pdu::bytes::NetworkBytes;
-use pdu::tcp::TcpSegment;
-use pdu::Incomplete;
-use tcp::connection::{Connection, PassiveOpenError, RecvStatusFlags};
-use tcp::{seq_after, NextSegmentStatus, MAX_WINDOW_SIZE};
 use utils::time::timestamp_cycles;
 
 // TODO: These are currently expressed in cycles. Normally, they would be the equivalent of a
@@ -376,9 +376,9 @@ mod tests {
     use std::fmt;
     use std::str::from_utf8;
 
-    use pdu::tcp::Flags as TcpFlags;
-    use tcp::connection::tests::ConnectionTester;
-    use tcp::tests::mock_callback;
+    use crate::pdu::tcp::Flags as TcpFlags;
+    use crate::tcp::connection::tests::ConnectionTester;
+    use crate::tcp::tests::mock_callback;
 
     impl Endpoint {
         pub fn set_eviction_threshold(&mut self, value: u64) {

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -9,12 +9,12 @@ use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 
-use micro_http::{Request, Response};
-use pdu::bytes::NetworkBytes;
-use pdu::ipv4::{Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};
-use pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
-use tcp::endpoint::Endpoint;
-use tcp::{NextSegmentStatus, RstConfig};
+use crate::micro_http::{Request, Response};
+use crate::pdu::bytes::NetworkBytes;
+use crate::pdu::ipv4::{Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};
+use crate::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
+use crate::tcp::endpoint::Endpoint;
+use crate::tcp::{NextSegmentStatus, RstConfig};
 
 // TODO: This is currently IPv4 specific. Maybe change it to a more generic implementation.
 
@@ -505,10 +505,9 @@ impl TcpIPv4Handler {
 
 #[cfg(test)]
 mod tests {
-    use pdu::bytes::NetworkBytesMut;
-    use tcp::tests::mock_callback;
-
     use super::*;
+    use crate::pdu::bytes::NetworkBytesMut;
+    use crate::tcp::tests::mock_callback;
 
     fn inner_tcp_mut<'a, 'b, T: NetworkBytesMut>(
         p: &'a mut IPv4Packet<'b, T>,

--- a/src/dumbo/src/tcp/mod.rs
+++ b/src/dumbo/src/tcp/mod.rs
@@ -7,8 +7,8 @@ pub mod connection;
 mod endpoint;
 pub mod handler;
 
-use pdu::bytes::NetworkBytes;
-use pdu::tcp::{Flags as TcpFlags, TcpSegment};
+use crate::pdu::bytes::NetworkBytes;
+use crate::pdu::tcp::{Flags as TcpFlags, TcpSegment};
 
 use std::num::Wrapping;
 

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "firecracker"
 version = "0.21.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jailer"
 version = "0.21.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -6,8 +6,6 @@ use std::ffi::CStr;
 use std::path::Path;
 use std::ptr::null;
 
-use libc;
-
 use super::{to_cstring, Error, Result};
 use utils::syscall::SyscallReturnCode;
 

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -9,14 +9,12 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use libc;
-
-use cgroup::Cgroup;
-use chroot::chroot;
+use crate::cgroup::Cgroup;
+use crate::chroot::chroot;
+use crate::{Error, Result};
 use utils::arg_parser::Error::MissingValue;
 use utils::syscall::SyscallReturnCode;
 use utils::{arg_parser, validators};
-use {Error, Result};
 
 const STDIN_FILENO: libc::c_int = 0;
 const STDOUT_FILENO: libc::c_int = 1;
@@ -340,7 +338,7 @@ impl Env {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use build_arg_parser;
+    use crate::build_arg_parser;
 
     use std::os::linux::fs::MetadataExt;
     use std::os::unix::ffi::OsStrExt;

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::result;
 
-use env::Env;
+use crate::env::Env;
 use utils::arg_parser::{ArgParser, Argument, Error as ParsingError};
 use utils::validators;
 

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kernel"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies]
 vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -7,7 +7,6 @@
 
 //! Helper for loading a kernel image in the guest memory.
 
-use std;
 use std::ffi::CString;
 use std::fmt;
 use std::io::{Read, Seek, SeekFrom};

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -2,13 +2,13 @@
 name = "logger"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 lazy_static = ">=1.2"
 libc = ">=0.2.39"
 log = { version = ">=0.4", features = ["std"] }
-serde = ">=1.0.27"
-serde_derive = ">=1.0.27"
+serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
 
 utils = { path = "../utils" }

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Workaround to `macro_reexport`.
-#[macro_use]
 extern crate lazy_static;
 extern crate libc;
-#[cfg_attr(test, macro_use)]
 extern crate log;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_json;
 extern crate utils;
 
@@ -17,12 +13,12 @@ mod init;
 mod logger;
 mod metrics;
 
+use std::sync::LockResult;
+
+pub use crate::logger::{LoggerError, LOGGER};
+pub use crate::metrics::{Metric, MetricsError, SharedMetric, METRICS};
 pub use log::Level::*;
 pub use log::*;
-pub use logger::{LoggerError, LOGGER};
-pub use metrics::{Metric, MetricsError, SharedMetric, METRICS};
-
-use std::sync::LockResult;
 
 fn extract_guard<G>(lock_result: LockResult<G>) -> G {
     match lock_result {

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -96,13 +96,14 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, RwLock};
 
+use crate::metrics::{Metric, METRICS};
+use lazy_static::lazy_static;
 use log::{max_level, set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
-use metrics::{Metric, METRICS};
 use utils::time::LocalTime;
 
 use super::extract_guard;
-use init;
-use init::Init;
+use crate::init;
+use crate::init::Init;
 
 /// Type for returning functions outcome.
 pub type Result<T> = result::Result<T, LoggerError>;
@@ -453,9 +454,11 @@ impl Log for Logger {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Read;
     use std::sync::Arc;
+
+    use super::*;
+    use log::info;
 
     const TEST_INSTANCE_ID: &str = "TEST-INSTANCE-ID";
     const TEST_APP_HEADER: &str = "App header";

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -55,13 +55,13 @@
 //! If if turns out this approach is not really what we want, it's pretty easy to resort to
 //! something else, while working behind the same interface.
 
-use std;
 use std::fmt;
 use std::io::Write;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
+use lazy_static::lazy_static;
 use serde::{Serialize, Serializer};
 
 use super::extract_guard;

--- a/src/micro_http/Cargo.toml
+++ b/src/micro_http/Cargo.toml
@@ -2,6 +2,7 @@
 name = "micro_http"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/micro_http/src/common/headers.rs
+++ b/src/micro_http/src/common/headers.rs
@@ -3,7 +3,7 @@
 
 use std::result::Result;
 
-use RequestError;
+use crate::RequestError;
 
 /// Wrapper over an HTTP Header type.
 #[derive(Debug, Eq, Hash, PartialEq)]

--- a/src/micro_http/src/connection.rs
+++ b/src/micro_http/src/connection.rs
@@ -4,12 +4,12 @@
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 
-use common::ascii::{CR, CRLF_LEN, LF};
-use common::Body;
-pub use common::{ConnectionError, RequestError};
-use headers::Headers;
-use request::{find, Request, RequestLine};
-use response::{Response, StatusCode};
+use crate::common::ascii::{CR, CRLF_LEN, LF};
+use crate::common::Body;
+pub use crate::common::{ConnectionError, RequestError};
+use crate::headers::Headers;
+use crate::request::{find, Request, RequestLine};
+use crate::response::{Response, StatusCode};
 
 const BUFFER_SIZE: usize = 1024;
 
@@ -481,10 +481,11 @@ impl<T: Read + Write> HttpConnection<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use common::{Method, Version};
     use std::net::Shutdown;
     use std::os::unix::net::UnixStream;
+
+    use super::*;
+    use crate::common::{Method, Version};
 
     #[test]
     fn test_try_read_expect() {

--- a/src/micro_http/src/lib.rs
+++ b/src/micro_http/src/lib.rs
@@ -117,13 +117,13 @@ mod connection;
 mod request;
 mod response;
 mod server;
-use common::ascii;
-use common::headers;
+use crate::common::ascii;
+use crate::common::headers;
 
-pub use connection::{ConnectionError, HttpConnection};
-pub use request::{Request, RequestError};
-pub use response::{Response, StatusCode};
-pub use server::{HttpServer, ServerError, ServerRequest, ServerResponse};
+pub use crate::connection::{ConnectionError, HttpConnection};
+pub use crate::request::{Request, RequestError};
+pub use crate::response::{Response, StatusCode};
+pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
 
-pub use common::headers::{Headers, MediaType};
-pub use common::{Body, Method, Version};
+pub use crate::common::headers::{Headers, MediaType};
+pub use crate::common::{Body, Method, Version};

--- a/src/micro_http/src/request.rs
+++ b/src/micro_http/src/request.rs
@@ -3,10 +3,10 @@
 
 use std::str::from_utf8;
 
-use common::ascii::{CR, CRLF_LEN, LF, SP};
-pub use common::RequestError;
-use common::{Body, Method, Version};
-use headers::Headers;
+use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
+pub use crate::common::RequestError;
+use crate::common::{Body, Method, Version};
+use crate::headers::Headers;
 
 // This type represents the RequestLine raw parts: method, uri and version.
 type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);

--- a/src/micro_http/src/response.rs
+++ b/src/micro_http/src/response.rs
@@ -3,10 +3,10 @@
 
 use std::io::{Error as WriteError, Write};
 
-use ascii::{COLON, CR, LF, SP};
-use common::{Body, Version};
-use headers::{Header, MediaType};
-use Method;
+use crate::ascii::{COLON, CR, LF, SP};
+use crate::common::{Body, Version};
+use crate::headers::{Header, MediaType};
+use crate::Method;
 
 /// Wrapper over a response status code.
 ///

--- a/src/micro_http/src/server.rs
+++ b/src/micro_http/src/server.rs
@@ -7,11 +7,11 @@ use std::os::unix::io::RawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 
-use common::{Body, Version};
-pub use common::{ConnectionError, RequestError, ServerError};
-use connection::HttpConnection;
-use request::Request;
-use response::{Response, StatusCode};
+use crate::common::{Body, Version};
+pub use crate::common::{ConnectionError, RequestError, ServerError};
+use crate::connection::HttpConnection;
+use crate::request::Request;
+use crate::response::{Response, StatusCode};
 use std::collections::HashMap;
 
 use utils::epoll;
@@ -538,7 +538,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
 
-    use common::Body;
+    use crate::common::Body;
     use utils::tempfile::TempFile;
 
     fn get_temp_socket_file() -> TempFile {

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mmds"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 lazy_static = ">=1.1.0"

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -170,7 +170,6 @@ impl Mmds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
 
     #[test]
     fn test_mmds() {

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -20,7 +20,7 @@ pub mod persist;
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
 
-use data_store::{Error as MmdsError, Mmds, OutputFormat};
+use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
 use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
 
 lazy_static! {

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -301,10 +301,10 @@ impl MmdsNetworkStack {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use dumbo::pdu::tcp::{Flags as TcpFlags, TcpSegment};
     use std::str::FromStr;
+
+    use super::*;
+    use dumbo::pdu::tcp::{Flags as TcpFlags, TcpSegment};
 
     // We use LOCALHOST here because const new() is not stable yet, so just reuse this const, since
     // all we're interested in is having some address different from the MMDS one.

--- a/src/net_gen/Cargo.toml
+++ b/src/net_gen/Cargo.toml
@@ -2,3 +2,4 @@
 name = "net_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
+edition = "2018"

--- a/src/net_gen/src/lib.rs
+++ b/src/net_gen/src/lib.rs
@@ -25,7 +25,7 @@ pub mod inn;
 // generated with bindgen /usr/include/linux/sockios.h --no-unstable-rust
 // --constified-enum '*' --with-derive-default
 pub mod sockios;
-pub use if_tun::*;
-pub use iff::*;
-pub use inn::*;
-pub use sockios::*;
+pub use crate::if_tun::*;
+pub use crate::iff::*;
+pub use crate::inn::*;
+pub use crate::sockios::*;

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polly"
 version = "0.0.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/rate_limiter/Cargo.toml
+++ b/src/rate_limiter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rate_limiter"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/seccomp/Cargo.toml
+++ b/src/seccomp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "seccomp"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -1186,10 +1186,10 @@ impl SeccompLevel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SeccompCmpArgLen as ArgLen;
+    use crate::SeccompCmpOp::*;
+    use crate::SeccompCondition as Cond;
     use std::thread;
-    use SeccompCmpArgLen as ArgLen;
-    use SeccompCmpOp::*;
-    use SeccompCondition as Cond;
 
     // The type of the `req` parameter is different for the `musl` library. This will enable
     // successful build for other non-musl libraries.

--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -2,6 +2,7 @@
 name = "snapshot"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 autobenches = false
 
 [dependencies]

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -32,7 +32,7 @@ extern crate versionize;
 extern crate versionize_derive;
 
 mod persist;
-pub use persist::Persist;
+pub use crate::persist::Persist;
 
 use std::io::{Read, Write};
 use versionize::crc::{CRC64Reader, CRC64Writer};

--- a/src/virtio_gen/Cargo.toml
+++ b/src/virtio_gen/Cargo.toml
@@ -2,5 +2,6 @@
 name = "virtio_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
+edition = "2018"
 
 [dependencies]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vmm"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -776,16 +776,16 @@ pub mod tests {
     use std::io::Cursor;
 
     use super::*;
+    use crate::vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
+    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
+    use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
+    use crate::vmm_config::vsock::tests::default_config;
+    use crate::vmm_config::vsock::{VsockBuilder, VsockDeviceConfig};
     use arch::DeviceType;
     use devices::virtio::{TYPE_BLOCK, TYPE_VSOCK};
     use kernel::cmdline::Cmdline;
     use polly::event_manager::EventManager;
     use utils::tempfile::TempFile;
-    use vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
-    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
-    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
-    use vmm_config::vsock::tests::default_config;
-    use vmm_config::vsock::{VsockBuilder, VsockDeviceConfig};
 
     pub(crate) struct CustomBlockConfig {
         drive_id: String,
@@ -1196,7 +1196,7 @@ pub mod tests {
 
     #[test]
     fn test_error_messages() {
-        use builder::StartMicrovmError::*;
+        use crate::builder::StartMicrovmError::*;
         let err = AttachBlockDevice(io::Error::from_raw_os_error(0));
         let _ = format!("{}{:?}", err, err);
 

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -9,7 +9,6 @@
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-use devices;
 use kvm_ioctls::VmFd;
 use utils::eventfd::EventFd;
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -12,7 +12,6 @@ use std::{fmt, io};
 #[cfg(target_arch = "aarch64")]
 use arch::aarch64::DeviceInfoForFDT;
 use arch::DeviceType;
-use devices;
 use devices::pseudo::BootTimer;
 use devices::{virtio::MmioTransport, BusDevice};
 use kernel::cmdline as kernel_cmdline;
@@ -287,9 +286,8 @@ impl DeviceInfoForFDT for MMIODeviceInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::builder;
     use super::*;
-    use arch;
+    use crate::builder;
     use devices::virtio::{ActivateResult, Queue, VirtioDevice};
     use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -286,13 +286,12 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use builder::attach_boot_timer_device;
-    use builder::tests::*;
-    use utils::tempfile::TempFile;
-    use vmm_config::net::NetworkInterfaceConfig;
-    use vmm_config::vsock::VsockDeviceConfig;
-
+    use crate::builder::attach_boot_timer_device;
+    use crate::builder::tests::*;
+    use crate::vmm_config::net::NetworkInterfaceConfig;
+    use crate::vmm_config::vsock::VsockDeviceConfig;
     use polly::event_manager::EventManager;
+    use utils::tempfile::TempFile;
 
     impl PartialEq for ConnectedBlockState {
         fn eq(&self, other: &ConnectedBlockState) -> bool {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -67,16 +67,19 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use arch::DeviceType;
 #[cfg(target_arch = "x86_64")]
-use device_manager::legacy::PortIODeviceManager;
-use device_manager::mmio::MMIODeviceManager;
+use crate::device_manager::legacy::PortIODeviceManager;
+use crate::device_manager::mmio::MMIODeviceManager;
+#[cfg(target_arch = "x86_64")]
+use crate::memory_snapshot::SnapshotMemory;
+#[cfg(target_arch = "x86_64")]
+use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
+#[cfg(target_arch = "x86_64")]
+use crate::vstate::VcpuState;
+use crate::vstate::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
+use arch::DeviceType;
 use devices::BusDevice;
 use logger::{LoggerError, MetricsError, METRICS};
-#[cfg(target_arch = "x86_64")]
-use memory_snapshot::SnapshotMemory;
-#[cfg(target_arch = "x86_64")]
-use persist::{MicrovmState, MicrovmStateError, VmInfo};
 use polly::event_manager::{self, EventManager, Subscriber};
 use seccomp::BpfProgramRef;
 #[cfg(target_arch = "x86_64")]
@@ -84,9 +87,6 @@ use snapshot::Persist;
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;
 use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap};
-#[cfg(target_arch = "x86_64")]
-use vstate::VcpuState;
-use vstate::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
 
 /// Success exit code.
 pub const FC_EXIT_CODE_OK: u8 = 0;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -17,13 +17,13 @@ use crate::device_manager::persist::Error as DevicePersistError;
 use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
 use crate::vstate::{self, VcpuState, VmState};
 
-use device_manager::persist::DeviceStates;
-use memory_snapshot;
-use memory_snapshot::{GuestMemoryState, SnapshotMemory};
+use crate::device_manager::persist::DeviceStates;
+use crate::memory_snapshot;
+use crate::memory_snapshot::{GuestMemoryState, SnapshotMemory};
+use crate::version_map::FC_VERSION_TO_SNAP_VERSION;
 use polly::event_manager::EventManager;
 use seccomp::BpfProgramRef;
 use snapshot::Snapshot;
-use version_map::FC_VERSION_TO_SNAP_VERSION;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_create_snapshot_error_display() {
-        use persist::CreateSnapshotError::*;
+        use crate::persist::CreateSnapshotError::*;
         use vm_memory::GuestMemoryError;
 
         let err = DirtyBitmap;
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_load_snapshot_error_display() {
-        use persist::LoadSnapshotError::*;
+        use crate::persist::LoadSnapshotError::*;
 
         let err = BuildMicroVm(StartMicrovmError::InitrdLoad);
         let _ = format!("{}{:?}", err, err);
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_microvm_state_error_display() {
-        use persist::MicrovmStateError::*;
+        use crate::persist::MicrovmStateError::*;
 
         let err = InvalidInput;
         let _ = format!("{}{:?}", err, err);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -5,20 +5,20 @@
 
 use std::fs::File;
 
-use mmds::ns::MmdsNetworkStack;
-use utils::net::ipv4addr::is_link_local_valid;
-use vmm_config::boot_source::{
+use crate::vmm_config::boot_source::{
     BootConfig, BootSourceConfig, BootSourceConfigError, DEFAULT_KERNEL_CMDLINE,
 };
-use vmm_config::drive::*;
-use vmm_config::instance_info::InstanceInfo;
-use vmm_config::logger::{init_logger, LoggerConfig, LoggerConfigError};
-use vmm_config::machine_config::{VmConfig, VmConfigError};
-use vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError};
-use vmm_config::mmds::{MmdsConfig, MmdsConfigError};
-use vmm_config::net::*;
-use vmm_config::vsock::*;
-use vstate::VcpuConfig;
+use crate::vmm_config::drive::*;
+use crate::vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::logger::{init_logger, LoggerConfig, LoggerConfigError};
+use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
+use crate::vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError};
+use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
+use crate::vmm_config::net::*;
+use crate::vmm_config::vsock::*;
+use crate::vstate::VcpuConfig;
+use mmds::ns::MmdsNetworkStack;
+use utils::net::ipv4addr::is_link_local_valid;
 
 type Result<E> = std::result::Result<(), E>;
 
@@ -298,17 +298,17 @@ mod tests {
     use std::os::linux::fs::MetadataExt;
 
     use super::*;
+    use crate::resources::VmResources;
+    use crate::vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
+    use crate::vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
+    use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
+    use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
+    use crate::vmm_config::vsock::tests::default_config;
+    use crate::vmm_config::RateLimiterConfig;
+    use crate::vstate::VcpuConfig;
     use dumbo::MacAddr;
     use logger::{LevelFilter, LOGGER};
-    use resources::VmResources;
     use utils::tempfile::TempFile;
-    use vmm_config::boot_source::{BootConfig, BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
-    use vmm_config::drive::{BlockBuilder, BlockDeviceConfig};
-    use vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
-    use vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
-    use vmm_config::vsock::tests::default_config;
-    use vmm_config::RateLimiterConfig;
-    use vstate::VcpuConfig;
 
     fn default_net_cfg() -> NetworkInterfaceConfig {
         NetworkInterfaceConfig {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -11,32 +11,32 @@ use std::sync::{Arc, Mutex};
 use super::Vmm;
 
 use super::Error as VmmError;
-use arch::DeviceType;
-use builder::{self, StartMicrovmError};
-use device_manager::mmio::MMIO_CFG_SPACE_OFF;
-use devices::virtio::{Block, MmioTransport, Net, TYPE_BLOCK, TYPE_NET};
-use logger::{update_metric_with_elapsed_time, METRICS};
+use crate::builder::{self, StartMicrovmError};
+use crate::device_manager::mmio::MMIO_CFG_SPACE_OFF;
 #[cfg(target_arch = "x86_64")]
-use persist::{self, CreateSnapshotError, LoadSnapshotError};
-use polly::event_manager::EventManager;
-use resources::VmResources;
-use seccomp::BpfProgram;
+use crate::persist::{self, CreateSnapshotError, LoadSnapshotError};
+use crate::resources::VmResources;
 #[cfg(target_arch = "x86_64")]
-use version_map::VERSION_MAP;
-use vmm_config;
-use vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
-use vmm_config::drive::{BlockDeviceConfig, DriveError};
-use vmm_config::instance_info::InstanceInfo;
-use vmm_config::logger::{LoggerConfig, LoggerConfigError};
-use vmm_config::machine_config::{VmConfig, VmConfigError};
-use vmm_config::metrics::{MetricsConfig, MetricsConfigError};
-use vmm_config::mmds::{MmdsConfig, MmdsConfigError};
-use vmm_config::net::{
+use crate::version_map::VERSION_MAP;
+use crate::vmm_config;
+use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
+use crate::vmm_config::drive::{BlockDeviceConfig, DriveError};
+use crate::vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::logger::{LoggerConfig, LoggerConfigError};
+use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
+use crate::vmm_config::metrics::{MetricsConfig, MetricsConfigError};
+use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
+use crate::vmm_config::net::{
     NetworkInterfaceConfig, NetworkInterfaceError, NetworkInterfaceUpdateConfig,
 };
 #[cfg(target_arch = "x86_64")]
-use vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
-use vmm_config::vsock::{VsockConfigError, VsockDeviceConfig};
+use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
+use crate::vmm_config::vsock::{VsockConfigError, VsockDeviceConfig};
+use arch::DeviceType;
+use devices::virtio::{Block, MmioTransport, Net, TYPE_BLOCK, TYPE_NET};
+use logger::{update_metric_with_elapsed_time, METRICS};
+use polly::event_manager::EventManager;
+use seccomp::BpfProgram;
 
 /// This enum represents the public interface of the VMM. Each action contains various
 /// bits of information (ids, paths, etc.).

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use self::logger_crate::{LevelFilter, LOGGER};
 use super::{open_file_nonblock, FcLineWriter};
-use vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::instance_info::InstanceInfo;
 
 /// Enum used for setting the log level.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -158,7 +158,6 @@ mod tests {
     use std::io::{BufRead, BufReader};
 
     use super::*;
-
     use devices::pseudo::BootTimer;
     use devices::BusDevice;
     use utils::tempfile::TempFile;

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -18,7 +18,7 @@ use std::thread;
 
 use super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 
-use arch;
+use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 #[cfg(target_arch = "aarch64")]
 use arch::aarch64::gic::GICDevice;
 #[cfg(target_arch = "x86_64")]
@@ -44,7 +44,6 @@ use versionize_derive::Versionize;
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
 };
-use vmm_config::machine_config::CpuFeaturesTemplate;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;
@@ -1401,7 +1400,7 @@ pub(crate) mod tests {
 
     impl PartialEq for VcpuResponse {
         fn eq(&self, other: &Self) -> bool {
-            use VcpuResponse::*;
+            use crate::VcpuResponse::*;
             // Guard match with no wildcard to make sure we catch new enum variants.
             match self {
                 Paused | Resumed | Exited(_) => (),
@@ -1426,7 +1425,7 @@ pub(crate) mod tests {
 
     impl fmt::Debug for VcpuResponse {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            use VcpuResponse::*;
+            use crate::VcpuResponse::*;
             match self {
                 Paused => write!(f, "VcpuResponse::Paused"),
                 Resumed => write!(f, "VcpuResponse::Resumed"),
@@ -1747,7 +1746,7 @@ pub(crate) mod tests {
 
     #[cfg(target_arch = "x86_64")]
     fn load_good_kernel(vm_memory: &GuestMemoryMmap) -> GuestAddress {
-        use vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
+        use crate::vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
 
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let parent = path.parent().unwrap();

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -43,12 +43,12 @@ use vmm::vmm_config::boot_source::BootSourceConfig;
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, SnapshotType};
 use vmm::Vmm;
 
-use mock_devices::MockSerialInput;
+use crate::mock_devices::MockSerialInput;
 #[cfg(target_arch = "x86_64")]
-use mock_resources::NOISY_KERNEL_IMAGE;
-use mock_resources::{MockBootSourceConfig, MockVmResources};
-use mock_seccomp::MockSeccomp;
-use test_utils::{restore_stdin, set_panic_hook};
+use crate::mock_resources::NOISY_KERNEL_IMAGE;
+use crate::mock_resources::{MockBootSourceConfig, MockVmResources};
+use crate::mock_seccomp::MockSeccomp;
+use crate::test_utils::{restore_stdin, set_panic_hook};
 
 fn default_vmm(_kernel_image: Option<&str>) -> (Arc<Mutex<Vmm>>, EventManager) {
     let mut event_manager = EventManager::new().unwrap();

--- a/tests/integration_tests/security/demo_seccomp/Cargo.toml
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "demo_seccomp"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"


### PR DESCRIPTION
## Reason for This PR

Resolves #839 

## Description of Changes

This PR updates all crates in `firecracker` to `edition="2018"`. The goal of the PR is to change a _minimal_ surface area of the project to make it 2018-edition idiomatic.

General notes:

- Non-compilation adjustments were made in addition to import statements and idiom fixes based on compiler and clippy suggestions. ~All instances of `extern crate` have been removed~ (this change will come later), `fn main()` decls were removed from doctests, remove unnecessary boxing & cloning, etc.
- I've not tried to standardize code _style_ outside of what passes the `rustfmt` integration tests. Since different authors have worked on different crates, I attempted to stick to whichever style they appeared to use (especially in regards to import organization)


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
