### PR TITLE
devtool: added support for cpus/mems confinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
 - Added new jailer command line argument `--cgroup` which allow the user to
   specify the cgroups that are going to be set by the Jailer.
+- Added devtool test `-c|--cpuset-cpus` flag for cpus confinement when tests
+  run.
+- Added devtool test `-m|--cpuset-mems` flag for memory confinement when tests
+  run.
 
 ### Fixed
 

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -39,7 +39,7 @@ class JailerContext:
             self,
             jailer_id,
             exec_file,
-            numa_node=0,
+            numa_node=None,
             uid=1234,
             gid=1234,
             chroot_base=DEFAULT_CHROOT_PATH,

--- a/tools/devtool
+++ b/tools/devtool
@@ -434,6 +434,8 @@ cmd_help() {
     echo "        Run the Firecracker integration tests."
     echo "        The Firecracker testing system is based on pytest. All arguments after --"
     echo "        will be passed through to pytest."
+    echo "        -c, --cpuset-cpus cpulist    Set a dedicated cpulist to be used by the tests."
+    echo "        -m, --cpuset-mems memlist    Set a dedicated memlist to be used by the tests."
     echo ""
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
@@ -584,6 +586,14 @@ cmd_test() {
     while [ $# -gt 0 ]; do
         case "$1" in
             "-h"|"--help")      { cmd_help; exit 1; } ;;
+            "-c"|"--cpuset-cpus")
+                shift
+                local cpuset_cpus="$1"
+                ;;
+            "-m"|"--cpuset-mems")
+                shift
+                local cpuset_mems="$1"
+                ;;
             "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
@@ -596,7 +606,6 @@ cmd_test() {
     ensure_kvm
     ensure_devctr
     ensure_build_dir
-
 
     # If we got to here, we've got all we need to continue.
     say "$(date -u +'%F %H:%M:%S %Z')"
@@ -612,6 +621,8 @@ cmd_test() {
         --ulimit core=0 \
         --ulimit nofile=4096:4096 \
         --workdir "$CTR_FC_ROOT_DIR/tests" \
+        --cpuset-cpus="$cpuset_cpus" \
+        --cpuset-mems="$cpuset_mems" \
         -- \
         pytest "$@"
 


### PR DESCRIPTION
## Reason for This PR

When running tests with devtool, one might want to explicitly restrict the cpus and mems to a specific NUMA node or cross NUMA nodes.

## Description of Changes

Added two devtool flags:
* -c|--cpuset-cpus _cpulist_
* -m|--cpuset-mems _memlist_

The _cpulist_ and _memlist_ are forwarded to docker `--cpuset-cpus` and `--cpuset-mems`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
~~- [ ] All added/changed functionality is tested.~~
