### PR TITLE
Snapshot restore - devices sanity checks

### DIFF
--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -259,13 +259,13 @@ impl Queue {
             );
             false
         } else if desc_table.raw_value() & 0xf != 0 {
-            error!("virtio queue descriptor table breaks alignment contraints");
+            error!("virtio queue descriptor table breaks alignment constraints");
             false
         } else if avail_ring.raw_value() & 0x1 != 0 {
-            error!("virtio queue available ring breaks alignment contraints");
+            error!("virtio queue available ring breaks alignment constraints");
             false
         } else if used_ring.raw_value() & 0x3 != 0 {
-            error!("virtio queue used ring breaks alignment contraints");
+            error!("virtio queue used ring breaks alignment constraints");
             false
         } else {
             true

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -14,6 +14,8 @@ mod unix;
 
 use std::os::unix::io::AsRawFd;
 
+use crate::virtio::persist::Error as VirtioStateError;
+
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::device::Vsock;
 pub use self::unix::{Error as VsockUnixBackendError, VsockUnixBackend};
@@ -30,9 +32,11 @@ mod defs {
 
     /// Number of virtio queues.
     pub const NUM_QUEUES: usize = 3;
+    /// Max size of virtio queues.
+    pub const QUEUE_SIZE: u16 = 256;
     /// Virtio queue sizes, in number of descriptor chain heads.
     /// There are 3 queues for a virtio device (in this order): RX, TX, Event
-    pub const QUEUE_SIZES: &[u16] = &[256; NUM_QUEUES];
+    pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 
     /// Max vsock packet data/buffer size.
     pub const MAX_PKT_BUF_SIZE: usize = 64 * 1024;
@@ -94,6 +98,8 @@ pub enum VsockError {
     BufDescTooSmall,
     /// The vsock data/buffer virtio descriptor is expected, but missing.
     BufDescMissing,
+    /// EventFd error
+    EventFd(std::io::Error),
     /// Chained GuestMemoryMmap error.
     GuestMemoryMmap(GuestMemoryError),
     /// Bounds check failed on guest memory pointer.
@@ -110,8 +116,8 @@ pub enum VsockError {
     UnreadableDescriptor,
     /// Encountered an unexpected read-only virtio descriptor.
     UnwritableDescriptor,
-    /// EventFd error
-    EventFd(std::io::Error),
+    /// Invalid virtio configuration.
+    VirtioState(VirtioStateError),
     VsockUdsBackend(VsockUnixBackendError),
 }
 

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -13,7 +13,7 @@ use versionize_derive::Versionize;
 use vm_memory::GuestMemoryMmap;
 
 use crate::virtio::persist::VirtioDeviceState;
-use crate::virtio::{DeviceState, Queue};
+use crate::virtio::{DeviceState, Queue, TYPE_VSOCK};
 
 #[derive(Versionize)]
 pub struct VsockState {
@@ -96,6 +96,11 @@ where
         constructor_args: Self::ConstructorArgs,
         state: &Self::State,
     ) -> std::result::Result<Self, Self::Error> {
+        state
+            .virtio_state
+            .sanity_check(TYPE_VSOCK, defs::NUM_QUEUES, defs::QUEUE_SIZE)
+            .map_err(VsockError::VirtioState)?;
+
         // Restore queues.
         let mut vsock = Self::with_queues(
             state.cid,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -382,6 +382,7 @@ impl Vmm {
             .map(|response| match response {
                 VcpuResponse::SavedState(state) => Ok(*state),
                 VcpuResponse::Error(e) => Err(SaveVcpuState(e)),
+                VcpuResponse::NotAllowed(reason) => Err(MicrovmStateError::NotAllowed(reason)),
                 _ => Err(UnexpectedVcpuResponse),
             })
             .collect::<std::result::Result<Vec<VcpuState>, MicrovmStateError>>()?;
@@ -443,6 +444,9 @@ impl Vmm {
                     let _ = self.exit_vcpus();
                     self.stop(i32::from(FC_EXIT_CODE_BAD_CONFIGURATION));
                     unreachable!()
+                }
+                VcpuResponse::NotAllowed(reason) => {
+                    return Err(MicrovmStateError::NotAllowed(reason))
                 }
                 _ => return Err(MicrovmStateError::UnexpectedVcpuResponse),
             }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -57,6 +57,8 @@ pub struct MicrovmState {
 pub enum MicrovmStateError {
     /// Provided MicroVM state is invalid.
     InvalidInput,
+    /// Operation not allowed.
+    NotAllowed(String),
     /// Failed to restore devices.
     RestoreDevices(DevicePersistError),
     /// Failed to restore Vcpu state.
@@ -78,6 +80,7 @@ impl Display for MicrovmStateError {
         use self::MicrovmStateError::*;
         match self {
             InvalidInput => write!(f, "Provided MicroVM state is invalid."),
+            NotAllowed(msg) => write!(f, "Operation not allowed: {}", msg),
             RestoreDevices(err) => write!(f, "Cannot restore devices. Error: {:?}", err),
             RestoreVcpuState(err) => write!(f, "Cannot restore Vcpu state. Error: {:?}", err),
             RestoreVmState(err) => write!(f, "Cannot restore Vm state. Error: {:?}", err),
@@ -426,6 +429,9 @@ mod tests {
         use crate::persist::MicrovmStateError::*;
 
         let err = InvalidInput;
+        let _ = format!("{}{:?}", err, err);
+
+        let err = NotAllowed(String::from(""));
         let _ = format!("{}{:?}", err, err);
 
         let err = RestoreDevices(DevicePersistError::MmioTransport);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.50, "AMD": 84.45}
+COVERAGE_DICT = {"Intel": 84.56, "AMD": 84.55}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Description of Changes

Added sanity checks along the restore from snapshot path for device manager and virtio devices.

Also provided support for explicit user-facing error when attempting snapshot-create without pausing.

Fixes #2099 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
