### PR TITLE
Update docs to reflect experimental status of gnu builds and glibc jailer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ The **API endpoint** can be used to:
 **Built-in Capabilities**:
 
 - Demand fault paging and CPU oversubscription enabled by default.
+- Advanced seccomp filters for enhanced security.
 - [Jailer](docs/jailer.md) process for starting Firecracker in production
-  scenarios; applies a cgroup/namespace/seccomp rule isolation barrier and then
+  scenarios; applies a cgroup/namespace isolation barrier and then
   drops privileges.
 
 ## Performance

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -280,8 +280,9 @@ git checkout tags/v0.10.1
 
 Within the Firecracker repository root directory:
 
-1. with the default musl target: ```tools/devtool build```
-1. using the gnu target: ```tools/devtool build -l gnu```
+1. with the __default__ musl target: ```tools/devtool build```
+1. (__Experimental only__) using the gnu target: 
+```tools/devtool build -l gnu```
 
 This will build and place the two Firecracker binaries at:
 
@@ -320,8 +321,9 @@ arch=`uname -m`
 cargo build --target ${arch}-unknown-linux-gnu
 ```
 
-That being said, Firecracker binaries built without `devtool` are always
-considered experimental and should not be used in production.
+That being said, Firecracker binaries linked with glibc or built without
+`devtool` are always considered experimental and should not be used in
+production.
 
 ## Running the Integration Test Suite
 

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -1,5 +1,10 @@
 # The Firecracker Jailer
 
+## Disclaimer
+
+The jailer is designed to work only with statically linked binaries (with
+the default musl toolchain) and will not work with experimental gnu builds.
+
 ## Jailer Usage
 
 The jailer is invoked in this manner:


### PR DESCRIPTION
Update docs to reflect experimental status of gnu builds and glibc jailer support.

Signed-off-by: alindima <alindima@amazon.com>

## Reason for This PR

A couple of parts in the documentation need to be updated:

- Using the jailer with glibc linked binaries is not supported.
- glibc Firecracker builds are considered experimental and not recommended for production.
- The jailer no longer installs the seccomp filters, the Firecracker process does.

## Description of Changes

Updated relevant documentation files.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
