### PR TITLE
Net: retry frame tx/rx in case of queue related error

### DIFF
--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -10,6 +10,6 @@ libc = "0.2"
 versionize = "0.1.2"
 versionize_derive = ">=0.1.1"
 
-[[bench]]
-name = "main"
-harness = false
+#[[bench]]
+#name = "main"
+#harness = false

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.05, "AMD": 84.28}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.33}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Net: retry frame tx/rx in case of queue error

## Description of Changes

Net: retry frame tx/rx in case of queue error

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
