### PR TITLE
Add cross-version save/load integration tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,20 +128,26 @@ def _test_images_s3_bucket():
 MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(_test_images_s3_bucket())
 
 
-def init_microvm(root_path, bin_cloner_path):
+def init_microvm(root_path, bin_cloner_path,
+                 fc_binary=None, jailer_binary=None):
     """Auxiliary function for instantiating a microvm and setting it up."""
     # pylint: disable=redefined-outer-name
     # The fixture pattern causes a pylint false positive for that rule.
     microvm_id = str(uuid.uuid4())
-    fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+    if fc_binary is None:
+        fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+    # Make sure we always have both binaries.
+    assert fc_binary
+    assert jailer_binary
 
     vm = Microvm(
-        resource_path=root_path,
-        fc_binary_path=fc_binary,
-        jailer_binary_path=jailer_binary,
-        microvm_id=microvm_id,
-        bin_cloner_path=bin_cloner_path
-    )
+         resource_path=root_path,
+         fc_binary_path=fc_binary,
+         jailer_binary_path=jailer_binary,
+         microvm_id=microvm_id,
+         bin_cloner_path=bin_cloner_path)
     vm.setup()
     return vm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def init_microvm(root_path, bin_cloner_path,
     # The fixture pattern causes a pylint false positive for that rule.
     microvm_id = str(uuid.uuid4())
 
-    if fc_binary is None:
+    if fc_binary is None or jailer_binary is None:
         fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
 
     # Make sure we always have both binaries.

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -166,7 +166,7 @@ class SnapshotArtifact:
         # Get the name of the snapshot folder.
         snapshot_name = self.name
         self._local_folder = os.path.join(ARTIFACTS_LOCAL_ROOT,
-                                          self.type.strip('/'),
+                                          self.type.value,
                                           snapshot_name)
 
     @property
@@ -349,7 +349,7 @@ class ArtifactCollection:
             # Select only files with specified keyword.
             if (key[-1] == "/" and key != prefix and
                (keyword is None or keyword in snapshot_dir.key)):
-                artifact_type = ArtifactCollection.ARTIFACTS_SNAPSHOTS
+                artifact_type = ArtifactType.SNAPSHOT
                 artifacts.append(SnapshotArtifact(self.bucket,
                                                   key,
                                                   artifact_type=artifact_type))

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -160,7 +160,6 @@ class SnapshotArtifact:
         for disk in snaphot_disks:
             artifact = Artifact(self._bucket, disk.key,
                                 artifact_type=ArtifactType.DISK)
-            # artifact.download()
             self._disks.append(artifact)
 
         # Get the name of the snapshot folder.

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -24,7 +24,6 @@ class MicrovmBuilder:
         self.bin_cloner_path = bin_cloner_path
         self.init_root_path()
 
-        # Update permissions to owner RWX.
         if fc_binary is not None:
             os.chmod(fc_binary, 0o555)
         if jailer_binary is not None:
@@ -68,13 +67,14 @@ class MicrovmBuilder:
         with open(config.local_path()) as microvm_config_file:
             microvm_config = json.load(microvm_config_file)
 
+        response = vm.basic_config(boot_args='console=ttyS0 reboot=k panic=1')
+
         # Apply the microvm artifact configuration and template.
-        response = test_microvm.machine_cfg.put(
+        response = vm.machine_cfg.put(
             vcpu_count=int(microvm_config['vcpu_count']),
             mem_size_mib=int(microvm_config['mem_size_mib']),
             ht_enabled=bool(microvm_config['ht_enabled']),
             track_dirty_pages=enable_diff_snapshots,
-            boot_args='console=ttyS0 reboot=k panic=1',
             cpu_template=cpu_template,
         )
         assert vm.api_session.is_status_no_content(response.status_code)

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -5,9 +5,8 @@
 import os
 import shutil
 import stat
-
+from pathlib import Path
 from retry.api import retry_call
-
 import framework.utils as utils
 from framework.defs import FC_BINARY_NAME
 
@@ -123,7 +122,7 @@ class JailerContext:
         return os.path.join(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
-            FC_BINARY_NAME,
+            Path(self.exec_file).name,
             self.jailer_id
         )
 

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -7,8 +7,7 @@ of the cartesian product of all artifact sets.
 """
 
 import os
-
-ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
+from framework.artifacts import ARTIFACTS_LOCAL_ROOT
 
 
 class TestContext:

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -653,7 +653,8 @@ class Microvm:
     def pause_to_snapshot(self,
                           mem_file_path=None,
                           snapshot_path=None,
-                          diff=False):
+                          diff=False,
+                          version=None):
         """Pauses the microVM, and creates snapshot.
 
         This function validates that the microVM pauses successfully and
@@ -667,7 +668,8 @@ class Microvm:
 
         response = self.snapshot_create.put(mem_file_path=mem_file_path,
                                             snapshot_path=snapshot_path,
-                                            diff=diff)
+                                            diff=diff,
+                                            version=version)
         assert self.api_session.is_status_no_content(response.status_code)
 
     def resume_from_snapshot(self, mem_file_path, snapshot_path):

--- a/tests/framework/microvms.py
+++ b/tests/framework/microvms.py
@@ -108,7 +108,7 @@ class C3nano(VMBase):
                                   "2vcpu_256mb",
                                   "vmlinux-4.14",
                                   "ubuntu-18.04",
-                                  "C3"
+                                  "C3",
                                   start)
 
 
@@ -122,5 +122,5 @@ class C3micro(VMBase):
                                   "2vcpu_512mb",
                                   "vmlinux-4.14",
                                   "ubuntu-18.04",
-                                  "C3"
+                                  "C3",
                                   start)

--- a/tests/framework/microvms.py
+++ b/tests/framework/microvms.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Define helper functions that create predefined type of resources."""
+
+from framework.artifacts import ArtifactCollection
+from framework.builder import MicrovmBuilder
+import host_tools.network as net_tools
+from conftest import _test_images_s3_bucket
+
+
+class VmInstance:
+    """A class that describes a microvm instance resources."""
+
+    def __init__(self, config, kernel, disks, ssh_key, vm):
+        """Initialize a Vm configuration based on artifacts."""
+        self._config = config
+        self._kernel = kernel
+        self._disks = disks
+        self._ssh_key = ssh_key
+        self._vm = vm
+
+    @property
+    def config(self):
+        """Return machine config artifact."""
+        return self._config
+
+    @property
+    def kernel(self):
+        """Return the kernel artifact."""
+        return self._kernel
+
+    @property
+    def disks(self):
+        """Return an array of block file paths."""
+        return self._disks
+
+    @property
+    def ssh_key(self):
+        """Return ssh key artifact linked to the root block device."""
+        return self._ssh_key
+
+    @property
+    def vm(self):
+        """Return the Microvm object intsance."""
+        return self._vm
+
+
+# VM base class to abstract away the s3 artifacts we are using
+# to specify the configuration
+# Too few public methods (1/2) (too-few-public-methods)
+# pylint: disable=R0903
+class VMBase:
+    """Base class for constructing microvms."""
+
+    @classmethod
+    def from_artifacts(cls, bin_cloner_path, config,
+                       kernel, disks, cpu_template, start=False):
+        """Spawns a new Firecracker and applies specified config."""
+        artifacts = ArtifactCollection(_test_images_s3_bucket())
+        config = artifacts.microvms(keyword=config)[0]
+        kernel = artifacts.kernels(keyword=kernel)[0]
+        disks = artifacts.disks(keyword=disks)
+        config.download()
+        kernel.download()
+        attached_disks = []
+        for disk in disks:
+            disk.download()
+            attached_disks.append(disk.copy())
+
+        vm_builder = MicrovmBuilder(bin_cloner_path)
+
+        # SSH key is attached to root disk artifact.
+        # Builder will download ssh key in the VM root.
+        ssh_key = disks[0].ssh_key()
+
+        # Create a fresh microvm from aftifacts.
+        basevm = vm_builder.build(kernel=kernel,
+                                  disks=attached_disks,
+                                  ssh_key=ssh_key,
+                                  config=config,
+                                  cpu_template=cpu_template)
+
+        network_config = net_tools.UniqueIPv4Generator.instance()
+        # Host ip: 192.168.0.1
+        # Guest ip: 192.168.0.2
+        # TODO: we need to refactor the network config using artifacts.
+        basevm.ssh_network_config(network_config,
+                                  '1',
+                                  tapname="tap0")
+        if start:
+            basevm.start()
+            ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+
+            # Verify if we can run commands in guest via ssh.
+            exit_code, _, _ = ssh_connection.execute_command("sync")
+            assert exit_code == 0
+
+        return VmInstance(config, kernel, attached_disks, ssh_key, basevm)
+
+
+class C3nano(VMBase):
+    """Create VMs with 2vCPUs and 256 MB RAM."""
+
+    @classmethod
+    def spawn(cls, bin_cloner_path, start=False):
+        """Spawns and optionally starts the vm."""
+        return cls.from_artifacts(bin_cloner_path,
+                                  "2vcpu_256mb",
+                                  "vmlinux-4.14",
+                                  "ubuntu-18.04",
+                                  "C3"
+                                  start)
+
+
+class C3micro(VMBase):
+    """Create VMs with 2vCPUs and 512 MB RAM."""
+
+    @classmethod
+    def spawn(cls, bin_cloner_path, start=False):
+        """Spawns and optionally starts the vm."""
+        return cls.from_artifacts(bin_cloner_path,
+                                  "2vcpu_512mb",
+                                  "vmlinux-4.14",
+                                  "ubuntu-18.04",
+                                  "C3"
+                                  start)

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import re
+import subprocess
 import threading
 import typing
 
@@ -190,3 +191,9 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
         run_cmd_async(cmd=cmd,
                       ignore_return_code=ignore_return_code,
                       no_shell=no_shell))
+
+
+def is_amd():
+    """Return true if running on AMD cpus."""
+    brand_str = subprocess.check_output("lscpu", shell=True).strip().decode()
+    return 'AuthenticAMD' in brand_str

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 import threading
 import typing
-
+from enum import Enum, auto
 from collections import namedtuple
 
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
@@ -193,7 +193,16 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
                       no_shell=no_shell))
 
 
-def is_amd():
-    """Return true if running on AMD cpus."""
+class CpuVendor(Enum):
+    """CPU vendors enum."""
+
+    AMD = auto()
+    INTEL = auto()
+
+
+def get_cpu_vendor():
+    """Return the CPU vendor."""
     brand_str = subprocess.check_output("lscpu", shell=True).strip().decode()
-    return 'AuthenticAMD' in brand_str
+    if 'AuthenticAMD' in brand_str:
+        return CpuVendor.AMD
+    return CpuVendor.INTEL

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -4,37 +4,9 @@
 
 import platform
 import re
-
-from enum import Enum, auto
-
 import pytest
-
+from framework.utils import CpuVendor, get_cpu_vendor
 import host_tools.network as net_tools  # pylint: disable=import-error
-
-
-class CpuVendor(Enum):
-    """CPU vendors enum."""
-
-    AMD = auto()
-    INTEL = auto()
-
-
-def _get_cpu_vendor():
-    cif = open('/proc/cpuinfo', 'r')
-    host_vendor_id = None
-    while True:
-        line = cif.readline()
-        if line == '':
-            break
-        mo = re.search("^vendor_id\\s+:\\s+(.+)$", line)
-        if mo:
-            host_vendor_id = mo.group(1)
-    cif.close()
-    assert host_vendor_id is not None
-
-    if host_vendor_id == "AuthenticAMD":
-        return CpuVendor.AMD
-    return CpuVendor.INTEL
 
 
 def _check_guest_cmd_output(test_microvm, guest_cmd, expected_header,
@@ -115,7 +87,7 @@ def _check_cache_topology(test_microvm, num_vcpus_on_lvl_1_cache,
     expected_lvl_3_str = '{} ({})'.format(hex(num_vcpus_on_lvl_3_cache),
                                           num_vcpus_on_lvl_3_cache)
 
-    cpu_vendor = _get_cpu_vendor()
+    cpu_vendor = get_cpu_vendor()
     if cpu_vendor == CpuVendor.AMD:
         expected_level_1_topology = {
             "level": '0x1 (1)',
@@ -288,7 +260,7 @@ def test_brand_string(test_microvm_with_ssh, network_config):
     guest_brand_string = mo.group(1)
     assert guest_brand_string
 
-    cpu_vendor = _get_cpu_vendor()
+    cpu_vendor = get_cpu_vendor()
     expected_guest_brand_string = ""
     if cpu_vendor == CpuVendor.AMD:
         expected_guest_brand_string += "AMD EPYC"

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Basic tests scenarios for snapshot save/restore."""
+
+import logging
+import platform
+import pytest
+from conftest import _test_images_s3_bucket
+from framework.artifacts import ArtifactCollection
+from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.microvms import SmallVM
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_restore_from_past_versions(bin_cloner_path):
+    """Test scenario: restore all previous version snapshots."""
+    logger = logging.getLogger("snapshot_version")
+
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all snapshots artifacts.
+    # "fc_release" is the key that should be used for per release snapshot
+    # artifacts. Such snapshots are created at release time and target the
+    # current version. We are going to restore all these snapshots with current
+    # testing build.
+    snapshot_artifacts = artifacts.snapshots(keyword="fc_release")
+    builder = MicrovmBuilder(bin_cloner_path)
+
+    for snapshot_artifact in snapshot_artifacts:
+        snapshot_artifact.download()
+        snapshot = snapshot_artifact.copy(builder.root_path)
+
+        logger.info("Resuming from %s", snapshot_artifact.key)
+
+        # TODO: Define network config artifact that can be used to build
+        # new vms or can be used as part of the snapshot
+        # For now we are good with theses hardcoded values
+        microvm, _ = builder.build_from_snapshot(snapshot,
+                                                 "192.168.0.1",
+                                                 "192.168.0.2",
+                                                 30,
+                                                 True,
+                                                 False)
+        # Attempt to connect to resumed microvm.
+        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+
+        # Run a fio workload and validate succesfull execution.
+        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+        --ioengine=libaio --iodepth=16 --runtime=2 --numjobs=4 --time_based \
+        --group_reporting --name=iops-test-job --eta-newline=1 --readonly"""
+
+        exit_code, _, _ = ssh_connection.execute_command(fio)
+        assert exit_code == 0
+
+
+def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None):
+    """Create a snapshoft from a 2vcpu 512MB microvm."""
+    vm_instance = SmallVM.spawn(bin_cloner_path, True)
+    # Create a snapshot builder from a microvm.
+    snapshot_builder = SnapshotBuilder(vm_instance.vm)
+
+    # The snapshot builder expects disks as paths, not artifacts.
+    disks = []
+    for disk in vm_instance.disks:
+        disks.append(disk.local_path())
+
+    snapshot = snapshot_builder.create(disks,
+                                       vm_instance.ssh_key,
+                                       SnapshotType.FULL,
+                                       target_version)
+
+    vm_instance.vm.kill()
+    return snapshot
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_restore_in_past_versions(bin_cloner_path):
+    """Test scenario: create a snapshot and restore in previous versions."""
+    logger = logging.getLogger("snapshot_version")
+
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all snapshots artifacts.
+    # "fc_release" is the key that should be used for per release snapshot
+    # artifacts. Such snapshots are created at release time and target the
+    # current version. We are going to restore all these snapshots with current
+    # testing build.
+    firecracker_artifacts = artifacts.firecrackers()
+    for firecracker in firecracker_artifacts:
+        firecracker.download()
+        jailer = firecracker.jailer()
+        jailer.download()
+        # The target version is in the name of the firecracker binary from S3.
+        # We also strip the "v" as fc expects X.Y.Z version string.
+        target_version = firecracker.base_name()[1:]
+        logger.info("Creating snapshot for version: %s", target_version)
+
+        # Create a fresh snapshot targeted at the binary artifact version.
+        snapshot = create_512mb_full_snapshot(bin_cloner_path, target_version)
+
+        builder = MicrovmBuilder(bin_cloner_path,
+                                 firecracker.local_path(),
+                                 jailer.local_path())
+        microvm, _ = builder.build_from_snapshot(snapshot,
+                                                 "192.168.0.1",
+                                                 "192.168.0.2",
+                                                 30,
+                                                 True,
+                                                 False)
+
+        logger.info("Using Firecracker: %s", firecracker.local_path())
+        logger.info("Using Jailer: %s", jailer.local_path())
+
+        # Attempt to connect to resumed microvm.
+        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+
+        # Run a fio workload and validate succesfull execution.
+        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+        --ioengine=libaio --iodepth=16 --runtime=2 --numjobs=4 --time_based \
+        --group_reporting --name=iops-test-job --eta-newline=1 --readonly"""
+
+        exit_code, _, _ = ssh_connection.execute_command(fio)
+        assert exit_code == 0

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.microvms import SmallVM
+from framework.microvms import C3micro
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 
@@ -58,7 +58,7 @@ def test_restore_from_past_versions(bin_cloner_path):
 
 def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None):
     """Create a snapshoft from a 2vcpu 512MB microvm."""
-    vm_instance = SmallVM.spawn(bin_cloner_path, True)
+    vm_instance = C3micro.spawn(bin_cloner_path, True)
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(vm_instance.vm)
 

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -11,6 +11,7 @@ from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.utils import is_amd
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.logging as log_tools
 
@@ -213,7 +214,7 @@ def test_snapshot_create_latency(network_config,
 
 
 @pytest.mark.skipif(
-    platform.machine() != "x86_64",
+    platform.machine() != "x86_64" or is_amd(),
     reason="Not supported yet."
 )
 def test_snapshot_resume_latency(network_config,
@@ -254,7 +255,7 @@ def test_snapshot_resume_latency(network_config,
 
 
 @pytest.mark.skipif(
-    platform.machine() != "x86_64",
+    platform.machine() != "x86_64" or is_amd(),
     reason="Not supported yet."
 )
 def test_older_snapshot_resume_latency(bin_cloner_path):

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -182,7 +182,6 @@ kernel {}, disk {} """.format(snapshot_type,
 
         baseline = LOAD_LATENCY_BASELINES[context.microvm.name()]
         logger.info("Latency {}/{}: {} ms".format(i + 1, SAMPLE_COUNT, value))
-        value = value
         assert baseline > value, "LoadSnapshot latency degraded."
 
         microvm.kill()
@@ -272,8 +271,7 @@ def test_snapshot_resume_latency(network_config,
     platform.machine() != "x86_64",
     reason="Not supported yet."
 )
-def test_older_snapshot_resume_latency(network_config,
-                                       bin_cloner_path):
+def test_older_snapshot_resume_latency(bin_cloner_path):
     """Test scenario: Older snapshot load performance measurement."""
     logger = logging.getLogger("old_snapshot_load")
 
@@ -286,7 +284,7 @@ def test_older_snapshot_resume_latency(network_config,
         for i in range(SAMPLE_COUNT):
             snapshot = artifact.copy(builder.root_path)
 
-            logger.info("Resuming from {}".format(artifact.key))
+            logger.info("Resuming from %s", artifact.key)
 
             # TODO: Define network config artifact that can be used to build
             # new vms or can be used as part of the snapshot
@@ -308,11 +306,11 @@ def test_older_snapshot_resume_latency(network_config,
             metrics = microvm.get_all_metrics(metrics_fifo)
             for data_point in metrics:
                 metrics = json.loads(data_point)
-                cur_value = metrics['latencies_us']['load_snapshot'] / USEC_IN_MSEC
+                cur_value = metrics['latencies_us']['load_snapshot']
                 if cur_value > 0:
-                    value = cur_value
+                    value = cur_value / USEC_IN_MSEC
                     break
 
             baseline = LOAD_LATENCY_BASELINES[artifact.name]
-            logger.info("Latency {}/{}: {} ms".format(i + 1, SAMPLE_COUNT, value))
+            logger.info("Latency %s/%s: %s ms", i + 1, SAMPLE_COUNT, value)
             assert baseline > value, "LoadSnapshot latency degraded."

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -40,7 +40,7 @@ LOAD_LATENCY_BASELINES = {
     '2vcpu_512mb.json': 8,
     # We are also tracking restore from older version latency.
     # Snapshot properties: 2vCPU, 512MB RAM, 1 disk, 1 network iface.
-    'fc_release_v0.22': 8,
+    'fc_release_v0.23': 8,
 }
 
 
@@ -126,17 +126,6 @@ kernel {}, disk {} """.format(snapshot_type,
                               config=context.microvm,
                               enable_diff_snapshots=enable_diff_snapshots)
 
-    host_ip = None
-    guest_ip = None
-    netmask_len = None
-    network_config = net_tools.UniqueIPv4Generator.instance()
-    _, host_ip, guest_ip = basevm.ssh_network_config(network_config,
-                                                     iface_id='1',
-                                                     tapname="tap0")
-    logger.debug("Host IP: {}, Guest IP: {}".format(host_ip, guest_ip))
-
-    # # We will need netmask_len in build_from_snapshot() call later.
-    netmask_len = network_config.get_netmask_len()
     basevm.start()
     ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
 
@@ -157,9 +146,6 @@ kernel {}, disk {} """.format(snapshot_type,
     for i in range(SAMPLE_COUNT):
         microvm, metrics_fifo = vm_builder.build_from_snapshot(
                                                 snapshot,
-                                                host_ip,
-                                                guest_ip,
-                                                netmask_len,
                                                 True,
                                                 enable_diff_snapshots)
 
@@ -290,9 +276,6 @@ def test_older_snapshot_resume_latency(bin_cloner_path):
             # new vms or can be used as part of the snapshot
             # For now we are good with theses hardcoded values
             microvm, metrics_fifo = builder.build_from_snapshot(snapshot,
-                                                                "192.168.0.1",
-                                                                "192.168.0.2",
-                                                                30,
                                                                 True,
                                                                 False)
             # Attempt to connect to resumed microvm.


### PR DESCRIPTION
## Reason for This PR

This completes the test suite mentioned in issue #1850. 
Also fixes #2077 and #2075 - collateral from snapshot networking config changes.

## Description of Changes

Add two snapshot version integration tests:
- Use current version to load snapshots created with older versions.
- Create snapshots with current versions and load in older releases.

Framework changes:
- added binary path parameters in init_microvm()
- added FirecrackerArtifact class
- added SnapshotArtifact class
- added support to specify the fc version when creating a snapshot
- use static network configuration for snapshots

More details in commit messages.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
