### PR TITLE
Add std before u32::MAX for glibc build break

### DIFF
--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -65,7 +65,7 @@ pub fn json_patch(target: &mut Value, patch: &Value) {
 
 // Make the URI a correct JSON pointer value.
 fn sanitize_uri(mut uri: String) -> String {
-    let mut len = u32::MAX as usize;
+    let mut len = std::u32::MAX as usize;
     // Loop while the deduping decreases the sanitized len.
     // Each iteration will attempt to dedup "//".
     while uri.len() < len {


### PR DESCRIPTION
   Compiling mmds v0.1.0 (/home/lyan/studio/virt/firecracker/src/mmds)
error[E0599]: no associated item named `MAX` found for type `u32` in the current scope
  --> src/mmds/src/lib.rs:68:24
   |
68 |     let mut len = u32::MAX as usize;
   |                        ^^^ associated item not found in `u32`
   |
help: you are looking for the module in `std`, not the primitive type
   |
68 |     let mut len = std::u32::MAX as usize;
   |                   ^^^^^^^^^^^^^

error: aborting due to previous error

Signed-off-by: Liang Yan <lyan@suse.com>

## Reason for This PR

Break cargo build with glibc 

## Description of Changes

Add namespace std

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
