### PR TITLE
Remove extern crate, apply clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,6 @@ dependencies = [
  "rate_limiter 0.1.0",
  "seccomp 0.1.0",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "snapshot 0.1.0",
  "sysconf 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -1,18 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
-#[macro_use]
-extern crate logger;
-extern crate micro_http;
-extern crate mmds;
-extern crate seccomp;
-extern crate utils;
-extern crate vmm;
-
 mod parsed_request;
 mod request;
 
@@ -22,7 +9,7 @@ use std::sync::{mpsc, Arc, Mutex, RwLock};
 use std::{fmt, io};
 
 use crate::parsed_request::ParsedRequest;
-use logger::{update_metric_with_elapsed_time, Metric, METRICS};
+use logger::{debug, error, info, update_metric_with_elapsed_time, Metric, METRICS};
 pub use micro_http::{
     Body, HttpServer, Method, Request, RequestError, Response, ServerError, ServerRequest,
     ServerResponse, StatusCode, Version,
@@ -306,8 +293,6 @@ impl ApiServer {
 
 #[cfg(test)]
 mod tests {
-    extern crate libc;
-
     use std::convert::TryInto;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -22,6 +22,7 @@ use crate::request::vsock::parse_put_vsock;
 use crate::ApiServer;
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 
+use logger::{error, info};
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 
 pub enum ParsedRequest {

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -8,6 +8,8 @@ use crate::request::Body;
 use crate::request::StatusCode;
 use logger::{Metric, METRICS};
 
+use serde::{Deserialize, Serialize};
+
 // The names of the members from this enum must precisely correspond (as a string) to the possible
 // values of "action_type" from the json request body. This is useful to get a strongly typed
 // struct from the Serde deserialization process.

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -4,14 +4,6 @@
 #![deny(missing_docs)]
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.
-extern crate kvm_bindings;
-extern crate kvm_ioctls;
-extern crate libc;
-
-extern crate arch_gen;
-extern crate utils;
-extern crate vm_memory;
-
 use std::fmt;
 use std::result;
 

--- a/src/arch/src/x86_64/interrupts.rs
+++ b/src/arch/src/x86_64/interrupts.rs
@@ -65,8 +65,6 @@ pub fn set_lint(vcpu: &VcpuFd) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    extern crate utils;
-
     use super::*;
     use kvm_ioctls::Kvm;
 

--- a/src/cpuid/src/bit_helper.rs
+++ b/src/cpuid/src/bit_helper.rs
@@ -8,16 +8,12 @@
 /// # Example
 ///
 /// ```
-/// #[macro_use]
-/// extern crate cpuid;
 /// use cpuid::bit_helper::*;
 ///
-/// fn main() {
-///     let range = BitRange {
-///         msb_index: 7,
-///         lsb_index: 3,
-///     };
-/// }
+/// let range = BitRange {
+///     msb_index: 7,
+///     lsb_index: 3,
+/// };
 /// ```
 /// The BitRange specified above will represent the following part of the number 72:
 /// +-------------------------------------+---+---+---+---+---+---+---+---+---+---+
@@ -45,17 +41,13 @@ pub trait BitRangeExt<T> {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate cpuid;
     /// use cpuid::bit_helper::*;
     ///
-    /// fn main() {
-    ///     let range = BitRange {
-    ///         msb_index: 7,
-    ///         lsb_index: 3,
-    ///     };
-    ///     println!("binary value: {:b}", range.get_mask());
-    /// }
+    /// let range = BitRange {
+    ///    msb_index: 7,
+    ///    lsb_index: 3,
+    /// };
+    /// println!("binary value: {:b}", range.get_mask());
     /// ```
     /// The code above will print:
     /// ```bash
@@ -108,18 +100,14 @@ pub trait BitHelper {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate cpuid;
     /// use cpuid::bit_helper::*;
     ///
-    /// fn main() {
-    ///     let val: u32 = 0b000010001000;
-    ///     let range = BitRange {
-    ///         msb_index: 7,
-    ///         lsb_index: 3,
-    ///     };
-    ///     println!("binary value: {:b}", val.read_bits_in_range(&range));
-    /// }
+    /// let val: u32 = 0b000010001000;
+    /// let range = BitRange {
+    ///     msb_index: 7,
+    ///     lsb_index: 3,
+    /// };
+    /// println!("binary value: {:b}", val.read_bits_in_range(&range));
     /// ```
     /// The code above will print:
     /// ```bash
@@ -132,19 +120,15 @@ pub trait BitHelper {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate cpuid;
     /// use cpuid::bit_helper::*;
     ///
-    /// fn main() {
-    ///     let mut val: u32 = 0;
-    ///     let range = BitRange {
-    ///         msb_index: 7,
-    ///         lsb_index: 3,
-    ///     };
-    ///     val.write_bits_in_range(&range, 0b10001 as u32);
-    ///     println!("binary value: {:b}", val);
-    /// }
+    /// let mut val: u32 = 0;
+    /// let range = BitRange {
+    ///     msb_index: 7,
+    ///     lsb_index: 3,
+    /// };
+    /// val.write_bits_in_range(&range, 0b10001 as u32);
+    /// println!("binary value: {:b}", val);
     /// ```
     /// The code above will print:
     /// ```bash

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -9,10 +9,6 @@
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 #![cfg(target_arch = "x86_64")]
-
-extern crate kvm_bindings;
-extern crate kvm_ioctls;
-
 use kvm_bindings::CpuId;
 
 mod common;
@@ -42,10 +38,6 @@ mod brand_string;
 ///
 /// # Example
 /// ```
-/// extern crate cpuid;
-/// extern crate kvm_bindings;
-/// extern crate kvm_ioctls;
-///
 /// use cpuid::{filter_cpuid, VmSpec};
 /// use kvm_bindings::{CpuId, KVM_MAX_CPUID_ENTRIES};
 /// use kvm_ioctls::Kvm;

--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use logger::{Metric, METRICS};
+use logger::{error, warn, Metric, METRICS};
 use std::fmt;
 use std::num::Wrapping;
 use std::{io, result};

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -7,15 +7,12 @@
 //! This is achieved by generating an interrupt signal after counting for a programmed number of cycles of
 //! a real-time clock input.
 //!
-
-extern crate utils;
-
 use std::fmt;
 use std::time::Instant;
 use std::{io, result};
 
 use crate::BusDevice;
-use logger::{Metric, METRICS};
+use logger::{warn, Metric, METRICS};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 //use bus::Error;

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::os::unix::io::AsRawFd;
 
-use logger::{Metric, METRICS};
+use logger::{error, warn, Metric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -6,22 +6,6 @@
 // found in the THIRD-PARTY file.
 
 //! Emulates virtual and hardware devices.
-
-extern crate libc;
-
-extern crate dumbo;
-#[macro_use]
-extern crate logger;
-extern crate net_gen;
-extern crate polly;
-extern crate rate_limiter;
-extern crate snapshot;
-#[macro_use]
-extern crate utils;
-extern crate versionize;
-extern crate versionize_derive;
-extern crate vm_memory;
-
 use std::io;
 
 mod bus;
@@ -30,7 +14,7 @@ pub mod pseudo;
 pub mod virtio;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};
-use logger::{Metric, METRICS};
+use logger::{error, Metric, METRICS};
 
 // Function used for reporting error in terms of logging
 // but also in terms of METRICS net event fails.

--- a/src/devices/src/pseudo/boot_timer.rs
+++ b/src/devices/src/pseudo/boot_timer.rs
@@ -1,9 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use utils::time::TimestampUs;
-
 use crate::bus::BusDevice;
+use logger::info;
+use utils::time::TimestampUs;
 
 const MAGIC_VALUE_SIGNAL_GUEST_BOOT_COMPLETE: u8 = 123;
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -15,7 +15,7 @@ use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use logger::{Metric, METRICS};
+use logger::{error, warn, Metric, METRICS};
 use rate_limiter::{RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::*;

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::os::unix::io::AsRawFd;
 
+use logger::{debug, error, warn};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -9,6 +9,7 @@ use std::sync::{atomic::AtomicUsize, Arc};
 
 use super::{ActivateResult, Queue};
 use crate::virtio::AsAny;
+use logger::warn;
 use utils::eventfd::EventFd;
 use vm_memory::GuestMemoryMmap;
 

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -8,6 +8,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use logger::warn;
 use utils::byte_order;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -16,7 +16,7 @@ use crate::{report_net_event_fail, Error as DeviceError};
 use dumbo::pdu::ethernet::EthernetFrame;
 use dumbo::{MacAddr, MAC_ADDR_LEN};
 use libc::EAGAIN;
-use logger::{Metric, METRICS};
+use logger::{error, warn, Metric, METRICS};
 use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 #[cfg(not(test))]

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -3,7 +3,7 @@
 
 use std::os::unix::io::AsRawFd;
 
-use logger::{Metric, METRICS};
+use logger::{debug, error, warn, Metric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -11,6 +11,7 @@ use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::os::raw::*;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use utils::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
+use utils::{ioctl_expr, ioctl_ioc_nr, ioctl_iow_nr};
 
 // As defined in the Linux UAPI:
 // https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/if.h#L33

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -6,10 +6,10 @@
 use super::device::*;
 use super::queue::*;
 use crate::virtio::MmioTransport;
-use crate::vm_memory::Address;
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
+use vm_memory::Address;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 use std::num::Wrapping;

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use logger::error;
 use std::cmp::min;
 use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
@@ -351,8 +352,6 @@ impl Queue {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    extern crate vm_memory;
-
     use std::marker::PhantomData;
     use std::mem;
 

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -83,7 +83,7 @@ use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use logger::{Metric, METRICS};
+use logger::{debug, error, info, warn, Metric, METRICS};
 use utils::epoll::EventSet;
 
 use super::super::defs::uapi;

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -23,7 +23,7 @@ use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use logger::{Metric, METRICS};
+use logger::{debug, error, warn, Metric, METRICS};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 use vm_memory::GuestMemoryMmap;

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -24,7 +24,7 @@
 ///   - again, attempt to fetch any incoming packets queued by the backend into virtio RX buffers.
 use std::os::unix::io::AsRawFd;
 
-use logger::{Metric, METRICS};
+use logger::{debug, error, warn, Metric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -35,7 +35,7 @@ use std::io::Read;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 
-use logger::{Metric, METRICS};
+use logger::{debug, error, info, warn, Metric, METRICS};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 
 use super::super::csm::ConnState;
@@ -944,7 +944,7 @@ mod tests {
     }
     impl LocalListener {
         fn new<P: AsRef<Path> + Clone>(path: P) -> Self {
-            let path_buf = path.clone().as_ref().to_path_buf();
+            let path_buf = path.as_ref().to_path_buf();
             let sock = UnixListener::bind(path).unwrap();
             sock.set_nonblocking(true).unwrap();
             Self {

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -4,15 +4,6 @@
 #![deny(missing_docs)]
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
-
-#[macro_use]
-extern crate bitflags;
-
-extern crate logger;
-extern crate micro_http;
-extern crate serde;
-extern crate utils;
-
 mod mac;
 pub mod pdu;
 pub mod tcp;

--- a/src/dumbo/src/mac.rs
+++ b/src/dumbo/src/mac.rs
@@ -46,8 +46,6 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate dumbo;
-    ///
     /// use self::dumbo::MacAddr;
     /// MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
     /// ```
@@ -80,8 +78,6 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate dumbo;
-    ///
     /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes_unchecked(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
     /// println!("{}", mac.to_string());
@@ -104,8 +100,6 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate dumbo;
-    ///
     /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// println!("{}", mac.to_string());
@@ -122,8 +116,6 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// extern crate dumbo;
-    ///
     /// use self::dumbo::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// assert_eq!([0x01, 0x02, 0x03, 0x04, 0x05, 0x06], mac.get_bytes());
@@ -155,8 +147,6 @@ impl<'de> Deserialize<'de> for MacAddr {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
-
     use super::*;
 
     #[test]

--- a/src/dumbo/src/pdu/tcp.rs
+++ b/src/dumbo/src/pdu/tcp.rs
@@ -17,6 +17,8 @@ use super::Incomplete;
 use crate::pdu::ChecksumProto;
 use crate::ByteBuffer;
 
+use bitflags::bitflags;
+
 const SOURCE_PORT_OFFSET: usize = 0;
 const DESTINATION_PORT_OFFSET: usize = 2;
 const SEQ_NUMBER_OFFSET: usize = 4;

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -17,6 +17,8 @@ use crate::tcp::{
 use crate::ByteBuffer;
 use utils::rand::xor_psuedo_rng_u32;
 
+use bitflags::bitflags;
+
 bitflags! {
     // We use a set of flags, instead of a state machine, to represent the connection status. Some
     // parts of the status information are reflected in other fields of the Connection struct, such

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -13,13 +13,13 @@
 
 use std::num::{NonZeroU16, NonZeroU64, Wrapping};
 
-use crate::micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
 use crate::pdu::{bytes::NetworkBytes, tcp::TcpSegment, Incomplete};
 use crate::tcp::{
     connection::{Connection, PassiveOpenError, RecvStatusFlags},
     seq_after, NextSegmentStatus, MAX_WINDOW_SIZE,
 };
 use logger::{Metric, METRICS};
+use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
 use utils::time::timestamp_cycles;
 
 // TODO: These are currently expressed in cycles. Normally, they would be the equivalent of a

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -9,12 +9,12 @@ use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 
-use crate::micro_http::{Request, Response};
 use crate::pdu::bytes::NetworkBytes;
 use crate::pdu::ipv4::{Error as IPv4PacketError, IPv4Packet, PROTOCOL_TCP};
 use crate::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
 use crate::tcp::endpoint::Endpoint;
 use crate::tcp::{NextSegmentStatus, RstConfig};
+use micro_http::{Request, Response};
 
 // TODO: This is currently IPv4 specific. Maybe change it to a more generic implementation.
 

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,22 +1,29 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::os::unix::io::AsRawFd;
-use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
-use std::sync::{Arc, Mutex, RwLock};
-use std::thread;
+use std::{
+    os::unix::io::AsRawFd,
+    path::PathBuf,
+    sync::mpsc::{channel, Receiver, Sender, TryRecvError},
+    sync::{Arc, Mutex, RwLock},
+    thread,
+};
 
 use api_server::{ApiRequest, ApiResponse, ApiServer};
+use logger::{error, warn};
 use mmds::MMDS;
 use polly::event_manager::{EventManager, Subscriber};
 use seccomp::BpfProgram;
-use utils::epoll::{EpollEvent, EventSet};
-use utils::eventfd::EventFd;
-use vmm::rpc_interface::{PrebootApiController, RuntimeApiController};
-use vmm::vmm_config::instance_info::InstanceInfo;
-use vmm::vmm_config::machine_config::VmConfig;
-use vmm::Vmm;
+use utils::{
+    epoll::{EpollEvent, EventSet},
+    eventfd::EventFd,
+};
+use vmm::{
+    rpc_interface::{PrebootApiController, RuntimeApiController},
+    vmm_config::instance_info::InstanceInfo,
+    vmm_config::machine_config::VmConfig,
+    Vmm,
+};
 
 struct ApiServerAdapter {
     api_event_fd: EventFd,

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -1,17 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate api_server;
-extern crate libc;
-#[macro_use]
-extern crate logger;
-extern crate mmds;
-extern crate polly;
-extern crate seccomp;
-extern crate timerfd;
-extern crate utils;
-extern crate vmm;
-
 mod api_server_adapter;
 mod metrics;
 
@@ -22,7 +10,7 @@ use std::path::PathBuf;
 use std::process;
 use std::sync::{Arc, Mutex};
 
-use logger::{Metric, LOGGER, METRICS};
+use logger::{error, info, Metric, LOGGER, METRICS};
 use polly::event_manager::EventManager;
 use seccomp::{BpfProgram, SeccompLevel};
 use utils::arg_parser::{ArgParser, Argument};

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -4,7 +4,7 @@
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
-use logger::{Metric, METRICS};
+use logger::{error, warn, Metric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 use utils::epoll::{EpollEvent, EventSet};

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -662,7 +662,7 @@ mod tests {
             some_file_name.to_os_string()
         );
 
-        let dest_path = env.chroot_dir.to_path_buf().join(some_file_name);
+        let dest_path = env.chroot_dir.join(some_file_name);
         // Check that `fs::copy()` copied src content and permission bits to destination.
         let metadata_src = fs::metadata(&env.exec_file_path).unwrap();
         let metadata_dest = fs::metadata(&dest_path).unwrap();

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -1,11 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-extern crate regex;
-
-extern crate utils;
-
 mod cgroup;
 mod chroot;
 mod env;

--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -7,6 +7,3 @@
 
 pub mod cmdline;
 pub mod loader;
-
-extern crate utils;
-extern crate vm_memory;

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -1,14 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-// Workaround to `macro_reexport`.
-extern crate lazy_static;
-extern crate libc;
-extern crate log;
-extern crate serde;
-extern crate serde_json;
-extern crate utils;
-
 mod init;
 mod logger;
 mod metrics;

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -21,48 +21,36 @@
 //! ## Example for logging to stdout/stderr
 //!
 //! ```
-//! #[macro_use]
-//! extern crate logger;
-//! use logger::LOGGER;
+//! use logger::{warn, error, LOGGER};
 //! use std::ops::Deref;
 //!
-//! fn main() {
-//!     // Optionally do an initial configuration for the logger.
-//!     if let Err(e) = LOGGER.deref().configure(Some("MY-INSTANCE".to_string())) {
-//!         println!("Could not configure the log subsystem: {}", e);
-//!         return;
-//!     }
-//!     warn!("this is a warning");
-//!     error!("this is an error");
+//! // Optionally do an initial configuration for the logger.
+//! if let Err(e) = LOGGER.deref().configure(Some("MY-INSTANCE".to_string())) {
+//!     println!("Could not configure the log subsystem: {}", e);
+//!     return;
 //! }
+//! warn!("this is a warning");
+//! error!("this is an error");
 //! ```
 //! ## Example for logging to a `File`:
 //!
 //! ```
-//! extern crate libc;
-//! extern crate utils;
-//!
 //! use libc::c_char;
 //! use std::io::Cursor;
+//! use logger::{warn, error, LOGGER};
 //!
-//! #[macro_use]
-//! extern crate logger;
-//! use logger::LOGGER;
+//! let mut logs = Cursor::new(vec![0; 15]);
 //!
-//! fn main() {
-//!     let mut logs = Cursor::new(vec![0; 15]);
-//!
-//!     // Initialize the logger to log to a FIFO that was created beforehand.
-//!     assert!(LOGGER
-//!         .init(
-//!              "Running Firecracker v.x".to_string(),
-//!             Box::new(logs),
-//!         )
-//!         .is_ok());
-//!     // The following messages should appear in the in-memory buffer `logs`.
-//!     warn!("this is a warning");
-//!     error!("this is an error");
-//! }
+//! // Initialize the logger to log to a FIFO that was created beforehand.
+//! assert!(LOGGER
+//!     .init(
+//!         "Running Firecracker v.x".to_string(),
+//!         Box::new(logs),
+//!     )
+//!     .is_ok());
+//! // The following messages should appear in the in-memory buffer `logs`.
+//! warn!("this is a warning");
+//! error!("this is an error");
 //! ```
 
 //! # Plain log format
@@ -168,18 +156,13 @@ impl Logger {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate log;
-    /// extern crate logger;
-    /// use logger::LOGGER;
+    /// use logger::{warn, LOGGER};
     /// use std::ops::Deref;
     ///
-    /// fn main() {
-    ///     let l = LOGGER.deref();
-    ///     l.set_include_level(true);
-    ///     assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
-    ///     warn!("A warning log message with level included");
-    /// }
+    /// let l = LOGGER.deref();
+    /// l.set_include_level(true);
+    /// assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
+    /// warn!("A warning log message with level included");
     /// ```
     /// The code above will more or less print:
     /// ```bash
@@ -203,18 +186,14 @@ impl Logger {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate logger;
-    /// use logger::LOGGER;
+    /// use logger::{warn, LOGGER};
     /// use std::ops::Deref;
     ///
-    /// fn main() {
-    ///     let l = LOGGER.deref();
-    ///     l.set_include_origin(false, false);
-    ///     assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
+    /// let l = LOGGER.deref();
+    /// l.set_include_origin(false, false);
+    /// assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
     ///
-    ///     warn!("A warning log message with log origin disabled");
-    /// }
+    /// warn!("A warning log message with log origin disabled");
     /// ```
     /// The code above will more or less print:
     /// ```bash
@@ -246,19 +225,14 @@ impl Logger {
     /// # Example
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate logger;
-    /// extern crate log;
-    /// use logger::LOGGER;
+    /// use logger::{info, warn, LOGGER};
     /// use std::ops::Deref;
     ///
-    /// fn main() {
-    ///     let l = LOGGER.deref();
-    ///     l.set_max_level(log::LevelFilter::Warn);
-    ///     assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
-    ///     info!("An informational log message");
-    ///     warn!("A test warning message");
-    /// }
+    /// let l = LOGGER.deref();
+    /// l.set_max_level(log::LevelFilter::Warn);
+    /// assert!(l.configure(Some("MY-INSTANCE".to_string())).is_ok());
+    /// info!("An informational log message");
+    /// warn!("A test warning message");
     /// ```
     /// The code above will more or less print:
     /// ```bash
@@ -319,16 +293,13 @@ impl Logger {
     /// # Example
     ///
     /// ```
-    /// extern crate logger;
     /// use logger::LOGGER;
     /// use std::ops::Deref;
     ///
-    /// fn main() {
-    ///     LOGGER
-    ///         .deref()
-    ///         .configure(Some("MY-INSTANCE".to_string()))
-    ///         .unwrap();
-    /// }
+    /// LOGGER
+    ///    .deref()
+    ///    .configure(Some("MY-INSTANCE".to_string()))
+    ///    .unwrap();
     /// ```
     pub fn configure(&self, instance_id: Option<String>) -> Result<()> {
         self.init
@@ -356,19 +327,16 @@ impl Logger {
     /// # Example
     ///
     /// ```
-    /// extern crate logger;
     /// use logger::LOGGER;
     ///
     /// use std::io::Cursor;
     ///
-    /// fn main() {
-    ///     let mut logs = Cursor::new(vec![0; 15]);
+    /// let mut logs = Cursor::new(vec![0; 15]);
     ///
-    ///     LOGGER.init(
-    ///         "Running Firecracker v.x".to_string(),
-    ///         Box::new(logs),
-    ///     );
-    /// }
+    /// LOGGER.init(
+    ///     "Running Firecracker v.x".to_string(),
+    ///     Box::new(logs),
+    /// );
     /// ```
     pub fn init(&self, header: String, log_dest: Box<dyn Write + Send>) -> Result<()> {
         self.init
@@ -529,13 +497,16 @@ mod tests {
             assert!(self
                 .init(TEST_APP_HEADER.to_string(), Box::new(writer))
                 .is_ok());
-            validate_log(Box::new(&mut reader), &format!("{}\n", TEST_APP_HEADER));
+            validate_log(
+                &mut Box::new(&mut reader),
+                &format!("{}\n", TEST_APP_HEADER),
+            );
 
             reader
         }
     }
 
-    fn validate_log(mut log_reader: Box<&mut dyn Read>, expected: &str) {
+    fn validate_log(log_reader: &mut dyn Read, expected: &str) {
         let mut log = Vec::new();
         log_reader.read_to_end(&mut log).unwrap();
 
@@ -567,11 +538,14 @@ mod tests {
         assert!(logger
             .init(TEST_APP_HEADER.to_string(), Box::new(writer))
             .is_ok());
-        validate_log(Box::new(&mut reader), &format!("{}\n", TEST_APP_HEADER));
+        validate_log(
+            &mut Box::new(&mut reader),
+            &format!("{}\n", TEST_APP_HEADER),
+        );
         // Check that the logs are written to the configured writer.
         logger.mock_log(Level::Info, "info");
         validate_log(
-            Box::new(&mut reader),
+            &mut Box::new(&mut reader),
             "[TEST-INSTANCE-ID:INFO:logger.rs:0] info\n",
         );
     }
@@ -586,11 +560,14 @@ mod tests {
         assert!(logger
             .init(TEST_APP_HEADER.to_string(), Box::new(writer))
             .is_ok());
-        validate_log(Box::new(&mut reader), &format!("{}\n", TEST_APP_HEADER));
+        validate_log(
+            &mut Box::new(&mut reader),
+            &format!("{}\n", TEST_APP_HEADER),
+        );
         // Check that the logs are written to the configured writer.
         logger.mock_log(Level::Info, "info");
         validate_log(
-            Box::new(&mut reader),
+            &mut Box::new(&mut reader),
             "[TEST-INSTANCE-ID:INFO:logger.rs:0] info\n",
         );
 
@@ -602,10 +579,10 @@ mod tests {
         // Check that the logs are written only to the first writer.
         logger.mock_log(Level::Info, "info");
         validate_log(
-            Box::new(&mut reader),
+            &mut Box::new(&mut reader),
             "[TEST-INSTANCE-ID:INFO:logger.rs:0] info\n",
         );
-        validate_log(Box::new(&mut reader_2), "");
+        validate_log(&mut Box::new(&mut reader_2), "");
     }
 
     #[test]
@@ -621,35 +598,35 @@ mod tests {
             .set_include_level(false)
             .set_include_origin(false, true);
         logger.mock_log(Level::Info, "msg");
-        validate_log(Box::new(&mut reader), "[] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[] msg\n");
 
         // Check that the prefix is correctly shown when all flags are true.
         logger
             .set_include_level(true)
             .set_include_origin(true, true);
         logger.mock_log(Level::Info, "msg");
-        validate_log(Box::new(&mut reader), "[INFO:logger.rs:0] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[INFO:logger.rs:0] msg\n");
 
         // Check show_line_numbers=false.
         logger
             .set_include_level(true)
             .set_include_origin(true, false);
         logger.mock_log(Level::Debug, "msg");
-        validate_log(Box::new(&mut reader), "[DEBUG:logger.rs] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[DEBUG:logger.rs] msg\n");
 
         // Check show_file_path=false.
         logger
             .set_include_level(true)
             .set_include_origin(false, true);
         logger.mock_log(Level::Error, "msg");
-        validate_log(Box::new(&mut reader), "[ERROR] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[ERROR] msg\n");
 
         // Check show_level=false.
         logger
             .set_include_level(false)
             .set_include_origin(true, true);
         logger.mock_log(Level::Info, "msg");
-        validate_log(Box::new(&mut reader), "[logger.rs:0] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[logger.rs:0] msg\n");
 
         // Test with a mock instance id.
         logger.set_instance_id(TEST_INSTANCE_ID.to_string());
@@ -659,7 +636,7 @@ mod tests {
             .set_include_level(false)
             .set_include_origin(false, false);
         logger.mock_log(Level::Info, "msg");
-        validate_log(Box::new(&mut reader), "[TEST-INSTANCE-ID] msg\n");
+        validate_log(&mut Box::new(&mut reader), "[TEST-INSTANCE-ID] msg\n");
 
         // Check that the prefix is correctly shown when all flags are true.
         logger
@@ -667,7 +644,7 @@ mod tests {
             .set_include_origin(true, true);
         logger.mock_log(Level::Warn, "msg");
         validate_log(
-            Box::new(&mut reader),
+            &mut Box::new(&mut reader),
             "[TEST-INSTANCE-ID:WARN:logger.rs:0] msg\n",
         );
     }
@@ -680,7 +657,7 @@ mod tests {
         let mut reader = LOGGER.mock_init();
 
         info!("info");
-        validate_log(Box::new(&mut reader), "info\n");
+        validate_log(&mut Box::new(&mut reader), "info\n");
     }
 
     #[test]

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -688,7 +688,6 @@ pub struct FirecrackerMetrics {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
     use super::*;
 
     use std::io::ErrorKind;

--- a/src/micro_http/src/common/headers.rs
+++ b/src/micro_http/src/common/headers.rs
@@ -117,7 +117,6 @@ impl Headers {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Headers;
     ///
     /// let mut request_header = Headers::default();
@@ -217,7 +216,6 @@ impl Headers {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Headers;
     ///
     /// let request_headers = Headers::try_from(b"Content-Length: 55\r\n\r\n");
@@ -275,7 +273,6 @@ impl MediaType {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::MediaType;
     ///
     /// assert!(MediaType::try_from(b"application/json").is_ok());
@@ -299,7 +296,6 @@ impl MediaType {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::MediaType;
     ///
     /// let media_type = MediaType::ApplicationJson;

--- a/src/micro_http/src/common/mod.rs
+++ b/src/micro_http/src/common/mod.rs
@@ -116,7 +116,6 @@ impl Display for ServerError {
 ///
 /// ## Examples
 /// ```
-/// extern crate micro_http;
 /// use micro_http::Body;
 /// let body = Body::new("This is a test body.".to_string());
 /// assert_eq!(body.raw(), b"This is a test body.");
@@ -192,7 +191,6 @@ impl Method {
 ///
 /// # Examples
 /// ```
-/// extern crate micro_http;
 /// use micro_http::Version;
 /// let version = Version::try_from(b"HTTP/1.1");
 /// assert!(version.is_ok());

--- a/src/micro_http/src/lib.rs
+++ b/src/micro_http/src/lib.rs
@@ -45,7 +45,6 @@
 //!
 //! ## Example for parsing an HTTP Request from a slice
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{Request, Version};
 //!
 //! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
@@ -55,7 +54,6 @@
 //!
 //! ## Example for creating an HTTP Response
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{Body, MediaType, Response, StatusCode, Version};
 //!
 //! let mut response = Response::new(Version::Http10, StatusCode::OK);
@@ -82,7 +80,6 @@
 //! ## Example for using the server
 //!
 //! ```
-//! extern crate micro_http;
 //! use micro_http::{HttpServer, Response, StatusCode};
 //!
 //! let path_to_socket = "/tmp/example.sock";
@@ -108,9 +105,6 @@
 //!     break;
 //! }
 //! ```
-
-extern crate libc;
-extern crate utils;
 
 mod common;
 mod connection;

--- a/src/micro_http/src/request.rs
+++ b/src/micro_http/src/request.rs
@@ -179,7 +179,6 @@ impl Request {
     /// # Examples
     ///
     /// ```
-    /// extern crate micro_http;
     /// use micro_http::Request;
     ///
     /// let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();

--- a/src/micro_http/src/server.rs
+++ b/src/micro_http/src/server.rs
@@ -388,8 +388,6 @@ impl HttpServer {
     ///
     /// ## Non-blocking server
     /// ```
-    /// extern crate utils;
-    ///
     /// use std::os::unix::io::AsRawFd;
     ///
     /// use micro_http::{HttpServer, Response, StatusCode};

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -1,18 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use]
-extern crate lazy_static;
-extern crate serde_json;
-
-extern crate dumbo;
-extern crate logger;
-extern crate micro_http;
-extern crate snapshot;
-extern crate utils;
-extern crate versionize;
-extern crate versionize_derive;
-
 pub mod data_store;
 pub mod ns;
 pub mod persist;
@@ -21,6 +9,7 @@ use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
 
 use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
+use lazy_static::lazy_static;
 use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
 
 lazy_static! {
@@ -145,8 +134,6 @@ fn convert_to_response(request: Request) -> Response {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
-
     use super::*;
 
     #[test]

--- a/src/mmds/src/persist.rs
+++ b/src/mmds/src/persist.rs
@@ -11,7 +11,6 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 
 use super::ns::MmdsNetworkStack;
-use super::*;
 
 /// State of a MmdsNetworkStack.
 #[derive(Versionize)]

--- a/src/polly/src/lib.rs
+++ b/src/polly/src/lib.rs
@@ -1,6 +1,3 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-extern crate libc;
-extern crate utils;
-
 pub mod event_manager;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -43,16 +43,7 @@
 //! It is meant to be used in an external event loop and thus implements the `AsRawFd`
 //! trait and provides an *event-handler* as part of its API. This *event-handler*
 //! needs to be called by the user on every event on the rate limiter's `AsRawFd` FD.
-
-extern crate timerfd;
-
-extern crate utils;
-#[macro_use]
-extern crate logger;
-extern crate snapshot;
-extern crate versionize;
-extern crate versionize_derive;
-
+use logger::error;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 use std::{fmt, io};

--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -18,22 +18,18 @@
 //! ## Example with Filtering Disabled
 //!
 //! ```
-//! extern crate libc;
-//!
-//! fn main() {
-//!     let buf = "Hello, world!";
-//!     assert_eq!(
-//!         unsafe {
-//!             libc::syscall(
-//!                 libc::SYS_write,
-//!                 libc::STDOUT_FILENO,
-//!                 buf.as_bytes(),
-//!                 buf.len(),
-//!             );
-//!         },
-//!         ()
-//!     );
-//! }
+//! let buf = "Hello, world!";
+//! assert_eq!(
+//!     unsafe {
+//!         libc::syscall(
+//!             libc::SYS_write,
+//!             libc::STDOUT_FILENO,
+//!             buf.as_bytes(),
+//!             buf.len(),
+//!         );
+//!     },
+//!     ()
+//! );
 //! ```
 //!
 //! The code snippet above will print "Hello, world!" to stdout.
@@ -46,40 +42,35 @@
 //! Without a signal handler in place, the process will die with exit code 159 (128 + `SIGSYS`).
 //!
 //! ```should_panic
-//! extern crate libc;
-//! extern crate seccomp;
-//!
 //! use std::convert::TryInto;
 //! use seccomp::*;
 //!
-//! fn main() {
-//!     let buf = "Hello, world!";
-//!     let filter = SeccompFilter::new(
-//!         vec![
-//!             allow_syscall(libc::SYS_close),
-//!             allow_syscall(libc::SYS_execve),
-//!             allow_syscall(libc::SYS_exit_group),
-//!             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-//!             allow_syscall(libc::SYS_open),
-//!             #[cfg(target_arch = "aarch64")]
-//!             allow_syscall(libc::SYS_openat),
-//!             allow_syscall(libc::SYS_read),
-//!         ]
+//! let buf = "Hello, world!";
+//! let filter = SeccompFilter::new(
+//!     vec![
+//!         allow_syscall(libc::SYS_close),
+//!         allow_syscall(libc::SYS_execve),
+//!         allow_syscall(libc::SYS_exit_group),
+//!         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//!         allow_syscall(libc::SYS_open),
+//!         #[cfg(target_arch = "aarch64")]
+//!         allow_syscall(libc::SYS_openat),
+//!         allow_syscall(libc::SYS_read),
+//!     ]
 //!         .into_iter()
 //!         .collect(),
 //!         SeccompAction::Trap,
-//!     )
+//! )
 //!     .unwrap().try_into().unwrap();
 //!     SeccompFilter::apply(filter).unwrap();
-//!     unsafe {
-//!         libc::syscall(
-//!             libc::SYS_write,
-//!             libc::STDOUT_FILENO,
-//!             buf.as_bytes(),
-//!             buf.len(),
-//!         );
-//!     };
-//! }
+//! unsafe {
+//!     libc::syscall(
+//!         libc::SYS_write,
+//!         libc::STDOUT_FILENO,
+//!         buf.as_bytes(),
+//!         buf.len(),
+//!     );
+//! };
 //! ```
 //!
 //! The code snippet above will print "Hello, world!" to stdout and "Bad system call" to stderr.
@@ -118,9 +109,6 @@
 //! A signal handler will catch `SIGSYS` and exit with code 159 on any other syscall.
 //!
 //! ```should_panic
-//! extern crate libc;
-//! extern crate seccomp;
-//!
 //! use seccomp::*;
 //! use std::convert::TryInto;
 //! use std::mem;
@@ -242,9 +230,6 @@
 //! [`SeccompAction`]: enum.SeccompAction.html
 //! [`SeccompFilter`]: struct.SeccompFilter.html
 //! [`action`]: struct.SeccompRule.html#action
-
-extern crate libc;
-
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
@@ -912,7 +897,7 @@ impl SeccompFilter {
 
         self.rules
             .entry(syscall_number)
-            .or_insert_with(|| vec![])
+            .or_insert_with(std::vec::Vec::new)
             .append(&mut rules);
 
         Ok(())

--- a/src/snapshot/benches/main.rs
+++ b/src/snapshot/benches/main.rs
@@ -1,10 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-extern crate criterion;
-extern crate snapshot;
-extern crate versionize;
-extern crate versionize_derive;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use snapshot::Snapshot;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};

--- a/src/snapshot/benches/version_map.rs
+++ b/src/snapshot/benches/version_map.rs
@@ -1,10 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-extern crate criterion;
-extern crate snapshot;
-extern crate versionize;
-extern crate versionize_derive;
-
 use criterion::{black_box, criterion_group, Criterion};
 use snapshot::Snapshot;
 use versionize::{VersionMap, Versionize, VersionizeResult};

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -25,12 +25,6 @@
 //! implementation does not have any logic dependent on it.
 //!  - **the data version** which refers to the state.
 //!
-extern crate bincode;
-extern crate serde;
-extern crate serde_derive;
-extern crate versionize;
-extern crate versionize_derive;
-
 mod persist;
 pub use crate::persist::Persist;
 

--- a/src/snapshot/tests/test.rs
+++ b/src/snapshot/tests/test.rs
@@ -1,10 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate snapshot;
-extern crate versionize;
-extern crate versionize_derive;
-
 use snapshot::Snapshot;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate vmm_sys_util;
-
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).
 // More specifically, we are re-exporting modules from `vmm_sys_util` as part

--- a/src/utils/src/signal.rs
+++ b/src/utils/src/signal.rs
@@ -1,6 +1,3 @@
-extern crate libc;
-extern crate vmm_sys_util;
-
 use libc::c_int;
 pub use vmm_sys_util::signal::*;
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -9,8 +9,7 @@ kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", ta
 kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
 lazy_static = "1.4.0"
 libc = ">=0.2.39"
-serde = ">=1.0.27"
-serde_derive = ">=1.0.27"
+serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
 sysconf = "0.3.4"
 versionize = { version = "0.1.1" }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -23,6 +23,7 @@ use arch::InitrdConfig;
 use devices::legacy::Serial;
 use devices::virtio::{Block, MmioTransport, Net, VirtioDevice, Vsock, VsockUnixBackend};
 use kernel::cmdline::Cmdline as KernelCmdline;
+use logger::warn;
 use polly::event_manager::{Error as EventManagerError, EventManager, Subscriber};
 use seccomp::{BpfProgramRef, SeccompFilter};
 #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -1,9 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-extern crate utils;
-
 use std::convert::TryInto;
 
 use seccomp::{

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -10,34 +10,6 @@
 //! machine (microVM).
 #![deny(missing_docs)]
 
-extern crate kvm_bindings;
-extern crate kvm_ioctls;
-extern crate lazy_static;
-extern crate libc;
-extern crate polly;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate sysconf;
-
-extern crate arch;
-#[cfg(target_arch = "x86_64")]
-extern crate cpuid;
-extern crate devices;
-extern crate kernel;
-#[macro_use]
-extern crate logger;
-extern crate dumbo;
-extern crate mmds;
-extern crate rate_limiter;
-extern crate seccomp;
-extern crate snapshot;
-extern crate utils;
-extern crate versionize;
-extern crate versionize_derive;
-extern crate vm_memory;
-
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;
 /// Syscalls allowed through the seccomp filter.
@@ -79,7 +51,7 @@ use crate::vstate::VcpuState;
 use crate::vstate::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
 use arch::DeviceType;
 use devices::BusDevice;
-use logger::{LoggerError, MetricsError, METRICS};
+use logger::{error, info, warn, LoggerError, MetricsError, METRICS};
 use polly::event_manager::{self, EventManager, Subscriber};
 use seccomp::BpfProgramRef;
 #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -20,6 +20,8 @@ use crate::vstate::VcpuConfig;
 use mmds::ns::MmdsNetworkStack;
 use utils::net::ipv4addr::is_link_local_valid;
 
+use serde::Deserialize;
+
 type Result<E> = std::result::Result<(), E>;
 
 /// Errors encountered when configuring microVM resources.

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -34,7 +34,7 @@ use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, Snap
 use crate::vmm_config::vsock::{VsockConfigError, VsockDeviceConfig};
 use arch::DeviceType;
 use devices::virtio::{Block, MmioTransport, Net, TYPE_BLOCK, TYPE_NET};
-use logger::{update_metric_with_elapsed_time, METRICS};
+use logger::{info, update_metric_with_elapsed_time, METRICS};
 use polly::event_manager::EventManager;
 use seccomp::BpfProgram;
 

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -3,7 +3,7 @@
 
 use libc::{_exit, c_int, c_void, siginfo_t, SIGBUS, SIGSEGV, SIGSYS};
 
-use logger::{Metric, METRICS};
+use logger::{error, Metric, METRICS};
 use utils::signal::register_signal_handler;
 
 // The offset of `si_syscall` (offending syscall identifier) within the siginfo structure

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -4,6 +4,8 @@
 use std::fmt::{Display, Formatter, Result};
 use std::io;
 
+use serde::{Deserialize, Serialize};
+
 /// Default guest kernel command line:
 /// - `reboot=k` shut down the guest on reboot, instead of well... rebooting;
 /// - `panic=1` on panic, reboot after 1 second;

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -12,6 +12,8 @@ use std::sync::{Arc, Mutex};
 use super::RateLimiterConfig;
 use devices::virtio::Block;
 
+use serde::Deserialize;
+
 type Result<T> = result::Result<T, DriveError>;
 
 /// Errors associated with the operations allowed on a drive.

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -1,5 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use serde::Serialize;
 
 /// The strongly typed that contains general information about the microVM.
 #[derive(Clone, Debug, Serialize)]

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the logger.
-
-extern crate logger as logger_crate;
-
-use serde::{de, Deserialize, Deserializer};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
-use self::logger_crate::{LevelFilter, LOGGER};
 use super::{open_file_nonblock, FcLineWriter};
 use crate::vmm_config::instance_info::InstanceInfo;
+use logger::{LevelFilter, LOGGER};
 
 /// Enum used for setting the log level.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -160,6 +157,7 @@ mod tests {
     use super::*;
     use devices::pseudo::BootTimer;
     use devices::BusDevice;
+    use logger::warn;
     use utils::tempfile::TempFile;
     use utils::time::TimestampUs;
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{de, Deserialize};
+use serde::{de, Deserialize, Serialize};
 use std::fmt;
 
 /// Firecracker aims to support small scale workloads only, so limit the maximum

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Auxiliary module for configuring the metrics system.
-
-extern crate logger as logger_crate;
-
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
-use self::logger_crate::METRICS;
 use super::{open_file_nonblock, FcLineWriter};
+use logger::METRICS;
+
+use serde::{Deserialize, Serialize};
 
 /// Strongly typed structure used to describe the metrics system.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::export::Formatter;
+use serde::{export::Formatter, Deserialize};
 use std::fmt::{Display, Result};
 use std::net::Ipv4Addr;
 

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -8,6 +8,7 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
 use libc::O_NONBLOCK;
+use serde::Deserialize;
 
 use rate_limiter::RateLimiter;
 

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -12,6 +12,8 @@ use devices::virtio::Net;
 use dumbo::MacAddr;
 use rate_limiter::{BucketUpdate, TokenBucket};
 
+use serde::Deserialize;
+
 /// This struct represents the strongly typed equivalent of the json body from net iface
 /// related requests.
 #[derive(Debug, Deserialize, PartialEq)]

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -5,6 +5,8 @@
 
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
 /// The snapshot type options that are available when
 /// creating a new snapshot.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use devices::virtio::{Vsock, VsockError, VsockUnixBackend, VsockUnixBackendError};
 
+use serde::{Deserialize, Serialize};
+
 type MutexVsockUnix = Arc<Mutex<Vsock<VsockUnixBackend>>>;
 
 /// Errors associated with `NetworkInterfaceConfig`.

--- a/src/vmm/src/vstate.rs
+++ b/src/vmm/src/vstate.rs
@@ -32,7 +32,7 @@ use kvm_bindings::{
 };
 use kvm_bindings::{kvm_userspace_memory_region, KVM_API_VERSION, KVM_MEM_LOG_DIRTY_PAGES};
 use kvm_ioctls::*;
-use logger::{Metric, METRICS};
+use logger::{error, info, Metric, METRICS};
 use seccomp::{BpfProgram, SeccompFilter};
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
@@ -1393,7 +1393,6 @@ pub(crate) mod tests {
     #[cfg(target_arch = "x86_64")]
     use std::time::Duration;
 
-    use super::super::devices;
     use super::*;
 
     use utils::signal::validate_signal_num;

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -1,15 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate devices;
-extern crate libc;
-extern crate polly;
-extern crate seccomp;
-extern crate snapshot;
-extern crate utils;
-extern crate vm_memory;
-extern crate vmm;
-
 mod mock_devices;
 mod mock_resources;
 mod mock_seccomp;

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_advanced_jailer.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_advanced_jailer.rs
@@ -1,9 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-extern crate seccomp;
-
 mod seccomp_rules;
 
 use std::convert::TryInto;
@@ -11,7 +7,9 @@ use std::env::args;
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 
-use seccomp::{SeccompAction, SeccompCmpOp, SeccompCondition, SeccompFilter, SeccompRule, SeccompCmpArgLen};
+use seccomp::{
+    SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter, SeccompRule,
+};
 use seccomp_rules::*;
 
 fn main() {
@@ -28,7 +26,13 @@ fn main() {
         libc::SYS_write,
         vec![SeccompRule::new(
             vec![
-                SeccompCondition::new(0, SeccompCmpArgLen::DWORD, SeccompCmpOp::Eq, libc::STDOUT_FILENO as u64).unwrap(),
+                SeccompCondition::new(
+                    0,
+                    SeccompCmpArgLen::DWORD,
+                    SeccompCmpOp::Eq,
+                    libc::STDOUT_FILENO as u64,
+                )
+                .unwrap(),
                 SeccompCondition::new(2, SeccompCmpArgLen::QWORD, SeccompCmpOp::Eq, 14).unwrap(),
             ],
             SeccompAction::Allow,

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_basic_jailer.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_basic_jailer.rs
@@ -1,9 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-extern crate seccomp;
-
 mod seccomp_rules;
 
 use std::convert::TryInto;

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_harmless.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_harmless.rs
@@ -1,8 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-
 fn main() {
     unsafe {
         // Harmless print to standard output.

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_malicious.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_malicious.rs
@@ -1,8 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate libc;
-
 fn main() {
     unsafe {
         // In this example, the malicious component is outputing to standard input.

--- a/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
@@ -1,8 +1,5 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-extern crate seccomp;
-
 use seccomp::{allow_syscall, SyscallRuleSet};
 
 /// Returns a list of rules that allow syscalls required for running a rust program.


### PR DESCRIPTION
## Reason for This PR

Now that the project has been successfully migrated to 2018 edition, usage of `extern crate` is no longer required. In addition, clippy reports a few instances of unused imports, uneeded `Box`ing, and unneeded clones, and out of date doctest implementations.

## Description of Changes

- Remove all declarations of `extern crate`
- Refactor doctests per clippy to remove `fn main()` and correct imports
- Refactor unneeded imports, and broken macro imports 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
