### PR TITLE
Move MacAddr to utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,8 @@ version = "0.1.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -786,7 +788,6 @@ dependencies = [
  "arch 0.1.0",
  "cpuid 0.1.0",
  "devices 0.1.0",
- "dumbo 0.1.0",
  "kernel 0.1.0",
  "kvm-bindings 0.2.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.2.0-2)",
  "kvm-ioctls 0.5.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.5.0-2)",

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -14,7 +14,6 @@ use crate::virtio::{
 };
 use crate::{report_net_event_fail, Error as DeviceError};
 use dumbo::pdu::ethernet::EthernetFrame;
-use dumbo::{MacAddr, MAC_ADDR_LEN};
 use libc::EAGAIN;
 use logger::{error, warn, Metric, METRICS};
 use mmds::ns::MmdsNetworkStack;
@@ -27,6 +26,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::{cmp, mem, result};
 use utils::eventfd::EventFd;
+use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
 use virtio_gen::virtio_net::{
     virtio_net_hdr_v1, VIRTIO_F_VERSION_1, VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_UFO,

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -7,10 +7,10 @@ use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use dumbo::{MacAddr, MAC_ADDR_LEN};
 use mmds::{ns::MmdsNetworkStack, persist::MmdsNetworkStackState};
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
+use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::GuestMemoryMmap;

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -4,17 +4,17 @@
 #![deny(missing_docs)]
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
-mod mac;
 pub mod pdu;
 pub mod tcp;
 
-pub use crate::mac::{MacAddr, MAC_ADDR_LEN};
 pub use crate::pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
 pub use crate::pdu::ethernet::{
     EthernetFrame, ETHERTYPE_ARP, ETHERTYPE_IPV4, PAYLOAD_OFFSET as ETHERNET_PAYLOAD_OFFSET,
 };
 pub use crate::pdu::ipv4::{IPv4Packet, PROTOCOL_TCP, PROTOCOL_UDP};
 pub use crate::pdu::udp::{UdpDatagram, UDP_HEADER_SIZE};
+
+use utils::net::mac::MacAddr;
 
 use std::ops::Index;
 

--- a/src/dumbo/src/pdu/arp.rs
+++ b/src/dumbo/src/pdu/arp.rs
@@ -7,14 +7,14 @@
 //! A more detailed view of an ARP frame can be found [here].
 //!
 //! [here]: https://en.wikipedia.org/wiki/Address_Resolution_Protocol
-
 use std::convert::From;
 use std::net::Ipv4Addr;
 use std::result::Result;
 
 use super::bytes::{InnerBytes, NetworkBytes, NetworkBytesMut};
 use super::ethernet::{self, ETHERTYPE_IPV4};
-use crate::mac::{MacAddr, MAC_ADDR_LEN};
+
+use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
 
 /// ARP Request operation
 pub const OPER_REQUEST: u16 = 0x0001;

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -22,8 +22,8 @@ use dumbo::pdu::tcp::Error as TcpSegmentError;
 use dumbo::pdu::Incomplete;
 use dumbo::tcp::handler::{self, RecvEvent, TcpIPv4Handler, WriteEvent};
 use dumbo::tcp::NextSegmentStatus;
-use dumbo::MacAddr;
 use logger::{Metric, METRICS};
+use utils::net::mac::MacAddr;
 use utils::time::timestamp_cycles;
 
 const DEFAULT_MAC_ADDR: &str = "06:01:23:45:67:01";

--- a/src/mmds/src/persist.rs
+++ b/src/mmds/src/persist.rs
@@ -5,8 +5,8 @@
 
 use std::net::Ipv4Addr;
 
-use dumbo::{MacAddr, MAC_ADDR_LEN};
 use snapshot::Persist;
+use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"
+serde = ">=1.0.27"
 vmm-sys-util = ">=0.6.1"
 
 net_gen = { path = "../net_gen" }
+
+
+[dev-dependencies]
+serde_json = ">=1.0.9"
+

--- a/src/utils/src/net/mac.rs
+++ b/src/utils/src/net/mac.rs
@@ -46,7 +46,7 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// use self::dumbo::MacAddr;
+    /// use self::utils::net::mac::MacAddr;
     /// MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
     /// ```
     pub fn parse_str<S>(s: &S) -> Result<MacAddr, &str>
@@ -78,7 +78,7 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// use self::dumbo::MacAddr;
+    /// use self::utils::net::mac::MacAddr;
     /// let mac = MacAddr::from_bytes_unchecked(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
     /// println!("{}", mac.to_string());
     /// ```
@@ -100,7 +100,7 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// use self::dumbo::MacAddr;
+    /// use self::utils::net::mac::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// println!("{}", mac.to_string());
     /// ```
@@ -116,7 +116,7 @@ impl MacAddr {
     /// # Example
     ///
     /// ```
-    /// use self::dumbo::MacAddr;
+    /// use self::utils::net::mac::MacAddr;
     /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
     /// assert_eq!([0x01, 0x02, 0x03, 0x04, 0x05, 0x06], mac.get_bytes());
     /// ```

--- a/src/utils/src/net/mod.rs
+++ b/src/utils/src/net/mod.rs
@@ -13,3 +13,4 @@
 
 /// Provides IPv4 address utility methods.
 pub mod ipv4addr;
+pub mod mac;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -17,16 +17,15 @@ versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_d
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }
-dumbo = { path = "../dumbo" }
 kernel = { path = "../kernel" }
 logger = { path = "../logger" }
 vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 mmds = { path = "../mmds" }
-utils = { path = "../utils"}
 rate_limiter = { path = "../rate_limiter" }
 seccomp = { path = "../seccomp" }
 polly = { path = "../polly" }
 snapshot = { path = "../snapshot"}
+utils = { path = "../utils" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -310,8 +310,8 @@ mod tests {
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vmm_config::RateLimiterConfig;
     use crate::vstate::vcpu::VcpuConfig;
-    use dumbo::MacAddr;
     use logger::{LevelFilter, LOGGER};
+    use utils::net::mac::MacAddr;
     use utils::tempfile::TempFile;
 
     fn default_net_cfg() -> NetworkInterfaceConfig {

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use super::RateLimiterConfig;
 use devices::virtio::net::TapError;
 use devices::virtio::Net;
-use dumbo::MacAddr;
 use rate_limiter::{BucketUpdate, TokenBucket};
+use utils::net::mac::MacAddr;
 
 use serde::Deserialize;
 


### PR DESCRIPTION
## Reason for This PR

Move MacAddr from dumbo crate to net
Fixes #1765.

## Description of Changes

Move MacAddr from dumbo crate to net. Update references to reflect change. Remove now unneeded dependency on dumbo from devices.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
