### PR TITLE
Fix minor doc typo in patch-block.md

### DIFF
--- a/docs/api_requests/patch-block.md
+++ b/docs/api_requests/patch-block.md
@@ -4,8 +4,8 @@ Attached block devices require a PATCH /drives API call when the backing
 file's path or size changes, otherwise Firecracker and the running guest will
 not be notified of the changes.
 
-Is is important to note that the block device should not be mounted by the
-guest at the time of the API call, else the call will silently fail -
+It is important to note that the block device should not be mounted by the
+guest at the time of the API call, otherwise the call will silently fail -
 no error is returned from either the guest or the host, but the guest might end
 up in an inconsistent state.
 


### PR DESCRIPTION
`Is is` -> `It is`. Also changed `else` to `otherwise` for sentence clarity

## Reason for This PR

Fixing minor typo in docs

## Description of Changes

`Is is` -> `It is`. Also changed `else` to `otherwise` for sentence clarity

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
