### PR TITLE
docs: add documentation on snapshot uniqueness

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -241,7 +241,7 @@ reason, the wall-clock should be updated to the current time, on the guest-side.
 More details on how you could do this can be found at a
 [related FAQ](../../FAQ.md#my-guest-wall-clock-is-drifting-how-can-i-fix-it).
 
-### Important notes
+### Provisioning host disk space for snapshots
 
 Depending on VM memory size, snapshots can consume a lot of disk space. Firecracker 
 integrators **must** ensure that the provisioned disk space is sufficient for normal


### PR DESCRIPTION
## Reason for This PR

When snapshots are used in a such a manner that a given guest's state is resumed from more than once, guest information assumed to be unique may in fact not be; this information can include identifiers, random numbers and random number seeds, as well as cryptographic tokens. Without a strong mechanism that enables users to guarantee that unique things stay
unique across snapshot restores, we consider resuming execution from the same state more than once insecure.

This PR adds documentation about this, including examples.

We also outline a possible path forward, [referencing](https://lkml.org/lkml/2020/10/16/629) the discussion about Linux guest operating system handling this situation on lkml.

## Description of Changes

- Add documentation about the effects of resuming execution multiple times from the same state, with 3 examples.
- Update snapshot disk space topic heading.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
