### PR TITLE
Test block device ordering

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -545,13 +545,21 @@ class Microvm:
             )
             assert self._api_session.is_status_no_content(response.status_code)
 
-    def add_drive(self, drive_id, file, root_device=False, is_read_only=False):
+    def add_drive(
+            self,
+            drive_id,
+            file_path,
+            root_device=False,
+            is_read_only=False,
+            partuuid=None,
+    ):
         """Add a block device."""
         response = self.drive.put(
             drive_id=drive_id,
-            path_on_host=self.create_jailed_resource(file.path),
+            path_on_host=self.create_jailed_resource(file_path),
             is_root_device=root_device,
-            is_read_only=is_read_only
+            is_read_only=is_read_only,
+            partuuid=partuuid
         )
         assert self.api_session.is_status_no_content(response.status_code)
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -64,7 +64,7 @@ def _test_patch_drive_snapshot(context):
 
     # Add a scratch 128MB RW non-root block device.
     scratchdisk1 = drive_tools.FilesystemFile(tempfile.mktemp(), size=128)
-    basevm.add_drive('scratch', scratchdisk1)
+    basevm.add_drive('scratch', scratchdisk1.path)
 
     # We will need netmask_len in build_from_snapshot() call later.
     netmask_len = network_config.get_netmask_len()


### PR DESCRIPTION
## Reason for This PR

Fixes #1750

## Description of Changes

Add integration test that verifies that the root device corresponds to /dev/vda and the other
devices start from /dev/vdb and match the configuration order.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
