### PR TITLE
Improved virtqueue error handling for used ring

### DIFF
--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -14,6 +14,7 @@ pub mod pseudo;
 pub mod virtio;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};
+use crate::virtio::QueueError;
 use logger::{error, Metric, METRICS};
 
 // Function used for reporting error in terms of logging
@@ -33,4 +34,6 @@ pub enum Error {
     IoError(io::Error),
     /// Device received malformed payload.
     MalformedPayload,
+    /// Error during queue processing.
+    QueueError(QueueError),
 }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -272,7 +272,13 @@ impl Block {
                     len = 0;
                 }
             }
-            queue.add_used(mem, head.index, len);
+
+            queue.add_used(mem, head.index, len).unwrap_or_else(|e| {
+                error!(
+                    "Failed to add available descriptor head {}: {}",
+                    head.index, e
+                )
+            });
             used_any = true;
         }
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -319,7 +319,11 @@ impl Net {
             }
         }
 
-        rx_queue.add_used(mem, head_index, write_count as u32);
+        rx_queue
+            .add_used(mem, head_index, write_count as u32)
+            .unwrap_or_else(|e| {
+                error!("Failed to add available descriptor {}: {}", head_index, e);
+            });
 
         // Mark that we have at least one pending packet and we need to interrupt the guest.
         self.rx_deferred_irqs = true;
@@ -566,7 +570,9 @@ impl Net {
                 process_rx_for_mmds = true;
             }
 
-            tx_queue.add_used(mem, head_index, 0);
+            tx_queue
+                .add_used(mem, head_index, 0)
+                .map_err(DeviceError::QueueError)?;
             raise_irq = true;
         }
 

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -164,7 +164,11 @@ where
             };
 
             have_used = true;
-            self.queues[RXQ_INDEX].add_used(mem, head.index, used_len);
+            self.queues[RXQ_INDEX]
+                .add_used(mem, head.index, used_len)
+                .unwrap_or_else(|e| {
+                    error!("Failed to add available descriptor {}: {}", head.index, e)
+                });
         }
 
         have_used
@@ -189,7 +193,11 @@ where
                 Err(e) => {
                     error!("vsock: error reading TX packet: {:?}", e);
                     have_used = true;
-                    self.queues[TXQ_INDEX].add_used(mem, head.index, 0);
+                    self.queues[TXQ_INDEX]
+                        .add_used(mem, head.index, 0)
+                        .unwrap_or_else(|e| {
+                            error!("Failed to add available descriptor {}: {}", head.index, e);
+                        });
                     continue;
                 }
             };
@@ -200,7 +208,11 @@ where
             }
 
             have_used = true;
-            self.queues[TXQ_INDEX].add_used(mem, head.index, 0);
+            self.queues[TXQ_INDEX]
+                .add_used(mem, head.index, 0)
+                .unwrap_or_else(|e| {
+                    error!("Failed to add available descriptor {}: {}", head.index, e);
+                });
         }
 
         have_used

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.44, "AMD": 84.42}
+COVERAGE_DICT = {"Intel": 84.39, "AMD": 84.38}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

During snapshot load, attempting add available descriptor into the virtio used ring caused errors when the address was off.

## Description of Changes

Added error and exited gracefully to handle the case described above.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
