### PR TITLE
Add missing TIOCGWINSZ ioctl param.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   from the API (user) perspective.
 - Added metric for measuring the duration of loading a snapshot, from the API
   (user) perspective.
+- Added new jailer command line argument `--cgroup` which allow the user to
+  specify the cgroups that are going to be set by the Jailer.
 
 ### Fixed
 
@@ -86,7 +88,8 @@
   `--boot-timer` dedicated cmdline parameter.
 - `firecracker/jailer --version` now gets updated on each devtool
   build to the output of `git describe --dirty`, if the git repo is available.
-
+- MicroVM process is only attached to the cgroups defined by using `--cgroups`
+  or the ones defined indirectly by using `--node`.
 
 ## [0.21.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,6 @@
 ### Added
 
 - Added metric for throttled block device events.
-- Added a new API call, `PUT /metrics`, for configuring the metrics system.
-- Added `app_name` field in InstanceInfo struct for storing the application
-  name.
-- New command-line parameters for `firecracker`, named `--log-path`,
-  `--level`, `--show-level` and `--show-log-origin` that can be used
-  for configuring the Logger when starting the process. When using
-  this method for configuration, only `--log-path` is mandatory.
-- Added a [guide](docs/devctr-image.md) for updating the dev container image.
-- Added a new API call, `PUT /mmds/config`, for configuring the
-  `MMDS` with a custom valid link-local IPv4 address.
-- Added experimental JSON response format support for MMDS guest applications
-  requests.
-- Added `track_dirty_pages` field to `machine-config`. If enabled, Firecracker
-  can create incremental guest memory snapshots by saving the dirty guest pages
-  in a sparse file.
-- Added a new API call, `PATCH /vm`, for changing the microVM state (to
-  `Paused` or `Resumed`).
-- Added a new API call, `PUT /snapshot/create`, for creating a full snapshot.
-- Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
-- Added metrics for the vsock device.
-- Added `devtool strip` command which removes debug symbols from the release
-  binaries.
-- Added the `tx_malformed_frames` metric for the virtio net device, emitted
-  when a TX frame missing the VNET header is encountered.
 - Added metrics for counting rate limiter throttling events.
 - Added metric for counting MAC address updates.
 - Added metrics for counting TAP read and write errors.
@@ -45,8 +21,52 @@
   from the API (user) perspective.
 - Added metric for measuring the duration of loading a snapshot, from the API
   (user) perspective.
+- Added `track_dirty_pages` field to `machine-config`. If enabled, Firecracker
+  can create incremental guest memory snapshots by saving the dirty guest pages
+  in a sparse file.
+- Added a new API call, `PATCH /vm`, for changing the microVM state (to
+  `Paused` or `Resumed`).
+- Added a new API call, `PUT /snapshot/create`, for creating a full snapshot.
+- Added a new API call, `PUT /snapshot/load`, for loading a snapshot.
 - Added new jailer command line argument `--cgroup` which allow the user to
   specify the cgroups that are going to be set by the Jailer.
+
+### Fixed
+
+- Boot time on AMD achieves the desired performance (i.e under 150ms).
+
+### Changed
+
+- The logger `level` field is now case-insensitive.
+- Disabled boot timer device after restoring a snapshot.
+- Enabled boot timer device only when specifically requested, by using the
+  `--boot-timer` dedicated cmdline parameter.
+- firecracker and jailer `--version` now gets updated on each devtool
+  build to the output of `git describe --dirty`, if the git repo is available.
+- MicroVM process is only attached to the cgroups defined by using `--cgroups`
+  or the ones defined indirectly by using `--node`.
+
+## [0.22.0]
+
+### Added
+
+- Added a new API call, `PUT /metrics`, for configuring the metrics system.
+- Added `app_name` field in InstanceInfo struct for storing the application
+  name.
+- New command-line parameters for `firecracker`, named `--log-path`,
+  `--level`, `--show-level` and `--show-log-origin` that can be used
+  for configuring the Logger when starting the process. When using
+  this method for configuration, only `--log-path` is mandatory.
+- Added a [guide](docs/devctr-image.md) for updating the dev container image.
+- Added a new API call, `PUT /mmds/config`, for configuring the
+  `MMDS` with a custom valid link-local IPv4 address.
+- Added experimental JSON response format support for MMDS guest applications
+  requests.
+- Added metrics for the vsock device.
+- Added `devtool strip` command which removes debug symbols from the release
+  binaries.
+- Added the `tx_malformed_frames` metric for the virtio net device, emitted
+  when a TX frame missing the VNET header is encountered.
 
 ### Fixed
 
@@ -54,9 +74,14 @@
 - Return `405 Method Not Allowed` MMDS response for non HTTP `GET` MMDS
   requests originating from guest.
 - Fixed folder permissions in the jail (#1802).
-- Boot time on AMD achieves the desired performance (i.e under 150ms).
 - Any number of whitespace characters are accepted after ":" when parsing HTTP
   headers.
+- Potential panic condition caused by the net device expecting to find a VNET
+  header in every frame.
+- Potential crash scenario caused by "Content-Length" HTTP header field
+  accepting negative values.
+- Fixed #1754 - net: traffic blocks when running ingress UDP performance tests
+  with very large buffers.
 
 ### Changed
 
@@ -82,14 +107,6 @@
   `403 BadRequest`.
 - Segregated MMDS documentation in MMDS design documentation and MMDS user
   guide documentation.
-- The logger `level` field is now case-insensitive.
-- Disabled boot timer device after restoring a snapshot.
-- Enabled boot timer device only when specifically requested, by using the
-  `--boot-timer` dedicated cmdline parameter.
-- `firecracker/jailer --version` now gets updated on each devtool
-  build to the output of `git describe --dirty`, if the git repo is available.
-- MicroVM process is only attached to the cgroups defined by using `--cgroups`
-  or the ones defined indirectly by using `--node`.
 
 ## [0.21.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "snapshot 0.1.0",
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio_gen 0.1.0",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,7 +190,7 @@ name = "kvm-bindings"
 version = "0.2.0"
 source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.2.0-2#035141b47659a1d3532101c86bd196de3f1454e9"
 dependencies = [
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -259,7 +259,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "snapshot 0.1.0",
  "utils 0.1.0",
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -300,7 +300,7 @@ dependencies = [
  "snapshot 0.1.0",
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -365,7 +365,7 @@ name = "snapshot"
 version = "0.1.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "versionize"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,7 +484,7 @@ dependencies = [
  "snapshot 0.1.0",
  "sysconf 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -559,7 +559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0123bba5b202eb298259401ae5611d3a34e852f1d9b6963bbf266b344355a93d"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7be505e45004e3c3963dbea155aa333784724b91ae580f08e702eeaccfca93"
+"checksum versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9947d2d1888281839f86c26f727c5ef40accf0ef0762b3086e33a476cea858"
 "checksum versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7817377bbb6759686d790fb8fbbb22a0371521d509a21fdb125cf7c9c9d815a"
 "checksum vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aae367b8bd176f4936b5d35c4403606d4a8458a8151dff47c974f1d9d1a4c974"
 "checksum vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "api_server 0.1.0",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,21 +42,6 @@ name = "arch_gen"
 version = "0.1.0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "bincode"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,48 +56,14 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bstr"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bumpalo"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cast"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "clap"
-version = "2.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cpuid"
@@ -127,102 +78,6 @@ dependencies = [
 name = "crc64"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "criterion"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion-plot 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "device_tree"
@@ -244,7 +99,7 @@ dependencies = [
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
+ "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio_gen 0.1.0",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -256,19 +111,13 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "micro_http 0.1.0",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
 
 [[package]]
-name = "either"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "errno"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -306,22 +155,6 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,14 +166,6 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -411,22 +236,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memoffset"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "micro_http"
@@ -448,45 +260,12 @@ dependencies = [
  "snapshot 0.1.0",
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
+ "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net_gen"
 version = "0.1.0"
-
-[[package]]
-name = "num-traits"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "oorandom"
-version = "11.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "plotters"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "polly"
@@ -522,29 +301,7 @@ dependencies = [
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
-]
-
-[[package]]
-name = "rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -559,42 +316,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -603,19 +331,6 @@ version = "0.1.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -649,12 +364,8 @@ dependencies = [
 name = "snapshot"
 version = "0.1.0"
 dependencies = [
- "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
+ "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -672,18 +383,10 @@ name = "sysconf"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "errno 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,20 +404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "tinytemplate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
@@ -747,16 +436,6 @@ dependencies = [
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "versionize_derive"
-version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0#a3acfa67d521661f057779a4df2d3fa3e43e80c9"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -805,7 +484,7 @@ dependencies = [
  "sysconf 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)",
+ "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -816,74 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "web-sys"
-version = "0.3.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -911,100 +522,48 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
-"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
-"checksum bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum crc64 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
-"checksum criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
-"checksum criterion-plot 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
-"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
-"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
-"checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 "checksum device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
-"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum errno 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
+"checksum errno 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
-"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-"checksum js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvm-bindings 0.2.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.2.0-2)" = "<none>"
 "checksum kvm-ioctls 0.5.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.5.0-2)" = "<none>"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-"checksum oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
-"checksum plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
-"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
-"checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
-"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 "checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum sysconf 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "59e93f5d45535f49b6a05ef7ac2f0f795d28de494cf53a512751602c9849bea3"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0123bba5b202eb298259401ae5611d3a34e852f1d9b6963bbf266b344355a93d"
-"checksum tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
-"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum versionize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7be505e45004e3c3963dbea155aa333784724b91ae580f08e702eeaccfca93"
-"checksum versionize_derive 0.1.0 (git+https://github.com/firecracker-microvm/versionize_derive?tag=v0.1.0)" = "<none>"
 "checksum versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7817377bbb6759686d790fb8fbbb22a0371521d509a21fdb125cf7c9c9d815a"
 "checksum vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aae367b8bd176f4936b5d35c4403606d4a8458a8151dff47c974f1d9d1a4c974"
 "checksum vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"
-"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
-"checksum wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
-"checksum wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
-"checksum wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
-"checksum wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
-"checksum wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
-"checksum web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/docs/benchmarks/state-serialize.md
+++ b/docs/benchmarks/state-serialize.md
@@ -8,35 +8,35 @@ Snapshot size: 83886 bytes.
 - Architecture:        x86_64
 - CPU op-mode(s):      32-bit, 64-bit
 - Byte Order:          Little Endian
-- CPU(s):              12
+- CPU(s):              4
 - Thread(s) per core:  2
-- Core(s) per socket:  6
+- Core(s) per socket:  2
 - Socket(s):           1
 - NUMA node(s):        1
 - Vendor ID:           GenuineIntel
 - CPU family:          6
-- Model:               158
-- Model name:          Intel(R) Core(TM) i7-8700 - CPU @ 3.20GHz
-- Stepping:            10
-- CPU MHz:             800.077
-- CPU max MHz:         4600.0000
-- CPU min MHz:         800.0000
-- BogoMIPS:            6399.96
+- Model:               142
+- Model name:          Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz
+- Stepping:            9
+- CPU MHz:             1100.008
+- CPU max MHz:         3900.0000
+- CPU min MHz:         400.0000
+- BogoMIPS:            5799.77
 - Virtualization:      VT-x
 - L1d cache:           32K
 - L1i cache:           32K
 - L2 cache:            256K
-- L3 cache:            12288K
-- NUMA node0 CPU(s):   0-11
-- Flags:               `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d`
+- L3 cache:            4096K
+- NUMA node0 CPU(s):   0-3
+- Flags:               `fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d`
 
 ### Current baseline
 
 | Test                |      Mean     |
 |---------------------|---------------|
-| Serialize           |    354.18 us  |
-| Serialize + crc64   |    406.08 us  |
-| Deserialize         |    61.412 us  |
-| Deserialize + crc64 |    258.27 us  |
+| Serialize           |    371.38 us  |
+| Serialize + crc64   |    493.26 us  |
+| Deserialize         |    90.755 us  |
+| Deserialize + crc64 |    216.90 us  |
 
 Detailed criterion benchmarks available [here](https://s3.amazonaws.com/spec.ccfc.min/perf/snapshot-0.23/report/index.html).

--- a/docs/design.md
+++ b/docs/design.md
@@ -162,7 +162,7 @@ process, immediately before the execution of the untrusted guest code starts.
 
 #### Cgroups and Quotas
 
-Each Firecracker microVM is further encapsulated into a cgroup. By setting the
+Each Firecracker microVM can be further encapsulated into a cgroup. By setting the
 affinity of the Firecracker microVM to a node via the cpuset subsystem, one
 can prevent the migration of said microVM from one node to another, something
 that would impair performance and cause unnecessary contention on shared

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.21.0
+  version: 0.22.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -8,11 +8,10 @@ edition = "2018"
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
 libc = ">=0.2.39"
-utils = { path = "../utils" }
-
-arch_gen = { path = "../arch_gen" }
 vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 
-[dev-dependencies]
+arch_gen = { path = "../arch_gen" }
 utils = { path = "../utils" }
+
+[dev-dependencies]
 device_tree = ">=1.1.0"

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
+
 utils = { path = "../utils"}

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -6,16 +6,18 @@ edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"
+timerfd = ">=1.0"
+versionize = ">=0.1.2"
+versionize_derive = ">=0.1.1"
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
+
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
-utils = { path = "../utils" }
+mmds = { path = "../mmds" }
 net_gen = { path = "../net_gen" }
 polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
-timerfd = ">=1.0"
-versionize = { version = "0.1.1" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
+utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-mmds = { path = "../mmds" }
+

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 bitflags = ">=1.0.4"
-serde = ">=1.0.27"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2018"
 
 [dependencies]
 vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
+
 utils = { path = "../utils" }

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -13,5 +13,3 @@ serde_json = ">=1.0.9"
 
 utils = { path = "../utils" }
 
-[dev-dependencies]
-libc = ">=0.2.39"

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -578,6 +578,16 @@ pub struct SignalMetrics {
     pub sigbus: SharedMetric,
     /// Number of times that SIGSEGV was handled.
     pub sigsegv: SharedMetric,
+    /// Number of times that SIGXFSZ was handled.
+    pub sigxfsz: SharedMetric,
+    /// Number of times that SIGXCPU was handled.
+    pub sigxcpu: SharedMetric,
+    /// Number of times that SIGPIPE was handled.
+    pub sigpipe: SharedMetric,
+    /// Number of times that SIGHUP was handled.
+    pub sighup: SharedMetric,
+    /// Number of times that SIGILL was handled.
+    pub sigill: SharedMetric,
 }
 
 /// Metrics specific to VCPUs' mode of functioning.

--- a/src/micro_http/Cargo.toml
+++ b/src/micro_http/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"
+
 utils = { path = "../utils" }

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 [dependencies]
 lazy_static = ">=1.1.0"
 serde_json = ">=1.0.9"
+versionize = ">=0.1.2"
+versionize_derive = ">=0.1.1"
 
+dumbo = { path = "../dumbo" }
+logger = { path = "../logger" }
 micro_http = { path = "../micro_http" }
 utils = { path = "../utils" }
-logger = { path = "../logger" }
-dumbo = { path = "../dumbo" }
 snapshot = { path = "../snapshot" }
-versionize = { version = "0.1.1" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
+

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 libc = ">=0.2.39"
+
 utils = { path="../utils" }

--- a/src/rate_limiter/Cargo.toml
+++ b/src/rate_limiter/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2018"
 [dependencies]
 libc = ">=0.2.39"
 timerfd = ">=1.0"
+versionize = ">=0.1.2"
+versionize_derive = ">=0.1.1"
 
 logger = { path = "../logger" }
 utils = { path = "../utils" }
 snapshot = { path = "../snapshot" }
-versionize = { version = "0.1.1" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
+

--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -6,14 +6,8 @@ edition = "2018"
 autobenches = false
 
 [dependencies]
-serde = ">=1.0.27"
-serde_derive = ">=1.0.27"
-bincode = "1.2.1"
-versionize = { version = "0.1.1" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
-
-[dev-dependencies]
-criterion = "0.3.0"
+versionize = "0.1.2"
+versionize_derive = ">=0.1.1"
 
 [[bench]]
 name = "main"

--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 autobenches = false
 
 [dependencies]
+libc = "0.2"
 versionize = "0.1.2"
 versionize_derive = ">=0.1.1"
 

--- a/src/snapshot/benches/main.rs
+++ b/src/snapshot/benches/main.rs
@@ -87,9 +87,9 @@ impl Test {
 }
 
 #[inline]
-pub fn bench_restore_v1(mut snapshot_mem: &[u8], vm: VersionMap, crc: bool) {
+pub fn bench_restore_v1(mut snapshot_mem: &[u8], snapshot_len: usize, vm: VersionMap, crc: bool) {
     if crc {
-        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
     } else {
         Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
     }
@@ -151,6 +151,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             bench_restore_v1(
                 black_box(&mut snapshot_mem.as_slice()),
+                black_box(snapshot_len),
                 black_box(vm.clone()),
                 black_box(false),
             )
@@ -175,6 +176,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             bench_restore_v1(
                 black_box(&mut snapshot_mem.as_slice()),
+                black_box(snapshot_len),
                 black_box(vm.clone()),
                 black_box(true),
             )

--- a/src/snapshot/benches/main.rs
+++ b/src/snapshot/benches/main.rs
@@ -89,9 +89,9 @@ impl Test {
 #[inline]
 pub fn bench_restore_v1(mut snapshot_mem: &[u8], snapshot_len: usize, vm: VersionMap, crc: bool) {
     if crc {
-        Snapshot::load_with_crc64::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
+        Snapshot::load::<&[u8], Test>(&mut snapshot_mem, snapshot_len, vm).unwrap();
     } else {
-        Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+        Snapshot::unchecked_load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
     }
 }
 
@@ -115,9 +115,11 @@ pub fn bench_snapshot_v1<W: std::io::Write>(mut snapshot_mem: &mut W, vm: Versio
 
     let mut snapshot = Snapshot::new(vm.clone(), 4);
     if crc {
-        snapshot.save_with_crc64(&mut snapshot_mem, &state).unwrap();
-    } else {
         snapshot.save(&mut snapshot_mem, &state).unwrap();
+    } else {
+        snapshot
+            .save_without_crc(&mut snapshot_mem, &state)
+            .unwrap();
     }
 }
 

--- a/src/snapshot/benches/version_map.rs
+++ b/src/snapshot/benches/version_map.rs
@@ -27,7 +27,7 @@ struct Dummy {
 
 #[inline]
 fn restore(mut snapshot_mem: &[u8], vm: VersionMap) {
-    Snapshot::load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
+    Snapshot::unchecked_load::<&[u8], Test>(&mut snapshot_mem, vm).unwrap();
 }
 
 #[inline]
@@ -47,7 +47,9 @@ fn save<W: std::io::Write>(mut snapshot_mem: &mut W, vm: VersionMap) {
     };
 
     let mut snapshot = Snapshot::new(vm.clone(), vm.latest_version());
-    snapshot.save(&mut snapshot_mem, &state).unwrap();
+    snapshot
+        .save_without_crc(&mut snapshot_mem, &state)
+        .unwrap();
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -20,8 +20,8 @@
 //!
 //! Each structure, union or enum is versioned separately and only needs to increment their version
 //! if a field is added or removed. For each state snapshot we define 2 versions:
-//!  - **the format version** which refers to the SnapshotHdr, CRC, or the
-//! representation of primitives types (currently we use serde bincode as a backend). The current
+//!  - **the format version** which refers to the SnapshotHdr, CRC, or the representation of
+//! primitives types (currently we use versionize that uses serde bincode as a backend). The current
 //! implementation does not have any logic dependent on it.
 //!  - **the data version** which refers to the state.
 //!

--- a/src/snapshot/tests/test.rs
+++ b/src/snapshot/tests/test.rs
@@ -94,7 +94,7 @@ fn test_hardcoded_snapshot_deserialization() {
 
     let mut snapshot_blob = v1_hardcoded_snapshot;
 
-    let mut restored_struct: A = Snapshot::load(&mut snapshot_blob, vm.clone()).unwrap();
+    let mut restored_struct: A = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
 
     let mut expected_struct = A {
         a: 16u32,
@@ -106,7 +106,7 @@ fn test_hardcoded_snapshot_deserialization() {
 
     snapshot_blob = v2_hardcoded_snapshot;
 
-    restored_struct = Snapshot::load(&mut snapshot_blob, vm.clone()).unwrap();
+    restored_struct = Snapshot::unchecked_load(&mut snapshot_blob, vm.clone()).unwrap();
 
     expected_struct = A {
         a: 16u32,
@@ -142,7 +142,7 @@ fn test_invalid_format_version() {
     ];
 
     let mut result: Result<A, Error> =
-        Snapshot::load(&mut invalid_format_snap.as_ref(), VersionMap::new());
+        Snapshot::unchecked_load(&mut invalid_format_snap.as_ref(), VersionMap::new());
     let mut expected_err = Error::InvalidFormatVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);
 
@@ -168,7 +168,7 @@ fn test_invalid_format_version() {
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
 
-    result = Snapshot::load(&mut null_format_snap.as_ref(), VersionMap::new());
+    result = Snapshot::unchecked_load(&mut null_format_snap.as_ref(), VersionMap::new());
     expected_err = Error::InvalidFormatVersion(0);
     assert_eq!(result.unwrap_err(), expected_err);
 }
@@ -197,7 +197,7 @@ fn test_invalid_data_version() {
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
     let mut result: Result<A, Error> =
-        Snapshot::load(&mut invalid_data_version_snap.as_ref(), VersionMap::new());
+        Snapshot::unchecked_load(&mut invalid_data_version_snap.as_ref(), VersionMap::new());
     let mut expected_err = Error::InvalidDataVersion(0xAAAA);
     assert_eq!(result.unwrap_err(), expected_err);
 
@@ -222,7 +222,7 @@ fn test_invalid_data_version() {
         // + inner enum value (4 bytes).
         0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
     ];
-    result = Snapshot::load(&mut null_data_version_snap.as_ref(), VersionMap::new());
+    result = Snapshot::unchecked_load(&mut null_data_version_snap.as_ref(), VersionMap::new());
     expected_err = Error::InvalidDataVersion(0);
     assert_eq!(result.unwrap_err(), expected_err);
 }

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -11,7 +11,6 @@ vmm-sys-util = ">=0.6.1"
 
 net_gen = { path = "../net_gen" }
 
-
 [dev-dependencies]
 serde_json = ">=1.0.9"
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,25 +5,25 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
-kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
-lazy_static = "1.4.0"
+lazy_static = ">=1.4.0"
 libc = ">=0.2.39"
 serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
-sysconf = "0.3.4"
-versionize = { version = "0.1.1" }
-versionize_derive = { git = "https://github.com/firecracker-microvm/versionize_derive", tag = "v0.1.0" }
+sysconf = ">=0.3.4"
+versionize = ">=0.1.2"
+versionize_derive = ">=0.1.1"
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
 logger = { path = "../logger" }
-vm-memory = { version = ">=0.2.2", features = ["backend-mmap"] }
 mmds = { path = "../mmds" }
+polly = { path = "../polly" }
 rate_limiter = { path = "../rate_limiter" }
 seccomp = { path = "../seccomp" }
-polly = { path = "../polly" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
 

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -20,135 +20,104 @@ const FCNTL_F_SETFD: u64 = 2;
 // See include/uapi/linux/futex.h in the kernel code.
 const FUTEX_WAIT: u64 = 0;
 const FUTEX_WAKE: u64 = 1;
-const FUTEX_REQUEUE: u64 = 3;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE: u64 = 4;
 const FUTEX_PRIVATE_FLAG: u64 = 128;
 const FUTEX_WAIT_PRIVATE: u64 = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
 const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
-const FUTEX_REQUEUE_PRIVATE: u64 = FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
-const TCGETS: u64 = 0x5401;
-const TCSETS: u64 = 0x5402;
-const TIOCGWINSZ: u64 = 0x5413;
-const FIOCLEX: u64 = 0x5451;
 const FIONBIO: u64 = 0x5421;
-
-// Hardcoded here instead of getting values from kvm-ioctls, so that filtered values cannot be
-// mistakenly or intentionally altered from outside our codebase.
-
-// See include/uapi/linux/if_tun.h in the kernel code.
-const KVM_GET_API_VERSION: u64 = 0xae00;
-const KVM_CREATE_VM: u64 = 0xae01;
-const KVM_CHECK_EXTENSION: u64 = 0xae03;
-const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
-const KVM_CREATE_VCPU: u64 = 0xae41;
-const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
-const KVM_SET_TSS_ADDR: u64 = 0xae47;
-const KVM_CREATE_IRQCHIP: u64 = 0xae60;
-const KVM_RUN: u64 = 0xae80;
-const KVM_SET_MSRS: u64 = 0x4008_ae89;
-const KVM_SET_CPUID2: u64 = 0x4008_ae90;
-const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
-const KVM_IRQFD: u64 = 0x4020_ae76;
-const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
-const KVM_IOEVENTFD: u64 = 0x4040_ae79;
-const KVM_SET_REGS: u64 = 0x4090_ae82;
-const KVM_SET_SREGS: u64 = 0x4138_ae84;
-const KVM_SET_FPU: u64 = 0x41a0_ae8d;
-const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
-const KVM_GET_SREGS: u64 = 0x8138_ae83;
-const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
-const KVM_GET_MSR_INDEX_LIST: u64 = 0xc004_ae02;
-const KVM_GET_MSR_FEATURE_INDEX_LIST: u64 = 0xc004_ae0a;
-const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
-const KVM_GET_IRQCHIP: u64 = 0xc208_ae62;
-const KVM_SET_IRQCHIP: u64 = 0x8208_ae63;
-const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
-const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
-const KVM_GET_PIT2: u64 = 0x8070_ae9f;
-const KVM_SET_PIT2: u64 = 0x4070_aea0;
-const KVM_GET_REGS: u64 = 0x8090_ae81;
-const KVM_GET_MSRS: u64 = 0xc008_ae88;
-const KVM_GET_CPUID2: u64 = 0xc008_ae91;
-const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
-const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
-const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
-const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
-const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
-const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
-const KVM_GET_XSAVE: u64 = 0x9000_aea4;
-const KVM_SET_XSAVE: u64 = 0x5000_aea5;
-const KVM_GET_XCRS: u64 = 0x8188_aea6;
-const KVM_SET_XCRS: u64 = 0x4188_aea7;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
 const TUNSETIFF: u64 = 0x4004_54ca;
 const TUNSETOFFLOAD: u64 = 0x4004_54d0;
 const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
 
-fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
-    Ok(or![
-        and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CHECK_EXTENSION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VM)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_API_VERSION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SUPPORTED_CPUID,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_MMAP_SIZE,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_IRQCHIP,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_PIT2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VCPU)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_TSS_ADDR,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIOCLEX)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],
+// Hardcoded here instead of getting values from kvm-ioctls, so that filtered values cannot be
+// mistakenly or intentionally altered from outside our codebase.
+const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
+const KVM_RUN: u64 = 0xae80;
+const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
+const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
+const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
+const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
+
+// Use this mod to define ioctl params that are architecture specific.
+// To add other architectures, add another module declaration with the right cfg attribute.
+#[cfg(target_arch = "x86_64")]
+mod arch_specific_constants {
+    pub const KVM_SET_MSRS: u64 = 0x4008_ae89;
+    pub const KVM_SET_CPUID2: u64 = 0x4008_ae90;
+    pub const KVM_SET_REGS: u64 = 0x4090_ae82;
+    pub const KVM_SET_SREGS: u64 = 0x4138_ae84;
+    pub const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
+    pub const KVM_GET_SREGS: u64 = 0x8138_ae83;
+    pub const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
+    pub const KVM_GET_IRQCHIP: u64 = 0xc208_ae62;
+    pub const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
+    pub const KVM_GET_PIT2: u64 = 0x8070_ae9f;
+    pub const KVM_GET_REGS: u64 = 0x8090_ae81;
+    pub const KVM_GET_MSRS: u64 = 0xc008_ae88;
+    pub const KVM_GET_CPUID2: u64 = 0xc008_ae91;
+    pub const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
+    pub const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
+    pub const KVM_GET_XSAVE: u64 = 0x9000_aea4;
+    pub const KVM_SET_XSAVE: u64 = 0x5000_aea5;
+    pub const KVM_GET_XCRS: u64 = 0x8188_aea6;
+    pub const KVM_SET_XCRS: u64 = 0x4188_aea7;
+}
+
+fn create_arch_specific_ioctl_conditions() -> Result<Vec<SeccompRule>, Error> {
+    #[cfg(target_arch = "x86_64")]
+    use arch_specific_constants::*;
+
+    #[cfg(target_arch = "x86_64")]
+    return Ok(or![
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SREGS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CPUID2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_SREGS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSR_INDEX_LIST)?],
-        and![Cond::new(
-            1,
-            ArgLen::DWORD,
-            Eq,
-            KVM_GET_MSR_FEATURE_INDEX_LIST
-        )?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_IRQCHIP)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_IRQCHIP)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_PIT2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_PIT2)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CPUID2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DEBUGREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_DEBUGREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XSAVE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XCRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS)?],
-    ])
+    ]);
+
+    #[cfg(target_arch = "aarch64")]
+    return Ok(or![]);
+}
+
+fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
+    let mut rule = or![
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
+    ];
+
+    rule.append(&mut create_arch_specific_ioctl_conditions()?);
+
+    Ok(rule)
 }
 
 #[cfg(test)]

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -29,6 +29,7 @@ const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
+const TIOCGWINSZ: u64 = 0x5413;
 const FIONBIO: u64 = 0x5421;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
@@ -106,6 +107,9 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
+        // Triggered on microvm shutdown. If you remove it, tests will likely still pass,
+        // because the sigsys_handler exits the process.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -75,6 +75,16 @@ pub const FC_EXIT_CODE_BAD_SYSCALL: u8 = 148;
 pub const FC_EXIT_CODE_SIGBUS: u8 = 149;
 /// Firecracker was shut down after intercepting `SIGSEGV`.
 pub const FC_EXIT_CODE_SIGSEGV: u8 = 150;
+/// Firecracker was shut down after intercepting `SIGXFSZ`.
+pub const FC_EXIT_CODE_SIGXFSZ: u8 = 151;
+/// Firecracker was shut down after intercepting `SIGXCPU`.
+pub const FC_EXIT_CODE_SIGXCPU: u8 = 154;
+/// Firecracker was shut down after intercepting `SIGPIPE`.
+pub const FC_EXIT_CODE_SIGPIPE: u8 = 155;
+/// Firecracker was shut down after intercepting `SIGHUP`.
+pub const FC_EXIT_CODE_SIGHUP: u8 = 156;
+/// Firecracker was shut down after intercepting `SIGILL`.
+pub const FC_EXIT_CODE_SIGILL: u8 = 157;
 /// Bad configuration for microvm's resources, when using a single json.
 pub const FC_EXIT_CODE_BAD_CONFIGURATION: u8 = 152;
 /// Command line arguments parsing error.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -209,7 +209,7 @@ fn snapshot_state_to_file(
 
     let mut snapshot = Snapshot::new(version_map, snapshot_data_version);
     snapshot
-        .save_with_crc64(&mut snapshot_file, microvm_state)
+        .save(&mut snapshot_file, microvm_state)
         .map_err(SerializeMicrovmState)?;
 
     Ok(())
@@ -273,8 +273,7 @@ fn snapshot_state_from_file(
     let mut snapshot_reader = File::open(snapshot_path).map_err(SnapshotBackingFile)?;
     let metadata = std::fs::metadata(snapshot_path).map_err(SnapshotBackingFileMetadata)?;
     let snapshot_len = metadata.len() as usize;
-    Snapshot::load_with_crc64(&mut snapshot_reader, snapshot_len, version_map)
-        .map_err(DeserializeMicrovmState)
+    Snapshot::load(&mut snapshot_reader, snapshot_len, version_map).map_err(DeserializeMicrovmState)
 }
 
 fn guest_memory_from_file(

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -1,7 +1,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use libc::{_exit, c_int, c_void, siginfo_t, SIGBUS, SIGSEGV, SIGSYS};
+use libc::{
+    _exit, c_int, c_void, siginfo_t, SIGBUS, SIGHUP, SIGILL, SIGPIPE, SIGSEGV, SIGSYS, SIGXCPU,
+    SIGXFSZ,
+};
 
 use logger::{error, Metric, METRICS};
 use utils::signal::register_signal_handler;
@@ -15,17 +18,46 @@ const SI_OFF_SYSCALL: isize = 6;
 
 const SYS_SECCOMP_CODE: i32 = 1;
 
-/// Signal handler for `SIGSYS`.
-///
-/// Increments the `seccomp.num_faults` metric, logs an error message and terminates the process
-/// with a specific exit code.
-extern "C" fn sigsys_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) {
-    // Safe because we're just reading some fields from a supposedly valid argument.
-    let si_signo = unsafe { (*info).si_signo };
-    let si_code = unsafe { (*info).si_code };
+macro_rules! generate_handler {
+    ($fn_name:ident ,$signal_name:ident, $exit_code:ident, $signal_metric:expr, $body:ident) => {
+        #[inline(always)]
+        extern "C" fn $fn_name(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) {
+            // Safe because we're just reading some fields from a supposedly valid argument.
+            let si_signo = unsafe { (*info).si_signo };
+            let si_code = unsafe { (*info).si_code };
 
-    // Sanity check. The condition should never be true.
-    if num != si_signo || num != SIGSYS || si_code != SYS_SECCOMP_CODE as i32 {
+            if num != si_signo || num != $signal_name {
+                // Safe because we're terminating the process anyway.
+                unsafe { _exit(i32::from(super::FC_EXIT_CODE_UNEXPECTED_ERROR)) };
+            }
+            $signal_metric.inc();
+
+            $body(si_code, info);
+
+            error!(
+                "Shutting down VM after intercepting signal {}, code {}.",
+                si_signo, si_code
+            );
+            // Write the metrics before exiting.
+            if let Err(e) = METRICS.write() {
+                error!("Failed to write metrics while stopping: {}", e);
+            }
+
+            // Safe because we're terminating the process anyway. We don't actually do anything when
+            // running unit tests.
+            #[cfg(not(test))]
+            unsafe {
+                _exit(i32::from(match si_signo {
+                    $signal_name => super::$exit_code,
+                    _ => super::FC_EXIT_CODE_UNEXPECTED_ERROR,
+                }))
+            };
+        }
+    };
+}
+
+fn log_sigsys_err(si_code: c_int, info: *mut siginfo_t) {
+    if si_code != SYS_SECCOMP_CODE as i32 {
         // Safe because we're terminating the process anyway.
         unsafe { _exit(i32::from(super::FC_EXIT_CODE_UNEXPECTED_ERROR)) };
     }
@@ -33,79 +65,93 @@ extern "C" fn sigsys_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_v
     // Other signals which might do async unsafe things incompatible with the rest of this
     // function are blocked due to the sa_mask used when registering the signal handler.
     let syscall = unsafe { *(info as *const i32).offset(SI_OFF_SYSCALL) as usize };
-    METRICS.seccomp.num_faults.inc();
     error!(
         "Shutting down VM after intercepting a bad syscall ({}).",
         syscall
     );
-    // Write the metrics before exiting.
-    if let Err(e) = METRICS.write() {
-        error!("Failed to write metrics while stopping: {}", e);
-    }
-
-    // Safe because we're terminating the process anyway. We don't actually do anything when
-    // running unit tests.
-    #[cfg(not(test))]
-    unsafe {
-        _exit(i32::from(super::FC_EXIT_CODE_BAD_SYSCALL))
-    };
 }
 
-/// Signal handler for `SIGBUS` and `SIGSEGV`.
-///
-/// Logs an error message and terminates the process with a specific exit code.
-extern "C" fn sigbus_sigsegv_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) {
-    // Safe because we're just reading some fields from a supposedly valid argument.
-    let si_signo = unsafe { (*info).si_signo };
-    let si_code = unsafe { (*info).si_code };
+fn empty_fn(_si_code: c_int, _info: *mut siginfo_t) {}
 
-    // Sanity check. The condition should never be true.
-    if num != si_signo || (num != SIGBUS && num != SIGSEGV) {
-        // Safe because we're terminating the process anyway.
-        unsafe { _exit(i32::from(super::FC_EXIT_CODE_UNEXPECTED_ERROR)) };
-    }
+generate_handler!(
+    sigxfsz_handler,
+    SIGXFSZ,
+    FC_EXIT_CODE_SIGXFSZ,
+    METRICS.signals.sigxfsz,
+    empty_fn
+);
 
-    // Other signals which might do async unsafe things incompatible with the rest of this
-    // function are blocked due to the sa_mask used when registering the signal handler.
-    match si_signo {
-        SIGBUS => METRICS.signals.sigbus.inc(),
-        SIGSEGV => METRICS.signals.sigsegv.inc(),
-        _ => (),
-    }
+generate_handler!(
+    sigxcpu_handler,
+    SIGXCPU,
+    FC_EXIT_CODE_SIGXCPU,
+    METRICS.signals.sigxcpu,
+    empty_fn
+);
 
-    error!(
-        "Shutting down VM after intercepting signal {}, code {}.",
-        si_signo, si_code
-    );
-    // Write the metrics before exiting.
-    if let Err(e) = METRICS.write() {
-        error!("Failed to write metrics while stopping: {}", e);
-    }
+generate_handler!(
+    sigbus_handler,
+    SIGBUS,
+    FC_EXIT_CODE_SIGBUS,
+    METRICS.signals.sigbus,
+    empty_fn
+);
 
-    // Safe because we're terminating the process anyway. We don't actually do anything when
-    // running unit tests.
-    #[cfg(not(test))]
-    unsafe {
-        _exit(i32::from(match si_signo {
-            SIGBUS => super::FC_EXIT_CODE_SIGBUS,
-            SIGSEGV => super::FC_EXIT_CODE_SIGSEGV,
-            _ => super::FC_EXIT_CODE_UNEXPECTED_ERROR,
-        }))
-    };
-}
+generate_handler!(
+    sigsegv_handler,
+    SIGSEGV,
+    FC_EXIT_CODE_SIGSEGV,
+    METRICS.signals.sigsegv,
+    empty_fn
+);
 
+generate_handler!(
+    sigpipe_handler,
+    SIGPIPE,
+    FC_EXIT_CODE_SIGPIPE,
+    METRICS.signals.sigpipe,
+    empty_fn
+);
+
+generate_handler!(
+    sigsys_handler,
+    SIGSYS,
+    FC_EXIT_CODE_BAD_SYSCALL,
+    METRICS.seccomp.num_faults,
+    log_sigsys_err
+);
+
+generate_handler!(
+    sighup_handler,
+    SIGHUP,
+    FC_EXIT_CODE_SIGHUP,
+    METRICS.signals.sighup,
+    empty_fn
+);
+generate_handler!(
+    sigill_handler,
+    SIGILL,
+    FC_EXIT_CODE_SIGILL,
+    METRICS.signals.sigill,
+    empty_fn
+);
 /// Registers all the required signal handlers.
 ///
-/// Custom handlers are installed for: `SIGBUS`, `SIGSEGV`, `SIGSYS`.
+/// Custom handlers are installed for: `SIGBUS`, `SIGSEGV`, `SIGSYS`
+/// `SIGXFSZ` `SIGXCPU` `SIGPIPE` `SIGHUP` and `SIGILL`.
 pub fn register_signal_handlers() -> utils::errno::Result<()> {
     // Call to unsafe register_signal_handler which is considered unsafe because it will
     // register a signal handler which will be called in the current thread and will interrupt
     // whatever work is done on the current thread, so we have to keep in mind that the registered
     // signal handler must only do async-signal-safe operations.
     register_signal_handler(SIGSYS, sigsys_handler)?;
-    register_signal_handler(SIGBUS, sigbus_sigsegv_handler)?;
-    register_signal_handler(SIGSEGV, sigbus_sigsegv_handler)?;
-
+    register_signal_handler(SIGBUS, sigbus_handler)?;
+    register_signal_handler(SIGSEGV, sigsegv_handler)?;
+    register_signal_handler(SIGXFSZ, sigxfsz_handler)?;
+    register_signal_handler(SIGXCPU, sigxcpu_handler)?;
+    register_signal_handler(SIGPIPE, sigpipe_handler)?;
+    register_signal_handler(SIGHUP, sighup_handler)?;
+    register_signal_handler(SIGILL, sigill_handler)?;
     Ok(())
 }
 
@@ -185,6 +231,36 @@ mod tests {
             unsafe {
                 syscall(libc::SYS_kill, process::id(), SIGSEGV);
             }
+
+            // Call SIGXFSZ signal handler.
+            assert_eq!(METRICS.signals.sigxfsz.count(), 0);
+            unsafe {
+                syscall(libc::SYS_kill, process::id(), SIGXFSZ);
+            }
+
+            // Call SIGXCPU signal handler.
+            assert_eq!(METRICS.signals.sigxcpu.count(), 0);
+            unsafe {
+                syscall(libc::SYS_kill, process::id(), SIGXCPU);
+            }
+
+            // Call SIGPIPE signal handler.
+            assert_eq!(METRICS.signals.sigpipe.count(), 0);
+            unsafe {
+                syscall(libc::SYS_kill, process::id(), SIGPIPE);
+            }
+
+            // Call SIGHUP signal handler.
+            assert_eq!(METRICS.signals.sighup.count(), 0);
+            unsafe {
+                syscall(libc::SYS_kill, process::id(), SIGHUP);
+            }
+
+            // Call SIGILL signal handler.
+            assert_eq!(METRICS.signals.sigill.count(), 0);
+            unsafe {
+                syscall(libc::SYS_kill, process::id(), SIGILL);
+            }
         });
         assert!(child.join().is_ok());
 
@@ -202,5 +278,10 @@ mod tests {
         }
         assert!(METRICS.signals.sigbus.count() >= 1);
         assert!(METRICS.signals.sigsegv.count() >= 1);
+        assert!(METRICS.signals.sigxfsz.count() >= 1);
+        assert!(METRICS.signals.sigxcpu.count() >= 1);
+        assert!(METRICS.signals.sigpipe.count() >= 1);
+        assert!(METRICS.signals.sighup.count() >= 1);
+        assert!(METRICS.signals.sigill.count() >= 1);
     }
 }

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -361,7 +361,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
             let snapshot_path = snapshot_file.as_path().to_path_buf();
             let snapshot_file_metadata = std::fs::metadata(snapshot_path).unwrap();
             let snapshot_len = snapshot_file_metadata.len() as usize;
-            let restored_microvm_state: MicrovmState = Snapshot::load_with_crc64(
+            let restored_microvm_state: MicrovmState = Snapshot::load(
                 &mut snapshot_file.as_file(),
                 snapshot_len,
                 VERSION_MAP.clone(),
@@ -402,7 +402,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
             let snapshot_file_metadata = snapshot_file.as_file().metadata().unwrap();
             let snapshot_len = snapshot_file_metadata.len() as usize;
             snapshot_file.as_file().seek(SeekFrom::Start(0)).unwrap();
-            let microvm_state: MicrovmState = Snapshot::load_with_crc64(
+            let microvm_state: MicrovmState = Snapshot::load(
                 &mut snapshot_file.as_file(),
                 snapshot_len,
                 VERSION_MAP.clone(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,20 +128,26 @@ def _test_images_s3_bucket():
 MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(_test_images_s3_bucket())
 
 
-def init_microvm(root_path, bin_cloner_path):
+def init_microvm(root_path, bin_cloner_path,
+                 fc_binary=None, jailer_binary=None):
     """Auxiliary function for instantiating a microvm and setting it up."""
     # pylint: disable=redefined-outer-name
     # The fixture pattern causes a pylint false positive for that rule.
     microvm_id = str(uuid.uuid4())
-    fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+    if fc_binary is None:
+        fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
+
+    # Make sure we always have both binaries.
+    assert fc_binary
+    assert jailer_binary
 
     vm = Microvm(
-        resource_path=root_path,
-        fc_binary_path=fc_binary,
-        jailer_binary_path=jailer_binary,
-        microvm_id=microvm_id,
-        bin_cloner_path=bin_cloner_path
-    )
+         resource_path=root_path,
+         fc_binary_path=fc_binary,
+         jailer_binary_path=jailer_binary,
+         microvm_id=microvm_id,
+         bin_cloner_path=bin_cloner_path)
     vm.setup()
     return vm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def init_microvm(root_path, bin_cloner_path,
     # The fixture pattern causes a pylint false positive for that rule.
     microvm_id = str(uuid.uuid4())
 
-    if fc_binary is None:
+    if fc_binary is None or jailer_binary is None:
         fc_binary, jailer_binary = build_tools.get_firecracker_binaries()
 
     # Make sure we always have both binaries.

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -166,7 +166,7 @@ class SnapshotArtifact:
         # Get the name of the snapshot folder.
         snapshot_name = self.name
         self._local_folder = os.path.join(ARTIFACTS_LOCAL_ROOT,
-                                          self.type.strip('/'),
+                                          self.type.value,
                                           snapshot_name)
 
     @property
@@ -349,7 +349,7 @@ class ArtifactCollection:
             # Select only files with specified keyword.
             if (key[-1] == "/" and key != prefix and
                (keyword is None or keyword in snapshot_dir.key)):
-                artifact_type = ArtifactCollection.ARTIFACTS_SNAPSHOTS
+                artifact_type = ArtifactType.SNAPSHOT
                 artifacts.append(SnapshotArtifact(self.bucket,
                                                   key,
                                                   artifact_type=artifact_type))

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -160,7 +160,6 @@ class SnapshotArtifact:
         for disk in snaphot_disks:
             artifact = Artifact(self._bucket, disk.key,
                                 artifact_type=ArtifactType.DISK)
-            # artifact.download()
             self._disks.append(artifact)
 
         # Get the name of the snapshot folder.

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -24,7 +24,6 @@ class MicrovmBuilder:
         self.bin_cloner_path = bin_cloner_path
         self.init_root_path()
 
-        # Update permissions to owner RWX.
         if fc_binary is not None:
             os.chmod(fc_binary, 0o555)
         if jailer_binary is not None:
@@ -68,13 +67,14 @@ class MicrovmBuilder:
         with open(config.local_path()) as microvm_config_file:
             microvm_config = json.load(microvm_config_file)
 
+        response = vm.basic_config(boot_args='console=ttyS0 reboot=k panic=1')
+
         # Apply the microvm artifact configuration and template.
-        response = test_microvm.machine_cfg.put(
+        response = vm.machine_cfg.put(
             vcpu_count=int(microvm_config['vcpu_count']),
             mem_size_mib=int(microvm_config['mem_size_mib']),
             ht_enabled=bool(microvm_config['ht_enabled']),
             track_dirty_pages=enable_diff_snapshots,
-            boot_args='console=ttyS0 reboot=k panic=1',
             cpu_template=cpu_template,
         )
         assert vm.api_session.is_status_no_content(response.status_code)

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -34,6 +34,7 @@ class JailerContext:
     daemonize = None
     extra_args = None
     api_socket_name = None
+    cgroups = None
 
     def __init__(
             self,
@@ -45,6 +46,7 @@ class JailerContext:
             chroot_base=DEFAULT_CHROOT_PATH,
             netns=None,
             daemonize=True,
+            cgroups=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -63,11 +65,16 @@ class JailerContext:
         self.daemonize = daemonize
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
+        self.cgroups = cgroups
 
     def __del__(self):
         """Cleanup this jailer context."""
         self.cleanup()
 
+    # Disabling 'too-many-branches' warning for this function as it needs to
+    # check every argument, so the number of branches will increase
+    # with every new argument.
+    # pylint: disable=too-many-branches
     def construct_param_list(self):
         """Create the list of parameters we want the jailer to start with.
 
@@ -96,6 +103,9 @@ class JailerContext:
             jailer_param_list.extend(['--netns', str(self.netns_file_path())])
         if self.daemonize:
             jailer_param_list.append('--daemonize')
+        if self.cgroups is not None:
+            for cgroup in self.cgroups:
+                jailer_param_list.extend(['--cgroup', str(cgroup)])
         # applying neccessory extra args if needed
         if len(self.extra_args) > 0:
             jailer_param_list.append('--')
@@ -106,6 +116,7 @@ class JailerContext:
                     if key == "api-sock":
                         self.api_socket_name = value
         return jailer_param_list
+    # pylint: enable=too-many-branches
 
     def chroot_base_with_id(self):
         """Return the MicroVM chroot base + MicroVM ID."""
@@ -193,39 +204,40 @@ class JailerContext:
         # because we can't remove it unless we're sure there's no other running
         # microVM.
 
-        # Firecracker is interested in these 3 cgroups for the moment.
-        controllers = ('cpu', 'cpuset', 'pids')
-        for controller in controllers:
-            # Obtain the tasks from each cgroup and wait on them before
-            # removing the microvm's associated cgroup folder.
-            try:
-                retry_call(
-                    f=self._kill_crgoup_tasks,
-                    fargs=[controller],
-                    exceptions=TimeoutError,
-                    max_delay=5
+        if self.cgroups:
+            controllers = set()
+
+            # Extract the controller for every cgroup that needs to be set.
+            for cgroup in self.cgroups:
+                controllers.add(cgroup.split('.')[0])
+
+            for controller in controllers:
+                # Obtain the tasks from each cgroup and wait on them before
+                # removing the microvm's associated cgroup folder.
+                try:
+                    retry_call(
+                        f=self._kill_cgroup_tasks,
+                        fargs=[controller],
+                        exceptions=TimeoutError,
+                        max_delay=5
+                    )
+                except TimeoutError:
+                    pass
+
+                # Remove cgroups and sub cgroups.
+                back_cmd = r'-depth -type d -exec rmdir {} \;'
+                cmd = 'find /sys/fs/cgroup/{}/{}/{} {}'.format(
+                    controller,
+                    FC_BINARY_NAME,
+                    self.jailer_id,
+                    back_cmd
                 )
-            except TimeoutError:
-                pass
+                # We do not need to know if it succeeded or not; afterall,
+                # we are trying to clean up resources created by the jailer
+                # itself not the testing system.
+                utils.run_cmd(cmd, ignore_return_code=True)
 
-            # As the files inside a cgroup aren't real, they can't need
-            # to be removed, that is why 'rm -rf' and 'rmdir' fail.
-            # We only need to remove the cgroup directories. The "-depth"
-            # argument tells find to do a depth first recursion, so that
-            # we remove any sub cgroups first if they are there.
-            back_cmd = r'-depth -type d -exec rmdir {} \;'
-            cmd = 'find /sys/fs/cgroup/{}/{}/{} {}'.format(
-                controller,
-                FC_BINARY_NAME,
-                self.jailer_id,
-                back_cmd
-            )
-            # We do not need to know if it succeeded or not; afterall, we are
-            # trying to clean up resources created by the jailer itself not
-            # the testing system.
-            utils.run_cmd(cmd, ignore_return_code=True)
-
-    def _kill_crgoup_tasks(self, controller):
+    def _kill_cgroup_tasks(self, controller):
         """Simulate wait on pid.
 
         Read the tasks file and stay there until /proc/{pid}

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -5,9 +5,8 @@
 import os
 import shutil
 import stat
-
+from pathlib import Path
 from retry.api import retry_call
-
 import framework.utils as utils
 from framework.defs import FC_BINARY_NAME
 
@@ -123,7 +122,7 @@ class JailerContext:
         return os.path.join(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
-            FC_BINARY_NAME,
+            Path(self.exec_file).name,
             self.jailer_id
         )
 

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -7,8 +7,7 @@ of the cartesian product of all artifact sets.
 """
 
 import os
-
-ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts/"
+from framework.artifacts import ARTIFACTS_LOCAL_ROOT
 
 
 class TestContext:

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -653,7 +653,8 @@ class Microvm:
     def pause_to_snapshot(self,
                           mem_file_path=None,
                           snapshot_path=None,
-                          diff=False):
+                          diff=False,
+                          version=None):
         """Pauses the microVM, and creates snapshot.
 
         This function validates that the microVM pauses successfully and
@@ -667,7 +668,8 @@ class Microvm:
 
         response = self.snapshot_create.put(mem_file_path=mem_file_path,
                                             snapshot_path=snapshot_path,
-                                            diff=diff)
+                                            diff=diff,
+                                            version=version)
         assert self.api_session.is_status_no_content(response.status_code)
 
     def resume_from_snapshot(self, mem_file_path, snapshot_path):

--- a/tests/framework/microvms.py
+++ b/tests/framework/microvms.py
@@ -108,7 +108,7 @@ class C3nano(VMBase):
                                   "2vcpu_256mb",
                                   "vmlinux-4.14",
                                   "ubuntu-18.04",
-                                  "C3"
+                                  "C3",
                                   start)
 
 
@@ -122,5 +122,5 @@ class C3micro(VMBase):
                                   "2vcpu_512mb",
                                   "vmlinux-4.14",
                                   "ubuntu-18.04",
-                                  "C3"
+                                  "C3",
                                   start)

--- a/tests/framework/microvms.py
+++ b/tests/framework/microvms.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Define helper functions that create predefined type of resources."""
+
+from framework.artifacts import ArtifactCollection
+from framework.builder import MicrovmBuilder
+import host_tools.network as net_tools
+from conftest import _test_images_s3_bucket
+
+
+class VmInstance:
+    """A class that describes a microvm instance resources."""
+
+    def __init__(self, config, kernel, disks, ssh_key, vm):
+        """Initialize a Vm configuration based on artifacts."""
+        self._config = config
+        self._kernel = kernel
+        self._disks = disks
+        self._ssh_key = ssh_key
+        self._vm = vm
+
+    @property
+    def config(self):
+        """Return machine config artifact."""
+        return self._config
+
+    @property
+    def kernel(self):
+        """Return the kernel artifact."""
+        return self._kernel
+
+    @property
+    def disks(self):
+        """Return an array of block file paths."""
+        return self._disks
+
+    @property
+    def ssh_key(self):
+        """Return ssh key artifact linked to the root block device."""
+        return self._ssh_key
+
+    @property
+    def vm(self):
+        """Return the Microvm object intsance."""
+        return self._vm
+
+
+# VM base class to abstract away the s3 artifacts we are using
+# to specify the configuration
+# Too few public methods (1/2) (too-few-public-methods)
+# pylint: disable=R0903
+class VMBase:
+    """Base class for constructing microvms."""
+
+    @classmethod
+    def from_artifacts(cls, bin_cloner_path, config,
+                       kernel, disks, cpu_template, start=False):
+        """Spawns a new Firecracker and applies specified config."""
+        artifacts = ArtifactCollection(_test_images_s3_bucket())
+        config = artifacts.microvms(keyword=config)[0]
+        kernel = artifacts.kernels(keyword=kernel)[0]
+        disks = artifacts.disks(keyword=disks)
+        config.download()
+        kernel.download()
+        attached_disks = []
+        for disk in disks:
+            disk.download()
+            attached_disks.append(disk.copy())
+
+        vm_builder = MicrovmBuilder(bin_cloner_path)
+
+        # SSH key is attached to root disk artifact.
+        # Builder will download ssh key in the VM root.
+        ssh_key = disks[0].ssh_key()
+
+        # Create a fresh microvm from aftifacts.
+        basevm = vm_builder.build(kernel=kernel,
+                                  disks=attached_disks,
+                                  ssh_key=ssh_key,
+                                  config=config,
+                                  cpu_template=cpu_template)
+
+        network_config = net_tools.UniqueIPv4Generator.instance()
+        # Host ip: 192.168.0.1
+        # Guest ip: 192.168.0.2
+        # TODO: we need to refactor the network config using artifacts.
+        basevm.ssh_network_config(network_config,
+                                  '1',
+                                  tapname="tap0")
+        if start:
+            basevm.start()
+            ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+
+            # Verify if we can run commands in guest via ssh.
+            exit_code, _, _ = ssh_connection.execute_command("sync")
+            assert exit_code == 0
+
+        return VmInstance(config, kernel, attached_disks, ssh_key, basevm)
+
+
+class C3nano(VMBase):
+    """Create VMs with 2vCPUs and 256 MB RAM."""
+
+    @classmethod
+    def spawn(cls, bin_cloner_path, start=False):
+        """Spawns and optionally starts the vm."""
+        return cls.from_artifacts(bin_cloner_path,
+                                  "2vcpu_256mb",
+                                  "vmlinux-4.14",
+                                  "ubuntu-18.04",
+                                  "C3"
+                                  start)
+
+
+class C3micro(VMBase):
+    """Create VMs with 2vCPUs and 512 MB RAM."""
+
+    @classmethod
+    def spawn(cls, bin_cloner_path, start=False):
+        """Spawns and optionally starts the vm."""
+        return cls.from_artifacts(bin_cloner_path,
+                                  "2vcpu_512mb",
+                                  "vmlinux-4.14",
+                                  "ubuntu-18.04",
+                                  "C3"
+                                  start)

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import re
+import subprocess
 import threading
 import typing
 
@@ -190,3 +191,9 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
         run_cmd_async(cmd=cmd,
                       ignore_return_code=ignore_return_code,
                       no_shell=no_shell))
+
+
+def is_amd():
+    """Return true if running on AMD cpus."""
+    brand_str = subprocess.check_output("lscpu", shell=True).strip().decode()
+    return 'AuthenticAMD' in brand_str

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 import threading
 import typing
-
+from enum import Enum, auto
 from collections import namedtuple
 
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
@@ -193,7 +193,16 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
                       no_shell=no_shell))
 
 
-def is_amd():
-    """Return true if running on AMD cpus."""
+class CpuVendor(Enum):
+    """CPU vendors enum."""
+
+    AMD = auto()
+    INTEL = auto()
+
+
+def get_cpu_vendor():
+    """Return the CPU vendor."""
     brand_str = subprocess.check_output("lscpu", shell=True).strip().decode()
-    return 'AuthenticAMD' in brand_str
+    if 'AuthenticAMD' in brand_str:
+        return CpuVendor.AMD
+    return CpuVendor.INTEL

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.70, "AMD": 84.68}
+COVERAGE_DICT = {"Intel": 85.08, "AMD": 85.00}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.58, "AMD": 84.57}
+COVERAGE_DICT = {"Intel": 84.70, "AMD": 84.68}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -4,37 +4,9 @@
 
 import platform
 import re
-
-from enum import Enum, auto
-
 import pytest
-
+from framework.utils import CpuVendor, get_cpu_vendor
 import host_tools.network as net_tools  # pylint: disable=import-error
-
-
-class CpuVendor(Enum):
-    """CPU vendors enum."""
-
-    AMD = auto()
-    INTEL = auto()
-
-
-def _get_cpu_vendor():
-    cif = open('/proc/cpuinfo', 'r')
-    host_vendor_id = None
-    while True:
-        line = cif.readline()
-        if line == '':
-            break
-        mo = re.search("^vendor_id\\s+:\\s+(.+)$", line)
-        if mo:
-            host_vendor_id = mo.group(1)
-    cif.close()
-    assert host_vendor_id is not None
-
-    if host_vendor_id == "AuthenticAMD":
-        return CpuVendor.AMD
-    return CpuVendor.INTEL
 
 
 def _check_guest_cmd_output(test_microvm, guest_cmd, expected_header,
@@ -115,7 +87,7 @@ def _check_cache_topology(test_microvm, num_vcpus_on_lvl_1_cache,
     expected_lvl_3_str = '{} ({})'.format(hex(num_vcpus_on_lvl_3_cache),
                                           num_vcpus_on_lvl_3_cache)
 
-    cpu_vendor = _get_cpu_vendor()
+    cpu_vendor = get_cpu_vendor()
     if cpu_vendor == CpuVendor.AMD:
         expected_level_1_topology = {
             "level": '0x1 (1)',
@@ -288,7 +260,7 @@ def test_brand_string(test_microvm_with_ssh, network_config):
     guest_brand_string = mo.group(1)
     assert guest_brand_string
 
-    cpu_vendor = _get_cpu_vendor()
+    cpu_vendor = get_cpu_vendor()
     expected_guest_brand_string = ""
     if cpu_vendor == CpuVendor.AMD:
         expected_guest_brand_string += "AMD EPYC"

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -3,6 +3,7 @@
 """Tests scenarios for shutting down Firecracker/VM."""
 import os
 import time
+import json
 
 import framework.utils as utils
 
@@ -52,6 +53,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # Rebooting Firecracker sends an exit event and should gracefully kill.
     # the instance.
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+
     ssh_connection.execute_command("reboot")
 
     while True:
@@ -65,3 +67,6 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # Consume existing metrics
     lines = metrics_fifo.sequential_reader(100)
     assert len(lines) == 1
+
+    # Make sure that the FC process was not killed by a seccomp fault
+    assert json.loads(lines[0])["seccomp"]["num_faults"] == 0

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -4,8 +4,11 @@
 
 import json
 import os
-from signal import SIGBUS, SIGRTMIN, SIGSEGV
+from signal import \
+    (SIGBUS, SIGRTMIN, SIGSEGV, SIGXFSZ,
+     SIGXCPU, SIGPIPE, SIGHUP, SIGILL)
 from time import sleep
+import resource as res
 import pytest
 
 import host_tools.network as net_tools
@@ -14,15 +17,20 @@ import framework.utils as utils
 signum_str = {
     SIGBUS: "sigbus",
     SIGSEGV: "sigsegv",
+    SIGXFSZ: "sigxfsz",
+    SIGXCPU: "sigxcpu",
+    SIGPIPE: "sigpipe",
+    SIGHUP: "sighup",
+    SIGILL: "sigill",
 }
 
 
 @pytest.mark.parametrize(
     "signum",
-    [SIGBUS, SIGSEGV]
+    [SIGBUS, SIGSEGV, SIGXFSZ, SIGXCPU, SIGPIPE, SIGHUP, SIGILL]
 )
-def test_sigbus_sigsegv(test_microvm_with_api, signum):
-    """Test signal handling for `SIGBUS` and `SIGSEGV`."""
+def test_generic_signal_handler(test_microvm_with_api, signum):
+    """Test signal handling for all handled signals."""
     microvm = test_microvm_with_api
     microvm.spawn()
 
@@ -56,6 +64,54 @@ def test_sigbus_sigsegv(test_microvm_with_api, signum):
 
     metric_line = json.loads(metrics_fd.readlines()[0])
     assert metric_line["signals"][signum_str[signum]] == 1
+
+
+def test_sigxfsz_handler(test_microvm_with_api):
+    """Test intercepting and handling SIGXFSZ."""
+    microvm = test_microvm_with_api
+    microvm.spawn()
+
+    # We don't need to monitor the memory for this test.
+    microvm.memory_monitor = None
+
+    microvm.basic_config()
+
+    # Configure metrics based on a file.
+    metrics_path = os.path.join(microvm.path, 'metrics_fifo')
+    utils.run_cmd("touch {}".format(metrics_path))
+    response = microvm.metrics.put(
+        metrics_path=microvm.create_jailed_resource(metrics_path)
+    )
+    assert microvm.api_session.is_status_no_content(response.status_code)
+
+    microvm.start()
+
+    metrics_jail_path = os.path.join(microvm.jailer.chroot_path(),
+                                     metrics_path)
+    metrics_fd = open(metrics_jail_path)
+    line_metrics = metrics_fd.readlines()
+    print(line_metrics)
+    assert len(line_metrics) == 1
+
+    firecracker_pid = int(microvm.jailer_clone_pid)
+    size = os.path.getsize(metrics_jail_path)
+    # The SIGXFSZ is triggered because the size of rootfs is bigger than
+    # the size of metrics file times 3. Since the metrics file is flushed
+    # twice we have to make sure that the limit is bigger than that
+    # in order to make sure the SIGXFSZ metric is logged
+    res.prlimit(firecracker_pid, res.RLIMIT_FSIZE, (size*3, res.RLIM_INFINITY))
+
+    while True:
+        try:
+            utils.run_cmd("ps -p {}".format(firecracker_pid))
+            sleep(1)
+        except ChildProcessError:
+            break
+
+    msg = 'Shutting down VM after intercepting signal 25, code 0'
+    microvm.check_log_message(msg)
+    metric_line = json.loads(metrics_fd.readlines()[0])
+    assert metric_line["signals"]["sigxfsz"] == 1
 
 
 def test_handled_signals(test_microvm_with_ssh, network_config):

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Basic tests scenarios for snapshot save/restore."""
+
+import logging
+import platform
+import pytest
+from conftest import _test_images_s3_bucket
+from framework.artifacts import ArtifactCollection
+from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.microvms import SmallVM
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_restore_from_past_versions(bin_cloner_path):
+    """Test scenario: restore all previous version snapshots."""
+    logger = logging.getLogger("snapshot_version")
+
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all snapshots artifacts.
+    # "fc_release" is the key that should be used for per release snapshot
+    # artifacts. Such snapshots are created at release time and target the
+    # current version. We are going to restore all these snapshots with current
+    # testing build.
+    snapshot_artifacts = artifacts.snapshots(keyword="fc_release")
+    builder = MicrovmBuilder(bin_cloner_path)
+
+    for snapshot_artifact in snapshot_artifacts:
+        snapshot_artifact.download()
+        snapshot = snapshot_artifact.copy(builder.root_path)
+
+        logger.info("Resuming from %s", snapshot_artifact.key)
+
+        # TODO: Define network config artifact that can be used to build
+        # new vms or can be used as part of the snapshot
+        # For now we are good with theses hardcoded values
+        microvm, _ = builder.build_from_snapshot(snapshot,
+                                                 "192.168.0.1",
+                                                 "192.168.0.2",
+                                                 30,
+                                                 True,
+                                                 False)
+        # Attempt to connect to resumed microvm.
+        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+
+        # Run a fio workload and validate succesfull execution.
+        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+        --ioengine=libaio --iodepth=16 --runtime=2 --numjobs=4 --time_based \
+        --group_reporting --name=iops-test-job --eta-newline=1 --readonly"""
+
+        exit_code, _, _ = ssh_connection.execute_command(fio)
+        assert exit_code == 0
+
+
+def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None):
+    """Create a snapshoft from a 2vcpu 512MB microvm."""
+    vm_instance = SmallVM.spawn(bin_cloner_path, True)
+    # Create a snapshot builder from a microvm.
+    snapshot_builder = SnapshotBuilder(vm_instance.vm)
+
+    # The snapshot builder expects disks as paths, not artifacts.
+    disks = []
+    for disk in vm_instance.disks:
+        disks.append(disk.local_path())
+
+    snapshot = snapshot_builder.create(disks,
+                                       vm_instance.ssh_key,
+                                       SnapshotType.FULL,
+                                       target_version)
+
+    vm_instance.vm.kill()
+    return snapshot
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_restore_in_past_versions(bin_cloner_path):
+    """Test scenario: create a snapshot and restore in previous versions."""
+    logger = logging.getLogger("snapshot_version")
+
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all snapshots artifacts.
+    # "fc_release" is the key that should be used for per release snapshot
+    # artifacts. Such snapshots are created at release time and target the
+    # current version. We are going to restore all these snapshots with current
+    # testing build.
+    firecracker_artifacts = artifacts.firecrackers()
+    for firecracker in firecracker_artifacts:
+        firecracker.download()
+        jailer = firecracker.jailer()
+        jailer.download()
+        # The target version is in the name of the firecracker binary from S3.
+        # We also strip the "v" as fc expects X.Y.Z version string.
+        target_version = firecracker.base_name()[1:]
+        logger.info("Creating snapshot for version: %s", target_version)
+
+        # Create a fresh snapshot targeted at the binary artifact version.
+        snapshot = create_512mb_full_snapshot(bin_cloner_path, target_version)
+
+        builder = MicrovmBuilder(bin_cloner_path,
+                                 firecracker.local_path(),
+                                 jailer.local_path())
+        microvm, _ = builder.build_from_snapshot(snapshot,
+                                                 "192.168.0.1",
+                                                 "192.168.0.2",
+                                                 30,
+                                                 True,
+                                                 False)
+
+        logger.info("Using Firecracker: %s", firecracker.local_path())
+        logger.info("Using Jailer: %s", jailer.local_path())
+
+        # Attempt to connect to resumed microvm.
+        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+
+        # Run a fio workload and validate succesfull execution.
+        fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+        --ioengine=libaio --iodepth=16 --runtime=2 --numjobs=4 --time_based \
+        --group_reporting --name=iops-test-job --eta-newline=1 --readonly"""
+
+        exit_code, _, _ = ssh_connection.execute_command(fio)
+        assert exit_code == 0

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.microvms import SmallVM
+from framework.microvms import C3micro
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 
@@ -58,7 +58,7 @@ def test_restore_from_past_versions(bin_cloner_path):
 
 def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None):
     """Create a snapshoft from a 2vcpu 512MB microvm."""
-    vm_instance = SmallVM.spawn(bin_cloner_path, True)
+    vm_instance = C3micro.spawn(bin_cloner_path, True)
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(vm_instance.vm)
 

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -11,6 +11,7 @@ from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.utils import is_amd
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.logging as log_tools
 
@@ -213,7 +214,7 @@ def test_snapshot_create_latency(network_config,
 
 
 @pytest.mark.skipif(
-    platform.machine() != "x86_64",
+    platform.machine() != "x86_64" or is_amd(),
     reason="Not supported yet."
 )
 def test_snapshot_resume_latency(network_config,
@@ -254,7 +255,7 @@ def test_snapshot_resume_latency(network_config,
 
 
 @pytest.mark.skipif(
-    platform.machine() != "x86_64",
+    platform.machine() != "x86_64" or is_amd(),
     reason="Not supported yet."
 )
 def test_older_snapshot_resume_latency(bin_cloner_path):

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -182,7 +182,6 @@ kernel {}, disk {} """.format(snapshot_type,
 
         baseline = LOAD_LATENCY_BASELINES[context.microvm.name()]
         logger.info("Latency {}/{}: {} ms".format(i + 1, SAMPLE_COUNT, value))
-        value = value
         assert baseline > value, "LoadSnapshot latency degraded."
 
         microvm.kill()
@@ -272,8 +271,7 @@ def test_snapshot_resume_latency(network_config,
     platform.machine() != "x86_64",
     reason="Not supported yet."
 )
-def test_older_snapshot_resume_latency(network_config,
-                                       bin_cloner_path):
+def test_older_snapshot_resume_latency(bin_cloner_path):
     """Test scenario: Older snapshot load performance measurement."""
     logger = logging.getLogger("old_snapshot_load")
 
@@ -286,7 +284,7 @@ def test_older_snapshot_resume_latency(network_config,
         for i in range(SAMPLE_COUNT):
             snapshot = artifact.copy(builder.root_path)
 
-            logger.info("Resuming from {}".format(artifact.key))
+            logger.info("Resuming from %s", artifact.key)
 
             # TODO: Define network config artifact that can be used to build
             # new vms or can be used as part of the snapshot
@@ -308,11 +306,11 @@ def test_older_snapshot_resume_latency(network_config,
             metrics = microvm.get_all_metrics(metrics_fifo)
             for data_point in metrics:
                 metrics = json.loads(data_point)
-                cur_value = metrics['latencies_us']['load_snapshot'] / USEC_IN_MSEC
+                cur_value = metrics['latencies_us']['load_snapshot']
                 if cur_value > 0:
-                    value = cur_value
+                    value = cur_value / USEC_IN_MSEC
                     break
 
             baseline = LOAD_LATENCY_BASELINES[artifact.name]
-            logger.info("Latency {}/{}: {} ms".format(i + 1, SAMPLE_COUNT, value))
+            logger.info("Latency %s/%s: %s ms", i + 1, SAMPLE_COUNT, value)
             assert baseline > value, "LoadSnapshot latency degraded."

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -40,7 +40,7 @@ LOAD_LATENCY_BASELINES = {
     '2vcpu_512mb.json': 8,
     # We are also tracking restore from older version latency.
     # Snapshot properties: 2vCPU, 512MB RAM, 1 disk, 1 network iface.
-    'fc_release_v0.22': 8,
+    'fc_release_v0.23': 8,
 }
 
 
@@ -126,17 +126,6 @@ kernel {}, disk {} """.format(snapshot_type,
                               config=context.microvm,
                               enable_diff_snapshots=enable_diff_snapshots)
 
-    host_ip = None
-    guest_ip = None
-    netmask_len = None
-    network_config = net_tools.UniqueIPv4Generator.instance()
-    _, host_ip, guest_ip = basevm.ssh_network_config(network_config,
-                                                     iface_id='1',
-                                                     tapname="tap0")
-    logger.debug("Host IP: {}, Guest IP: {}".format(host_ip, guest_ip))
-
-    # # We will need netmask_len in build_from_snapshot() call later.
-    netmask_len = network_config.get_netmask_len()
     basevm.start()
     ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
 
@@ -157,9 +146,6 @@ kernel {}, disk {} """.format(snapshot_type,
     for i in range(SAMPLE_COUNT):
         microvm, metrics_fifo = vm_builder.build_from_snapshot(
                                                 snapshot,
-                                                host_ip,
-                                                guest_ip,
-                                                netmask_len,
                                                 True,
                                                 enable_diff_snapshots)
 
@@ -290,9 +276,6 @@ def test_older_snapshot_resume_latency(bin_cloner_path):
             # new vms or can be used as part of the snapshot
             # For now we are good with theses hardcoded values
             microvm, metrics_fifo = builder.build_from_snapshot(snapshot,
-                                                                "192.168.0.1",
-                                                                "192.168.0.2",
-                                                                30,
                                                                 True,
                                                                 False)
             # Attempt to connect to resumed microvm.


### PR DESCRIPTION
## Reason for This PR

During initial audit, I forgot to allow the `TIOCGWINSZ` param for the `ioctl` syscall.
This was not caught by the CI, because this param is used while shutting down the VM, and the bad syscall signal also resulted in exiting the process.
This was caught by running the test suite after removing the `exit()` call in the `sigsys_handler`.

**Because of a rebase from master, there are many commits in this PR. You only need to review the [latest commit](https://github.com/firecracker-microvm/firecracker/pull/2132/commits/9bd6f1f360d234d069d8e8d49189bbf2522b6014)**

## Description of Changes

Allow `TIOCGWINSZ` as a param for `ioctl`
Updated the `test_shut_down.py` test. Now it checks that the process was not killed due to a seccomp fault. This is what caused the bug.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
