### PR TITLE
vmm: use display trait in errors where possible

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -52,7 +52,7 @@ use crate::vstate::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse, Vm};
 use arch::DeviceType;
 use devices::BusDevice;
 use logger::{error, info, warn, LoggerError, MetricsError, METRICS};
-use polly::event_manager::{self, EventManager, Subscriber};
+use polly::event_manager::{EventManager, Subscriber};
 use seccomp::BpfProgramRef;
 #[cfg(target_arch = "x86_64")]
 use snapshot::Persist;
@@ -90,8 +90,6 @@ pub enum Error {
     DirtyBitmap(kvm_ioctls::Error),
     /// Cannot read from an Event file descriptor.
     EventFd(io::Error),
-    /// Polly error wrapper.
-    EventManager(event_manager::Error),
     /// I8042 Error.
     I8042Error(devices::legacy::I8042DeviceError),
     /// Cannot access kernel file.
@@ -140,23 +138,22 @@ impl Display for Error {
 
         match self {
             #[cfg(target_arch = "x86_64")]
-            CreateLegacyDevice(e) => write!(f, "Error creating legacy device: {:?}", e),
+            CreateLegacyDevice(e) => write!(f, "Error creating legacy device: {}", e),
             DirtyBitmap(e) => write!(f, "Error getting the KVM dirty bitmap. {}", e),
             EventFd(e) => write!(f, "Event fd error: {}", e),
-            EventManager(e) => write!(f, "Event manager error: {:?}", e),
             I8042Error(e) => write!(f, "I8042 error: {}", e),
             KernelFile(e) => write!(f, "Cannot access kernel file: {}", e),
-            KvmContext(e) => write!(f, "Failed to validate KVM support: {:?}", e),
+            KvmContext(e) => write!(f, "Failed to validate KVM support: {}", e),
             #[cfg(target_arch = "x86_64")]
             LegacyIOBus(e) => write!(f, "Cannot add devices to the legacy I/O Bus. {}", e),
             Logger(e) => write!(f, "Logger error: {}", e),
             Metrics(e) => write!(f, "Metrics error: {}", e),
             RegisterMMIODevice(e) => write!(f, "Cannot add a device to the MMIO Bus. {}", e),
             SeccompFilters(e) => write!(f, "Cannot build seccomp filters: {}", e),
-            Serial(e) => write!(f, "Error writing to the serial console: {:?}", e),
+            Serial(e) => write!(f, "Error writing to the serial console: {}", e),
             TimerFd(e) => write!(f, "Error creating timer fd: {}", e),
             Vcpu(e) => write!(f, "Vcpu error: {}", e),
-            VcpuEvent(e) => write!(f, "Cannot send event to vCPU. {:?}", e),
+            VcpuEvent(e) => write!(f, "Cannot send event to vCPU. {}", e),
             VcpuHandle(e) => write!(f, "Cannot create a vCPU handle. {}", e),
             VcpuPause => write!(f, "Failed to pause the vCPUs."),
             VcpuResume => write!(f, "Failed to resume the vCPUs."),
@@ -324,11 +321,6 @@ impl Vmm {
         unsafe {
             libc::_exit(exit_code);
         }
-    }
-
-    /// Returns a reference to the inner KVM Vm object.
-    pub fn kvm_vm(&self) -> &Vm {
-        &self.vm
     }
 
     /// Saves the state of a paused Microvm.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.50, "AMD": 84.45}
+COVERAGE_DICT = {"Intel": 84.50, "AMD": 84.51}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Also, fixes #1353.

## Description of Changes

Details in commit message.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
