### PR TITLE
Update changelog to include the v0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,6 @@
 ### Added
 
 - Added metric for throttled block device events.
-- Added a new API call, `PUT /metrics`, for configuring the metrics system.
-- Added `app_name` field in InstanceInfo struct for storing the application
-  name.
-- New command-line parameters for `firecracker`, named `--log-path`,
-  `--level`, `--show-level` and `--show-log-origin` that can be used
-  for configuring the Logger when starting the process. When using
-  this method for configuration, only `--log-path` is mandatory.
-- Added a [guide](docs/devctr-image.md) for updating the dev container image.
-- Added a new API call, `PUT /mmds/config`, for configuring the
-  `MMDS` with a custom valid link-local IPv4 address.
-- Added experimental JSON response format support for MMDS guest applications
-  requests.
-- Added `track_dirty_pages` field to `machine-config`. If enabled, Firecracker
-  can create incremental guest memory snapshots by saving the dirty guest pages
-  in a sparse file.
-- Added a new API call, `PATCH /vm`, for changing the microVM state (to
-  `Paused` or `Resumed`).
-- Added a new API call, `PUT /snapshot/create`, for creating a full snapshot.
-- Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
-- Added metrics for the vsock device.
-- Added `devtool strip` command which removes debug symbols from the release
-  binaries.
-- Added the `tx_malformed_frames` metric for the virtio net device, emitted
-  when a TX frame missing the VNET header is encountered.
 - Added metrics for counting rate limiter throttling events.
 - Added metric for counting MAC address updates.
 - Added metrics for counting TAP read and write errors.
@@ -45,8 +21,52 @@
   from the API (user) perspective.
 - Added metric for measuring the duration of loading a snapshot, from the API
   (user) perspective.
+- Added `track_dirty_pages` field to `machine-config`. If enabled, Firecracker
+  can create incremental guest memory snapshots by saving the dirty guest pages
+  in a sparse file.
+- Added a new API call, `PATCH /vm`, for changing the microVM state (to
+  `Paused` or `Resumed`).
+- Added a new API call, `PUT /snapshot/create`, for creating a full snapshot.
+- Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
 - Added new jailer command line argument `--cgroup` which allow the user to
   specify the cgroups that are going to be set by the Jailer.
+
+### Fixed
+
+- Boot time on AMD achieves the desired performance (i.e under 150ms).
+
+### Changed
+
+- The logger `level` field is now case-insensitive.
+- Disabled boot timer device after restoring a snapshot.
+- Enabled boot timer device only when specifically requested, by using the
+  `--boot-timer` dedicated cmdline parameter.
+- firecracker and jailer `--version` now gets updated on each devtool
+  build to the output of `git describe --dirty`, if the git repo is available.
+- MicroVM process is only attached to the cgroups defined by using `--cgroups`
+  or the ones defined indirectly by using `--node`.
+
+## [0.22.0]
+
+### Added
+
+- Added a new API call, `PUT /metrics`, for configuring the metrics system.
+- Added `app_name` field in InstanceInfo struct for storing the application
+  name.
+- New command-line parameters for `firecracker`, named `--log-path`,
+  `--level`, `--show-level` and `--show-log-origin` that can be used
+  for configuring the Logger when starting the process. When using
+  this method for configuration, only `--log-path` is mandatory.
+- Added a [guide](docs/devctr-image.md) for updating the dev container image.
+- Added a new API call, `PUT /mmds/config`, for configuring the
+  `MMDS` with a custom valid link-local IPv4 address.
+- Added experimental JSON response format support for MMDS guest applications
+  requests.
+- Added metrics for the vsock device.
+- Added `devtool strip` command which removes debug symbols from the release
+  binaries.
+- Added the `tx_malformed_frames` metric for the virtio net device, emitted
+  when a TX frame missing the VNET header is encountered.
 
 ### Fixed
 
@@ -54,9 +74,14 @@
 - Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
   requests originating from guest.
 - Fixed folder permissions in the jail (#1802).
-- Boot time on AMD achieves the desired performance (i.e under 150ms).
 - Any number of whitespace characters are accepted after ":" when parsing HTTP
   headers.
+- Potential panic condition caused by the net device expecting to find a VNET
+  header in every frame.
+- Potential crash scenario caused by "Content-Length" HTTP header field
+  accepting negative values.
+- Fixed #1754 - net: traffic blocks when running ingress UDP performance tests
+  with very large buffers.
 
 ### Changed
 
@@ -82,14 +107,6 @@
   `403 BadRequest`.
 - Segregated MMDS documentation in MMDS design documentation and MMDS user
   guide documentation.
-- The logger `level` field is now case-insensitive.
-- Disabled boot timer device after restoring a snapshot.
-- Enabled boot timer device only when specifically requested, by using the
-  `--boot-timer` dedicated cmdline parameter.
-- `firecracker/jailer --version` now gets updated on each devtool
-  build to the output of `git describe --dirty`, if the git repo is available.
-- MicroVM process is only attached to the cgroups defined by using `--cgroups`
-  or the ones defined indirectly by using `--node`.
 
 ## [0.21.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "api_server 0.1.0",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.21.0
+  version: 0.22.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"


### PR DESCRIPTION
Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

## Reason for This PR

This PR separates the changes done for 0.22.0 from the unreleased changes.
This was done as a separate PR because merging from v0.22.0 branch seems to be broken.

## Description of Changes

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
