### PR TITLE
Fix comments of copy miss

### DIFF
--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -372,7 +372,7 @@ pub struct I8042DeviceMetrics {
     pub error_count: SharedMetric,
     /// Number of superfluous read intents on this i8042 device.
     pub missed_read_count: SharedMetric,
-    /// Number of superfluous read intents on this i8042 device.
+    /// Number of superfluous write intents on this i8042 device.
     pub missed_write_count: SharedMetric,
     /// Bytes read by this device.
     pub read_count: SharedMetric,
@@ -519,14 +519,14 @@ pub struct PerformanceMetrics {
     pub vmm_resume_vm: SharedMetric,
 }
 
-/// Metrics specific to the i8042 device.
+/// Metrics specific to the RTC device.
 #[derive(Default, Serialize)]
 pub struct RTCDeviceMetrics {
-    /// Errors triggered while using the i8042 device.
+    /// Errors triggered while using the RTC device.
     pub error_count: SharedMetric,
-    /// Number of superfluous read intents on this i8042 device.
+    /// Number of superfluous read intents on this RTC device.
     pub missed_read_count: SharedMetric,
-    /// Number of superfluous read intents on this i8042 device.
+    /// Number of superfluous write intents on this RTC device.
     pub missed_write_count: SharedMetric,
 }
 


### PR DESCRIPTION
Comments for RTC devices may be copied from i8042 device.

Signed-off-by: bin liu <bin@hyper.sh>

## Reason for This PR

These comments are misleading.

## Description of Changes

Change them to correct comment.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
