### PR TITLE
Memory ballooning support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "polly 0.0.1",
  "rate_limiter 0.1.0",
  "snapshot 0.1.0",
+ "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -14,6 +14,7 @@ net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
+timerfd = ">=1.0"
 versionize = { version = "0.1.1" }
 versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
 virtio_gen = { path = "../virtio_gen" }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -24,7 +24,7 @@ pub(crate) fn report_net_event_fail(err: Error) {
     METRICS.net.event_fails.inc();
 }
 
-pub(crate) fn report_balloon_event_fail(err: Error) {
+pub(crate) fn report_balloon_event_fail(err: virtio::balloon::Error) {
     error!("{:?}", err);
     METRICS.balloon.event_fails.inc();
 }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -24,6 +24,10 @@ pub(crate) fn report_net_event_fail(err: Error) {
     METRICS.net.event_fails.inc();
 }
 
+pub(crate) fn report_balloon_event_fail(err: Error) {
+    error!("{:?}", err);
+}
+
 #[derive(Debug)]
 pub enum Error {
     /// Failed to read from the TAP device.
@@ -34,6 +38,8 @@ pub enum Error {
     IoError(io::Error),
     /// Device received malformed payload.
     MalformedPayload,
+    /// Device received malformed descriptor.
+    MalformedDescriptor,
     /// Error during queue processing.
     QueueError(QueueError),
 }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) fn report_net_event_fail(err: Error) {
 
 pub(crate) fn report_balloon_event_fail(err: Error) {
     error!("{:?}", err);
+    METRICS.balloon.event_fails.inc();
 }
 
 #[derive(Debug)]

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -1,0 +1,583 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp;
+use std::io::{self, Write};
+use std::result;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use logger::{error};
+use utils::eventfd::EventFd;
+use virtio_gen::virtio_blk::*;
+use vm_memory::{
+    Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap,
+};
+
+use super::{
+    super::{
+        ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BALLOON, VIRTIO_MMIO_INT_VRING,
+    },
+    DEFLATE_INDEX, INFLATE_INDEX, MAX_PAGES_IN_DESC, NUM_QUEUES, QUEUE_SIZES,
+    VIRTIO_BALLOON_F_DEFLATE_ON_OOM, VIRTIO_BALLOON_F_MUST_TELL_HOST, VIRTIO_BALLOON_PFN_SHIFT,
+    utils::{compact_page_frame_numbers, remove_range},
+};
+
+use crate::{report_balloon_event_fail, Error as DeviceError};
+
+const SIZE_OF_U32: usize = 4;
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ConfigSpace {
+    num_pages: u32,
+    actual_pages: u32,
+}
+
+// Safe because ConfigSpace only contains plain data.
+unsafe impl ByteValued for ConfigSpace {}
+
+// Virtio balloon device.
+pub struct Balloon {
+    // Virtio fields.
+    pub(crate) avail_features: u64,
+    pub(crate) acked_features: u64,
+    pub(crate) config_space: ConfigSpace,
+    pub(crate) activate_evt: EventFd,
+
+    // Transport related fields.
+    pub(crate) queues: Vec<Queue>,
+    pub(crate) interrupt_status: Arc<AtomicUsize>,
+    interrupt_evt: EventFd,
+    pub(crate) queue_evts: [EventFd; NUM_QUEUES],
+    pub(crate) device_state: DeviceState,
+}
+
+impl Balloon {
+    pub fn new(num_pages: u32, must_tell_host: bool, deflate_on_oom: bool) -> io::Result<Balloon> {
+        let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+
+        if must_tell_host {
+            avail_features |= 1u64 << VIRTIO_BALLOON_F_MUST_TELL_HOST;
+        };
+
+        if deflate_on_oom {
+            avail_features |= 1u64 << VIRTIO_BALLOON_F_DEFLATE_ON_OOM;
+        };
+
+        let queue_evts = [
+            EventFd::new(libc::EFD_NONBLOCK)?,
+            EventFd::new(libc::EFD_NONBLOCK)?,
+        ];
+
+        let queues = QUEUE_SIZES.iter().map(|&s| Queue::new(s)).collect();
+
+        Ok(Balloon {
+            avail_features,
+            acked_features: 0u64,
+            config_space: ConfigSpace {
+                num_pages,
+                actual_pages: 0,
+            },
+            interrupt_status: Arc::new(AtomicUsize::new(0)),
+            interrupt_evt: EventFd::new(libc::EFD_NONBLOCK)?,
+            queue_evts,
+            queues,
+            device_state: DeviceState::Inactive,
+            activate_evt: EventFd::new(libc::EFD_NONBLOCK)?,
+        })
+    }
+
+    pub(crate) fn process_inflate_queue_event(&mut self) {
+        if let Err(e) = self.queue_evts[INFLATE_INDEX].read() {
+            error!("Failed to get queue event: {:?}", e);
+        } else {
+            self.process_inflate()
+                .unwrap_or_else(report_balloon_event_fail);
+        }
+    }
+
+    pub(crate) fn process_deflate_queue_event(&mut self) {
+        if let Err(e) = self.queue_evts[DEFLATE_INDEX].read() {
+            error!("Failed to get queue event: {:?}", e);
+        } else if self.process_deflate_queue() {
+            let _ = self.signal_used_queue();
+        }
+    }
+
+    pub(crate) fn process_inflate(&mut self) -> Result<(), DeviceError> {
+        let mem = match self.device_state {
+            DeviceState::Activated(ref mem) => mem,
+            // This should never happen, it's been already validated in the event handler.
+            DeviceState::Inactive => unreachable!(),
+        };
+
+        let queue = &mut self.queues[INFLATE_INDEX];
+        let mut pages = Vec::with_capacity(MAX_PAGES_IN_DESC);
+        let mut needs_interrupt = false;
+
+        while let Some(head) = queue.pop(&mem) {
+            let len = head.len;
+            if !head.is_write_only() && len % SIZE_OF_U32 as u32 == 0 {
+                for index in (0..len).step_by(SIZE_OF_U32) {
+                    let addr = head
+                        .addr
+                        .checked_add(index as u64)
+                        .ok_or(DeviceError::MalformedDescriptor)?;
+
+                    let page_frame_number = mem
+                        .read_obj::<u32>(addr)
+                        .map_err(|_| DeviceError::MalformedDescriptor)?;
+
+                    pages.push(page_frame_number);
+                }
+            }
+
+            // Acknowledge the receipt of the descriptor.
+            // 0 is number of bytes the device has written to memory.
+            queue.add_used(&mem, head.index, 0);
+            needs_interrupt = true;
+        }
+
+        if needs_interrupt {
+            let _ = self.signal_used_queue();
+        }
+
+        // Compact pages into ranges.
+        let page_ranges = compact_page_frame_numbers(&mut pages);
+
+        // Remove the page ranges.
+        for (page_frame_number, range_len) in page_ranges {
+            let guest_addr = GuestAddress((page_frame_number as u64) << VIRTIO_BALLOON_PFN_SHIFT);
+
+            match remove_range(
+                &mem,
+                (guest_addr, u64::from(range_len) << VIRTIO_BALLOON_PFN_SHIFT),
+            ) {
+                Ok(_) => continue,
+                Err(e) => {
+                    error!("Error removing memory range: {:?}", e);
+                }
+            };
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn process_deflate_queue(&mut self) -> bool {
+        let mem = match self.device_state {
+            DeviceState::Activated(ref mem) => mem,
+            // This should never happen, it's been already validated in the event handler.
+            DeviceState::Inactive => unreachable!(),
+        };
+        let queue = &mut self.queues[DEFLATE_INDEX];
+        let mut needs_interrupt = false;
+
+        while let Some(head) = queue.pop(&mem) {
+            queue.add_used(&mem, head.index, 0);
+            needs_interrupt = true;
+        }
+
+        needs_interrupt
+    }
+
+    pub(crate) fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
+        self.interrupt_status
+            .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
+
+        self.interrupt_evt.write(1).map_err(|e| {
+            error!("Failed to signal used queue: {:?}", e);
+            DeviceError::FailedSignalingUsedQueue(e)
+        })?;
+        Ok(())
+    }
+
+    pub fn update_num_pages(&mut self, num_pages: u32) {
+        self.config_space.num_pages = num_pages;
+    }
+
+    pub fn num_pages(&self) -> u32 {
+        self.config_space.num_pages
+    }
+}
+
+impl VirtioDevice for Balloon {
+    fn device_type(&self) -> u32 {
+        TYPE_BALLOON
+    }
+
+    fn queues(&self) -> &[Queue] {
+        &self.queues
+    }
+
+    fn queues_mut(&mut self) -> &mut [Queue] {
+        &mut self.queues
+    }
+
+    fn queue_events(&self) -> &[EventFd] {
+        &self.queue_evts
+    }
+
+    fn interrupt_evt(&self) -> &EventFd {
+        &self.interrupt_evt
+    }
+
+    fn interrupt_status(&self) -> Arc<AtomicUsize> {
+        self.interrupt_status.clone()
+    }
+
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features;
+    }
+
+    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
+        let config_space_bytes = self.config_space.as_slice();
+        let config_len = config_space_bytes.len() as u64;
+        if offset >= config_len {
+            error!("Failed to read config space");
+            return;
+        }
+
+        if let Some(end) = offset.checked_add(data.len() as u64) {
+            // This write can't fail, offset and end are checked against config_len.
+            data.write_all(
+                &config_space_bytes[offset as usize..cmp::min(end, config_len) as usize],
+            )
+            .unwrap();
+        }
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        let data_len = data.len() as u64;
+        let config_space_bytes = self.config_space.as_mut_slice();
+        let config_len = config_space_bytes.len() as u64;
+        if offset + data_len > config_len {
+            error!("Failed to write config space");
+            return;
+        }
+        config_space_bytes[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
+    }
+
+    fn is_activated(&self) -> bool {
+        match self.device_state {
+            DeviceState::Inactive => false,
+            DeviceState::Activated(_) => true,
+        }
+    }
+
+    fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {
+        if self.activate_evt.write(1).is_err() {
+            error!("Balloon: Cannot write to activate_evt");
+            return Err(super::super::ActivateError::BadActivate);
+        }
+        self.device_state = DeviceState::Activated(mem);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::os::unix::io::AsRawFd;
+    use std::u32;
+
+    use super::super::CONFIG_SPACE_SIZE;
+    use super::*;
+    use crate::virtio::queue::tests::*;
+    use polly::event_manager::{EventManager, Subscriber};
+    use utils::epoll::{EpollEvent, EventSet};
+    use vm_memory::GuestAddress;
+
+    impl Balloon {
+        pub(crate) fn set_queue(&mut self, idx: usize, q: Queue) {
+            self.queues[idx] = q;
+        }
+
+        pub(crate) fn actual_pages(&self) -> u32 {
+            self.config_space.actual_pages
+        }
+
+        pub fn update_actual_pages(&mut self, actual_pages: u32) {
+            self.config_space.actual_pages = actual_pages;
+        }
+    }
+
+    pub fn default_mem() -> GuestMemoryMmap {
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap()
+    }
+
+    fn invoke_handler_for_queue_event(b: &mut Balloon, queue_index: usize) {
+        assert!(queue_index < NUM_QUEUES);
+        // Trigger the queue event.
+        b.queue_evts[queue_index].write(1).unwrap();
+        // Handle event.
+        b.process(
+            &EpollEvent::new(EventSet::IN, b.queue_evts[queue_index].as_raw_fd() as u64),
+            &mut EventManager::new().unwrap(),
+        );
+        // Validate the queue operation finished successfully.
+        assert_eq!(b.interrupt_evt.read().unwrap(), 1);
+    }
+
+    pub(crate) fn set_request(queue: &VirtQueue, idx: usize, addr: u64, len: u32, flags: u16) {
+        // Set the index of the next request.
+        queue.avail.idx.set((idx + 1) as u16);
+        // Set the current descriptor table entry index.
+        queue.avail.ring[idx].set(idx as u16);
+        // Set the current descriptor table entry.
+        queue.dtable[idx].set(addr, len, flags, 1);
+    }
+
+    pub(crate) fn check_request_completion(queue: &VirtQueue, idx: usize) {
+        // Check that the next used will be idx + 1.
+        assert_eq!(queue.used.idx.get(), (idx + 1) as u16);
+        // Check that the current used is idx.
+        assert_eq!(queue.used.ring[idx].get().id, idx as u32);
+        // The length of the completed request is 0.
+        assert_eq!(queue.used.ring[idx].get().len, 0);
+    }
+
+    #[test]
+    fn test_virtio_features() {
+        // Test all feature combinations.
+        for must_tell_host in vec![true, false].iter() {
+            for deflate_on_oom in vec![true, false].iter() {
+                let mut balloon = Balloon::new(0, *must_tell_host, *deflate_on_oom).unwrap();
+                assert_eq!(balloon.device_type(), TYPE_BALLOON);
+
+                let features: u64 = (1u64 << VIRTIO_F_VERSION_1)
+                    | ((if *must_tell_host { 1 } else { 0 }) << VIRTIO_BALLOON_F_MUST_TELL_HOST)
+                    | ((if *deflate_on_oom { 1 } else { 0 }) << VIRTIO_BALLOON_F_DEFLATE_ON_OOM);
+
+                assert_eq!(balloon.avail_features_by_page(0), features as u32);
+                assert_eq!(balloon.avail_features_by_page(1), (features >> 32) as u32);
+                for i in 2..10 {
+                    assert_eq!(balloon.avail_features_by_page(i), 0u32);
+                }
+
+                for i in 0..10 {
+                    balloon.ack_features_by_page(i, u32::MAX);
+                }
+                // Only present features should be acknowledged.
+                assert_eq!(balloon.acked_features, features);
+            }
+        }
+    }
+
+    #[test]
+    fn test_virtio_read_config() {
+        let balloon = Balloon::new(0x10, true, true).unwrap();
+
+        let mut actual_config_space = [0u8; CONFIG_SPACE_SIZE];
+        balloon.read_config(0, &mut actual_config_space);
+        // The first 4 bytes are num_pages, the last 4 bytes are actual_pages.
+        // The config space is little endian.
+        let expected_config_space: [u8; CONFIG_SPACE_SIZE] =
+            [0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(actual_config_space, expected_config_space);
+
+        // Invalid read.
+        let expected_config_space: [u8; CONFIG_SPACE_SIZE] =
+            [0xd, 0xe, 0xa, 0xd, 0xb, 0xe, 0xe, 0xf];
+        actual_config_space = expected_config_space;
+        balloon.read_config(CONFIG_SPACE_SIZE as u64 + 1, &mut actual_config_space);
+
+        // Validate read failed (the config space was not updated).
+        assert_eq!(actual_config_space, expected_config_space);
+    }
+
+    #[test]
+    fn test_virtio_write_config() {
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+
+        let expected_config_space: [u8; CONFIG_SPACE_SIZE] =
+            [0x00, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        balloon.write_config(0, &expected_config_space);
+
+        let mut actual_config_space = [0u8; CONFIG_SPACE_SIZE];
+        balloon.read_config(0, &mut actual_config_space);
+        assert_eq!(actual_config_space, expected_config_space);
+
+        // Invalid write.
+        let new_config_space = [0xd, 0xe, 0xa, 0xd, 0xb, 0xe, 0xe, 0xf];
+        balloon.write_config(5, &new_config_space);
+        // Make sure nothing got written.
+        balloon.read_config(0, &mut actual_config_space);
+        assert_eq!(actual_config_space, expected_config_space);
+    }
+
+    #[test]
+    fn test_invalid_request() {
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+        let mem = default_mem();
+        // Only initialize the inflate queue to demonstrate invalid request handling.
+        let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        balloon.set_queue(INFLATE_INDEX, infq.create_queue());
+        balloon.activate(mem.clone()).unwrap();
+
+        // Fill the second page with non-zero bytes.
+        for i in 0..0x1000 {
+            assert!(mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).is_ok());
+        }
+
+        // Will write the page frame number of the affected frame at this
+        // arbitrary address in memory.
+        let page_addr = 0x10;
+
+        // Invalid case: the descriptor is write-only.
+        {
+            mem.write_obj::<u32>(0x1, GuestAddress(page_addr)).unwrap();
+            set_request(
+                &infq,
+                0,
+                page_addr,
+                SIZE_OF_U32 as u32,
+                VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE,
+            );
+
+            invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX);
+            check_request_completion(&infq, 0);
+
+            // Check that the page was not zeroed.
+            for i in 0..0x1000 {
+                assert_eq!(mem.read_obj::<u8>(GuestAddress((1 << 12) + i)).unwrap(), 1);
+            }
+        }
+
+        // Invalid case: descriptor len is not a multiple of 'SIZE_OF_U32'.
+        {
+            mem.write_obj::<u32>(0x1, GuestAddress(page_addr)).unwrap();
+            set_request(
+                &infq,
+                1,
+                page_addr,
+                SIZE_OF_U32 as u32 + 1,
+                VIRTQ_DESC_F_NEXT,
+            );
+
+            invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX);
+            check_request_completion(&infq, 1);
+
+            // Check that the page was not zeroed.
+            for i in 0..0x1000 {
+                assert_eq!(mem.read_obj::<u8>(GuestAddress((1 << 12) + i)).unwrap(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_inflate() {
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+        let mem = default_mem();
+        let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        balloon.set_queue(INFLATE_INDEX, infq.create_queue());
+        balloon.activate(mem.clone()).unwrap();
+
+        let mut event_manager = EventManager::new().unwrap();
+        let queue_evt = EpollEvent::new(
+            EventSet::IN,
+            balloon.queue_evts[INFLATE_INDEX].as_raw_fd() as u64,
+        );
+
+        // Fill the third page with non-zero bytes.
+        for i in 0..0x1000 {
+            assert!(mem.write_obj::<u8>(1, GuestAddress((1 << 12) + i)).is_ok());
+        }
+
+        // Will write the page frame number of the affected frame at this
+        // arbitrary address in memory.
+        let page_addr = 0x10;
+
+        // Error case: the request is well-formed, but we forgot
+        // to trigger the inflate event queue.
+        {
+            mem.write_obj::<u32>(0x1, GuestAddress(page_addr)).unwrap();
+            set_request(&infq, 0, page_addr, SIZE_OF_U32 as u32, VIRTQ_DESC_F_NEXT);
+
+            balloon.process(&queue_evt, &mut event_manager);
+            // Verify that nothing got processed.
+            assert_eq!(infq.used.idx.get(), 0);
+
+            // Check that the page was not zeroed.
+            for i in 0..0x1000 {
+                assert_eq!(mem.read_obj::<u8>(GuestAddress((1 << 12) + i)).unwrap(), 1);
+            }
+        }
+
+        // Test the happy case.
+        {
+            mem.write_obj::<u32>(0x1, GuestAddress(page_addr)).unwrap();
+            set_request(&infq, 0, page_addr, SIZE_OF_U32 as u32, VIRTQ_DESC_F_NEXT);
+
+            invoke_handler_for_queue_event(&mut balloon, INFLATE_INDEX);
+            check_request_completion(&infq, 0);
+
+            // Check that the page was zeroed.
+            for i in 0..0x1000 {
+                assert_eq!(mem.read_obj::<u8>(GuestAddress((1 << 12) + i)).unwrap(), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_deflate() {
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+        let mem = default_mem();
+        let defq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        balloon.set_queue(DEFLATE_INDEX, defq.create_queue());
+        balloon.activate(mem.clone()).unwrap();
+
+        let mut event_manager = EventManager::new().unwrap();
+        let queue_evt = EpollEvent::new(
+            EventSet::IN,
+            balloon.queue_evts[DEFLATE_INDEX].as_raw_fd() as u64,
+        );
+
+        let page_addr = 0x10;
+
+        // Error case: forgot to trigger deflate event queue.
+        {
+            set_request(&defq, 0, page_addr, SIZE_OF_U32 as u32, VIRTQ_DESC_F_NEXT);
+            balloon.process(&queue_evt, &mut event_manager);
+            // Verify that nothing got processed.
+            assert_eq!(defq.used.idx.get(), 0);
+        }
+
+        // Happy case.
+        {
+            set_request(&defq, 1, page_addr, SIZE_OF_U32 as u32, VIRTQ_DESC_F_NEXT);
+            invoke_handler_for_queue_event(&mut balloon, DEFLATE_INDEX);
+            check_request_completion(&defq, 1);
+        }
+    }
+
+    #[test]
+    fn test_num_pages() {
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+        assert_eq!(balloon.num_pages(), 0);
+        assert_eq!(balloon.actual_pages(), 0);
+
+        // Update fields through the API.
+        balloon.update_actual_pages(0x1234);
+        balloon.update_num_pages(0x1000);
+
+        let mut actual_config = vec![0; CONFIG_SPACE_SIZE];
+        balloon.read_config(0, &mut actual_config);
+        assert_eq!(actual_config, vec![0x0, 0x10, 0x0, 0x0, 0x34, 0x12, 0, 0]);
+        assert_eq!(balloon.num_pages(), 0x1000);
+        assert_eq!(balloon.actual_pages(), 0x1234);
+
+        // Update fields through the config space.
+        let expected_config = vec![0x44, 0x33, 0x22, 0x11, 0x78, 0x56, 0x34, 0x12];
+        balloon.write_config(0, &expected_config);
+        assert_eq!(balloon.num_pages(), 0x11223344);
+        assert_eq!(balloon.actual_pages(), 0x12345678);
+    }
+}

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -1,0 +1,169 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::io::AsRawFd;
+
+use logger::{debug, error, warn};
+use polly::event_manager::{EventManager, Subscriber};
+use utils::epoll::{EpollEvent, EventSet};
+
+use crate::virtio::balloon::device::Balloon;
+use crate::virtio::{VirtioDevice, DEFLATE_INDEX, INFLATE_INDEX};
+
+impl Balloon {
+    fn process_activate_event(&self, event_manager: &mut EventManager) {
+        debug!("balloon: activate event");
+        if let Err(e) = self.activate_evt.read() {
+            error!("Failed to consume balloon activate event: {:?}", e);
+        }
+        let activate_fd = self.activate_evt.as_raw_fd();
+        // The subscriber must exist as we previously registered activate_evt via
+        // `interest_list()`.
+        let self_subscriber = match event_manager.subscriber(activate_fd) {
+            Ok(subscriber) => subscriber,
+            Err(e) => {
+                error!("Failed to process balloon activate evt: {:?}", e);
+                return;
+            }
+        };
+
+        // Interest list changes when the device is activated.
+        let interest_list = self.interest_list();
+        for event in interest_list {
+            event_manager
+                .register(event.data() as i32, event, self_subscriber.clone())
+                .unwrap_or_else(|e| {
+                    error!("Failed to register balloon events: {:?}", e);
+                });
+        }
+
+        event_manager.unregister(activate_fd).unwrap_or_else(|e| {
+            error!("Failed to unregister balloon activate evt: {:?}", e);
+        });
+    }
+}
+
+impl Subscriber for Balloon {
+    fn process(&mut self, event: &EpollEvent, evmgr: &mut EventManager) {
+        let source = event.fd();
+        let event_set = event.event_set();
+
+        // TODO: also check for errors. Pending high level discussions on how we want
+        // to handle errors in devices.
+        let supported_events = EventSet::IN;
+        if !supported_events.contains(event_set) {
+            warn!(
+                "Received unknown event: {:?} from source: {:?}",
+                event_set, source
+            );
+            return;
+        }
+
+        if self.is_activated() {
+            let virtq_inflate_ev_fd = self.queue_evts[INFLATE_INDEX].as_raw_fd();
+            let virtq_deflate_ev_fd = self.queue_evts[DEFLATE_INDEX].as_raw_fd();
+            let activate_fd = self.activate_evt.as_raw_fd();
+
+            // Looks better than C style if/else if/else.
+            match source {
+                _ if source == virtq_inflate_ev_fd => self.process_inflate_queue_event(),
+                _ if source == virtq_deflate_ev_fd => self.process_deflate_queue_event(),
+                _ if activate_fd == source => self.process_activate_event(evmgr),
+                _ => {
+                    warn!("Balloon: Spurious event received: {:?}", source);
+                }
+            }
+        } else {
+            warn!(
+                "Balloon: The device is not yet activated. Spurious event received: {:?}",
+                source
+            );
+        }
+    }
+
+    fn interest_list(&self) -> Vec<EpollEvent> {
+        // This function can be called during different points in the device lifetime:
+        //  - shortly after device creation,
+        //  - on device activation (is-activated already true at this point),
+        //  - on device restore from snapshot.
+        if self.is_activated() {
+            vec![
+                EpollEvent::new(
+                    EventSet::IN,
+                    self.queue_evts[INFLATE_INDEX].as_raw_fd() as u64,
+                ),
+                EpollEvent::new(
+                    EventSet::IN,
+                    self.queue_evts[DEFLATE_INDEX].as_raw_fd() as u64,
+                ),
+            ]
+        } else {
+            vec![EpollEvent::new(
+                EventSet::IN,
+                self.activate_evt.as_raw_fd() as u64,
+            )]
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::virtio::balloon::device::tests::*;
+    use crate::virtio::queue::tests::*;
+    use vm_memory::GuestAddress;
+
+    #[test]
+    fn test_event_handler() {
+        let mut event_manager = EventManager::new().unwrap();
+        let mut balloon = Balloon::new(0, true, true).unwrap();
+        let mem = default_mem();
+        let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        balloon.set_queue(INFLATE_INDEX, infq.create_queue());
+
+        let balloon = Arc::new(Mutex::new(balloon));
+        event_manager.add_subscriber(balloon.clone()).unwrap();
+
+        // Push a queue event, use the inflate queue in this test.
+        {
+            let addr = 0x100;
+            set_request(&infq, 0, addr, 4, 0);
+            balloon.lock().unwrap().queue_evts[INFLATE_INDEX]
+                .write(1)
+                .unwrap();
+        }
+
+        // EventManager should report no events since balloon has only registered
+        // its activation event so far (even though there is also a queue event pending).
+        let ev_count = event_manager.run_with_timeout(50).unwrap();
+        assert_eq!(ev_count, 0);
+
+        // Manually force a queue event and check it's ignored pre-activation.
+        {
+            let mut b = balloon.lock().unwrap();
+            let raw_infq_evt = b.queue_evts[INFLATE_INDEX].as_raw_fd() as u64;
+            // Artificially push event.
+            b.process(
+                &EpollEvent::new(EventSet::IN, raw_infq_evt),
+                &mut event_manager,
+            );
+            // Validate there was no queue operation.
+            assert_eq!(infq.used.idx.get(), 0);
+        }
+
+        // Now activate the device.
+        balloon.lock().unwrap().activate(mem.clone()).unwrap();
+        // Process the activate event.
+        let ev_count = event_manager.run_with_timeout(50).unwrap();
+        assert_eq!(ev_count, 1);
+
+        // Handle the previously pushed queue event through EventManager.
+        event_manager
+            .run_with_timeout(100)
+            .expect("Metrics event timeout or error.");
+        // Make sure the data queue advanced.
+        assert_eq!(infq.used.idx.get(), 1);
+    }
+}

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod device;
+pub mod event_handler;
+mod utils;
+
+use vm_memory::GuestMemoryError;
+
+pub use self::device::Balloon;
+pub use self::event_handler::*;
+
+pub const CONFIG_SPACE_SIZE: usize = 8;
+pub const QUEUE_SIZE: u16 = 256;
+pub const NUM_QUEUES: usize = 2;
+pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE, QUEUE_SIZE];
+// The maximum number of pages that can be received in a single descriptor.
+pub const MAX_PAGES_IN_DESC: usize = 256;
+// The addresses given by the driver are divided by 4096.
+pub const VIRTIO_BALLOON_PFN_SHIFT: u32 = 12;
+// The index of the deflate queue from Balloon device queues/queues_evts vector.
+pub const INFLATE_INDEX: usize = 0;
+// The index of the deflate queue from Balloon device queues/queues_evts vector.
+pub const DEFLATE_INDEX: usize = 1;
+
+// The feature bitmap for virtio balloon.
+const VIRTIO_BALLOON_F_MUST_TELL_HOST: u32 = 0; // Tell before reclaiming pages.
+const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u32 = 2; // Deflate balloon on OOM.
+
+#[derive(Debug)]
+pub enum Error {
+    /// Guest gave us too few descriptors in a descriptor chain.
+    DescriptorChainTooShort,
+    /// Guest gave us a descriptor that was too short to use.
+    DescriptorLengthTooSmall,
+    /// Guest gave us bad memory addresses.
+    GuestMemory(GuestMemoryError),
+    /// Guest gave us a malformed descriptor.
+    MalformedDescriptor,
+    /// Error removing a memory region at inflate time.
+    RemoveMemoryRegion(RemoveRegionError),
+    /// Guest gave us a read only descriptor that protocol says to write to.
+    UnexpectedReadOnlyDescriptor,
+    /// Guest gave us a write only descriptor that protocol says to read from.
+    UnexpectedWriteOnlyDescriptor,
+}
+
+#[derive(Debug)]
+pub enum RemoveRegionError {
+    AddressTranslation,
+    MalformedRange,
+    MadviseFail(std::io::Error),
+    MmapFail(std::io::Error),
+    RegionNotFound,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -45,20 +45,24 @@ const VIRTIO_BALLOON_S_HTLB_PGFAIL: u16 = 9;
 
 #[derive(Debug)]
 pub enum Error {
-    /// Guest gave us too few descriptors in a descriptor chain.
-    DescriptorChainTooShort,
-    /// Guest gave us a descriptor that was too short to use.
-    DescriptorLengthTooSmall,
+    /// Activation error.
+    Activate(super::ActivateError),
+    /// EventFd error.
+    EventFd(std::io::Error),
+    /// Failed to signal the virtio used queue.
+    FailedSignalingUsedQueue(std::io::Error),
     /// Guest gave us bad memory addresses.
     GuestMemory(GuestMemoryError),
     /// Guest gave us a malformed descriptor.
     MalformedDescriptor,
+    /// Guest gave us a malformed payload.
+    MalformedPayload,
+    /// Error while processing the virt queues.
+    Queue(super::QueueError),
     /// Error removing a memory region at inflate time.
     RemoveMemoryRegion(RemoveRegionError),
-    /// Guest gave us a read only descriptor that protocol says to write to.
-    UnexpectedReadOnlyDescriptor,
-    /// Guest gave us a write only descriptor that protocol says to read from.
-    UnexpectedWriteOnlyDescriptor,
+    /// Error creating the statistics timer.
+    Timer(std::io::Error),
 }
 
 #[derive(Debug)]

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod device;
 pub mod event_handler;
+pub mod persist;
 mod utils;
 
 use vm_memory::GuestMemoryError;

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -12,8 +12,8 @@ pub use self::event_handler::*;
 
 pub const CONFIG_SPACE_SIZE: usize = 8;
 pub const QUEUE_SIZE: u16 = 256;
-pub const NUM_QUEUES: usize = 2;
-pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE, QUEUE_SIZE];
+pub const NUM_QUEUES: usize = 3;
+pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE, QUEUE_SIZE, QUEUE_SIZE];
 // The maximum number of pages that can be received in a single descriptor.
 pub const MAX_PAGES_IN_DESC: usize = 256;
 // The addresses given by the driver are divided by 4096.
@@ -22,10 +22,25 @@ pub const VIRTIO_BALLOON_PFN_SHIFT: u32 = 12;
 pub const INFLATE_INDEX: usize = 0;
 // The index of the deflate queue from Balloon device queues/queues_evts vector.
 pub const DEFLATE_INDEX: usize = 1;
+// The index of the deflate queue from Balloon device queues/queues_evts vector.
+pub const STATS_INDEX: usize = 2;
 
 // The feature bitmap for virtio balloon.
 const VIRTIO_BALLOON_F_MUST_TELL_HOST: u32 = 0; // Tell before reclaiming pages.
+const VIRTIO_BALLOON_F_STATS_VQ: u32 = 1; // Enable statistics.
 const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u32 = 2; // Deflate balloon on OOM.
+
+// The statistics tags.
+const VIRTIO_BALLOON_S_SWAP_IN: u16 = 0;
+const VIRTIO_BALLOON_S_SWAP_OUT: u16 = 1;
+const VIRTIO_BALLOON_S_MAJFLT: u16 = 2;
+const VIRTIO_BALLOON_S_MINFLT: u16 = 3;
+const VIRTIO_BALLOON_S_MEMFREE: u16 = 4;
+const VIRTIO_BALLOON_S_MEMTOT: u16 = 5;
+const VIRTIO_BALLOON_S_AVAIL: u16 = 6;
+const VIRTIO_BALLOON_S_CACHES: u16 = 7;
+const VIRTIO_BALLOON_S_HTLB_PGALLOC: u16 = 8;
+const VIRTIO_BALLOON_S_HTLB_PGFAIL: u16 = 9;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -1,0 +1,139 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines the structures needed for saving/restoring balloon devices.
+
+use std::io;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+use std::time::Duration;
+use timerfd::{SetTimeFlags, TimerState};
+
+use snapshot::Persist;
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+
+use vm_memory::GuestMemoryMmap;
+
+use super::*;
+
+use crate::virtio::balloon::device::{BalloonStats, ConfigSpace};
+use crate::virtio::persist::VirtioDeviceState;
+use crate::virtio::{DeviceState, Queue};
+
+#[derive(Versionize)]
+pub struct BalloonState {
+    stats_polling_interval_s: u16,
+    stats_desc_index: Option<u16>,
+    latest_stats: BalloonStats,
+    config_space: ConfigSpace,
+    virtio_state: VirtioDeviceState,
+}
+
+pub struct BalloonConstructorArgs {
+    pub mem: GuestMemoryMmap,
+}
+
+impl Persist<'_> for Balloon {
+    type State = BalloonState;
+    type ConstructorArgs = BalloonConstructorArgs;
+    type Error = io::Error;
+
+    fn save(&self) -> Self::State {
+        BalloonState {
+            stats_polling_interval_s: self.stats_polling_interval_s,
+            stats_desc_index: self.stats_desc_index,
+            latest_stats: self.latest_stats.clone(),
+            config_space: self.config_space,
+            virtio_state: VirtioDeviceState::from_device(self),
+        }
+    }
+
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error> {
+        // We can safely create the balloon with arbitrary flags and
+        // num_pages because we will overwrite them after.
+        let mut balloon = Balloon::new(0, false, false, state.stats_polling_interval_s)?;
+
+        balloon.queues = state
+            .virtio_state
+            .queues
+            .iter()
+            .map(|queue_state| Queue::restore((), &queue_state).unwrap())
+            .collect();
+        balloon.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        balloon.avail_features = state.virtio_state.avail_features;
+        balloon.acked_features = state.virtio_state.acked_features;
+        balloon.config_space = state.config_space;
+
+        if state.virtio_state.activated {
+            balloon.device_state = DeviceState::Activated(constructor_args.mem);
+
+            // Restart timer if needed.
+            if balloon.stats_enabled() {
+                let timer_state = TimerState::Periodic {
+                    current: Duration::from_secs(state.stats_polling_interval_s as u64),
+                    interval: Duration::from_secs(state.stats_polling_interval_s as u64),
+                };
+                balloon
+                    .stats_timer
+                    .set_state(timer_state, SetTimeFlags::Default);
+            }
+        }
+
+        Ok(balloon)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtio::balloon::device::tests::default_mem;
+    use crate::virtio::device::VirtioDevice;
+    use crate::virtio::TYPE_BALLOON;
+
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_persistence() {
+        let guest_mem = default_mem();
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        // Create and save the balloon device.
+        let mut balloon = Balloon::new(0x42, true, false, 2).unwrap();
+        balloon.activate(guest_mem.clone()).unwrap();
+
+        <Balloon as Persist>::save(&balloon)
+            .serialize(&mut mem.as_mut_slice(), &version_map, 1)
+            .unwrap();
+
+        // Deserialize and restore the balloon device.
+        let restored_balloon = Balloon::restore(
+            BalloonConstructorArgs { mem: guest_mem },
+            &BalloonState::deserialize(&mut mem.as_slice(), &version_map, 1).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(restored_balloon.device_type(), TYPE_BALLOON);
+
+        assert_eq!(restored_balloon.acked_features, balloon.acked_features);
+        assert_eq!(restored_balloon.avail_features, balloon.avail_features);
+        assert_eq!(restored_balloon.config_space, balloon.config_space);
+        assert_eq!(restored_balloon.queues(), balloon.queues());
+        assert_eq!(
+            restored_balloon.interrupt_status().load(Ordering::Relaxed),
+            balloon.interrupt_status().load(Ordering::Relaxed)
+        );
+        assert_eq!(restored_balloon.is_activated(), balloon.is_activated());
+
+        assert_eq!(
+            restored_balloon.stats_polling_interval_s,
+            balloon.stats_polling_interval_s
+        );
+        assert_eq!(restored_balloon.stats_desc_index, balloon.stats_desc_index);
+        assert_eq!(restored_balloon.latest_stats, balloon.latest_stats);
+    }
+}

--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -1,0 +1,190 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+
+use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use super::{MAX_PAGES_IN_DESC, RemoveRegionError};
+
+/// This takes a vector of page frame numbers, and compacts them
+/// into ranges of consecutive pages. The result is a vector
+/// of (start_page_frame_number, range_length) pairs.
+pub(crate) fn compact_page_frame_numbers(v: &mut Vec<u32>) -> Vec<(u32, u32)> {
+    if v.is_empty() {
+        return vec![];
+    }
+
+    // Since the total number of pages that can be
+    // received at once from a single descriptor is `MAX_PAGES_IN_DESC`,
+    // this sort does not change the complexity of handling
+    // an inflation.
+    v.sort();
+
+    // Since there are at most `MAX_PAGES_IN_DESC` pages, setting the
+    // capacity of `result` to this makes sense.
+    let mut result = Vec::with_capacity(MAX_PAGES_IN_DESC);
+
+    // The most recent range of pages is [previous..previous + length).
+    let mut previous = v[0];
+    let mut length = 1;
+
+    for page_frame_number in &v[1..] {
+        // Check if the current page frame number is adjacent to the most recent page range.
+        if *page_frame_number == previous + length {
+            // If so, extend that range.
+            length += 1;
+        } else {
+            // Otherwise, push (previous, length) to the result vector.
+            result.push((previous, length));
+            // And update the most recent range of pages.
+            previous = *page_frame_number;
+            length = 1;
+        }
+    }
+
+    // Don't forget to push the last range to the result.
+    result.push((previous, length));
+
+    result
+}
+
+pub(crate) fn remove_range(
+    guest_memory: &GuestMemoryMmap,
+    range: (GuestAddress, u64),
+) -> std::result::Result<(), RemoveRegionError> {
+    let (guest_address, range_len) = range;
+
+    if let Some(region) = guest_memory.find_region(guest_address) {
+        if guest_address.0 + range_len > region.start_addr().0 + region.len() {
+            return Err(RemoveRegionError::MalformedRange);
+        }
+        let phys_address = guest_memory
+            .get_host_address(guest_address)
+            .map_err(|_| RemoveRegionError::AddressTranslation)?;
+
+        // Mmap a new anonymous region over the present one in order to create a hole.
+        // This workaround is (only) needed after resuming from a snapshot because the guest memory
+        // is mmaped from file as private and there is no `madvise` flag that works for this case.
+        let ret = unsafe {
+            libc::mmap(
+                phys_address as *mut _,
+                range_len as usize,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                -1,
+                0,
+            )
+        };
+        if ret < 0 as *mut _ || ret != phys_address as *mut _ {
+            return Err(RemoveRegionError::MmapFail(io::Error::last_os_error()));
+        }
+
+        // Madvise the region in order to mark it as not used.
+        let ret = unsafe {
+            libc::madvise(
+                phys_address as *mut _,
+                range_len as usize,
+                libc::MADV_DONTNEED,
+            )
+        };
+        if ret < 0 {
+            return Err(RemoveRegionError::MadviseFail(io::Error::last_os_error()));
+        }
+
+        Ok(())
+    } else {
+        Err(RemoveRegionError::RegionNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vm_memory::Bytes;
+
+    /// This asserts that $lhs matches $rhs.
+    macro_rules! assert_match {
+        ($lhs:expr, $rhs:pat) => {{
+            assert!(match $lhs {
+                $rhs => true,
+                _ => false,
+            })
+        }};
+    }
+
+    #[test]
+    fn test_compact_page_indices() {
+        // Test empty input.
+        assert!(compact_page_frame_numbers(&mut vec![]).is_empty());
+
+        // Test single compact range.
+        assert_eq!(
+            compact_page_frame_numbers(&mut (0 as u32..100 as u32).collect()),
+            vec![(0, 100)]
+        );
+
+        // `compact_page_frame_numbers` works even when given out of order input.
+        assert_eq!(
+            compact_page_frame_numbers(&mut (0 as u32..100 as u32).rev().collect()),
+            vec![(0, 100)]
+        );
+
+        // Test with 100 distinct ranges.
+        assert_eq!(
+            compact_page_frame_numbers(
+                &mut (0 as u32..10000 as u32)
+                    .step_by(100)
+                    .flat_map(|x| (x..x + 10).rev())
+                    .collect()
+            ),
+            (0 as u32..10000 as u32)
+                .step_by(100)
+                .map(|x| (x, 10 as u32))
+                .collect::<Vec<(u32, u32)>>()
+        );
+    }
+
+    #[test]
+    fn test_remove_range() {
+        let page_size: usize = 0x1000;
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 2 * page_size)]).unwrap();
+
+        // Fill the memory with ones.
+        let ones = vec![1u8; 2 * page_size];
+        mem.write(&ones[..], GuestAddress(0)).unwrap();
+
+        // Remove the first page.
+        assert!(remove_range(&mem, (GuestAddress(0), page_size as u64)).is_ok());
+
+        // Check that the first page is zeroed.
+        let mut actual_page = vec![0u8; page_size];
+        mem.read(&mut actual_page.as_mut_slice(), GuestAddress(0))
+            .unwrap();
+        assert_eq!(vec![0u8; page_size], actual_page);
+        // Check that the second page still contains ones.
+        mem.read(
+            &mut actual_page.as_mut_slice(),
+            GuestAddress(page_size as u64),
+        )
+        .unwrap();
+        assert_eq!(vec![1u8; page_size], actual_page);
+
+        // Malformed range: the len is too big.
+        assert_match!(
+            remove_range(&mem, (GuestAddress(0), 0x10000)).unwrap_err(),
+            RemoveRegionError::MalformedRange
+        );
+
+        // Region not mapped.
+        assert_match!(
+            remove_range(&mem, (GuestAddress(0x10000), 0x10)).unwrap_err(),
+            RemoveRegionError::RegionNotFound
+        );
+
+        // Mmap fail: the guest address is not aligned to the page size.
+        assert_match!(
+            remove_range(&mem, (GuestAddress(0x20), page_size as u64)).unwrap_err(),
+            RemoveRegionError::MmapFail(_)
+        );
+    }
+}

--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -3,8 +3,8 @@
 
 use std::io;
 
+use super::{RemoveRegionError, MAX_PAGES_IN_DESC};
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
-use super::{MAX_PAGES_IN_DESC, RemoveRegionError};
 
 /// This takes a vector of page frame numbers, and compacts them
 /// into ranges of consecutive pages. The result is a vector
@@ -75,7 +75,7 @@ pub(crate) fn remove_range(
                 0,
             )
         };
-        if ret < 0 as *mut _ || ret != phys_address as *mut _ {
+        if ret == libc::MAP_FAILED {
             return Err(RemoveRegionError::MmapFail(io::Error::last_os_error()));
         }
 

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -9,6 +9,7 @@
 use std::any::Any;
 use std::io::Error as IOError;
 
+pub mod balloon;
 pub mod block;
 pub mod device;
 mod mmio;
@@ -17,6 +18,7 @@ pub mod persist;
 mod queue;
 pub mod vsock;
 
+pub use self::balloon::*;
 pub use self::block::*;
 pub use self::device::*;
 pub use self::mmio::*;
@@ -46,6 +48,7 @@ mod device_status {
 /// Type 0 is not used by virtio. Use it as wildcard for non-virtio devices
 pub const TYPE_NET: u32 = 1;
 pub const TYPE_BLOCK: u32 = 2;
+pub const TYPE_BALLOON: u32 = 5;
 
 /// Interrupt flags (re: interrupt status & acknowledge registers).
 /// See linux/virtio_mmio.h.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -328,6 +328,19 @@ pub struct PatchRequestsMetrics {
     pub machine_cfg_fails: SharedMetric,
 }
 
+/// Balloon Device associated metrics.
+#[derive(Default, Serialize)]
+pub struct BalloonDeviceMetrics {
+    /// Number of times when activate failed on a balloon device.
+    pub activate_fails: SharedMetric,
+    /// Number of balloon device inflations.
+    pub inflate_count: SharedMetric,
+    /// Number of balloon device deflations.
+    pub deflate_count: SharedMetric,
+    /// Number of times when handling events on a balloon device failed.
+    pub event_fails: SharedMetric,
+}
+
 /// Block Device associated metrics.
 #[derive(Default, Serialize)]
 pub struct BlockDeviceMetrics {
@@ -652,6 +665,8 @@ pub struct FirecrackerMetrics {
     utc_timestamp_ms: SerializeToUtcTimestampMs,
     /// API Server related metrics.
     pub api_server: ApiServerMetrics,
+    /// A balloon device's related metrics.
+    pub balloon: BalloonDeviceMetrics,
     /// A block device's related metrics.
     pub block: BlockDeviceMetrics,
     /// Metrics related to API GET requests.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -335,6 +335,8 @@ pub struct BalloonDeviceMetrics {
     pub activate_fails: SharedMetric,
     /// Number of balloon device inflations.
     pub inflate_count: SharedMetric,
+    // Number of balloon statistics updates from the driver.
+    pub stats_updates_count: SharedMetric,
     /// Number of balloon device deflations.
     pub deflate_count: SharedMetric,
     /// Number of times when handling events on a balloon device failed.

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -337,6 +337,8 @@ pub struct BalloonDeviceMetrics {
     pub inflate_count: SharedMetric,
     // Number of balloon statistics updates from the driver.
     pub stats_updates_count: SharedMetric,
+    // Number of balloon statistics update failures.
+    pub stats_update_fails: SharedMetric,
     /// Number of balloon device deflations.
     pub deflate_count: SharedMetric,
     /// Number of times when handling events on a balloon device failed.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.39, "AMD": 84.38}
+COVERAGE_DICT = {"Intel": 84.5, "AMD": 84.52}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -30,6 +30,7 @@ def test_flush_metrics(test_microvm_with_api):
     exp_keys = [
         'utc_timestamp_ms',
         'api_server',
+        'balloon',
         'block',
         'get_api_requests',
         'i8042',


### PR DESCRIPTION
## Reason for This PR
#1571 

## Description of Changes

Added a virtio balloon device that supports statistics.

Note: Because Firecracker uses a private anonymous mapping for freshly booted microVMs and private file-backed mapping for snapshot resumed microVMs, a madvise call for releasing memory is not sufficient to work in both cases.
This PR currently uses a hacky approach: before madvise, mmap a fresh private anonymous region over the one that we want the kernel to release.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
