### PR TITLE
snapshot: compute crc check before deserization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/docs/benchmarks/state-serialize.md
+++ b/docs/benchmarks/state-serialize.md
@@ -8,35 +8,35 @@ Snapshot size: 83886 bytes.
 - Architecture:        x86_64
 - CPU op-mode(s):      32-bit, 64-bit
 - Byte Order:          Little Endian
-- CPU(s):              12
+- CPU(s):              4
 - Thread(s) per core:  2
-- Core(s) per socket:  6
+- Core(s) per socket:  2
 - Socket(s):           1
 - NUMA node(s):        1
 - Vendor ID:           GenuineIntel
 - CPU family:          6
-- Model:               158
-- Model name:          Intel(R) Core(TM) i7-8700 - CPU @ 3.20GHz
-- Stepping:            10
-- CPU MHz:             800.077
-- CPU max MHz:         4600.0000
-- CPU min MHz:         800.0000
-- BogoMIPS:            6399.96
+- Model:               142
+- Model name:          Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz
+- Stepping:            9
+- CPU MHz:             1100.008
+- CPU max MHz:         3900.0000
+- CPU min MHz:         400.0000
+- BogoMIPS:            5799.77
 - Virtualization:      VT-x
 - L1d cache:           32K
 - L1i cache:           32K
 - L2 cache:            256K
-- L3 cache:            12288K
-- NUMA node0 CPU(s):   0-11
-- Flags:               `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d`
+- L3 cache:            4096K
+- NUMA node0 CPU(s):   0-3
+- Flags:               `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d`
 
 ### Current baseline
 
 | Test                |      Mean     |
 |---------------------|---------------|
-| Serialize           |    354.18 us  |
-| Serialize + crc64   |    406.08 us  |
-| Deserialize         |    61.412 us  |
-| Deserialize + crc64 |    258.27 us  |
+| Serialize           |    371.38 us  |
+| Serialize + crc64   |    493.26 us  |
+| Deserialize         |    90.755 us  |
+| Deserialize + crc64 |    216.90 us  |
 
 Detailed criterion benchmarks available [here](https://s3.amazonaws.com/spec.ccfc.min/perf/snapshot-0.23/report/index.html).

--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 autobenches = false
 
 [dependencies]
+libc = "0.2"
 versionize = "0.1.2"
 versionize_derive = ">=0.1.1"
 

--- a/src/snapshot/benches/main.rs
+++ b/src/snapshot/benches/main.rs
@@ -87,9 +87,9 @@ impl Test {
 }
 
 #[inline]
-pub fn bench_restore_v1(mut snapshot_mem: &[u8], vm: VersionMap, crc: bool) {
+pub fn bench_restore_v1(mut snapshot_mem: &[u8], snapshot_len: usize, vm: VersionMap, crc: bool) {
     if crc {
-        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
     } else {
         Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
     }
@@ -151,6 +151,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             bench_restore_v1(
                 black_box(&mut snapshot_mem.as_slice()),
+                black_box(snapshot_len),
                 black_box(vm.clone()),
                 black_box(false),
             )
@@ -175,6 +176,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             bench_restore_v1(
                 black_box(&mut snapshot_mem.as_slice()),
+                black_box(snapshot_len),
                 black_box(vm.clone()),
                 black_box(true),
             )

--- a/src/snapshot/benches/main.rs
+++ b/src/snapshot/benches/main.rs
@@ -89,9 +89,9 @@ impl Test {
 #[inline]
 pub fn bench_restore_v1(mut snapshot_mem: &[u8], snapshot_len: usize, vm: VersionMap, crc: bool) {
     if crc {
-        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
+        Snapshot::load::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
     } else {
-        Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+        Snapshot::unchecked_load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
     }
 }
 
@@ -115,9 +115,11 @@ pub fn bench_snapshot_v1<W: std::io::Write>(mut snapshot_mem: &mut W, vm: Versio
 
     let mut snapshot = Snapshot::new(vm.clone(), 4);
     if crc {
-        snapshot.save_with_crc64(&mut snapshot_mem, &state).unwrap();
-    } else {
         snapshot.save(&mut snapshot_mem, &state).unwrap();
+    } else {
+        snapshot
+            .save_without_crc(&mut snapshot_mem, &state)
+            .unwrap();
     }
 }
 

--- a/src/snapshot/benches/version_map.rs
+++ b/src/snapshot/benches/version_map.rs
@@ -27,7 +27,7 @@ struct Dummy {
 
 #[inline]
 fn restore(mut snapshot_mem: &[u8], vm: VersionMap) {
-    Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+    Snapshot::unchecked_load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
 }
 
 #[inline]
@@ -47,7 +47,9 @@ fn save<W: std::io::Write>(mut snapshot_mem: &mut W, vm: VersionMap) {
     };
 
     let mut snapshot = Snapshot::new(vm.clone(), vm.latest_version());
-    snapshot.save(&mut snapshot_mem, &state).unwrap();
+    snapshot
+        .save_without_crc(&mut snapshot_mem, &state)
+        .unwrap();
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/src/snapshot/tests/test.rs
+++ b/src/snapshot/tests/test.rs
@@ -94,7 +94,7 @@ fn test_hardcoded_snapshot_deserialization() {
 
     let mut snapshot_blob = v1_hardcoded_snapshot;
 
-    let mut restored_struct: A = Snapshot::load(&mut snapshot_blob, vm.clone()).unwrap();
+    let mut restored_struct: A = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
 
     let mut expected_struct = A {
         a: 16u32,
@@ -106,7 +106,7 @@ fn test_hardcoded_snapshot_deserialization() {
 
     snapshot_blob = v2_hardcoded_snapshot;
 
-    restored_struct = Snapshot::load(&mut snapshot_blob, vm.clone()).unwrap();
+    restored_struct = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
 
     expected_struct = A {
         a: 16u32,
@@ -142,7 +142,7 @@ fn test_invalid_format_version() {
     ];
 
     let mut result: Result<A, Error> =
-        Snapshot::load(&mut invalid_format_snap.as_ref(), VersionMap::new());
+        Snapshot::unchecked_load(&mut invalid_format_snap.as_ref(), VersionMap::new());
     let mut expected_err = Error::InvalidFormatVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);
 
@@ -168,7 +168,7 @@ fn test_invalid_format_version() {
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
 
-    result = Snapshot::load(&mut null_format_snap.as_ref(), VersionMap::new());
+    result = Snapshot::unchecked_load(&mut null_format_snap.as_ref(), VersionMap::new());
     expected_err = Error::InvalidFormatVersion(0);
     assert_eq!(result.unwrap_err(), expected_err);
 }
@@ -197,7 +197,7 @@ fn test_invalid_data_version() {
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
     let mut result: Result<A, Error> =
-        Snapshot::load(&mut invalid_data_version_snap.as_ref(), VersionMap::new());
+        Snapshot::unchecked_load(&mut invalid_data_version_snap.as_ref(), VersionMap::new());
     let mut expected_err = Error::InvalidDataVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);
 
@@ -222,7 +222,7 @@ fn test_invalid_data_version() {
         // + inner enum value (4 bytes).
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
-    result = Snapshot::load(&mut null_data_version_snap.as_ref(), VersionMap::new());
+    result = Snapshot::unchecked_load(&mut null_data_version_snap.as_ref(), VersionMap::new());
     expected_err = Error::InvalidDataVersion(0);
     assert_eq!(result.unwrap_err(), expected_err);
 }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -209,7 +209,7 @@ fn snapshot_state_to_file(
 
     let mut snapshot = Snapshot::new(version_map, snapshot_data_version);
     snapshot
-        .save_with_crc64(&mut snapshot_file, microvm_state)
+        .save(&mut snapshot_file, microvm_state)
         .map_err(SerializeMicrovmState)?;
 
     Ok(())
@@ -273,8 +273,7 @@ fn snapshot_state_from_file(
     let mut snapshot_reader = File::open(snapshot_path).map_err(SnapshotBackingFile)?;
     let metadata = std::fs::metadata(snapshot_path).map_err(SnapshotBackingFileMetadata)?;
     let snapshot_len = metadata.len() as usize;
-    Snapshot::load_with_crc64(&mut snapshot_reader, snapshot_len, version_map)
-        .map_err(DeserializeMicrovmState)
+    Snapshot::load(&mut snapshot_reader, snapshot_len, version_map).map_err(DeserializeMicrovmState)
 }
 
 fn guest_memory_from_file(

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -361,7 +361,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
             let snapshot_path = snapshot_file.as_path().to_path_buf();
             let snapshot_file_metadata = std::fs::metadata(snapshot_path).unwrap();
             let snapshot_len = snapshot_file_metadata.len() as usize;
-            let restored_microvm_state: MicrovmState = Snapshot::load_with_crc64(
+            let restored_microvm_state: MicrovmState = Snapshot::load(
                 &mut snapshot_file.as_file(),
                 snapshot_len,
                 VERSION_MAP.clone(),
@@ -402,7 +402,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             let snapshot_file_metadata = snapshot_file.as_file().metadata().unwrap();
             let snapshot_len = snapshot_file_metadata.len() as usize;
             snapshot_file.as_file().seek(SeekFrom::Start(0)).unwrap();
-            let microvm_state: MicrovmState = Snapshot::load_with_crc64(
+            let microvm_state: MicrovmState = Snapshot::load(
                 &mut snapshot_file.as_file(),
                 snapshot_len,
                 VERSION_MAP.clone(),


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

CRC checksum was computed after deserialization of the snapshot state file.

## Description of Changes

Changed API to compute and add CRC checksum during snapshot save/load and moved CRC check before snapshot deserialization.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
