### PR TITLE
tests: refactor memory monitor

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -151,7 +151,7 @@ class Microvm:
 
         if self._memory_monitor and self._memory_monitor.is_alive():
             self._memory_monitor.signal_stop()
-            self._memory_monitor.join()
+            self._memory_monitor.join(timeout=1)
             self._memory_monitor.check_samples()
 
         if self._cpu_load_monitor:

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -1,78 +1,125 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Utilities for measuring memory utilization for a process."""
+from queue import Queue
 import time
-
 from threading import Thread
 
 import framework.utils as utils
 
 
-MAX_MEMORY = 5 * 1024
-MEMORY_COP_TIMEOUT = 1
-
-
 class MemoryUsageExceededException(Exception):
     """A custom exception containing details on excessive memory usage."""
 
-    def __init__(self, usage):
+    def __init__(self, usage, threshold):
         """Compose the error message containing the memory consumption."""
         super(MemoryUsageExceededException, self).__init__(
             'Memory usage ({} KiB) exceeded maximum threshold ({} KiB).\n'
-            .format(usage, MAX_MEMORY)
+            .format(usage, threshold)
         )
 
 
-def threaded_memory_monitor(mem_size_mib, pid, exceeded_queue):
-    """Spawns a thread that monitors memory consumption of a process.
+class MemoryMonitor(Thread):
+    """Class to represent a RSS memory monitor for a Firecracker process.
 
-    If at some point the memory used exceeds mem_size_mib, the calling thread
-    will trigger error.
+    The guest's memory region is skipped, as the main interest is the
+    VMM memory usage.
     """
-    memory_cop_thread = Thread(target=_memory_cop, args=(
-        mem_size_mib,
-        pid,
-        exceeded_queue
-    ))
-    memory_cop_thread.start()
 
+    MEMORY_THRESHOLD = 5 * 1024
+    MEMORY_SAMPLE_TIMEOUT_S = 1
 
-def _memory_cop(mem_size_mib, pid, exceeded_queue):
-    """Thread for monitoring memory consumption of some pid.
+    def __init__(self):
+        """Initialize monitor attributes."""
+        Thread.__init__(self)
+        self._pid = None
+        self._guest_mem_mib = None
+        self._exceeded_queue = Queue()
+        self._threshold = self.MEMORY_THRESHOLD
+        self._should_stop = False
 
-    `pmap` is used to compute the memory overhead. If it exceeds
-    the maximum value, it is pushed in a thread safe queue and memory
-    monitoring ceases. It is up to the caller to check the queue.
-    """
-    pmap_cmd = 'pmap -xq {}'.format(pid)
-    while True:
-        mem_total = 0
-        try:
-            _, stdout, _ = utils.run_cmd(pmap_cmd)
-            pmap_out = stdout.split("\n")
-        except ChildProcessError:
-            break
-        for line in pmap_out:
-            tokens = line.split()
-            if not tokens:
-                break
+    @property
+    def pid(self):
+        """Get the pid."""
+        return self._pid
+
+    @property
+    def guest_mem_mib(self):
+        """Get the guest memory in MiB."""
+        return self._guest_mem_mib
+
+    @property
+    def threshold(self):
+        """Get the memory threshold."""
+        return self._threshold
+
+    @property
+    def exceeded_queue(self):
+        """Get the exceeded queue."""
+        return self._exceeded_queue
+
+    @guest_mem_mib.setter
+    def guest_mem_mib(self, guest_mem_mib):
+        """Set the guest memory MiB."""
+        self._guest_mem_mib = guest_mem_mib
+
+    @pid.setter
+    def pid(self, pid):
+        """Set the pid."""
+        self._pid = pid
+
+    @threshold.setter
+    def threshold(self, threshold):
+        """Set the threshold."""
+        self._threshold = threshold
+
+    def signal_stop(self):
+        """Signal that the thread should stop."""
+        self._should_stop = True
+
+    def run(self):
+        """Thread for monitoring the RSS memory usage of a Firecracker process.
+
+        `pmap` is used to compute the memory overhead. If it exceeds
+        the maximum value, it is pushed in a thread safe queue and memory
+        monitoring ceases. It is up to the caller to check the queue.
+        """
+        pmap_cmd = 'pmap -xq {}'.format(self.pid)
+
+        while not self._should_stop:
+            mem_total = 0
             try:
-                total_size = int(tokens[1])
-                rss = int(tokens[2])
-            except ValueError:
-                # This line doesn't contain memory related information.
-                continue
-            if total_size == mem_size_mib * 1024:
-                # This is the guest's memory region.
-                # TODO Check for the address of the guest's memory instead.
-                continue
-            mem_total += rss
+                _, stdout, _ = utils.run_cmd(pmap_cmd)
+                pmap_out = stdout.split("\n")
+            except ChildProcessError:
+                return
+            for line in pmap_out:
+                tokens = line.split()
+                if not tokens:
+                    break
+                try:
+                    total_size = int(tokens[1])
+                    rss = int(tokens[2])
+                except ValueError:
+                    # This line doesn't contain memory related information.
+                    continue
+                if total_size == self.guest_mem_mib * 1024:
+                    # This is the guest's memory region.
+                    # TODO Check for the address of the guest's memory instead.
+                    continue
+                mem_total += rss
 
-        if mem_total > MAX_MEMORY:
-            exceeded_queue.put(mem_total)
-            return
+            if mem_total > self.threshold:
+                self.exceeded_queue.put(mem_total)
+                return
 
-        if not mem_total:
-            return
+            if not mem_total:
+                return
 
-        time.sleep(MEMORY_COP_TIMEOUT)
+            time.sleep(self.MEMORY_SAMPLE_TIMEOUT_S)
+
+    def check_samples(self):
+        """Check that there are no samples over the threshold."""
+        if not self.exceeded_queue.empty():
+            raise MemoryUsageExceededException(
+                self.exceeded_queue.get(), self.threshold)

--- a/tests/integration_tests/functional/test_initrd.py
+++ b/tests/integration_tests/functional/test_initrd.py
@@ -13,7 +13,7 @@ def test_microvm_initrd_with_serial(
     vm = test_microvm_with_initrd
     vm.jailer.daemonize = False
     vm.spawn()
-    vm.memory_events_queue = None
+    vm.memory_monitor = None
 
     vm.basic_config(
         add_root_device=False,

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -58,7 +58,7 @@ def test_serial_console_login(test_microvm_with_ssh):
 
     # We don't need to monitor the memory for this test because we are
     # just rebooting and the process dies before pmap gets the RSS.
-    microvm.memory_events_queue = None
+    microvm.memory_monitor = None
 
     # Set up the microVM with 1 vCPU and a serial console.
     microvm.basic_config(vcpu_count=1,

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -17,7 +17,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
 
     # We don't need to monitor the memory for this test because we are
     # just rebooting and the process dies before pmap gets the RSS.
-    test_microvm.memory_events_queue = None
+    test_microvm.memory_monitor = None
 
     # Set up the microVM with 4 vCPUs, 256 MiB of RAM, 0 network ifaces, and
     # a root file system with the rw permission. The network interfaces is

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -21,7 +21,7 @@ def test_sigbus_sigsegv(test_microvm_with_api, signum):
     test_microvm.spawn()
 
     # We don't need to monitor the memory for this test.
-    test_microvm.memory_events_queue = None
+    test_microvm.memory_monitor = None
 
     test_microvm.basic_config()
 
@@ -42,7 +42,7 @@ def test_handled_signals(test_microvm_with_ssh, network_config):
     microvm.spawn()
 
     # We don't need to monitor the memory for this test.
-    microvm.memory_events_queue = None
+    microvm.memory_monitor = None
 
     microvm.basic_config(vcpu_count=2)
 


### PR DESCRIPTION
## Reason for This PR

This PR refactors the memory monitor from the testing framework into a class, similar to how the [cpu load monitor](https://github.com/firecracker-microvm/firecracker-embargo/commit/42c42172ef2290fb9143cb089d9201985f492a14) is structured. 

Currently, the memory monitor determines the usage by parsing the `pmap` output and always skipping the region that has the same size as the guest memory region (because we are interested only in the VMM overhead).
The assumption that the guest region has the expected size is broken by the [current balloon memory release logic](https://github.com/firecracker-microvm/firecracker/pull/2054/), which `mmaps` a new region before using `madvise` to release it.


## Description of Changes

In this PR, a slightly different way of determining the guest memory region is used: 
1. first time we encounter the region with the guest memory size, we remember the start address
2. from that point on, we consider the guest memory region to consist of all `pmap` entries in the range `[start_address, start_address + guest_size]`

A more elegant approach would be to know beforehand the start address of the guest region and always use the logic from step 2.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
