### PR TITLE
Fix superseded advice about region choice for EC2 bare metal

### DIFF
--- a/docs/dev-machine-setup.md
+++ b/docs/dev-machine-setup.md
@@ -62,9 +62,7 @@ Firecracker development environment on AWS can be setup using bare metal instanc
 Follow these steps to create a bare metal instance.
 
 1. If you don't already have an AWS account, create one using the [AWS Portal](https://portal.aws.amazon.com/billing/signup).
-1. Login to [AWS console](https://console.aws.amazon.com/console/home?region=us-east-1). Bare metal instances are
- only supported in `US East (N. Virginia)` region at this time. This
-region is preselected for you in the Console.
+1. Login to [AWS console](https://console.aws.amazon.com/console/home). You must select a region that offers bare metal EC2 instances. To check which regions support bare-metal, visit [Amazon EC2 On-Demand Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) and look for `*.metal` instance types.
 1. Click on `Launch a virtual machine` in `Build Solution` section.
 1. Firecracker requires a relatively new kernel, so you should use a recent
 Linux distribution - such as `Ubuntu Server 18.04 LTS (HVM), SSD Volume Type`.


### PR DESCRIPTION
## Reason for This PR

Outdated information in [Setting up a Development Environment for Firecracker](https://github.com/firecracker-microvm/firecracker/blob/22908c9fb0cd5fb20febc5d18ff1284caa5f3a53/docs/dev-machine-setup.md#readme)

## Description of Changes

Replace cautionary note that AWS only provide bare-metal instances in one region; these are now more widely available.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
