### PR TITLE
rate_limiter: enforce limit for large requests

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -1901,8 +1901,8 @@ pub mod tests {
         {
             // create ops rate limiter that allows 10 ops/s with bucket size 1 ops
             let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100).unwrap();
-            // use up the budget
-            assert!(rl.consume(0x800, TokenType::Ops));
+            // use up the initial budget
+            assert!(rl.consume(1, TokenType::Ops));
 
             // set this rx rate limiter to be used
             th.net().rx_rate_limiter = rl;


### PR DESCRIPTION
Handled the corner case where a request to the rate limiter wanted
to consume more tokens than the bucket size by emptying the bucket
and arming the timer with a custom duration such that the rate
limiting is consistent.

Signed-off-by: George Pisaltu <gpl@amazon.com>

## Reason for This PR

Fixes #259 

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
