### PR TITLE
Made Invalid Header error more verbose

### DIFF
--- a/src/micro_http/src/lib.rs
+++ b/src/micro_http/src/lib.rs
@@ -120,4 +120,4 @@ pub use crate::response::{Response, StatusCode};
 pub use crate::server::{HttpServer, ServerError, ServerRequest, ServerResponse};
 
 pub use crate::common::headers::{Headers, MediaType};
-pub use crate::common::{Body, Method, Version};
+pub use crate::common::{Body, HttpHeaderError, Method, Version};

--- a/src/micro_http/src/request.rs
+++ b/src/micro_http/src/request.rs
@@ -4,6 +4,7 @@
 use std::str::from_utf8;
 
 use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
+pub use crate::common::HttpHeaderError;
 pub use crate::common::RequestError;
 use crate::common::{Body, Method, Version};
 use crate::headers::Headers;
@@ -481,14 +482,13 @@ mod tests {
         Request::try_from(b"PATCH http://localhost/home HTTP/1.1\r\n").unwrap_err();
 
         // Test for an invalid encoding.
-        let request = Request::try_from(
+        assert!(Request::try_from(
             b"PATCH http://localhost/home HTTP/1.1\r\n\
                                      Expect: 100-continue\r\n\
                                      Transfer-Encoding: identity; q=0\r\n\
                                      Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
         )
-        .unwrap_err();
-        assert_eq!(request, RequestError::InvalidHeader);
+        .is_ok());
 
         // Test for an invalid content length.
         let request = Request::try_from(

--- a/src/micro_http/src/server.rs
+++ b/src/micro_http/src/server.rs
@@ -744,14 +744,14 @@ mod tests {
 
         assert!(server.requests().unwrap().is_empty());
         assert!(server.requests().unwrap().is_empty());
-        let mut buf: [u8; 198] = [0; 198];
+        let mut buf: [u8; 255] = [0; 255];
         assert!(socket.read(&mut buf[..]).unwrap() > 0);
         let error_message = b"HTTP/1.1 400 \r\n\
                               Server: Firecracker API\r\n\
                               Connection: keep-alive\r\n\
                               Content-Type: application/json\r\n\
-                              Content-Length: 80\r\n\r\n{ \"error\": \"Invalid header.\n\
-                              All previous unanswered requests will be dropped.\" }";
+                              Content-Length: 136\r\n\r\n{ \"error\": \"Invalid header. \
+                              Reason: Invalid value. Key:Content-Length; Value: alpha\nAll previous unanswered requests will be dropped.\" }";
         assert_eq!(&buf[..], &error_message[..]);
     }
 


### PR DESCRIPTION
Signed-off-by: cihodar <cihodar@amazon.com>

## Reason for This PR

Fixes #1976
Made the output of InvalidHeader more verbose.

## Description of Changes
 
Modified InvalidHeader error such that it will give more context.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
