### PR TITLE
Fix snapshots of uVMs with PATCHed block devices

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -29,61 +29,103 @@ use super::{
 
 use crate::Error as DeviceError;
 
-pub fn build_config_space(disk_size: u64) -> Vec<u8> {
-    // We only support disk size, which uses the first two words of the configuration space.
-    // If the image is not a multiple of the sector size, the tail bits are not exposed.
-    // The config space is little endian.
-    if disk_size % SECTOR_SIZE != 0 {
-        warn!(
-            "Disk size {} is not a multiple of sector size {}; \
-             the remainder will not be visible to the guest.",
-            disk_size, SECTOR_SIZE
+/// Helper object for setting up all `Block` fields derived from its backing file.
+pub(crate) struct DiskProperties {
+    file_path: String,
+    file: File,
+    nsectors: u64,
+    image_id: Vec<u8>,
+}
+
+impl DiskProperties {
+    pub fn new(disk_image_path: String, is_disk_read_only: bool) -> io::Result<Self> {
+        let mut disk_image = OpenOptions::new()
+            .read(true)
+            .write(!is_disk_read_only)
+            .open(PathBuf::from(&disk_image_path))?;
+        let disk_size = disk_image.seek(SeekFrom::End(0))? as u64;
+
+        // We only support disk size, which uses the first two words of the configuration space.
+        // If the image is not a multiple of the sector size, the tail bits are not exposed.
+        if disk_size % SECTOR_SIZE != 0 {
+            warn!(
+                "Disk size {} is not a multiple of sector size {}; \
+                 the remainder will not be visible to the guest.",
+                disk_size, SECTOR_SIZE
+            );
+        }
+
+        Ok(Self {
+            nsectors: disk_size >> SECTOR_SHIFT,
+            image_id: Self::build_disk_image_id(&disk_image),
+            file_path: disk_image_path,
+            file: disk_image,
+        })
+    }
+
+    pub fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    pub fn nsectors(&self) -> u64 {
+        self.nsectors
+    }
+
+    pub fn image_id(&self) -> &[u8] {
+        &self.image_id
+    }
+
+    fn build_device_id(disk_file: &File) -> result::Result<String, Error> {
+        let blk_metadata = disk_file.metadata().map_err(Error::GetFileMetadata)?;
+        // This is how kvmtool does it.
+        let device_id = format!(
+            "{}{}{}",
+            blk_metadata.st_dev(),
+            blk_metadata.st_rdev(),
+            blk_metadata.st_ino()
         );
+        Ok(device_id)
     }
-    let mut config = Vec::with_capacity(CONFIG_SPACE_SIZE);
-    let num_sectors = disk_size >> SECTOR_SHIFT;
-    for i in 0..CONFIG_SPACE_SIZE {
-        config.push((num_sectors >> (8 * i)) as u8);
-    }
-    config
-}
 
-fn build_device_id(disk_image: &File) -> result::Result<String, Error> {
-    let blk_metadata = disk_image.metadata().map_err(Error::GetFileMetadata)?;
-    // This is how kvmtool does it.
-    let device_id = format!(
-        "{}{}{}",
-        blk_metadata.st_dev(),
-        blk_metadata.st_rdev(),
-        blk_metadata.st_ino()
-    );
-    Ok(device_id)
-}
-
-fn build_disk_image_id(disk_image: &File) -> Vec<u8> {
-    let mut default_disk_image_id = vec![0; VIRTIO_BLK_ID_BYTES as usize];
-    match build_device_id(disk_image) {
-        Err(_) => {
-            warn!("Could not generate device id. We'll use a default.");
+    fn build_disk_image_id(disk_file: &File) -> Vec<u8> {
+        let mut default_id = vec![0; VIRTIO_BLK_ID_BYTES as usize];
+        match Self::build_device_id(disk_file) {
+            Err(_) => {
+                warn!("Could not generate device id. We'll use a default.");
+            }
+            Ok(m) => {
+                // The kernel only knows to read a maximum of VIRTIO_BLK_ID_BYTES.
+                // This will also zero out any leftover bytes.
+                let disk_id = m.as_bytes();
+                let bytes_to_copy = cmp::min(disk_id.len(), VIRTIO_BLK_ID_BYTES as usize);
+                default_id[..bytes_to_copy].clone_from_slice(&disk_id[..bytes_to_copy])
+            }
         }
-        Ok(m) => {
-            // The kernel only knows to read a maximum of VIRTIO_BLK_ID_BYTES.
-            // This will also zero out any leftover bytes.
-            let disk_id = m.as_bytes();
-            let bytes_to_copy = cmp::min(disk_id.len(), VIRTIO_BLK_ID_BYTES as usize);
-            default_disk_image_id[..bytes_to_copy].clone_from_slice(&disk_id[..bytes_to_copy])
-        }
+        default_id
     }
-    default_disk_image_id
+
+    /// Backing file path.
+    pub fn file_path(&self) -> &String {
+        &self.file_path
+    }
+
+    /// Provides vec containing the virtio block configuration space
+    /// buffer. The config space is populated with the disk size based
+    /// on the backing file size.
+    pub fn virtio_block_config_space(&self) -> Vec<u8> {
+        // The config space is little endian.
+        let mut config = Vec::with_capacity(CONFIG_SPACE_SIZE);
+        for i in 0..CONFIG_SPACE_SIZE {
+            config.push((self.nsectors >> (8 * i)) as u8);
+        }
+        config
+    }
 }
 
 /// Virtio device for exposing block level read/write operations on a host file.
 pub struct Block {
     // Host file and properties.
-    disk_image: File,
-    pub(crate) disk_image_path: String,
-    disk_nsectors: u64,
-    disk_image_id: Vec<u8>,
+    pub(crate) disk: DiskProperties,
 
     // Virtio fields.
     pub(crate) avail_features: u64,
@@ -117,12 +159,7 @@ impl Block {
         is_disk_root: bool,
         rate_limiter: RateLimiter,
     ) -> io::Result<Block> {
-        let mut disk_image = OpenOptions::new()
-            .read(true)
-            .write(!is_disk_read_only)
-            .open(PathBuf::from(&disk_image_path))?;
-
-        let disk_size = disk_image.seek(SeekFrom::End(0))? as u64;
+        let disk_properties = DiskProperties::new(disk_image_path, is_disk_read_only)?;
 
         let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_BLK_F_FLUSH);
 
@@ -138,14 +175,11 @@ impl Block {
             id,
             root_device: is_disk_root,
             partuuid,
-            disk_image_id: build_disk_image_id(&disk_image),
-            disk_image,
-            disk_image_path,
-            disk_nsectors: disk_size / SECTOR_SIZE,
+            rate_limiter,
+            config_space: disk_properties.virtio_block_config_space(),
+            disk: disk_properties,
             avail_features,
             acked_features: 0u64,
-            config_space: build_config_space(disk_size),
-            rate_limiter,
             interrupt_status: Arc::new(AtomicUsize::new(0)),
             interrupt_evt: EventFd::new(libc::EFD_NONBLOCK)?,
             queue_evts,
@@ -216,12 +250,7 @@ impl Block {
                             break;
                         }
                     }
-                    let status = match request.execute(
-                        &mut self.disk_image,
-                        self.disk_nsectors,
-                        mem,
-                        &self.disk_image_id,
-                    ) {
+                    let status = match request.execute(&mut self.disk, mem) {
                         Ok(l) => {
                             len = l;
                             VIRTIO_BLK_S_OK
@@ -266,15 +295,11 @@ impl Block {
         Ok(())
     }
 
-    /// Update the backing file for the Block device.
-    pub fn update_disk_image(&mut self, disk_image: File) -> result::Result<(), DeviceError> {
-        self.disk_image = disk_image;
-        self.disk_nsectors = self
-            .disk_image
-            .seek(SeekFrom::End(0))
-            .map_err(DeviceError::IoError)?
-            / SECTOR_SIZE;
-        self.disk_image_id = build_disk_image_id(&self.disk_image);
+    /// Update the backing file and the config space of the block device.
+    pub fn update_disk_image(&mut self, disk_image_path: String) -> io::Result<()> {
+        let disk_properties = DiskProperties::new(disk_image_path, self.is_read_only())?;
+        self.disk = disk_properties;
+        self.config_space = self.disk.virtio_block_config_space();
         METRICS.block.update_count.inc();
         Ok(())
     }
@@ -488,6 +513,29 @@ pub(crate) mod tests {
         );
         // Validate the queue operation finished successfully.
         assert_eq!(b.interrupt_evt.read().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_disk_backing_file_helper() {
+        let num_sectors = 2;
+        let f = TempFile::new().unwrap();
+        let size = SECTOR_SIZE * num_sectors;
+        f.as_file().set_len(size).unwrap();
+
+        let disk_properties =
+            DiskProperties::new(String::from(f.as_path().to_str().unwrap()), true).unwrap();
+
+        assert_eq!(size, SECTOR_SIZE * num_sectors);
+        assert_eq!(disk_properties.nsectors, num_sectors);
+        let cfg = disk_properties.virtio_block_config_space();
+        assert_eq!(cfg.len(), CONFIG_SPACE_SIZE);
+        for (i, byte) in cfg.iter().enumerate() {
+            assert_eq!(*byte, (num_sectors >> (8 * i)) as u8);
+        }
+        // Testing `backing_file.virtio_block_disk_image_id()` implies
+        // duplicating that logic in tests, so skipping it.
+
+        assert!(DiskProperties::new("invalid-disk-path".to_string(), true).is_err());
     }
 
     #[test]
@@ -789,7 +837,7 @@ pub(crate) mod tests {
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let data_addr = GuestAddress(vq.dtable[1].addr.get());
         let status_addr = GuestAddress(vq.dtable[2].addr.get());
-        let blk_metadata = block.disk_image.metadata();
+        let blk_metadata = block.disk.file.metadata();
 
         // Test that the driver receives the correct device id.
         {
@@ -1020,12 +1068,11 @@ pub(crate) mod tests {
         id[..cmp::min(part_id.len(), VIRTIO_BLK_ID_BYTES as usize)]
             .clone_from_slice(&part_id[..cmp::min(part_id.len(), VIRTIO_BLK_ID_BYTES as usize)]);
 
-        block.update_disk_image(f.into_file()).unwrap();
+        block
+            .update_disk_image(String::from(path.to_str().unwrap()))
+            .unwrap();
 
-        assert_eq!(
-            block.disk_image.metadata().unwrap().st_ino(),
-            mdata.st_ino()
-        );
-        assert_eq!(block.disk_image_id, id);
+        assert_eq!(block.disk.file.metadata().unwrap().st_ino(), mdata.st_ino());
+        assert_eq!(block.disk.image_id, id);
     }
 }

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -43,7 +43,7 @@ impl Persist<'_> for Block {
             id: self.id.clone(),
             partuuid: self.partuuid.clone(),
             root_device: self.root_device,
-            disk_path: self.disk_image_path.clone(),
+            disk_path: self.disk.file_path().clone(),
             virtio_state: VirtioDeviceState::from_device(self),
             rate_limiter_state: self.rate_limiter.save(),
         }
@@ -139,6 +139,6 @@ mod tests {
         assert_eq!(restored_block.is_activated(), block.is_activated());
 
         // Test that block specific fields are the same.
-        assert_eq!(&restored_block.disk_image_path, &block.disk_image_path);
+        assert_eq!(restored_block.disk.file_path(), block.disk.file_path());
     }
 }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -67,10 +67,6 @@ type Result<T> = ::std::result::Result<T, Error>;
 /// Currently hardcoded to 4K.
 const MMIO_LEN: u64 = 0x1000;
 
-/// This represents the offset at which the device should call BusDevice::write in order to write
-/// to its configuration space.
-pub const MMIO_CFG_SPACE_OFF: u64 = 0x100;
-
 /// Stores the address range and irq allocated to this device.
 #[derive(Clone, Debug, PartialEq, Versionize)]
 pub struct MMIODeviceInfo {

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -20,7 +20,7 @@ type Result<T> = result::Result<T, DriveError>;
 #[derive(Debug)]
 pub enum DriveError {
     /// Cannot update the block device.
-    BlockDeviceUpdateFailed,
+    BlockDeviceUpdateFailed(io::Error),
     /// Unable to seek the block device backing file due to invalid permissions or
     /// the file was corrupted.
     CreateBlockDevice(io::Error),
@@ -39,18 +39,18 @@ pub enum DriveError {
 impl Display for DriveError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::DriveError::*;
-        match *self {
-            CreateBlockDevice(ref e) => write!(
+        match self {
+            CreateBlockDevice(e) => write!(
                 f,
                 "Unable to seek the block device backing file due to invalid permissions or \
                  the file was corrupted. Error number: {}",
                 e
             ),
-            BlockDeviceUpdateFailed => write!(f, "The update operation failed!"),
-            CreateRateLimiter(ref e) => write!(f, "Cannot create RateLimiter: {}", e),
+            BlockDeviceUpdateFailed(e) => write!(f, "The update operation failed: {}", e),
+            CreateRateLimiter(e) => write!(f, "Cannot create RateLimiter: {}", e),
             InvalidBlockDeviceID => write!(f, "Invalid block device ID!"),
             InvalidBlockDevicePath => write!(f, "Invalid block device path!"),
-            OpenBlockDevice(ref e) => write!(
+            OpenBlockDevice(e) => write!(
                 f,
                 "Cannot open block device. Invalid permission/path: {}",
                 e

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -89,7 +89,9 @@ class MicrovmBuilder:
         jailed_mem = vm.create_jailed_resource(snapshot.mem)
         jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
         assert len(snapshot.disks) > 0, "Snapshot requiures at least one disk."
-        _jailed_disk = vm.create_jailed_resource(snapshot.disks[0])
+        _jailed_disks = []
+        for disk in snapshot.disks:
+            _jailed_disks.append(vm.create_jailed_resource(disk))
         vm.ssh_config['ssh_key_path'] = snapshot.ssh_key
 
         if host_ip is not None:
@@ -121,7 +123,7 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
         self._microvm = microvm
 
     def create(self,
-               disks: [DiskArtifact],
+               disks,
                ssh_key: Artifact,
                snapshot_type: SnapshotType = SnapshotType.FULL):
         """Create a Snapshot object from a microvm and artifacts."""
@@ -150,5 +152,5 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
                         # simple and flexible way to store snapshot artifacts
                         # in S3. This should be done in a PR where we add tests
                         # that resume from S3 snapshot artifacts.
-                        disks=[disks[0].local_path()],
+                        disks=disks,
                         ssh_key=ssh_key_copy.local_path())

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -531,6 +531,14 @@ class Microvm:
         )
         assert self.api_session.is_status_no_content(response.status_code)
 
+    def patch_drive(self, drive_id, file):
+        """Modify/patch an existing block device."""
+        response = self.drive.patch(
+            drive_id=drive_id,
+            path_on_host=self.create_jailed_resource(file.path),
+        )
+        assert self.api_session.is_status_no_content(response.status_code)
+
     def ssh_network_config(
             self,
             network_config,

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -521,6 +521,16 @@ class Microvm:
             )
             assert self._api_session.is_status_no_content(response.status_code)
 
+    def add_drive(self, drive_id, file, root_device=False, is_read_only=False):
+        """Add a block device."""
+        response = self.drive.put(
+            drive_id=drive_id,
+            path_on_host=self.create_jailed_resource(file.path),
+            is_root_device=root_device,
+            is_read_only=is_read_only
+        )
+        assert self.api_session.is_status_no_content(response.status_code)
+
     def ssh_network_config(
             self,
             network_config,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.40, "AMD": 84.40}
+COVERAGE_DICT = {"Intel": 84.50, "AMD": 84.45}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -691,7 +691,7 @@ def _drive_patch(test_microvm):
         path_on_host='foo.bar'
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert "Cannot open block device. Invalid permission/path" \
+    assert "The update operation failed: No such file or directory" \
            in response.text
 
     fs = drive_tools.FilesystemFile(

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -76,12 +76,13 @@ def _test_seq_snapshots(context):
         ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
 
         # Start a new instance of fio on each iteration.
-        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k
-        --ioengine=libaio --iodepth=16 --runtime=10 --numjobs=4 --time_based
+        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+        --ioengine=libaio --iodepth=16 --runtime=10 --numjobs=4 --time_based \
         --group_reporting --name=iops-test-job --eta-newline=1 --readonly"""
         ssh_cmd = "screen -L -Logfile /tmp/fio{} -dmS test{} {}"
         ssh_cmd = ssh_cmd.format(i, i, fio)
         exit_code, _, _ = ssh_connection.execute_command(ssh_cmd)
+        assert exit_code == 0
 
         logger.info("Create snapshot #{}.".format(i + 1))
 

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -145,7 +145,7 @@ kernel {}, disk {} """.format(snapshot_type,
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(basevm)
 
-    snapshot = snapshot_builder.create([rw_disk],
+    snapshot = snapshot_builder.create([rw_disk.local_path()],
                                        ssh_key,
                                        snapshot_type)
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -13,7 +13,7 @@ timeout = 300
 cache_dir = ../build/pytest_cache
 
 ; Set logger format and level
-log_level = DEBUG
+log_level = INFO
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 ; Uncomment the line below to get the live logger output
 ;log_cli = true


### PR DESCRIPTION
## Draft status

Needs regression test before upgrading to mergeable PR.

## Reason for This PR

Fixes #1974 

## Description of Changes

When doing a Block device backing file update we have to update multiple properties built from the backing file.

The actual backing file path was not being updated so snapshots would use the old path and snapshot restores would malfunction.

Created `DiskProperties` helper object for setting up all `Block` fields derived from the backing file. The object can be used in both construction and update paths for the `Block` device.
It provides functionality for setting up all backing file related fields so that all related logic is contained.

This commit fixes snapshots of uVMs with PATCHed block devices.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
