### PR TITLE
tests: pin processes to cpu cores

### DIFF
--- a/tests/framework/decorators.py
+++ b/tests/framework/decorators.py
@@ -14,7 +14,7 @@ def timed_request(method):
 
         def __init__(self, duration, method, resource, payload):
             """Compose the error message from the API call components."""
-            super(ApiTimeoutException, self).__init__(
+            super().__init__(
                 'API call exceeded maximum duration: {:.2f} ms.\n'
                 'Call: {} {} {}'.format(duration, method, resource, payload)
             )

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -16,7 +16,7 @@ class Session(requests_unixsocket.Session):
 
     def __init__(self):
         """Create a Session object and set the is_good_response callback."""
-        super(Session, self).__init__()
+        super().__init__()
 
         def is_good_response(response: int):
             """Return `True` for all HTTP 2xx response codes."""
@@ -49,24 +49,24 @@ class Session(requests_unixsocket.Session):
         """Wrap the GET call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).get(url, **kwargs)
+        return super().get(url, **kwargs)
 
     @decorators.timed_request
     def patch(self, url, data=None, **kwargs):
         """Wrap the PATCH call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).patch(url, data=data, **kwargs)
+        return super().patch(url, data=data, **kwargs)
 
     @decorators.timed_request
     def put(self, url, data=None, **kwargs):
         """Wrap the PUT call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).put(url, data=data, **kwargs)
+        return super().put(url, data=data, **kwargs)
 
     def untime(self):
         """Restore the HTTP methods to their un-timed selves."""
-        self.get = super(Session, self).get
-        self.patch = super(Session, self).patch
-        self.put = super(Session, self).put
+        self.get = super().get
+        self.patch = super().patch
+        self.put = super().put

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -144,7 +144,7 @@ class StoppableThread(threading.Thread):
 
     def __init__(self, *args, **kwargs):
         """Set up a Stoppable thread."""
-        super(StoppableThread, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._should_stop = False
 
     def stop(self):

--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -18,7 +18,7 @@ class CpuLoadExceededException(Exception):
 
     def __init__(self, cpu_load_samples, threshold):
         """Compose the error message containing the cpu load details."""
-        super(CpuLoadExceededException, self).__init__(
+        super().__init__(
             'Cpu load samples {} exceeded maximum threshold {}.\n'
             .format(cpu_load_samples, threshold)
         )

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -13,7 +13,7 @@ class MemoryUsageExceededException(Exception):
 
     def __init__(self, usage, threshold):
         """Compose the error message containing the memory consumption."""
-        super(MemoryUsageExceededException, self).__init__(
+        super().__init__(
             'Memory usage ({} KiB) exceeded maximum threshold ({} KiB).\n'
             .format(usage, threshold)
         )

--- a/tests/host_tools/proc.py
+++ b/tests/host_tools/proc.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Utility functions for interacting with the processor."""
 import re
-import framework.utils as utils
+from framework import utils
 
 
 def proc_type():

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -52,7 +52,9 @@ RUN apt-get update \
         wheel \
     && python3 -m pip install \
         boto3 \
+        dataclasses \
         nsenter \
+        psutil \
         pycodestyle \
         pydocstyle \
         pylint \
@@ -62,6 +64,7 @@ RUN apt-get update \
         requests \
         requests-unixsocket \
         retry \
+        typing-extensions \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Rust toolchain

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -52,7 +52,9 @@ RUN apt-get update \
         wheel \
     && python3 -m pip install \
         boto3 \
+        dataclasses \
         nsenter \
+        psutil \
         pycodestyle \
         pydocstyle \
         pylint \
@@ -62,6 +64,7 @@ RUN apt-get update \
         requests \
         requests-unixsocket \
         retry \
+        typing-extensions \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Rust toolchain

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v17"
+DEVCTR_IMAGE="fcuvm/dev:v19"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

Performance tests might need core pinning  for spawned processes.

## Description of Changes

Added `psutil` python3 package to a new version of dev container and used it to get/set cpu affinity for processes but retrieve a process threads as well. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~~- [] Any required documentation changes (code and docs) are included in this PR.~~
- [x] Any newly added `unsafe` code is properly documented.~~
~~- [] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [] All added/changed functionality is tested.~~
