### PR TITLE
tests: added statistics component

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ import pytest
 import host_tools.cargo_build as build_tools
 import host_tools.network as net_tools
 
+from framework.artifacts import ArtifactCollection
 import framework.utils as utils
 from framework.microvm import Microvm
 from framework.s3fetcher import MicrovmImageS3Fetcher
@@ -125,6 +126,7 @@ def _test_images_s3_bucket():
     )
 
 
+ARTIFACTS_COLLECTION = ArtifactCollection(_test_images_s3_bucket())
 MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(_test_images_s3_bucket())
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,7 @@ def pytest_configure(config):
 
     Initialize the test scheduler and IPC services.
     """
+    config.addinivalue_line("markers", "nonci: mark test as nonci.")
     PytestScheduler.instance().register_mp_singleton(
         net_tools.UniqueIPv4Generator.instance()
     )

--- a/tests/framework/statistics/__init__.py
+++ b/tests/framework/statistics/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single threaded producer/consumer for statistics gathering."""
+
+from . import core
+from . import consumer
+from . import producer
+from . import types
+from . import criteria
+from . import function

--- a/tests/framework/statistics/consumer.py
+++ b/tests/framework/statistics/consumer.py
@@ -1,0 +1,145 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module for multiple statistics consumers."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+from collections import defaultdict
+from .types import MeasurementDef, StatisticDef
+
+
+class Consumer(ABC):
+    """Base class for statistics aggregation class."""
+
+    UNIT_KEY = "unit"
+    DATA_KEY = "data"
+
+    # pylint: disable=W0102
+    def __init__(self,
+                 consume_stats,
+                 custom=dict()):
+        """Initialize a consumer."""
+        self._results = defaultdict()  # Aggregated results.
+        self._measurements_defs = defaultdict(MeasurementDef)
+        self._statistics_defs = defaultdict()
+        self._consume_stats = consume_stats
+        self._custom = custom
+        self._statistics = dict()
+        self._iteration = 0
+
+    @abstractmethod
+    def ingest(self, iteration: int, raw_data: Any):
+        """Abstract method for ingesting the raw result."""
+
+    def consume_stat(self, st_name: str, ms_name: str, value: MeasurementDef):
+        """Aggregate statistics."""
+        results = self._results.get(ms_name)
+        if not results:
+            self._results[ms_name] = dict()
+        st_data = self._results[ms_name].get(st_name)
+        if not st_data:
+            self._results[ms_name][st_name] = list()
+        self._results[ms_name][st_name].append(value)
+
+    def consume_measurement(self,
+                            ms_name: str,
+                            value: MeasurementDef):
+        """Aggregate measurement."""
+        results = self._results.get(ms_name)
+        if results is None:
+            self._results[ms_name] = dict()
+            self._results[ms_name][self.DATA_KEY] = list()
+        self._results[ms_name][self.DATA_KEY].append(value)
+
+    def consume_custom(self, name, value: Any):
+        """Aggregate custom information."""
+        if not self._custom[self._iteration]:
+            self._custom[self._iteration] = {}
+        self._custom[self._iteration][name] = value
+
+    def set_stat_def(self, value: StatisticDef):
+        """Set statistics definition."""
+        if not self._statistics_defs.get(value.measurement_name):
+            self._statistics_defs[value.measurement_name] = dict()
+
+        self._statistics_defs[value.measurement_name][value.name] = value
+
+    def set_measurement_def(self, value: MeasurementDef):
+        """Set measurement definition."""
+        self._measurements_defs[value.name] = value
+
+    def process(self) -> Dict[str, dict]:
+        """Generate statistics as a dictionary."""
+        # Verify that the statistics/measurements correspondence
+        # is backed by corresponding measurements definitions.
+        for ms_name in self._statistics_defs:
+            assert ms_name in self._measurements_defs
+
+        if self._consume_stats:
+            # Verify if the gathered results for a measurement are
+            # backed by measurements definitions.
+            for ms_name in self._results:
+                assert ms_name in self._measurements_defs
+                # Verify if the gathered statistics are backed by
+                # statistics definitions.
+                for st_name in self._results[ms_name]:
+                    assert st_name in self._statistics_defs[ms_name]
+        else:
+            # Verify if the gathered measurements are backed by
+            # measurements definitions.
+            for ms_name in self._results:
+                assert ms_name in self._measurements_defs
+
+            # Verify if the defined statistics have corresponding
+            # gathered measurements.
+            for ms_name in self._statistics_defs:
+                assert ms_name in self._results
+
+        # Generate consumer stats.
+        for ms_name in self._statistics_defs:
+            self._statistics.setdefault(ms_name, {})[self.UNIT_KEY] \
+                = self._measurements_defs[ms_name].unit
+            for st_name in self._statistics_defs[ms_name]:
+                # We can either consume directly statistics, or compute them
+                # based on measurements.
+                stat = self._statistics_defs[ms_name][st_name]
+                if self._consume_stats:
+                    self._statistics[ms_name][st_name] = \
+                        stat.func_cls(self._results[ms_name][st_name])()
+                else:
+                    self._statistics[ms_name][st_name] = \
+                        stat.func_cls(self._results[ms_name][self.DATA_KEY])()
+
+                # Check pass criteria.
+                if stat.criteria:
+                    res = self._statistics[ms_name][st_name]
+                    stat.criteria.check(res)
+
+        return self._statistics, self._custom
+
+
+class LambdaConsumer(Consumer):
+    """Consumer which executes a function in the ingestion step.
+
+    The function called in the ingestion step must have the following
+    signature: `def func(cons: Consumer, raw_output: Any, *args)`.
+    """
+
+    def __init__(self,
+                 consume_stats,
+                 func,
+                 func_kwargs=None):
+        """Initialize the LambdaConsumer."""
+        super().__init__(consume_stats)
+        assert callable(func)
+        self._func = func
+        self._func_kwargs = func_kwargs
+
+    def ingest(self, iteration, raw_data):
+        """Execute the function with or without arguments."""
+        self._iteration = iteration
+        if self._func_kwargs:
+            self._func(self, raw_data, **self._func_kwargs)
+        else:
+            self._func(self, raw_data)

--- a/tests/framework/statistics/core.py
+++ b/tests/framework/statistics/core.py
@@ -1,0 +1,101 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Core module for statistics component management."""
+
+
+from datetime import datetime
+from collections import namedtuple, defaultdict
+import types
+from typing_extensions import TypedDict
+from framework.statistics.producer import Producer
+from framework.statistics.consumer import Consumer
+
+
+# pylint: disable=R0903
+class Statistics(TypedDict):
+    """Data class for aggregated statistic results."""
+
+    name: str
+    iterations: int
+    results: dict
+    custom: dict
+
+
+Pipe = namedtuple("Pipe", "producer consumer")
+
+
+class Core:
+    """Base class for statistics core driver."""
+
+    # pylint: disable=W0102
+    def __init__(self, name, iterations, custom={}):
+        """Core constructor."""
+        self._pipes = defaultdict(Pipe)
+        self._statistics = Statistics(name=name,
+                                      iterations=iterations,
+                                      results={},
+                                      custom=custom)
+
+    def add_pipe(self, producer: Producer, consumer: Consumer, tag=None):
+        """Add a new producer-consumer pipe."""
+        if tag is None:
+            tag = self._statistics['name'] + "_" + \
+                str(datetime.timestamp(datetime.now()))
+        self._pipes[tag] = Pipe(producer, consumer)
+
+    def run_exercise(self) -> Statistics:
+        """Drive the statistics producers until completion."""
+        for pipe in self._pipes.values():
+            iterations = self._statistics['iterations']
+            for iteration in range(iterations):
+                raw_data = pipe.producer.produce()
+                if isinstance(raw_data, types.GeneratorType):
+                    for data in raw_data:
+                        pipe.consumer.ingest(iteration, data)
+                else:
+                    pipe.consumer.ingest(iteration, raw_data)
+
+        for tag, pipe in self._pipes.items():
+            result, custom = pipe.consumer.process()
+            self._statistics['results'][tag] = result
+            # Custom information extracted from all the iterations.
+            if len(custom) > 0:
+                self._statistics['custom'][tag] = custom
+
+        return self._statistics
+
+    @property
+    def name(self):
+        """Return statistics name."""
+        return self._statistics.name
+
+    @name.setter
+    def name(self, name):
+        """Set statistics name."""
+        self._statistics.name = name
+
+    @property
+    def iterations(self):
+        """Return statistics iterations count."""
+        return self._statistics.iterations
+
+    @iterations.setter
+    def iterations(self, iterations):
+        """Set statistics iterations count."""
+        self._statistics.iterations = iterations
+
+    @property
+    def custom(self):
+        """Return statistics custom information."""
+        return self._statistics.custom
+
+    @custom.setter
+    def custom(self, custom):
+        """Set statistics custom information."""
+        self._statistics.custom = custom
+
+    @property
+    def statistics(self):
+        """Return statistics gathered so far."""
+        return self._statistics

--- a/tests/framework/statistics/criteria.py
+++ b/tests/framework/statistics/criteria.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module for comparision criteria."""
+
+from numbers import Number
+from abc import ABC, abstractmethod
+
+
+# pylint: disable=R0903
+class ComparisonCriteria(ABC):
+    """Comparison criteria between results and targets."""
+
+    def __init__(self, name: str, target: Number):
+        """Initialize the comparison criteria."""
+        self.target = target
+        self.name = name
+
+    @abstractmethod
+    def check(self, actual):
+        """Compare the target and the actual."""
+
+
+# pylint: disable=R0903
+class GraterThan(ComparisonCriteria):
+    """Greater than comparison criteria."""
+
+    def __init__(self, target: Number):
+        """Initialize the criteria."""
+        super().__init__("GreaterThan", target)
+
+    def check(self, actual):
+        """Compare the target and the actual."""
+        fail_msg = self.name + f" failed. Target: '{self.target} " \
+                               f"vs Actual: '{actual}'."
+        assert self.target < actual, fail_msg
+
+
+# pylint: disable=R0903
+class LowerThan(ComparisonCriteria):
+    """Lower than comparison criteria."""
+
+    def __init__(self, target: Number):
+        """Initialize the criteria."""
+        super().__init__("LowerThan", target)
+
+    def check(self, actual):
+        """Compare the target and the actual."""
+        fail_msg = self.name + f" failed. Target: '{self.target} " \
+                               f"vs Actual: '{actual}'."
+        assert self.target > actual, fail_msg
+
+
+# pylint: disable=R0903
+class EqualWith(ComparisonCriteria):
+    """Equal with comparison criteria."""
+
+    def __init__(self, target: Number, tolerance: Number):
+        """Initialize the criteria."""
+        super().__init__("EqualWith", target)
+        self.tolerance = tolerance
+
+    def check(self, actual):
+        """Compare the target and the actual."""
+        fail_msg = self.name + f" failed. Target: '{self.target} +- " \
+                               f"{self.tolerance}' " \
+                               f"vs Actual: '{actual}'."
+        assert abs(self.target - actual) <= self.tolerance, fail_msg

--- a/tests/framework/statistics/function.py
+++ b/tests/framework/statistics/function.py
@@ -1,0 +1,146 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module for statistical functions."""
+
+
+from abc import ABC, abstractmethod
+from numbers import Number
+from typing import Any, List
+# pylint: disable=E0611
+from statistics import mean, stdev
+
+
+# pylint: disable=R0903
+class StatisticFunction(ABC):
+    """Statistic function abstract class."""
+
+    def __init__(self, results: List[Number]):
+        """Initialize the statistic function."""
+        self.results = results
+
+    @abstractmethod
+    def __call__(self) -> Any:
+        """Builtin function needs to be implemented."""
+
+
+# pylint: disable=R0903
+class Identity(StatisticFunction):
+    """A function which extracts the last observation from a list of...
+
+    ...observations.
+    """
+
+    def __call__(self) -> Any:
+        """Get the last result only."""
+        assert len(self.results) == 1
+        return self.results[0]
+
+
+# pylint: disable=R0903
+class Min(StatisticFunction):
+    """A function which computes the minimum observation from a list of...
+
+    ...observations.
+    """
+
+    def __call__(self) -> Any:
+        """Get the minimum observation."""
+        return min(self.results)
+
+
+# pylint: disable=R0903
+class Max(StatisticFunction):
+    """A function which computes the maximum observation from a list of...
+
+    ...observations.
+    """
+
+    def __call__(self) -> Any:
+        """Get the maximum observation."""
+        return max(self.results)
+
+
+# pylint: disable=R0903
+class Avg(StatisticFunction):
+    """A function which computes the average of a list of observations."""
+
+    def __call__(self) -> Any:
+        """Get the average."""
+        return mean(self.results)
+
+
+# pylint: disable=R0903
+class Stddev(StatisticFunction):
+    """A function which computes the standard deviation of a list of...
+
+    ...observations.
+    """
+
+    def call(self) -> Any:
+        """Get the stddev."""
+        assert len(self.results) > 0
+        # pylint: disable=R0123
+        if len(self.results) is 1:
+            return self.results[0]
+        return stdev(self.results)
+
+
+# pylint: disable=R0903
+class Percentile(StatisticFunction):
+    """A function which computes the kth percentile of a list of...
+
+    ...observations.
+    """
+
+    def __init__(self, results: List, k: int):
+        """Initialize the function."""
+        super().__init__(results)
+        self.k = k
+
+    def __call__(self, results) -> Any:
+        """Get the kth percentile of the statistical exercise."""
+        # pylint: disable=R0123
+        if len(self.results) is 1:
+            return self.results[0]
+
+        length = len(self.results)
+        self.results.sort()
+        idx = length * self.k / 100
+        if idx is not int(idx):
+            return (self.results[int(idx)] + self.results[(int(idx) + 1)]) / 2
+
+        return self.results[int(idx)]
+
+
+class Percentile50(Percentile):
+    """A function which computes the 50th percentile of a list of...
+
+    ...observations.
+    """
+
+    def __init__(self, results: List):
+        """Initialize the function."""
+        super().__init__(results, 50)
+
+
+class Percentile90(Percentile):
+    """A function which computes the 90th percentile of a list of...
+
+    ...observations.
+    """
+
+    def __init__(self, results: List):
+        """Initialize the function."""
+        super().__init__(results, 90)
+
+
+class Percentile99(Percentile):
+    """A function which computes the 99th percentile of a list of...
+
+    ...observations.
+    """
+
+    def __init__(self, results: List):
+        """Initialize the function."""
+        super().__init__(results, 99)

--- a/tests/framework/statistics/producer.py
+++ b/tests/framework/statistics/producer.py
@@ -1,0 +1,129 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Producer of statistics."""
+
+from abc import ABC, abstractmethod
+from typing import Callable, Any
+import types
+from framework import utils
+
+
+# pylint: disable=R0903
+class Producer(ABC):
+    """Base class for raw results producer."""
+
+    @abstractmethod
+    def produce(self) -> Any:
+        """Produce raw results."""
+
+
+class SSHCommand(Producer):
+    """Producer from executing ssh commands."""
+
+    def __init__(self, cmd, ssh_connection):
+        """Initialize the raw data producer."""
+        self._cmd = cmd
+        self._ssh_connection = ssh_connection
+
+    def produce(self) -> Any:
+        """Return the output of the executed ssh command."""
+        rc, stdout, stderr = \
+            self._ssh_connection.execute_command(self._cmd)
+        assert rc == 0
+        assert stderr.read() == ""
+
+        return stdout.read()
+
+    @property
+    def ssh_connection(self):
+        """Return the ssh connection used by the producer.
+
+        The ssh connection used by the producer to execute commands on
+        the guest.
+        """
+        return self._ssh_connection
+
+    @ssh_connection.setter
+    def ssh_connection(self, ssh_connection):
+        """Set the ssh connection used by the producer."""
+        self._ssh_connection = ssh_connection
+
+    @property
+    def cmd(self):
+        """Return the command executed on guest."""
+        return self._cmd
+
+    @cmd.setter
+    def cmd(self, cmd):
+        """Set the command executed on guest."""
+        self._cmd = cmd
+
+
+class HostCommand(Producer):
+    """Producer from executing commands on host."""
+
+    def __init__(self, cmd):
+        """Initialize the raw data producer."""
+        self._cmd = cmd
+
+    def produce(self) -> Any:
+        """Return output of the executed command."""
+        result = utils.run_cmd(self._cmd)
+        return result.stdout
+
+    @property
+    def cmd(self):
+        """Return the command executed on host."""
+        return self._cmd
+
+    @cmd.setter
+    def cmd(self, cmd):
+        """Set the command executed on host."""
+        self._cmd = cmd
+
+
+class LambdaProducer(Producer):
+    """Producer from calling python functions."""
+
+    def __init__(self, func, func_kwargs=None):
+        """Initialize the raw data producer."""
+        assert callable(func)
+        self._func = func
+        self._func_kwargs = func_kwargs
+
+    # pylint: disable=R1710
+    def produce(self) -> Any:
+        """Call `self._func`."""
+        if self._func_kwargs:
+            raw_data = self._func(**self._func_kwargs)
+            if isinstance(raw_data, types.GeneratorType):
+                for res in raw_data:
+                    yield res
+            else:
+                return raw_data
+        else:
+            raw_data = self._func()
+            if isinstance(raw_data, types.GeneratorType):
+                for res in raw_data:
+                    yield res
+            else:
+                return raw_data
+
+    @property
+    def func(self):
+        """Return producer function."""
+        return self._func
+
+    @func.setter
+    def func(self, func: Callable):
+        self._func = func
+
+    @property
+    def func_kwargs(self):
+        """Return producer function arguments."""
+        return self._func_kwargs
+
+    @func_kwargs.setter
+    def func_kwargs(self, func_kwargs):
+        self._func_kwargs = func_kwargs

--- a/tests/framework/statistics/types.py
+++ b/tests/framework/statistics/types.py
@@ -1,0 +1,120 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module for common types definitions."""
+
+from collections import namedtuple, defaultdict
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+from .criteria import ComparisonCriteria
+from .function import StatisticFunction, Max, Min, \
+    Stddev, Percentile50, Percentile90, Percentile99, Avg
+
+MeasurementDef = namedtuple("MeasurementDefinition", "name unit")
+
+
+class DefaultStat(Enum):
+    """Default statistics."""
+
+    MAX = (1, "max")
+    MIN = (2, "min")
+    AVG = (3, "avg")
+    STDDEV = (4, "stddev")
+    P50 = (5, "p50")
+    P90 = (6, "p90")
+    P99 = (7, "p99")
+
+
+@dataclass
+class StatisticDef:
+    """Statistic definition data class."""
+
+    name: str
+    measurement_name: str
+    func_cls: StatisticFunction
+    criteria: ComparisonCriteria = None
+
+    @classmethod
+    def max(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return max statistics definition."""
+        return StatisticDef(DefaultStat.MAX.name,
+                            measurement_name,
+                            Max,
+                            criteria)
+
+    @classmethod
+    def min(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return min statistics definition."""
+        return StatisticDef(DefaultStat.MIN.name,
+                            measurement_name,
+                            Min,
+                            criteria)
+
+    @classmethod
+    def avg(cls, measurement_name, criteria):
+        """Return average statistics definition."""
+        return StatisticDef(DefaultStat.AVG.name,
+                            measurement_name,
+                            Avg,
+                            criteria)
+
+    @classmethod
+    def stddev(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return standard deviation statistics definition."""
+        return StatisticDef(DefaultStat.STDDEV.name,
+                            measurement_name,
+                            Stddev,
+                            criteria)
+
+    @classmethod
+    def p50(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return 50th percentile statistics definition."""
+        return StatisticDef(DefaultStat.P50.name,
+                            measurement_name,
+                            Percentile50,
+                            criteria)
+
+    @classmethod
+    def p90(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return 90th percentile statistics definition."""
+        return StatisticDef(DefaultStat.P90.name,
+                            measurement_name,
+                            Percentile90,
+                            criteria)
+
+    @classmethod
+    def p99(cls, measurement_name: str, criteria: ComparisonCriteria):
+        """Return 99th percentile statistics definition."""
+        return StatisticDef(DefaultStat.P99.name,
+                            measurement_name,
+                            Percentile99,
+                            criteria)
+
+    @classmethod
+    def defaults(cls,
+                 measurement_name: str,
+                 pass_criteria: dict = None) \
+            -> List['StatisticDef']:
+        """Return list with default statistics definitions."""
+        if pass_criteria is None:
+            pass_criteria = defaultdict()
+        else:
+            pass_criteria = defaultdict(None, pass_criteria)
+
+        return [
+            cls.max(measurement_name,
+                    pass_criteria.get(DefaultStat.MAX.name)),
+            cls.min(measurement_name,
+                    pass_criteria.get(DefaultStat.MIN.name)),
+            cls.avg(measurement_name,
+                    pass_criteria.get(DefaultStat.AVG.name)),
+            cls.stddev(measurement_name,
+                       pass_criteria.get(DefaultStat.STDDEV.name)),
+            cls.p50(measurement_name,
+                    pass_criteria.get(DefaultStat.P50.name)),
+            cls.p90(measurement_name,
+                    pass_criteria.get(DefaultStat.P90.name)),
+            cls.p99(measurement_name,
+                    pass_criteria.get(DefaultStat.P99.name))
+        ]

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -321,3 +321,9 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
         run_cmd_async(cmd=cmd,
                       ignore_return_code=ignore_return_code,
                       no_shell=no_shell))
+
+
+def eager_map(func, iterable):
+    """Map version for Python 3.x which is eager and returns nothing."""
+    for _ in map(func, iterable):
+        continue

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -1,0 +1,203 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the network latency of a Firecracker guest."""
+
+import logging
+import platform
+import re
+import pytest
+import host_tools.network as net_tools
+from conftest import ARTIFACTS_COLLECTION
+from framework.artifacts import ArtifactSet
+from framework.matrix import TestMatrix, TestContext
+from framework.builder import MicrovmBuilder
+from framework.statistics import core, consumer, producer, types, criteria,\
+    function
+from framework.utils import eager_map
+
+
+PING = "ping -c {} -i {} {}"
+BASELINES = {
+    "x86_64": {
+        "target": 0.140,
+        "delta": 0.025
+    }
+}
+
+PKT_LOSS = "pkt_loss"
+LATENCY = "latency"
+
+
+def pass_criteria():
+    """Define pass criteria for the statistics."""
+    delta = BASELINES[platform.machine()]["delta"]
+    target = BASELINES[platform.machine()]["target"]
+
+    return {
+        types.DefaultStat.AVG.name: criteria.EqualWith(target, delta)
+    }
+
+
+def measurements():
+    """Define the produced measurements."""
+    return [types.MeasurementDef(LATENCY, "millisecond"),
+            types.MeasurementDef(PKT_LOSS, "percentage")]
+
+
+def stats():
+    """Define statistics based on the measurements."""
+    # Add default statistics for "latency" measurement.
+    stats_defs = types.StatisticDef.defaults(LATENCY, pass_criteria())
+    stats_defs.append(consumer.StatisticDef(PKT_LOSS,
+                                            PKT_LOSS,
+                                            function.Identity))
+    return stats_defs
+
+
+def consume_ping_output(cons, raw_data, requests):
+    """Consume ping output.
+
+    Output example:
+    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+    64 bytes from 8.8.8.8: icmp_seq=1 ttl=118 time=17.7 ms
+    64 bytes from 8.8.8.8: icmp_seq=2 ttl=118 time=17.7 ms
+    64 bytes from 8.8.8.8: icmp_seq=3 ttl=118 time=17.4 ms
+    64 bytes from 8.8.8.8: icmp_seq=4 ttl=118 time=17.8 ms
+
+    --- 8.8.8.8 ping statistics ---
+    4 packets transmitted, 4 received, 0% packet loss, time 3005ms
+    rtt min/avg/max/mdev = 17.478/17.705/17.808/0.210 ms
+    """
+    eager_map(cons.set_measurement_def, measurements())
+    eager_map(cons.set_stat_def, stats())
+
+    st_keys = [types.DefaultStat.MIN.name,
+               types.DefaultStat.MAX.name,
+               types.DefaultStat.AVG.name,
+               types.DefaultStat.STDDEV.name]
+
+    output = raw_data.strip().split('\n')
+    assert len(output) > 2
+
+    # E.g: round-trip min/avg/max/stddev = 17.478/17.705/17.808/0.210 ms
+    stat_values = output[-1]
+    pattern_stats = "round-trip min/avg/max/stddev = (.+)/(.+)/(.+)/(.+) ms"
+    stat_values = re.findall(pattern_stats, stat_values)[0]
+    assert len(stat_values) == 4
+
+    for index, stat_value in enumerate(stat_values[:4]):
+        cons.consume_stat(st_name=st_keys[index],
+                          ms_name=LATENCY,
+                          value=float(stat_value))
+
+    # E.g: 4 packets transmitted, 4 received, 0% packet loss
+    packet_stats = output[-2]
+    pattern_packet = ".+ packet.+transmitted, .+ received," \
+                     " (.+)% packet loss"
+    pkt_loss = re.findall(pattern_packet, packet_stats)[0]
+    assert len(pkt_loss) == 1
+    cons.consume_stat(st_name=PKT_LOSS,
+                      ms_name=PKT_LOSS,
+                      value=pkt_loss[0])
+
+    # Compute percentiles.
+    seqs = output[1:requests + 1]
+    times = list()
+    pattern_time = ".+ bytes from .+: icmp_seq=.+ ttl=.+ time=(.+) ms"
+    for index, seq in enumerate(seqs):
+        time = re.findall(pattern_time, seq)
+        assert len(time) == 1
+        times.append(time[0])
+
+    times.sort()
+    cons.consume_stat(st_name=types.DefaultStat.P50.name,
+                      ms_name=LATENCY,
+                      value=times[int(requests * 0.5)])
+    cons.consume_stat(st_name=types.DefaultStat.P90.name,
+                      ms_name=LATENCY,
+                      value=times[int(requests * 0.9)])
+    cons.consume_stat(st_name=types.DefaultStat.P99.name,
+                      ms_name=LATENCY,
+                      value=times[int(requests * 0.99)])
+
+
+@pytest.mark.nonci
+@pytest.mark.skipif(platform.machine() != "x86_64",
+                    reason="This test was observed only on x86_64. Further "
+                           "support need to be added for aarch64 and amd64.")
+def test_network_latency(network_config, bin_cloner_path):
+    """Test network latency driver for multiple artifacts."""
+    logger = logging.getLogger("network_latency")
+    microvm_artifacts = ArtifactSet(
+        ARTIFACTS_COLLECTION.microvms(keyword="2vcpu_1024mb")
+    )
+    kernel_artifacts = ArtifactSet(ARTIFACTS_COLLECTION.kernels())
+    disk_artifacts = ArtifactSet(ARTIFACTS_COLLECTION.disks(keyword="ubuntu"))
+
+    # Create a test context and add builder, logger, network.
+    test_context = TestContext()
+    test_context.custom = {
+        'builder': MicrovmBuilder(bin_cloner_path),
+        'network_config': network_config,
+        'logger': logger,
+        'requests': 10,
+        'interval': 0.2,  # Seconds.
+        'name': 'network_latency'
+    }
+
+    # Create the test matrix.
+    test_matrix = TestMatrix(context=test_context,
+                             artifact_sets=[
+                                 microvm_artifacts,
+                                 kernel_artifacts,
+                                 disk_artifacts
+                             ])
+
+    test_matrix.run_test(_g2h_send_ping)
+
+
+def _g2h_send_ping(context):
+    """Send ping from guest to host."""
+    logger = context.custom['logger']
+    vm_builder = context.custom['builder']
+    network_config = context.custom['network_config']
+    interval_between_req = context.custom['interval']
+    name = context.custom['name']
+
+    logger.info("Testing {} with microvm: \"{}\", kernel {}, disk {} "
+                .format(name,
+                        context.microvm.name(),
+                        context.kernel.name(),
+                        context.disk.name()))
+
+    # Create a rw copy artifact.
+    rw_disk = context.disk.copy()
+    # Get ssh key from read-only artifact.
+    ssh_key = context.disk.ssh_key()
+    # Create a fresh microvm from aftifacts.
+    basevm = vm_builder.build(kernel=context.kernel,
+                              disks=[rw_disk],
+                              ssh_key=ssh_key,
+                              config=context.microvm,
+                              network_config=network_config)
+
+    _tap, host_ip, _ = basevm.ssh_network_config(network_config, '1')
+
+    basevm.start()
+    custom = {"microvm": context.microvm.name(),
+              "kernel": context.kernel.name(),
+              "disk": context.disk.name()}
+    st_core = core.Core(name="network_latency", iterations=1, custom=custom)
+    cons = consumer.LambdaConsumer(
+        consume_stats=True,
+        func=consume_ping_output,
+        func_kwargs={"requests": context.custom['requests']}
+    )
+    prod = producer.SSHCommand(PING.format(context.custom['requests'],
+                                           interval_between_req,
+                                           host_ip),
+                               net_tools.SSHConnection(basevm.ssh_config))
+    st_core.add_pipe(producer=prod, consumer=cons, tag="ping")
+
+    # Gather results and verify pass criteria.
+    st_core.run_exercise()


### PR DESCRIPTION
## Reason for This PR

This PR adds a generic statistical information gathering component. It can be used for performance testing, where statistical information can be inferred from multiple iterations.

An usage example of this component was added for `test_network_latency.py` performance test, provided in #1916 .

## Description of Changes

The component has three entities:
* Statistics core: base class which exposes the loop for managing multiple measurements.
* Statistics producer: base class which is used by the core to run measurements on host or guest and produce raw data output.
* Statistics consumer: base class which consumes multiple results, in multiple iterations, parses them and computes the statistics.

**Note**: This PR is focused only on the results computation of statistical tests. The statistics result is a JSON which will be augmented on a need basis, depending on how we want to individualize/customize the details about a test run (environment, platform, tests inputs etc.). These results can be considered tests artifacts and are supposed to be indexed later on, queried/visualized and monitored for alarming.

~~- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).~~

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] Any newly added `unsafe` code is properly documented.~~
- ~~[ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- ~~[ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
