### PR TITLE
upgrade vm-memory version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "kvm-ioctls 0.5.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.5.0-2)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
  "virtio_gen 0.1.0",
- "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "utils 0.1.0",
- "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -772,7 +772,7 @@ version = "0.1.0"
 
 [[package]]
 name = "vm-memory"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +804,7 @@ dependencies = [
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
- "vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7be505e45004e3c3963dbea155aa333784724b91ae580f08e702eeaccfca93"
 "checksum versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)" = "<none>"
 "checksum versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7817377bbb6759686d790fb8fbbb22a0371521d509a21fdb125cf7c9c9d815a"
-"checksum vm-memory 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41fb10d355a0de221e0524cb18491d3dc6e2a0981747f75fd0a3a12109f1712f"
+"checksum vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aae367b8bd176f4936b5d35c4403606d4a8458a8151dff47c974f1d9d1a4c974"
 "checksum vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -11,7 +11,7 @@ libc = ">=0.2.39"
 utils = { path = "../utils" }
 
 arch_gen = { path = "../arch_gen" }
-vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 
 [dev-dependencies]
 utils = { path = "../utils" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 libc = ">=0.2.39"
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 utils = { path = "../utils" }
 net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 utils = { path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -20,7 +20,7 @@ devices = { path = "../devices" }
 dumbo = { path = "../dumbo" }
 kernel = { path = "../kernel" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 mmds = { path = "../mmds" }
 utils = { path = "../utils"}
 rate_limiter = { path = "../rate_limiter" }


### PR DESCRIPTION
## Reason for This PR

upgrade vm-memory version to 0.2.2

## Description of Changes

upgrade vm-memory version to 0.2.2

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
