### PR TITLE
Improved error handling for rate limiter

### DIFF
--- a/src/rate_limiter/src/persist.rs
+++ b/src/rate_limiter/src/persist.rs
@@ -71,15 +71,16 @@ impl Persist<'_> for RateLimiter {
 
     fn restore(_: Self::ConstructorArgs, state: &Self::State) -> Result<Self, Self::Error> {
         let rate_limiter = RateLimiter {
-            // Safe to unwrap because TokenBucket::restore doesn't return errors.
-            ops: state
-                .ops
-                .as_ref()
-                .map(|ops| TokenBucket::restore((), ops).unwrap()),
-            bandwidth: state
-                .bandwidth
-                .as_ref()
-                .map(|bw| TokenBucket::restore((), bw).unwrap()),
+            ops: if let Some(ops) = state.ops.as_ref() {
+                Some(TokenBucket::restore((), ops)?)
+            } else {
+                None
+            },
+            bandwidth: if let Some(bw) = state.bandwidth.as_ref() {
+                Some(TokenBucket::restore((), bw)?)
+            } else {
+                None
+            },
             timer_fd: TimerFd::new_custom(ClockId::Monotonic, true, true)?,
             timer_active: false,
         };


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

Invalid inputs for rate limiter might cause Firecracker to panic while loading a snapshot.

## Description of Changes

Propagated the error upwards.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
