### PR TITLE
Fixed jailer build process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
   build to the output of `git describe --dirty`, if the git repo is available.
 - MicroVM process is only attached to the cgroups defined by using `--cgroups`
   or the ones defined indirectly by using `--node`.
+- Changed `devtool build` to build jailer binary for `musl` only targets. Building
+  jailer binary for `non-musl` targets have been removed.
 
 ## [0.22.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["src/firecracker", "src/jailer"]
+default-members = ["src/firecracker"]
 
 [profile.dev]
 panic = "abort"

--- a/tools/devtool
+++ b/tools/devtool
@@ -517,6 +517,22 @@ cmd_build() {
             "${cargo_args[@]}"
     ret=$?
 
+    [ $ret -ne 0 ] && return $ret
+
+    # Build jailer only in case of musl for compatibility reasons
+    if [ "$libc" == "musl" ];then
+        run_devctr \
+            --user "$(id -u):$(id -g)" \
+            --workdir "$CTR_FC_ROOT_DIR" \
+            -- \
+            cargo build -p jailer \
+                --target-dir "$CTR_CARGO_TARGET_DIR" \
+                "${cargo_args[@]}"
+
+    fi
+
+    ret=$?
+    
     # If `cargo build` was successful, let's copy the binaries to a more
     # accessible location.
     [ $ret -eq 0 ] && {


### PR DESCRIPTION
This fix is to make tools/devtool to build jailer binary
only for musl targets.

Currently, jailer binary gets built successfully for even
non-musl targets but doesn't work with corresponding
firecracker binary.

## Reason for This PR

As mentioned in #2102 

Currently, jailer binary gets built successfully for even
non-musl targets but doesn't work with corresponding
firecracker binary. This commit ensures jailer is not built for non-musl
targets.

## Description of Changes

- Modifed Cargo.toml workspace to exclude jailer for default build
- Modified devtool script to build jailer binary only for musl targets
- Updated changelog with the fix information

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
