### PR TITLE
make CPU templates vendor specific

### DIFF
--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -8,15 +8,21 @@ use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
 
 use crate::cpu_leaf::*;
 
+/// Intel brand string.
 pub const VENDOR_ID_INTEL: &[u8; 12] = b"GenuineIntel";
+/// AMD brand string.
 pub const VENDOR_ID_AMD: &[u8; 12] = b"AuthenticAMD";
 
+/// cpuid related error.
 #[derive(Clone, Debug)]
 pub enum Error {
+    /// The function was called with invalid parameters.
     InvalidParameters(String),
+    /// Function not supported on the current architecture.
     NotSupported,
 }
 
+/// Extract entry from the cpuid.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
     // TODO: replace with validation based on `has_cpuid()` when it becomes stable:

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -18,8 +18,8 @@ use crate::common::*;
 pub mod bit_helper;
 
 mod template;
-pub use crate::template::c3;
-pub use crate::template::t2;
+pub use crate::template::intel::c3;
+pub use crate::template::intel::t2;
 
 mod cpu_leaf;
 

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -11,7 +11,8 @@
 #![cfg(target_arch = "x86_64")]
 use kvm_bindings::CpuId;
 
-mod common;
+/// cpuid utility functions.
+pub mod common;
 use crate::common::*;
 
 /// Contains helper methods for bit operations.

--- a/src/cpuid/src/template/intel/c3.rs
+++ b/src/cpuid/src/template/intel/c3.rs
@@ -3,6 +3,7 @@
 
 use crate::bit_helper::BitHelper;
 use crate::cpu_leaf::*;
+use crate::template::intel::validate_vendor_id;
 use crate::transformer::*;
 use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 
@@ -19,10 +20,10 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         .write_bits_in_range(&eax::PROCESSOR_TYPE_BITRANGE, 0)
         // Processor Family = 6
         .write_bits_in_range(&eax::PROCESSOR_FAMILY_BITRANGE, 6)
-        // Processor Model = 15
-        .write_bits_in_range(&eax::PROCESSOR_MODEL_BITRANGE, 15)
-        // Stepping = 2
-        .write_bits_in_range(&eax::STEPPING_BITRANGE, 2);
+        // Processor Model = 14
+        .write_bits_in_range(&eax::PROCESSOR_MODEL_BITRANGE, 14)
+        // Stepping = 4
+        .write_bits_in_range(&eax::STEPPING_BITRANGE, 4);
 
     // Disable Features
     entry
@@ -33,8 +34,10 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         .write_bit(ecx::TM2_BITINDEX, false)
         .write_bit(ecx::CNXT_ID_BITINDEX, false)
         .write_bit(ecx::SDBG_BITINDEX, false)
+        .write_bit(ecx::FMA_BITINDEX, false)
         .write_bit(ecx::XTPR_UPDATE_BITINDEX, false)
         .write_bit(ecx::PDCM_BITINDEX, false)
+        .write_bit(ecx::MOVBE_BITINDEX, false)
         .write_bit(ecx::OSXSAVE_BITINDEX, false);
 
     entry
@@ -59,8 +62,12 @@ fn update_structured_extended_entry(
         entry
             .ebx
             .write_bit(ebx::SGX_BITINDEX, false)
+            .write_bit(ebx::BMI1_BITINDEX, false)
             .write_bit(ebx::HLE_BITINDEX, false)
+            .write_bit(ebx::AVX2_BITINDEX, false)
             .write_bit(ebx::FPDP_BITINDEX, false)
+            .write_bit(ebx::BMI2_BITINDEX, false)
+            .write_bit(ebx::INVPCID_BITINDEX, false)
             .write_bit(ebx::RTM_BITINDEX, false)
             .write_bit(ebx::RDT_M_BITINDEX, false)
             .write_bit(ebx::RDT_A_BITINDEX, false)
@@ -135,17 +142,20 @@ fn update_extended_feature_info_entry(
 ) -> Result<(), Error> {
     use crate::cpu_leaf::leaf_0x80000001::*;
 
-    entry.ecx.write_bit(ecx::PREFETCH_BITINDEX, false);
+    entry
+        .ecx
+        .write_bit(ecx::PREFETCH_BITINDEX, false)
+        .write_bit(ecx::LZCNT_BITINDEX, false);
 
     entry.edx.write_bit(edx::PDPE1GB_BITINDEX, false);
 
     Ok(())
 }
 
-/// Sets up the cpuid entries for a given VCPU following a T2 template.
-struct T2CpuidTransformer {}
+/// Sets up the cpuid entries for a given VCPU following a C3 template.
+struct C3CpuidTransformer {}
 
-impl CpuidTransformer for T2CpuidTransformer {
+impl CpuidTransformer for C3CpuidTransformer {
     fn entry_transformer_fn(&self, entry: &mut kvm_cpuid_entry2) -> Option<EntryTransformerFn> {
         match entry.function {
             leaf_0x1::LEAF_NUM => Some(update_feature_info_entry),
@@ -157,7 +167,8 @@ impl CpuidTransformer for T2CpuidTransformer {
     }
 }
 
-/// Sets up the cpuid entries for a given VCPU following a T2 template.
+/// Sets up the cpuid entries for a given VCPU following a C3 template.
 pub fn set_cpuid_entries(kvm_cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
-    T2CpuidTransformer {}.process_cpuid(kvm_cpuid, vm_spec)
+    validate_vendor_id()?;
+    C3CpuidTransformer {}.process_cpuid(kvm_cpuid, vm_spec)
 }

--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -1,0 +1,16 @@
+/// Follows a C3 template in setting up the CPUID.
+pub mod c3;
+/// Follows a T2 template in setting up the CPUID.
+pub mod t2;
+
+use crate::common::{get_vendor_id, VENDOR_ID_INTEL};
+use crate::transformer::Error;
+
+pub fn validate_vendor_id() -> Result<(), Error> {
+    let vendor_id = get_vendor_id().map_err(Error::InternalError)?;
+    if &vendor_id != VENDOR_ID_INTEL {
+        return Err(Error::InvalidVendor);
+    }
+
+    Ok(())
+}

--- a/src/cpuid/src/template/mod.rs
+++ b/src/cpuid/src/template/mod.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Follows a C3 template in setting up the CPUID.
-pub mod c3;
-/// Follows a T2 template in setting up the CPUID.
-pub mod t2;
+// Contains Intel specific templates.
+pub mod intel;

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -60,6 +60,8 @@ pub enum Error {
     FamError(utils::fam::Error),
     /// A call to an internal helper method failed
     InternalError(super::common::Error),
+    /// The operation is not permitted for the current vendor
+    InvalidVendor,
     /// The maximum number of addressable logical CPUs cannot be stored in an `u8`.
     VcpuCountOverflow,
 }

--- a/tests/framework/microvms.py
+++ b/tests/framework/microvms.py
@@ -95,7 +95,7 @@ class VMBase:
         return VmInstance(config, kernel, attached_disks, ssh_key, basevm)
 
 
-class C3nano(VMBase):
+class VMNano(VMBase):
     """Create VMs with 2vCPUs and 256 MB RAM."""
 
     @classmethod
@@ -106,13 +106,13 @@ class C3nano(VMBase):
                                      "2vcpu_256mb",
                                      "vmlinux-4.14",
                                      "ubuntu-18.04",
-                                     "C3",
+                                     None,
                                      start,
                                      fc_binary,
                                      jailer_binary)
 
 
-class C3micro(VMBase):
+class VMMicro(VMBase):
     """Create VMs with 2vCPUs and 512 MB RAM."""
 
     @classmethod
@@ -123,7 +123,7 @@ class C3micro(VMBase):
                                      "2vcpu_512mb",
                                      "vmlinux-4.14",
                                      "ubuntu-18.04",
-                                     "C3",
+                                     None,
                                      start,
                                      fc_binary,
                                      jailer_binary)

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.08, "AMD": 85.00}
+COVERAGE_DICT = {"Intel": 85.08, "AMD": 84.28}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -4,7 +4,7 @@
 
 import platform
 import pytest
-from framework.microvms import C3nano
+from framework.microvms import VMNano
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 
@@ -14,7 +14,7 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 )
 def test_pause_resume(bin_cloner_path):
     """Test scenario: boot/pause/resume."""
-    vm_instance = C3nano.spawn(bin_cloner_path)
+    vm_instance = VMNano.spawn(bin_cloner_path)
     microvm = vm_instance.vm
 
     # Pausing the microVM before being started is not allowed.

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -13,7 +13,7 @@ from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.utils_vsock import make_blob, \
     check_host_connections, check_guest_connections
-from framework.microvms import C3nano
+from framework.microvms import VMNano
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.drive as drive_tools
 
@@ -161,7 +161,7 @@ def test_patch_drive_snapshot(bin_cloner_path):
     enable_diff_snapshots = False
 
     # Use a predefined vm instance.
-    vm_instance = C3nano.spawn(bin_cloner_path)
+    vm_instance = VMNano.spawn(bin_cloner_path)
     basevm = vm_instance.vm
     root_disk = vm_instance.disks[0]
     ssh_key = vm_instance.ssh_key

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.microvms import C3micro
+from framework.microvms import VMMicro
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 
@@ -51,7 +51,7 @@ def test_restore_from_past_versions(bin_cloner_path):
 def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None,
                                fc_binary=None, jailer_binary=None):
     """Create a snapshoft from a 2vcpu 512MB microvm."""
-    vm_instance = C3micro.spawn(bin_cloner_path, True,
+    vm_instance = VMMicro.spawn(bin_cloner_path, True,
                                 fc_binary, jailer_binary)
     # Attempt to connect to the fresh microvm.
     ssh_connection = net_tools.SSHConnection(vm_instance.vm.ssh_config)

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -10,7 +10,7 @@ import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.matrix import TestMatrix, TestContext
-from framework.microvms import C3micro
+from framework.microvms import VMMicro
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.utils import CpuVendor, get_cpu_vendor
 import host_tools.network as net_tools  # pylint: disable=import-error
@@ -279,7 +279,7 @@ def test_older_snapshot_resume_latency(bin_cloner_path):
 
         for i in range(SAMPLE_COUNT):
             # Create a fresh microvm with the binary artifacts.
-            vm_instance = C3micro.spawn(bin_cloner_path, True,
+            vm_instance = VMMicro.spawn(bin_cloner_path, True,
                                         firecracker.local_path(),
                                         jailer.local_path())
             # Attempt to connect to the fresh microvm.


### PR DESCRIPTION
## Reason for This PR

#2130 

## Description of Changes

For the moment we have 2 CPUID templates: T2 and C3. They are both Intel-specific.

We have to store this information and validate it when applying a template. We shouldn't be able to apply Intel templates on AMD or vice-versa.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
