### PR TITLE
Boot timer prod removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
 - Segregated MMDS documentation in MMDS design documentation and MMDS user
   guide documentation.
 - The logger `level` field is now case-insensitive.
+- Disabled boot timer device after restoring a snapshot.
+- Enabled boot timer device only when specifically requested, by using the
+  `--boot-timer` dedicated cmdline parameter.
+  
 
 ## [0.21.0]
 

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -103,6 +103,7 @@ pub fn run_with_api(
     instance_info: InstanceInfo,
     start_time_us: Option<u64>,
     start_time_cpu_us: Option<u64>,
+    boot_timer_enabled: bool,
 ) {
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
@@ -167,9 +168,13 @@ pub fn run_with_api(
 
     // Configure, build and start the microVM.
     let (vm_resources, vmm) = match config_json {
-        Some(json) => {
-            super::build_microvm_from_json(seccomp_filter, &mut event_manager, json, &instance_info)
-        }
+        Some(json) => super::build_microvm_from_json(
+            seccomp_filter,
+            &mut event_manager,
+            json,
+            &instance_info,
+            boot_timer_enabled,
+        ),
         None => PrebootApiController::build_microvm_from_requests(
             seccomp_filter,
             &mut event_manager,
@@ -190,6 +195,7 @@ pub fn run_with_api(
                     .send(Box::new(response))
                     .expect("one-shot channel closed")
             },
+            boot_timer_enabled,
         ),
     };
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -311,7 +311,9 @@ pub fn build_microvm_for_boot(
         vcpu_config.vcpu_count,
     )?;
 
-    attach_boot_timer_device(&mut vmm, request_ts)?;
+    if vm_resources.boot_timer {
+        attach_boot_timer_device(&mut vmm, request_ts)?;
+    }
 
     attach_block_devices(
         &mut vmm,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -188,11 +188,6 @@ impl<'a> Persist<'a> for MMIODeviceManager {
         let vm = constructor_args.vm;
         let event_manager = constructor_args.event_manager;
 
-        let boot_timer = BootTimer::new(TimestampUs::default());
-        dev_manager
-            .register_new_mmio_boot_timer(boot_timer)
-            .map_err(Error::DeviceManager)?;
-
         for block_state in &state.block_devices {
             let device = Arc::new(Mutex::new(
                 Block::restore(
@@ -408,10 +403,6 @@ mod tests {
             let mut event_manager = EventManager::new().expect("Unable to create EventManager");
             let mut vmm = default_vmm();
             let mut cmdline = default_kernel_cmdline();
-
-            // Add a boot timer device.
-            let request_ts = TimestampUs::default();
-            attach_boot_timer_device(&mut vmm, request_ts);
 
             // Add a block device.
             let drive_id = String::from("root");

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -84,6 +84,8 @@ pub struct VmResources {
     pub net_builder: NetBuilder,
     /// The configuration for `MmdsNetworkStack`.
     pub mmds_config: Option<MmdsConfig>,
+    /// Whether or not to load boot timer device.
+    pub boot_timer: bool,
 }
 
 impl VmResources {
@@ -377,6 +379,7 @@ mod tests {
             vsock: Default::default(),
             net_builder: default_net_builder(),
             mmds_config: None,
+            boot_timer: false,
         }
     }
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -213,12 +213,14 @@ impl<'a> PrebootApiController<'a> {
         instance_info: InstanceInfo,
         recv_req: F,
         respond: G,
+        boot_timer_enabled: bool,
     ) -> (VmResources, Arc<Mutex<Vmm>>)
     where
         F: Fn() -> VmmAction,
         G: Fn(result::Result<VmmData, VmmActionError>),
     {
         let mut vm_resources = VmResources::default();
+        vm_resources.boot_timer = boot_timer_enabled;
         let mut preboot_controller = PrebootApiController::new(
             seccomp_filter,
             instance_info,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.50, "AMD": 84.51}
+COVERAGE_DICT = {"Intel": 84.44, "AMD": 84.42}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

[#2069](https://github.com/firecracker-microvm/firecracker/issues/2069)

## Description of Changes

- Disabled boot timer device when restoring a snapshot.
- Added a dedicated **--boot-timer** parameter in order to activate the boot timer feature.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
