### PR TITLE
Handled Firecracker panic when socket address is already in use

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -104,7 +104,10 @@ impl ApiServer {
         start_time_cpu_us: Option<u64>,
         seccomp_filter: BpfProgram,
     ) -> Result<()> {
-        let mut server = HttpServer::new(path).expect("Error creating the HTTP server");
+        let mut server = HttpServer::new(path).unwrap_or_else(|e| {
+            error!("Error creating the HTTP server: {}", e);
+            std::process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
+        });
 
         if let Some(start_time) = start_time_us {
             let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

Firecracker panics if socket address is already in use.

## Description of Changes

Caught the error that caused the panic and gracefully exited with the proper code and error message.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
