### PR TITLE
vmm: broke up vstate in 2 separate files

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -16,7 +16,11 @@ use crate::device_manager::{legacy::PortIODeviceManager, persist::MMIODevManager
 #[cfg(target_arch = "x86_64")]
 use crate::persist::{MicrovmState, MicrovmStateError};
 use crate::vmm_config::boot_source::BootConfig;
-use crate::vstate::{KvmContext, Vcpu, VcpuConfig, Vm};
+use crate::vstate::{
+    system::KvmContext,
+    vcpu::{Vcpu, VcpuConfig},
+    vm::Vm,
+};
 use crate::{device_manager, Error, Vmm, VmmEventsObserver};
 
 use arch::InitrdConfig;

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -100,7 +100,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     1,
                     ArgLen::DWORD,
                     Eq,
-                    (sigrtmin() + super::super::vstate::VCPU_RTSIG_OFFSET) as u64
+                    (sigrtmin() + super::super::vstate::vcpu::VCPU_RTSIG_OFFSET) as u64
                 )?]],
             ),
             #[cfg(target_env = "gnu")]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -47,8 +47,11 @@ use crate::memory_snapshot::SnapshotMemory;
 #[cfg(target_arch = "x86_64")]
 use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
 #[cfg(target_arch = "x86_64")]
-use crate::vstate::VcpuState;
-use crate::vstate::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
+use crate::vstate::vcpu::VcpuState;
+use crate::vstate::{
+    vcpu::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse},
+    vm::Vm,
+};
 use arch::DeviceType;
 use devices::BusDevice;
 use logger::{error, info, warn, LoggerError, MetricsError, METRICS};
@@ -98,7 +101,7 @@ pub enum Error {
     KernelFile(io::Error),
     /// Cannot open /dev/kvm. Either the host does not have KVM or Firecracker does not have
     /// permission to open the file descriptor.
-    KvmContext(vstate::Error),
+    KvmContext(vstate::system::Error),
     #[cfg(target_arch = "x86_64")]
     /// Cannot add devices to the Legacy I/O Bus.
     LegacyIOBus(device_manager::legacy::Error),
@@ -115,11 +118,11 @@ pub enum Error {
     /// Cannot create Timer file descriptor.
     TimerFd(io::Error),
     /// Vcpu error.
-    Vcpu(vstate::Error),
+    Vcpu(vstate::vcpu::Error),
     /// Cannot send event to vCPU.
-    VcpuEvent(vstate::Error),
+    VcpuEvent(vstate::vcpu::Error),
     /// Cannot create a vCPU handle.
-    VcpuHandle(vstate::Error),
+    VcpuHandle(vstate::vcpu::Error),
     /// vCPU pause failed.
     VcpuPause,
     /// vCPU resume failed.
@@ -127,7 +130,7 @@ pub enum Error {
     /// Cannot spawn a new Vcpu thread.
     VcpuSpawn(io::Error),
     /// Vm error.
-    Vm(vstate::Error),
+    Vm(vstate::vm::Error),
     /// Error thrown by observer object on Vmm initialization.
     VmmObserverInit(utils::errno::Error),
     /// Error thrown by observer object on Vmm teardown.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use crate::builder::{self, StartMicrovmError};
 use crate::device_manager::persist::Error as DevicePersistError;
 use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
-use crate::vstate::{self, VcpuState, VmState};
+use crate::vstate::{self, vcpu::VcpuState, vm::VmState};
 
 use crate::device_manager::persist::DeviceStates;
 use crate::memory_snapshot;
@@ -60,15 +60,15 @@ pub enum MicrovmStateError {
     /// Failed to restore devices.
     RestoreDevices(DevicePersistError),
     /// Failed to restore Vcpu state.
-    RestoreVcpuState(vstate::Error),
+    RestoreVcpuState(vstate::vcpu::Error),
     /// Failed to restore VM state.
-    RestoreVmState(vstate::Error),
+    RestoreVmState(vstate::vm::Error),
     /// Failed to save Vcpu state.
-    SaveVcpuState(vstate::Error),
+    SaveVcpuState(vstate::vcpu::Error),
     /// Failed to save VM state.
-    SaveVmState(vstate::Error),
+    SaveVmState(vstate::vm::Error),
     /// Failed to send event.
-    SignalVcpu(vstate::Error),
+    SignalVcpu(vstate::vcpu::Error),
     /// Vcpu is in unexpected state.
     UnexpectedVcpuResponse,
 }
@@ -97,7 +97,7 @@ pub enum CreateSnapshotError {
     /// Failed to translate microVM version to snapshot data version.
     InvalidVersion,
     /// Failed to save VM state.
-    InvalidVmState(vstate::Error),
+    InvalidVmState(vstate::vm::Error),
     /// Failed to write memory to snapshot.
     Memory(memory_snapshot::Error),
     /// Failed to open memory backing file.
@@ -292,7 +292,7 @@ mod tests {
     use crate::memory_snapshot::SnapshotMemory;
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::vsock::tests::default_config;
-    use crate::vstate::tests::default_vcpu_state;
+    use crate::vstate::vcpu::tests::default_vcpu_state;
     use crate::Vmm;
 
     use polly::event_manager::EventManager;
@@ -379,7 +379,7 @@ mod tests {
         let err = InvalidVersion;
         let _ = format!("{}{:?}", err, err);
 
-        let err = InvalidVmState(vstate::Error::NotEnoughMemorySlots);
+        let err = InvalidVmState(vstate::vm::Error::NotEnoughMemorySlots);
         let _ = format!("{}{:?}", err, err);
 
         let err = Memory(memory_snapshot::Error::WriteMemory(
@@ -432,19 +432,19 @@ mod tests {
         let err = RestoreDevices(DevicePersistError::MmioTransport);
         let _ = format!("{}{:?}", err, err);
 
-        let err = RestoreVcpuState(vstate::Error::HTNotInitialized);
+        let err = RestoreVcpuState(vstate::vcpu::Error::HTNotInitialized);
         let _ = format!("{}{:?}", err, err);
 
-        let err = RestoreVmState(vstate::Error::NotEnoughMemorySlots);
+        let err = RestoreVmState(vstate::vm::Error::NotEnoughMemorySlots);
         let _ = format!("{}{:?}", err, err);
 
-        let err = SaveVcpuState(vstate::Error::HTNotInitialized);
+        let err = SaveVcpuState(vstate::vcpu::Error::HTNotInitialized);
         let _ = format!("{}{:?}", err, err);
 
-        let err = SaveVmState(vstate::Error::NotEnoughMemorySlots);
+        let err = SaveVmState(vstate::vm::Error::NotEnoughMemorySlots);
         let _ = format!("{}{:?}", err, err);
 
-        let err = SignalVcpu(vstate::Error::VcpuCountNotInitialized);
+        let err = SignalVcpu(vstate::vcpu::Error::VcpuCountNotInitialized);
         let _ = format!("{}{:?}", err, err);
 
         let err = UnexpectedVcpuResponse;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -16,7 +16,7 @@ use crate::vmm_config::metrics::{init_metrics, MetricsConfig, MetricsConfigError
 use crate::vmm_config::mmds::{MmdsConfig, MmdsConfigError};
 use crate::vmm_config::net::*;
 use crate::vmm_config::vsock::*;
-use crate::vstate::VcpuConfig;
+use crate::vstate::vcpu::VcpuConfig;
 use mmds::ns::MmdsNetworkStack;
 use utils::net::ipv4addr::is_link_local_valid;
 
@@ -307,7 +307,7 @@ mod tests {
     use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig};
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vmm_config::RateLimiterConfig;
-    use crate::vstate::VcpuConfig;
+    use crate::vstate::vcpu::VcpuConfig;
     use dumbo::MacAddr;
     use logger::{LevelFilter, LOGGER};
     use utils::tempfile::TempFile;

--- a/src/vmm/src/vstate/mod.rs
+++ b/src/vmm/src/vstate/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod system;
+pub(crate) mod vcpu;
+pub(crate) mod vm;

--- a/src/vmm/src/vstate/system.rs
+++ b/src/vmm/src/vstate/system.rs
@@ -1,0 +1,114 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::{
+    fmt::{Display, Formatter},
+    result,
+};
+
+use kvm_bindings::KVM_API_VERSION;
+use kvm_ioctls::Kvm;
+
+/// Errors associated with the wrappers over KVM ioctls.
+#[derive(Debug)]
+pub enum Error {
+    /// The host kernel reports an invalid KVM API version.
+    KvmApiVersion(i32),
+    /// Cannot initialize the KVM context due to missing capabilities.
+    KvmCap(kvm_ioctls::Cap),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use self::Error::*;
+
+        match self {
+            KvmApiVersion(v) => write!(
+                f,
+                "The host kernel reports an invalid KVM API version: {}",
+                v
+            ),
+            KvmCap(cap) => write!(f, "Missing KVM capabilities: {:?}", cap),
+        }
+    }
+}
+
+type Result<T> = result::Result<T, Error>;
+
+/// Describes a KVM context that gets attached to the microVM.
+/// It gives access to the functionality of the KVM wrapper as
+/// long as every required KVM capability is present on the host.
+pub struct KvmContext {
+    kvm: Kvm,
+    max_memslots: usize,
+}
+
+impl KvmContext {
+    pub fn new() -> Result<Self> {
+        use kvm_ioctls::Cap::*;
+        let kvm = Kvm::new().expect("Error creating the Kvm object");
+
+        // Check that KVM has the correct version.
+        if kvm.get_api_version() != KVM_API_VERSION as i32 {
+            return Err(Error::KvmApiVersion(kvm.get_api_version()));
+        }
+
+        // A list of KVM capabilities we want to check.
+        #[cfg(target_arch = "x86_64")]
+        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, SetTssAddr];
+
+        #[cfg(target_arch = "aarch64")]
+        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, ArmPsci02];
+
+        // Check that all desired capabilities are supported.
+        match capabilities
+            .iter()
+            .find(|&capability| !kvm.check_extension(*capability))
+        {
+            None => {
+                let max_memslots = kvm.get_nr_memslots();
+                Ok(KvmContext { kvm, max_memslots })
+            }
+
+            Some(c) => Err(Error::KvmCap(*c)),
+        }
+    }
+
+    pub fn fd(&self) -> &Kvm {
+        &self.kvm
+    }
+
+    /// Get the maximum number of memory slots reported by this KVM context.
+    pub fn max_memslots(&self) -> usize {
+        self.max_memslots
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use super::*;
+
+    #[test]
+    fn test_kvm_context() {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::{AsRawFd, FromRawFd};
+
+        let c = KvmContext::new().unwrap();
+
+        assert!(c.max_memslots() >= 32);
+
+        let kvm = Kvm::new().unwrap();
+        let f = unsafe { File::from_raw_fd(kvm.as_raw_fd()) };
+        let m1 = f.metadata().unwrap();
+        let m2 = File::open("/dev/kvm").unwrap().metadata().unwrap();
+
+        assert_eq!(m1.dev(), m2.dev());
+        assert_eq!(m1.ino(), m2.ino());
+    }
+}

--- a/src/vmm/src/vstate/vcpu.rs
+++ b/src/vmm/src/vstate/vcpu.rs
@@ -6,44 +6,41 @@
 // found in the THIRD-PARTY file.
 
 use libc::{c_int, c_void, siginfo_t};
-use std::cell::Cell;
-use std::fmt::{Display, Formatter};
-use std::io;
-use std::result;
-use std::sync::atomic::{fence, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 #[cfg(not(test))]
 use std::sync::Barrier;
-use std::thread;
-
-use super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
+use std::{
+    cell::Cell,
+    fmt::{Display, Formatter},
+    io, result,
+    sync::{
+        atomic::{fence, Ordering},
+        mpsc::{channel, Receiver, Sender, TryRecvError},
+    },
+    thread,
+};
 
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
-#[cfg(target_arch = "aarch64")]
-use arch::aarch64::gic::GICDevice;
+use crate::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3, filter_cpuid, t2, VmSpec};
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{
-    kvm_clock_data, kvm_debugregs, kvm_irqchip, kvm_lapic_state, kvm_mp_state, kvm_pit_config,
-    kvm_pit_state2, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs, kvm_xsave, CpuId, MsrList,
-    Msrs, KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
-    KVM_MAX_CPUID_ENTRIES, KVM_PIT_SPEAKER_DUMMY,
+    kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs,
+    kvm_xsave, CpuId, MsrList, Msrs,
 };
-use kvm_bindings::{kvm_userspace_memory_region, KVM_API_VERSION, KVM_MEM_LOG_DIRTY_PAGES};
 use kvm_ioctls::*;
 use logger::{error, info, Metric, METRICS};
 use seccomp::{BpfProgram, SeccompFilter};
-use utils::eventfd::EventFd;
-use utils::signal::{register_signal_handler, sigrtmin, Killable};
-use utils::sm::StateMachine;
+use utils::{
+    eventfd::EventFd,
+    signal::{register_signal_handler, sigrtmin, Killable},
+    sm::StateMachine,
+};
 #[cfg(target_arch = "x86_64")]
 use versionize::{VersionMap, Versionize, VersionizeResult};
 #[cfg(target_arch = "x86_64")]
 use versionize_derive::Versionize;
-use vm_memory::{
-    Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
-};
+use vm_memory::{Address, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;
@@ -59,17 +56,10 @@ pub enum Error {
     FPUConfiguration(arch::x86_64::regs::Error),
     /// Invalid guest memory configuration.
     GuestMemoryMmap(GuestMemoryError),
-    #[cfg(target_arch = "x86_64")]
-    /// Retrieving supported guest MSRs fails.
-    GuestMSRs(arch::x86_64::msr::Error),
     /// Hyperthreading flag is not initialized.
     HTNotInitialized,
     /// Cannot configure the IRQ.
     Irq(kvm_ioctls::Error),
-    /// The host kernel reports an invalid KVM API version.
-    KvmApiVersion(i32),
-    /// Cannot initialize the KVM context due to missing capabilities.
-    KvmCap(kvm_ioctls::Cap),
     #[cfg(target_arch = "x86_64")]
     /// Cannot set the local interruption due to bad configuration.
     LocalIntConfiguration(arch::x86_64::interrupts::Error),
@@ -84,11 +74,6 @@ pub enum Error {
     #[cfg(target_arch = "x86_64")]
     /// Error configuring the general purpose registers
     REGSConfiguration(arch::x86_64::regs::Error),
-    #[cfg(target_arch = "aarch64")]
-    /// Error setting up the global interrupt controller.
-    SetupGIC(arch::aarch64::gic::Error),
-    /// Cannot set the memory regions.
-    SetUserMemoryRegion(kvm_ioctls::Error),
     /// Failed to signal Vcpu.
     SignalVcpu(utils::errno::Error),
     #[cfg(target_arch = "x86_64")]
@@ -174,28 +159,6 @@ pub enum Error {
     VcpuTlsNotPresent,
     /// Unexpected KVM_RUN exit reason
     VcpuUnhandledKvmExit,
-    /// Cannot open the VM file descriptor.
-    VmFd(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm pit state.
-    VmGetPit2(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm clock.
-    VmGetClock(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to get KVM vm irqchip.
-    VmGetIrqChip(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm pit state.
-    VmSetPit2(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm clock.
-    VmSetClock(kvm_ioctls::Error),
-    #[cfg(target_arch = "x86_64")]
-    /// Failed to set KVM vm irqchip.
-    VmSetIrqChip(kvm_ioctls::Error),
-    /// Cannot configure the microvm.
-    VmSetup(kvm_ioctls::Error),
 }
 
 impl Display for Error {
@@ -206,23 +169,13 @@ impl Display for Error {
             #[cfg(target_arch = "x86_64")]
             CpuId(e) => write!(f, "Cpuid error: {:?}", e),
             GuestMemoryMmap(e) => write!(f, "Guest memory error: {:?}", e),
-            #[cfg(target_arch = "x86_64")]
-            GuestMSRs(e) => write!(f, "Retrieving supported guest MSRs fails: {:?}", e),
             HTNotInitialized => write!(f, "Hyperthreading flag is not initialized"),
-            KvmApiVersion(v) => write!(
-                f,
-                "The host kernel reports an invalid KVM API version: {}",
-                v
-            ),
-            KvmCap(cap) => write!(f, "Missing KVM capabilities: {:?}", cap),
             VcpuCountNotInitialized => write!(f, "vCPU count is not initialized"),
-            VmFd(e) => write!(f, "Cannot open the VM file descriptor: {}", e),
             VcpuFd(e) => write!(f, "Cannot open the VCPU file descriptor: {}", e),
-            VmSetup(e) => write!(f, "Cannot configure the microvm: {}", e),
             VcpuRun(e) => write!(f, "Cannot run the VCPUs: {}", e),
             NotEnoughMemorySlots => write!(
                 f,
-                "The number of configured slots is bigger than the maximum reported by KVM"
+                "The number of configured SetUserMemoryRegionslots is bigger than the maximum reported by KVM"
             ),
             #[cfg(target_arch = "x86_64")]
             LocalIntConfiguration(e) => write!(
@@ -230,7 +183,6 @@ impl Display for Error {
                 "Cannot set the local interruption due to bad configuration: {:?}",
                 e
             ),
-            SetUserMemoryRegion(e) => write!(f, "Cannot set the memory regions: {}", e),
             SignalVcpu(e) => write!(f, "Failed to signal Vcpu: {}", e),
             #[cfg(target_arch = "x86_64")]
             MSRSConfiguration(e) => write!(f, "Error configuring the MSR registers: {:?}", e),
@@ -255,6 +207,12 @@ impl Display for Error {
                 e
             ),
             Irq(e) => write!(f, "Cannot configure the IRQ: {}", e),
+            #[cfg(target_arch = "aarch64")]
+            VcpuArmPreferredTarget(e) => {
+                write!(f, "Error getting the Vcpu preferred target on Arm: {}", e)
+            }
+            #[cfg(target_arch = "aarch64")]
+            VcpuArmInit(e) => write!(f, "Error doing Vcpu Init on Arm: {}", e),
             #[cfg(target_arch = "x86_64")]
             VcpuGetDebugRegs(e) => write!(f, "Failed to get KVM vcpu debug regs: {}", e),
             #[cfg(target_arch = "x86_64")]
@@ -299,284 +257,11 @@ impl Display for Error {
             VcpuTlsInit => write!(f, "Cannot clean init vcpu TLS"),
             VcpuTlsNotPresent => write!(f, "Vcpu not present in TLS"),
             VcpuUnhandledKvmExit => write!(f, "Unexpected KVM_RUN exit reason"),
-            #[cfg(target_arch = "x86_64")]
-            VmGetPit2(e) => write!(f, "Failed to get KVM vm pit state: {}", e),
-            #[cfg(target_arch = "x86_64")]
-            VmGetClock(e) => write!(f, "Failed to get KVM vm clock: {}", e),
-            #[cfg(target_arch = "x86_64")]
-            VmGetIrqChip(e) => write!(f, "Failed to get KVM vm irqchip: {}", e),
-            #[cfg(target_arch = "x86_64")]
-            VmSetPit2(e) => write!(f, "Failed to set KVM vm pit state: {}", e),
-            #[cfg(target_arch = "x86_64")]
-            VmSetClock(e) => write!(f, "Failed to set KVM vm clock: {}", e),
-            #[cfg(target_arch = "x86_64")]
-            VmSetIrqChip(e) => write!(f, "Failed to set KVM vm irqchip: {}", e),
-            #[cfg(target_arch = "aarch64")]
-            SetupGIC(e) => write!(
-                f,
-                "Error setting up the global interrupt controller: {:?}",
-                e
-            ),
-            #[cfg(target_arch = "aarch64")]
-            VcpuArmPreferredTarget(e) => {
-                write!(f, "Error getting the Vcpu preferred target on Arm: {}", e)
-            }
-            #[cfg(target_arch = "aarch64")]
-            VcpuArmInit(e) => write!(f, "Error doing Vcpu Init on Arm: {}", e),
         }
     }
 }
 
 pub type Result<T> = result::Result<T, Error>;
-
-/// Describes a KVM context that gets attached to the microVM.
-/// It gives access to the functionality of the KVM wrapper as
-/// long as every required KVM capability is present on the host.
-pub struct KvmContext {
-    kvm: Kvm,
-    max_memslots: usize,
-}
-
-impl KvmContext {
-    pub fn new() -> Result<Self> {
-        use kvm_ioctls::Cap::*;
-        let kvm = Kvm::new().expect("Error creating the Kvm object");
-
-        // Check that KVM has the correct version.
-        if kvm.get_api_version() != KVM_API_VERSION as i32 {
-            return Err(Error::KvmApiVersion(kvm.get_api_version()));
-        }
-
-        // A list of KVM capabilities we want to check.
-        #[cfg(target_arch = "x86_64")]
-        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, SetTssAddr];
-
-        #[cfg(target_arch = "aarch64")]
-        let capabilities = vec![Irqchip, Ioeventfd, Irqfd, UserMemory, ArmPsci02];
-
-        // Check that all desired capabilities are supported.
-        match capabilities
-            .iter()
-            .find(|&capability| !kvm.check_extension(*capability))
-        {
-            None => {
-                let max_memslots = kvm.get_nr_memslots();
-                Ok(KvmContext { kvm, max_memslots })
-            }
-
-            Some(c) => Err(Error::KvmCap(*c)),
-        }
-    }
-
-    pub fn fd(&self) -> &Kvm {
-        &self.kvm
-    }
-
-    /// Get the maximum number of memory slots reported by this KVM context.
-    pub fn max_memslots(&self) -> usize {
-        self.max_memslots
-    }
-}
-
-/// A wrapper around creating and using a VM.
-pub struct Vm {
-    fd: VmFd,
-
-    // X86 specific fields.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    supported_cpuid: CpuId,
-    #[cfg(target_arch = "x86_64")]
-    supported_msrs: MsrList,
-
-    // Arm specific fields.
-    // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
-    #[cfg(target_arch = "aarch64")]
-    irqchip_handle: Option<Box<dyn GICDevice>>,
-}
-
-impl Vm {
-    /// Constructs a new `Vm` using the given `Kvm` instance.
-    pub fn new(kvm: &Kvm) -> Result<Self> {
-        //create fd for interacting with kvm-vm specific functions
-        let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        let supported_cpuid = kvm
-            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
-            .map_err(Error::VmFd)?;
-        #[cfg(target_arch = "x86_64")]
-        let supported_msrs =
-            arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
-
-        Ok(Vm {
-            fd: vm_fd,
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            supported_cpuid,
-            #[cfg(target_arch = "x86_64")]
-            supported_msrs,
-            #[cfg(target_arch = "aarch64")]
-            irqchip_handle: None,
-        })
-    }
-
-    /// Returns a ref to the supported `CpuId` for this Vm.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    pub fn supported_cpuid(&self) -> &CpuId {
-        &self.supported_cpuid
-    }
-
-    /// Returns a ref to the supported `MsrList` for this Vm.
-    #[cfg(target_arch = "x86_64")]
-    pub fn supported_msrs(&self) -> &MsrList {
-        &self.supported_msrs
-    }
-
-    /// Initializes the guest memory.
-    pub fn memory_init(
-        &mut self,
-        guest_mem: &GuestMemoryMmap,
-        kvm_max_memslots: usize,
-        track_dirty_pages: bool,
-    ) -> Result<()> {
-        if guest_mem.num_regions() > kvm_max_memslots {
-            return Err(Error::NotEnoughMemorySlots);
-        }
-        self.set_kvm_memory_regions(guest_mem, track_dirty_pages)?;
-        #[cfg(target_arch = "x86_64")]
-        self.fd
-            .set_tss_address(arch::x86_64::layout::KVM_TSS_ADDRESS as usize)
-            .map_err(Error::VmSetup)?;
-
-        Ok(())
-    }
-
-    /// Creates the irq chip and an in-kernel device model for the PIT.
-    #[cfg(target_arch = "x86_64")]
-    pub fn setup_irqchip(&self) -> Result<()> {
-        self.fd.create_irq_chip().map_err(Error::VmSetup)?;
-        let mut pit_config = kvm_pit_config::default();
-        // We need to enable the emulation of a dummy speaker port stub so that writing to port 0x61
-        // (i.e. KVM_SPEAKER_BASE_ADDRESS) does not trigger an exit to user space.
-        pit_config.flags = KVM_PIT_SPEAKER_DUMMY;
-        self.fd.create_pit2(pit_config).map_err(Error::VmSetup)
-    }
-
-    /// Creates the GIC (Global Interrupt Controller).
-    #[cfg(target_arch = "aarch64")]
-    pub fn setup_irqchip(&mut self, vcpu_count: u8) -> Result<()> {
-        self.irqchip_handle = Some(
-            arch::aarch64::gic::create_gic(&self.fd, vcpu_count.into()).map_err(Error::SetupGIC)?,
-        );
-        Ok(())
-    }
-
-    /// Gets a reference to the irqchip of the VM
-    #[cfg(target_arch = "aarch64")]
-    pub fn get_irqchip(&self) -> &dyn GICDevice {
-        self.irqchip_handle
-            .as_ref()
-            .expect("IRQ chip not set")
-            .as_ref()
-    }
-
-    /// Gets a reference to the kvm file descriptor owned by this VM.
-    pub fn fd(&self) -> &VmFd {
-        &self.fd
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    /// Saves and returns the Kvm Vm state.
-    pub fn save_state(&self) -> Result<VmState> {
-        let pitstate = self.fd.get_pit2().map_err(Error::VmGetPit2)?;
-
-        let mut clock = self.fd.get_clock().map_err(Error::VmGetClock)?;
-        // This bit is not accepted in SET_CLOCK, clear it.
-        clock.flags &= !KVM_CLOCK_TSC_STABLE;
-
-        let mut pic_master = kvm_irqchip::default();
-        pic_master.chip_id = KVM_IRQCHIP_PIC_MASTER;
-        self.fd
-            .get_irqchip(&mut pic_master)
-            .map_err(Error::VmGetIrqChip)?;
-
-        let mut pic_slave = kvm_irqchip::default();
-        pic_slave.chip_id = KVM_IRQCHIP_PIC_SLAVE;
-        self.fd
-            .get_irqchip(&mut pic_slave)
-            .map_err(Error::VmGetIrqChip)?;
-
-        let mut ioapic = kvm_irqchip::default();
-        ioapic.chip_id = KVM_IRQCHIP_IOAPIC;
-        self.fd
-            .get_irqchip(&mut ioapic)
-            .map_err(Error::VmGetIrqChip)?;
-
-        Ok(VmState {
-            pitstate,
-            clock,
-            pic_master,
-            pic_slave,
-            ioapic,
-        })
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    /// Restores the Kvm Vm state.
-    pub fn restore_state(&self, state: &VmState) -> Result<()> {
-        self.fd
-            .set_pit2(&state.pitstate)
-            .map_err(Error::VmSetPit2)?;
-        self.fd.set_clock(&state.clock).map_err(Error::VmSetClock)?;
-        self.fd
-            .set_irqchip(&state.pic_master)
-            .map_err(Error::VmSetIrqChip)?;
-        self.fd
-            .set_irqchip(&state.pic_slave)
-            .map_err(Error::VmSetIrqChip)?;
-        self.fd
-            .set_irqchip(&state.ioapic)
-            .map_err(Error::VmSetIrqChip)?;
-        Ok(())
-    }
-
-    pub(crate) fn set_kvm_memory_regions(
-        &self,
-        guest_mem: &GuestMemoryMmap,
-        track_dirty_pages: bool,
-    ) -> Result<()> {
-        let mut flags = 0u32;
-        if track_dirty_pages {
-            flags |= KVM_MEM_LOG_DIRTY_PAGES;
-        }
-        guest_mem
-            .with_regions(|index, region| {
-                let memory_region = kvm_userspace_memory_region {
-                    slot: index as u32,
-                    guest_phys_addr: region.start_addr().raw_value() as u64,
-                    memory_size: region.len() as u64,
-                    // It's safe to unwrap because the guest address is valid.
-                    userspace_addr: guest_mem.get_host_address(region.start_addr()).unwrap() as u64,
-                    flags,
-                };
-
-                // Safe because the fd is a valid KVM file descriptor.
-                unsafe { self.fd.set_user_memory_region(memory_region) }
-            })
-            .map_err(Error::SetUserMemoryRegion)?;
-        Ok(())
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[derive(Versionize)]
-/// Structure holding VM kvm state.
-pub struct VmState {
-    pitstate: kvm_pit_state2,
-    clock: kvm_clock_data,
-    pic_master: kvm_irqchip,
-    pic_slave: kvm_irqchip,
-    ioapic: kvm_irqchip,
-}
 
 /// Encapsulates configuration parameters for the guest vCPUS.
 #[derive(Debug, PartialEq)]
@@ -1381,20 +1066,13 @@ enum VcpuEmulation {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "x86_64")]
-    use std::convert::TryInto;
     use std::fmt;
-    use std::fs::File;
-    #[cfg(target_arch = "x86_64")]
-    use std::os::unix::io::AsRawFd;
-    #[cfg(target_arch = "x86_64")]
-    use std::path::PathBuf;
     use std::sync::{Arc, Barrier};
     #[cfg(target_arch = "x86_64")]
-    use std::time::Duration;
+    use std::{convert::TryInto, fs::File, os::unix::io::AsRawFd, path::PathBuf, time::Duration};
 
     use super::*;
-
+    use crate::vstate::{system::KvmContext, vm::Vm};
     use utils::signal::validate_signal_num;
 
     impl PartialEq for VcpuResponse {
@@ -1500,42 +1178,6 @@ pub(crate) mod tests {
         assert!(vcpu.mmio_bus.is_none());
         vcpu.set_mmio_bus(devices::Bus::new());
         assert!(vcpu.mmio_bus.is_some());
-    }
-
-    #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn test_get_supported_cpuid() {
-        let kvm = KvmContext::new().unwrap();
-        let vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
-        let cpuid = kvm
-            .kvm
-            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
-            .expect("Cannot get supported cpuid");
-        assert_eq!(vm.supported_cpuid().as_slice(), cpuid.as_slice());
-    }
-
-    #[test]
-    fn test_vm_memory_init() {
-        let mut kvm_context = KvmContext::new().unwrap();
-        let mut vm = Vm::new(kvm_context.fd()).expect("Cannot create new vm");
-
-        // Create valid memory region and test that the initialization is successful.
-        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        assert!(vm
-            .memory_init(&gm, kvm_context.max_memslots(), true)
-            .is_ok());
-
-        // Set the maximum number of memory slots to 1 in KvmContext to check the error
-        // path of memory_init. Create 2 non-overlapping memory slots.
-        kvm_context.max_memslots = 1;
-        let gm = GuestMemoryMmap::from_ranges(&[
-            (GuestAddress(0x0), 0x1000),
-            (GuestAddress(0x1001), 0x2000),
-        ])
-        .unwrap();
-        assert!(vm
-            .memory_init(&gm, kvm_context.max_memslots(), true)
-            .is_err());
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -1645,24 +1287,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_kvm_context() {
-        use std::os::unix::fs::MetadataExt;
-        use std::os::unix::io::{AsRawFd, FromRawFd};
-
-        let c = KvmContext::new().unwrap();
-
-        assert!(c.max_memslots >= 32);
-
-        let kvm = Kvm::new().unwrap();
-        let f = unsafe { File::from_raw_fd(kvm.as_raw_fd()) };
-        let m1 = f.metadata().unwrap();
-        let m2 = File::open("/dev/kvm").unwrap().metadata().unwrap();
-
-        assert_eq!(m1.dev(), m2.dev());
-        assert_eq!(m1.ino(), m2.ino());
-    }
-
-    #[test]
     fn test_vcpu_tls() {
         let (_, mut vcpu, _) = setup_vcpu(0x1000);
 
@@ -1708,7 +1332,7 @@ pub(crate) mod tests {
         let (vm, mut vcpu, _mem) = setup_vcpu(0x1000);
 
         let kvm_run =
-            KvmRunWrapper::mmap_from_fd(&vcpu.fd, vm.fd.run_size()).expect("cannot mmap kvm-run");
+            KvmRunWrapper::mmap_from_fd(&vcpu.fd, vm.fd().run_size()).expect("cannot mmap kvm-run");
         let success = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let vcpu_success = success.clone();
         let barrier = Arc::new(Barrier::new(2));
@@ -1893,29 +1517,6 @@ pub(crate) mod tests {
     #[test]
     fn test_vcpu_rtsig_offset() {
         assert!(validate_signal_num(sigrtmin() + VCPU_RTSIG_OFFSET).is_ok());
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[test]
-    fn test_vm_save_restore_state() {
-        let kvm_fd = Kvm::new().unwrap();
-        let vm = Vm::new(&kvm_fd).expect("new vm failed");
-        // Irqchips, clock and pitstate are not configured so trying to save state should fail.
-        assert!(vm.save_state().is_err());
-
-        let (vm, _, _mem) = setup_vcpu(0x1000);
-        let vm_state = vm.save_state().unwrap();
-        assert_eq!(
-            vm_state.pitstate.flags | KVM_PIT_SPEAKER_DUMMY,
-            KVM_PIT_SPEAKER_DUMMY
-        );
-        assert_eq!(vm_state.clock.flags & KVM_CLOCK_TSC_STABLE, 0);
-        assert_eq!(vm_state.pic_master.chip_id, KVM_IRQCHIP_PIC_MASTER);
-        assert_eq!(vm_state.pic_slave.chip_id, KVM_IRQCHIP_PIC_SLAVE);
-        assert_eq!(vm_state.ioapic.chip_id, KVM_IRQCHIP_IOAPIC);
-
-        let (vm, _, _mem) = setup_vcpu(0x1000);
-        assert!(vm.restore_state(&vm_state).is_ok());
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1,0 +1,377 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::{
+    fmt::{Display, Formatter},
+    result,
+};
+
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::gic::GICDevice;
+#[cfg(target_arch = "x86_64")]
+use kvm_bindings::{
+    kvm_clock_data, kvm_irqchip, kvm_pit_config, kvm_pit_state2, CpuId, MsrList,
+    KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
+    KVM_MAX_CPUID_ENTRIES, KVM_PIT_SPEAKER_DUMMY,
+};
+use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_LOG_DIRTY_PAGES};
+use kvm_ioctls::{Kvm, VmFd};
+#[cfg(target_arch = "x86_64")]
+use versionize::{VersionMap, Versionize, VersionizeResult};
+#[cfg(target_arch = "x86_64")]
+use versionize_derive::Versionize;
+use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+
+/// Errors associated with the wrappers over KVM ioctls.
+#[derive(Debug)]
+pub enum Error {
+    #[cfg(target_arch = "x86_64")]
+    /// Retrieving supported guest MSRs fails.
+    GuestMSRs(arch::x86_64::msr::Error),
+    /// The number of configured slots is bigger than the maximum reported by KVM.
+    NotEnoughMemorySlots,
+    /// Cannot set the memory regions.
+    SetUserMemoryRegion(kvm_ioctls::Error),
+    #[cfg(target_arch = "aarch64")]
+    /// Cannot create the global interrupt controller..
+    VmCreateGIC(arch::aarch64::gic::Error),
+    /// Cannot open the VM file descriptor.
+    VmFd(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to get KVM vm pit state.
+    VmGetPit2(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to get KVM vm clock.
+    VmGetClock(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to get KVM vm irqchip.
+    VmGetIrqChip(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to set KVM vm pit state.
+    VmSetPit2(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to set KVM vm clock.
+    VmSetClock(kvm_ioctls::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Failed to set KVM vm irqchip.
+    VmSetIrqChip(kvm_ioctls::Error),
+    /// Cannot configure the microvm.
+    VmSetup(kvm_ioctls::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use self::Error::*;
+
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            GuestMSRs(e) => write!(f, "Retrieving supported guest MSRs fails: {:?}", e),
+            #[cfg(target_arch = "aarch64")]
+            VmCreateGIC(e) => write!(f, "Error creating the global interrupt controller: {:?}", e),
+            VmFd(e) => write!(f, "Cannot open the VM file descriptor: {}", e),
+            VmSetup(e) => write!(f, "Cannot configure the microvm: {}", e),
+            NotEnoughMemorySlots => write!(
+                f,
+                "The number of configured slots is bigger than the maximum reported by KVM"
+            ),
+            SetUserMemoryRegion(e) => write!(f, "Cannot set the memory regions: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmGetPit2(e) => write!(f, "Failed to get KVM vm pit state: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmGetClock(e) => write!(f, "Failed to get KVM vm clock: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmGetIrqChip(e) => write!(f, "Failed to get KVM vm irqchip: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmSetPit2(e) => write!(f, "Failed to set KVM vm pit state: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmSetClock(e) => write!(f, "Failed to set KVM vm clock: {}", e),
+            #[cfg(target_arch = "x86_64")]
+            VmSetIrqChip(e) => write!(f, "Failed to set KVM vm irqchip: {}", e),
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// A wrapper around creating and using a VM.
+pub struct Vm {
+    fd: VmFd,
+
+    // X86 specific fields.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    supported_cpuid: CpuId,
+    #[cfg(target_arch = "x86_64")]
+    supported_msrs: MsrList,
+
+    // Arm specific fields.
+    // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
+    #[cfg(target_arch = "aarch64")]
+    irqchip_handle: Option<Box<dyn GICDevice>>,
+}
+
+impl Vm {
+    /// Constructs a new `Vm` using the given `Kvm` instance.
+    pub fn new(kvm: &Kvm) -> Result<Self> {
+        // Create fd for interacting with kvm-vm specific functions.
+        let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        let supported_cpuid = kvm
+            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
+            .map_err(Error::VmFd)?;
+        #[cfg(target_arch = "x86_64")]
+        let supported_msrs =
+            arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
+
+        Ok(Vm {
+            fd: vm_fd,
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            supported_cpuid,
+            #[cfg(target_arch = "x86_64")]
+            supported_msrs,
+            #[cfg(target_arch = "aarch64")]
+            irqchip_handle: None,
+        })
+    }
+
+    /// Returns a ref to the supported `CpuId` for this Vm.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub fn supported_cpuid(&self) -> &CpuId {
+        &self.supported_cpuid
+    }
+
+    /// Returns a ref to the supported `MsrList` for this Vm.
+    #[cfg(target_arch = "x86_64")]
+    pub fn supported_msrs(&self) -> &MsrList {
+        &self.supported_msrs
+    }
+
+    /// Initializes the guest memory.
+    pub fn memory_init(
+        &mut self,
+        guest_mem: &GuestMemoryMmap,
+        kvm_max_memslots: usize,
+        track_dirty_pages: bool,
+    ) -> Result<()> {
+        if guest_mem.num_regions() > kvm_max_memslots {
+            return Err(Error::NotEnoughMemorySlots);
+        }
+        self.set_kvm_memory_regions(guest_mem, track_dirty_pages)?;
+        #[cfg(target_arch = "x86_64")]
+        self.fd
+            .set_tss_address(arch::x86_64::layout::KVM_TSS_ADDRESS as usize)
+            .map_err(Error::VmSetup)?;
+
+        Ok(())
+    }
+
+    /// Creates the irq chip and an in-kernel device model for the PIT.
+    #[cfg(target_arch = "x86_64")]
+    pub fn setup_irqchip(&self) -> Result<()> {
+        self.fd.create_irq_chip().map_err(Error::VmSetup)?;
+        let mut pit_config = kvm_pit_config::default();
+        // We need to enable the emulation of a dummy speaker port stub so that writing to port 0x61
+        // (i.e. KVM_SPEAKER_BASE_ADDRESS) does not trigger an exit to user space.
+        pit_config.flags = KVM_PIT_SPEAKER_DUMMY;
+        self.fd.create_pit2(pit_config).map_err(Error::VmSetup)
+    }
+
+    /// Creates the GIC (Global Interrupt Controller).
+    #[cfg(target_arch = "aarch64")]
+    pub fn setup_irqchip(&mut self, vcpu_count: u8) -> Result<()> {
+        self.irqchip_handle = Some(
+            arch::aarch64::gic::create_gic(&self.fd, vcpu_count.into())
+                .map_err(Error::VmCreateGIC)?,
+        );
+        Ok(())
+    }
+
+    /// Gets a reference to the irqchip of the VM
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_irqchip(&self) -> &dyn GICDevice {
+        self.irqchip_handle
+            .as_ref()
+            .expect("IRQ chip not set")
+            .as_ref()
+    }
+
+    /// Gets a reference to the kvm file descriptor owned by this VM.
+    pub fn fd(&self) -> &VmFd {
+        &self.fd
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    /// Saves and returns the Kvm Vm state.
+    pub fn save_state(&self) -> Result<VmState> {
+        let pitstate = self.fd.get_pit2().map_err(Error::VmGetPit2)?;
+
+        let mut clock = self.fd.get_clock().map_err(Error::VmGetClock)?;
+        // This bit is not accepted in SET_CLOCK, clear it.
+        clock.flags &= !KVM_CLOCK_TSC_STABLE;
+
+        let mut pic_master = kvm_irqchip::default();
+        pic_master.chip_id = KVM_IRQCHIP_PIC_MASTER;
+        self.fd
+            .get_irqchip(&mut pic_master)
+            .map_err(Error::VmGetIrqChip)?;
+
+        let mut pic_slave = kvm_irqchip::default();
+        pic_slave.chip_id = KVM_IRQCHIP_PIC_SLAVE;
+        self.fd
+            .get_irqchip(&mut pic_slave)
+            .map_err(Error::VmGetIrqChip)?;
+
+        let mut ioapic = kvm_irqchip::default();
+        ioapic.chip_id = KVM_IRQCHIP_IOAPIC;
+        self.fd
+            .get_irqchip(&mut ioapic)
+            .map_err(Error::VmGetIrqChip)?;
+
+        Ok(VmState {
+            pitstate,
+            clock,
+            pic_master,
+            pic_slave,
+            ioapic,
+        })
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    /// Restores the Kvm Vm state.
+    pub fn restore_state(&self, state: &VmState) -> Result<()> {
+        self.fd
+            .set_pit2(&state.pitstate)
+            .map_err(Error::VmSetPit2)?;
+        self.fd.set_clock(&state.clock).map_err(Error::VmSetClock)?;
+        self.fd
+            .set_irqchip(&state.pic_master)
+            .map_err(Error::VmSetIrqChip)?;
+        self.fd
+            .set_irqchip(&state.pic_slave)
+            .map_err(Error::VmSetIrqChip)?;
+        self.fd
+            .set_irqchip(&state.ioapic)
+            .map_err(Error::VmSetIrqChip)?;
+        Ok(())
+    }
+
+    pub(crate) fn set_kvm_memory_regions(
+        &self,
+        guest_mem: &GuestMemoryMmap,
+        track_dirty_pages: bool,
+    ) -> Result<()> {
+        let mut flags = 0u32;
+        if track_dirty_pages {
+            flags |= KVM_MEM_LOG_DIRTY_PAGES;
+        }
+        guest_mem
+            .with_regions(|index, region| {
+                let memory_region = kvm_userspace_memory_region {
+                    slot: index as u32,
+                    guest_phys_addr: region.start_addr().raw_value() as u64,
+                    memory_size: region.len() as u64,
+                    // It's safe to unwrap because the guest address is valid.
+                    userspace_addr: guest_mem.get_host_address(region.start_addr()).unwrap() as u64,
+                    flags,
+                };
+
+                // Safe because the fd is a valid KVM file descriptor.
+                unsafe { self.fd.set_user_memory_region(memory_region) }
+            })
+            .map_err(Error::SetUserMemoryRegion)?;
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[derive(Versionize)]
+/// Structure holding VM kvm state.
+pub struct VmState {
+    pitstate: kvm_pit_state2,
+    clock: kvm_clock_data,
+    pic_master: kvm_irqchip,
+    pic_slave: kvm_irqchip,
+    ioapic: kvm_irqchip,
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::vstate::system::KvmContext;
+    use vm_memory::GuestAddress;
+
+    #[cfg(target_arch = "x86_64")]
+    // Auxiliary function being used throughout the tests.
+    fn setup_vm(mem_size: usize) -> (Vm, GuestMemoryMmap) {
+        let kvm = KvmContext::new().unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), mem_size)]).unwrap();
+        let mut vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
+        assert!(vm.memory_init(&gm, kvm.max_memslots(), false).is_ok());
+        vm.setup_irqchip().unwrap();
+
+        (vm, gm)
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn test_get_supported_cpuid() {
+        let kvm = KvmContext::new().unwrap();
+        let vm = Vm::new(kvm.fd()).expect("Cannot create new vm");
+        let cpuid = kvm
+            .fd()
+            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
+            .expect("Cannot get supported cpuid");
+        assert_eq!(vm.supported_cpuid().as_slice(), cpuid.as_slice());
+    }
+
+    #[test]
+    fn test_vm_memory_init() {
+        let mut kvm_context = KvmContext::new().unwrap();
+        let mut vm = Vm::new(kvm_context.fd()).expect("Cannot create new vm");
+
+        // Create valid memory region and test that the initialization is successful.
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+        assert!(vm
+            .memory_init(&gm, kvm_context.max_memslots(), true)
+            .is_ok());
+
+        // Set the maximum number of memory slots to 1 in KvmContext to check the error
+        // path of memory_init. Create 2 non-overlapping memory slots.
+        kvm_context.set_max_memslots(1);
+        let gm = GuestMemoryMmap::from_ranges(&[
+            (GuestAddress(0x0), 0x1000),
+            (GuestAddress(0x1001), 0x2000),
+        ])
+        .unwrap();
+        assert!(vm
+            .memory_init(&gm, kvm_context.max_memslots(), true)
+            .is_err());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_vm_save_restore_state() {
+        let kvm_fd = Kvm::new().unwrap();
+        let vm = Vm::new(&kvm_fd).expect("new vm failed");
+        // Irqchips, clock and pitstate are not configured so trying to save state should fail.
+        assert!(vm.save_state().is_err());
+
+        let (vm, _mem) = setup_vm(0x1000);
+        let vm_state = vm.save_state().unwrap();
+        assert_eq!(
+            vm_state.pitstate.flags | KVM_PIT_SPEAKER_DUMMY,
+            KVM_PIT_SPEAKER_DUMMY
+        );
+        assert_eq!(vm_state.clock.flags & KVM_CLOCK_TSC_STABLE, 0);
+        assert_eq!(vm_state.pic_master.chip_id, KVM_IRQCHIP_PIC_MASTER);
+        assert_eq!(vm_state.pic_slave.chip_id, KVM_IRQCHIP_PIC_SLAVE);
+        assert_eq!(vm_state.ioapic.chip_id, KVM_IRQCHIP_IOAPIC);
+
+        let (vm, _mem) = setup_vm(0x1000);
+        assert!(vm.restore_state(&vm_state).is_ok());
+    }
+}


### PR DESCRIPTION

## Reason for This PR

Fixes #1605.

## Description of Changes

vstate.rs is now a module with 2 submodules: vm.rs and vcpu.rs.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
