### PR TITLE
Added dirty page tracking functionality to local vm-memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ version = "0.1.0"
 name = "vm-memory"
 version = "0.1.0"
 dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/vm-memory/Cargo.toml
+++ b/src/vm-memory/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2018"
 
 [dependencies]
 vm-memory-upstream = { package = "vm-memory", version = ">=0.2.2", features = ["backend-mmap"] }
-
-[dev-dependencies]
+libc = ">=0.2.39"
 vmm-sys-util = ">= 0.4.0"

--- a/src/vm-memory/src/mmap.rs
+++ b/src/vm-memory/src/mmap.rs
@@ -22,7 +22,9 @@ use vm_memory_upstream::address::Address;
 use vm_memory_upstream::guest_memory::{
     self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
 };
-use vm_memory_upstream::volatile_memory::{VolatileMemory, VolatileSlice};
+use vm_memory_upstream::volatile_memory::{
+    Error as VolatileMemoryError, VolatileMemory, VolatileSlice,
+};
 use vm_memory_upstream::{ByteValued, Bytes};
 
 use vmm_sys_util::errno;
@@ -107,15 +109,16 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     type E = guest_memory::Error;
 
     fn write(&self, buf: &[u8], addr: MemoryRegionAddress) -> guest_memory::Result<usize> {
-        // TODO: here be write!
         let maddr = addr.raw_value() as usize;
-        self.local_volatile_slice()
+        let bytes = self
+            .local_volatile_slice()
             .write(buf, maddr)
-            .map_err(Into::into)
+            .map_err(Into::<guest_memory::Error>::into)?;
+        self.mark_dirty_pages(maddr, bytes);
+        Ok(bytes)
     }
 
     fn read(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> guest_memory::Result<usize> {
-        // TODO: here be read!
         let maddr = addr.raw_value() as usize;
         self.local_volatile_slice()
             .read(buf, maddr)
@@ -123,15 +126,22 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     }
 
     fn write_slice(&self, buf: &[u8], addr: MemoryRegionAddress) -> guest_memory::Result<()> {
-        // TODO: here be write!
         let maddr = addr.raw_value() as usize;
-        self.local_volatile_slice()
-            .write_slice(buf, maddr)
-            .map_err(Into::into)
+        match self.local_volatile_slice().write_slice(buf, maddr) {
+            Ok(()) => {
+                self.mark_dirty_pages(maddr, buf.len());
+                Ok(())
+            }
+            Err(e) => {
+                if let VolatileMemoryError::PartialBuffer { completed, .. } = e {
+                    self.mark_dirty_pages(maddr, completed);
+                }
+                Err(e.into())
+            }
+        }
     }
 
     fn read_slice(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> guest_memory::Result<()> {
-        // TODO: here be read!
         let maddr = addr.raw_value() as usize;
         self.local_volatile_slice()
             .read_slice(buf, maddr)
@@ -164,11 +174,13 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     where
         F: Read,
     {
-        // TODO: here be write!
         let maddr = addr.raw_value() as usize;
-        self.local_volatile_slice()
+        let bytes = self
+            .local_volatile_slice()
             .read_from::<F>(maddr, src, count)
-            .map_err(Into::into)
+            .map_err(Into::<guest_memory::Error>::into)?;
+        self.mark_dirty_pages(maddr, bytes);
+        Ok(bytes)
     }
 
     fn read_exact_from<F>(
@@ -180,11 +192,12 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     where
         F: Read,
     {
-        // TODO: here be write!
         let maddr = addr.raw_value() as usize;
         self.local_volatile_slice()
             .read_exact_from::<F>(maddr, src, count)
-            .map_err(Into::into)
+            .map_err(Into::<guest_memory::Error>::into)?;
+        self.mark_dirty_pages(maddr, count);
+        Ok(())
     }
 
     fn write_to<F>(
@@ -196,7 +209,6 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     where
         F: Write,
     {
-        // TODO: here be read!
         let maddr = addr.raw_value() as usize;
         self.local_volatile_slice()
             .write_to::<F>(maddr, dst, count)
@@ -212,7 +224,6 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     where
         F: Write,
     {
-        // TODO: here be read!
         let maddr = addr.raw_value() as usize;
         self.local_volatile_slice()
             .write_all_to::<F>(maddr, dst, count)
@@ -537,6 +548,55 @@ mod tests {
         // does not override the bitmap
         mmap.enable_dirty_page_tracking();
         assert!(mmap.dirty_bitmap().unwrap().is_addr_set(128));
+    }
+
+    #[test]
+    fn test_bitmap_update_on_write() {
+        let page_size = 4096 as usize;
+        let mut mmap =
+            GuestRegionMmap::new(MmapRegion::new(page_size * 5).unwrap(), GuestAddress(0x0))
+                .unwrap();
+        mmap.enable_dirty_page_tracking();
+
+        // check write_obj
+        let sample_val = 0xaa55_aa55_aa55_aa55 as u64;
+        assert!(!mmap.dirty_bitmap().unwrap().is_addr_set(0));
+        assert!(mmap.write_obj(sample_val, MemoryRegionAddress(0)).is_ok());
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(0));
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size - 1));
+
+        // check write; dirty same page twice
+        let sample_buf = [1, 2, 3];
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(100));
+        assert!(mmap.write(&sample_buf, MemoryRegionAddress(100)).is_ok());
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(100));
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(102));
+
+        // check read_from
+        let mut file = File::open(Path::new("/dev/zero")).unwrap();
+        assert!(!mmap.dirty_bitmap().unwrap().is_addr_set(page_size));
+        assert!(mmap
+            .read_from(
+                MemoryRegionAddress(page_size as u64),
+                &mut file,
+                mem::size_of::<u32>()
+            )
+            .is_ok());
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size));
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size * 2 - 1));
+
+        // check read_exact_from; dirty multiple pages
+        assert!(!mmap.dirty_bitmap().unwrap().is_addr_set(page_size * 2));
+        assert!(mmap
+            .read_exact_from(
+                MemoryRegionAddress(page_size as u64 * 2),
+                &mut file,
+                page_size * 2 + 1
+            )
+            .is_ok());
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size * 2));
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size * 3));
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(page_size * 4));
     }
 
     fn check_guest_memory_mmap(
@@ -1014,14 +1074,17 @@ mod tests {
         let bad_addr2 = GuestAddress(0x1ffc);
         let max_addr = GuestAddress(0x2000);
 
-        let gm =
-            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges_with_tracking(&[
+            (start_addr1, 0x1000),
+            (start_addr2, 0x1000),
+        ])
+        .unwrap();
         let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
             &[
                 (start_addr1, 0x1000, Some(FileOffset::new(f1, 0))),
                 (start_addr2, 0x1000, Some(FileOffset::new(f2, 0))),
             ],
-            false,
+            true,
         )
         .unwrap();
 
@@ -1033,6 +1096,10 @@ mod tests {
                 format!("{:?}", gm.write_obj(val1, bad_addr).err().unwrap()),
                 format!("InvalidGuestAddress({:?})", bad_addr,)
             );
+            let _res: guest_memory::Result<()> = gm.with_regions(|_, r| {
+                assert!(!r.dirty_bitmap().unwrap().is_bit_set(0));
+                Ok(())
+            });
             assert_eq!(
                 format!("{:?}", gm.write_obj(val1, bad_addr2).err().unwrap()),
                 format!(
@@ -1041,9 +1108,16 @@ mod tests {
                     max_addr.checked_offset_from(bad_addr2).unwrap()
                 )
             );
+            assert!(!gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
+            assert!(gm.regions[1].dirty_bitmap().unwrap().is_bit_set(0));
 
             gm.write_obj(val1, GuestAddress(0x500)).unwrap();
             gm.write_obj(val2, GuestAddress(0x1000 + 32)).unwrap();
+            let _res: guest_memory::Result<()> = gm.with_regions(|_, r| {
+                assert!(r.dirty_bitmap().unwrap().is_bit_set(0));
+                Ok(())
+            });
+
             let num1: u64 = gm.read_obj(GuestAddress(0x500)).unwrap();
             let num2: u64 = gm.read_obj(GuestAddress(0x1000 + 32)).unwrap();
             assert_eq!(val1, num1);
@@ -1057,10 +1131,10 @@ mod tests {
         f.set_len(0x400).unwrap();
 
         let mut start_addr = GuestAddress(0x1000);
-        let gm = GuestMemoryMmap::from_ranges(&[(start_addr, 0x400)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges_with_tracking(&[(start_addr, 0x400)]).unwrap();
         let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
             &[(start_addr, 0x400, Some(FileOffset::new(f, 0)))],
-            false,
+            true,
         )
         .unwrap();
 
@@ -1068,7 +1142,9 @@ mod tests {
         for gm in gm_list.iter() {
             let sample_buf = &[1, 2, 3, 4, 5];
 
+            assert!(!gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
             assert_eq!(gm.write(sample_buf, start_addr).unwrap(), 5);
+            assert!(gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
 
             let buf = &mut [0u8; 5];
             assert_eq!(gm.read(buf, start_addr).unwrap(), 5);
@@ -1076,6 +1152,7 @@ mod tests {
 
             start_addr = GuestAddress(0x13ff);
             assert_eq!(gm.write(sample_buf, start_addr).unwrap(), 1);
+            assert!(gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
             assert_eq!(gm.read(buf, start_addr).unwrap(), 1);
             assert_eq!(buf[0], sample_buf[0]);
             start_addr = GuestAddress(0x1000);
@@ -1087,10 +1164,11 @@ mod tests {
         let f = TempFile::new().unwrap().into_file();
         f.set_len(0x400).unwrap();
 
-        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0x1000), 0x400)]).unwrap();
+        let gm =
+            GuestMemoryMmap::from_ranges_with_tracking(&[(GuestAddress(0x1000), 0x400)]).unwrap();
         let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
             &[(GuestAddress(0x1000), 0x400, Some(FileOffset::new(f, 0)))],
-            false,
+            true,
         )
         .unwrap();
 
@@ -1102,6 +1180,8 @@ mod tests {
             } else {
                 File::open(Path::new("c:\\Windows\\system32\\ntoskrnl.exe")).unwrap()
             };
+
+            assert!(!gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
             gm.write_obj(!0u32, addr).unwrap();
             gm.read_exact_from(addr, &mut file, mem::size_of::<u32>())
                 .unwrap();
@@ -1111,6 +1191,7 @@ mod tests {
             } else {
                 assert_eq!(value, 0x0090_5a4d);
             }
+            assert!(gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
 
             let mut sink = Vec::new();
             gm.write_all_to(addr, &mut sink, mem::size_of::<u32>())

--- a/src/vm-memory/src/mmap.rs
+++ b/src/vm-memory/src/mmap.rs
@@ -25,6 +25,10 @@ use vm_memory_upstream::guest_memory::{
 use vm_memory_upstream::volatile_memory::{VolatileMemory, VolatileSlice};
 use vm_memory_upstream::{ByteValued, Bytes};
 
+use vmm_sys_util::errno;
+
+use crate::bitmap::Bitmap;
+
 pub use vm_memory_upstream::mmap::{MmapRegion, MmapRegionError};
 
 // Here are some things that originate in this module, and we can continue to use the upstream
@@ -40,6 +44,8 @@ pub use vm_memory_upstream::mmap::{check_file_offset, Error};
 pub struct GuestRegionMmap {
     mapping: MmapRegion,
     guest_base: GuestAddress,
+    // handles dirty page tracking
+    dirty_bitmap: Option<Bitmap>,
 }
 
 impl GuestRegionMmap {
@@ -51,7 +57,34 @@ impl GuestRegionMmap {
         Ok(GuestRegionMmap {
             mapping,
             guest_base,
+            dirty_bitmap: None,
         })
+    }
+
+    /// Provide the region with a dedicated bitmap to handle dirty page tracking.
+    pub fn enable_dirty_page_tracking(&mut self) {
+        let page_size = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
+            -1 => panic!(
+                "Failed to enable dirty page tracking: {}",
+                errno::Error::last()
+            ),
+            ps => ps as usize,
+        };
+        if self.dirty_bitmap.is_none() {
+            self.dirty_bitmap = Some(Bitmap::new(self.len() as usize, page_size));
+        }
+    }
+
+    /// Get the dirty page bitmap representative for this memory region (if any).
+    pub fn dirty_bitmap(&self) -> Option<&Bitmap> {
+        self.dirty_bitmap.as_ref()
+    }
+
+    /// Mark pages dirty starting from 'start_addr' and continuing for 'len' bytes.
+    pub fn mark_dirty_pages(&self, start_addr: usize, len: usize) {
+        if let Some(bitmap) = self.dirty_bitmap() {
+            bitmap.set_addr_range(start_addr, len);
+        }
     }
 
     // This is exclusively used for the local `Bytes` implementation.
@@ -448,6 +481,26 @@ mod tests {
     fn basic_map() {
         let m = MmapRegion::new(1024).unwrap();
         assert_eq!(1024, m.len());
+    }
+
+    #[test]
+    fn test_guest_region_mmap() {
+        let mut mmap =
+            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0xc000)).unwrap();
+        assert!(mmap.dirty_bitmap().is_none());
+
+        mmap.enable_dirty_page_tracking();
+        assert!(mmap.dirty_bitmap().is_some());
+
+        mmap.mark_dirty_pages(128, 129);
+        let bitmap = mmap.dirty_bitmap().unwrap();
+        assert!(bitmap.is_addr_set(128));
+        assert!(!bitmap.is_addr_set(4097));
+
+        // check that enabling dirty page tracking multiple times
+        // does not override the bitmap
+        mmap.enable_dirty_page_tracking();
+        assert!(mmap.dirty_bitmap().unwrap().is_addr_set(128));
     }
 
     fn check_guest_memory_mmap(

--- a/src/vm-memory/src/mmap.rs
+++ b/src/vm-memory/src/mmap.rs
@@ -1175,32 +1175,20 @@ mod tests {
         let gm_list = vec![gm, gm_backed_by_file];
         for gm in gm_list.iter() {
             let addr = GuestAddress(0x1010);
-            let mut file = if cfg!(unix) {
-                File::open(Path::new("/dev/zero")).unwrap()
-            } else {
-                File::open(Path::new("c:\\Windows\\system32\\ntoskrnl.exe")).unwrap()
-            };
+            let mut file = File::open(Path::new("/dev/zero")).unwrap();
 
             assert!(!gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
             gm.write_obj(!0u32, addr).unwrap();
             gm.read_exact_from(addr, &mut file, mem::size_of::<u32>())
                 .unwrap();
             let value: u32 = gm.read_obj(addr).unwrap();
-            if cfg!(unix) {
-                assert_eq!(value, 0);
-            } else {
-                assert_eq!(value, 0x0090_5a4d);
-            }
+            assert_eq!(value, 0);
             assert!(gm.regions[0].dirty_bitmap().unwrap().is_bit_set(0));
 
             let mut sink = Vec::new();
             gm.write_all_to(addr, &mut sink, mem::size_of::<u32>())
                 .unwrap();
-            if cfg!(unix) {
-                assert_eq!(sink, vec![0; mem::size_of::<u32>()]);
-            } else {
-                assert_eq!(sink, vec![0x4d, 0x5a, 0x90, 0x00]);
-            };
+            assert_eq!(sink, vec![0; mem::size_of::<u32>()]);
         }
     }
 
@@ -1350,12 +1338,7 @@ mod tests {
         assert!(region.file_offset().is_some());
     }
 
-    // Windows needs a dedicated test where it will retrieve the allocation
-    // granularity to determine a proper offset (other than 0) that can be
-    // used for the backing file. Refer to Microsoft docs here:
-    // https://docs.microsoft.com/en-us/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile
     #[test]
-    #[cfg(unix)]
     fn test_retrieve_offset_from_fd_backing_memory_region() {
         let f = TempFile::new().unwrap().into_file();
         f.set_len(0x1400).unwrap();

--- a/src/vm-memory/src/mmap.rs
+++ b/src/vm-memory/src/mmap.rs
@@ -302,14 +302,32 @@ impl GuestMemoryMmap {
     ///
     /// Valid memory regions are specified as a slice of (Address, Size) tuples sorted by Address.
     pub fn from_ranges(ranges: &[(GuestAddress, usize)]) -> result::Result<Self, Error> {
-        Self::from_ranges_with_files(ranges.iter().map(|r| (r.0, r.1, None)))
+        Self::from_ranges_with_files(ranges.iter().map(|r| (r.0, r.1, None)), false)
+    }
+
+    /// Creates a container, allocates anonymous memory for guest memory regions and enables dirty
+    /// page tracking.
+    ///
+    /// Valid memory regions are specified as a slice of (Address, Size) tuples sorted by Address.
+    pub fn from_ranges_with_tracking(
+        ranges: &[(GuestAddress, usize)],
+    ) -> result::Result<Self, Error> {
+        Self::from_ranges_with_files(ranges.iter().map(|r| (r.0, r.1, None)), true)
     }
 
     /// Creates a container and allocates anonymous memory for guest memory regions.
     ///
-    /// Valid memory regions are specified as a sequence of (Address, Size, Option<FileOffset>)
-    /// tuples sorted by Address.
-    pub fn from_ranges_with_files<A, T>(ranges: T) -> result::Result<Self, Error>
+    /// # Arguments
+    ///
+    /// * 'ranges' - Iterator over a sequence of (Address, Size, Option<FileOffset>)
+    ///              tuples sorted by Address.
+    /// * 'track_dirty_pages' - Whether or not dirty page tracking is enabled.
+    ///                         If set, it creates a dedicated bitmap for tracing memory writes
+    ///                         specific to every region.
+    pub fn from_ranges_with_files<A, T>(
+        ranges: T,
+        track_dirty_pages: bool,
+    ) -> result::Result<Self, Error>
     where
         A: Borrow<(GuestAddress, usize, Option<FileOffset>)>,
         T: IntoIterator<Item = A>,
@@ -327,7 +345,13 @@ impl GuestMemoryMmap {
                         MmapRegion::new(size)
                     }
                     .map_err(Error::MmapRegion)
-                    .and_then(|r| GuestRegionMmap::new(r, guest_base))
+                    .and_then(|r| {
+                        let mut mmap = GuestRegionMmap::new(r, guest_base)?;
+                        if track_dirty_pages {
+                            mmap.enable_dirty_page_tracking();
+                        }
+                        Ok(mmap)
+                    })
                 })
                 .collect::<result::Result<Vec<_>, Error>>()?,
         )
@@ -380,13 +404,20 @@ impl GuestMemoryMmap {
     /// Insert a region into the `GuestMemoryMmap` object and return a new `GuestMemoryMmap`.
     ///
     /// # Arguments
-    /// * `region`: the memory region to insert into the guest memory object.
+    /// * `region` - the memory region to insert into the guest memory object.
     pub fn insert_region(
         &self,
-        region: Arc<GuestRegionMmap>,
+        mut region: GuestRegionMmap,
     ) -> result::Result<GuestMemoryMmap, Error> {
+        let dirty_page_tracking = self.is_dirty_tracking_enabled();
+        if dirty_page_tracking {
+            region.enable_dirty_page_tracking();
+        } else {
+            region.dirty_bitmap = None;
+        }
+
         let mut regions = self.regions.clone();
-        regions.push(region);
+        regions.push(Arc::new(region));
         regions.sort_by_key(|x| x.start_addr());
 
         Self::from_arc_regions(regions)
@@ -396,8 +427,8 @@ impl GuestMemoryMmap {
     /// on success, together with the removed region.
     ///
     /// # Arguments
-    /// * `base`: base address of the region to be removed
-    /// * `size`: size of the region to be removed
+    /// * `base` - base address of the region to be removed
+    /// * `size` - size of the region to be removed
     pub fn remove_region(
         &self,
         base: GuestAddress,
@@ -412,6 +443,11 @@ impl GuestMemoryMmap {
         }
 
         Err(Error::InvalidGuestRegion)
+    }
+
+    /// Return true if dirty page tracking is enabled for `GuestMemoryMmap`, and else otherwise.
+    pub fn is_dirty_tracking_enabled(&self) -> bool {
+        self.regions.iter().all(|r| r.dirty_bitmap().is_some())
     }
 }
 
@@ -579,7 +615,13 @@ mod tests {
             })
             .collect();
 
-        GuestMemoryMmap::from_ranges_with_files(&regions)
+        GuestMemoryMmap::from_ranges_with_files(&regions, false)
+    }
+
+    fn new_guest_memory_mmap_with_tracking(
+        regions_summary: &[(GuestAddress, usize)],
+    ) -> Result<GuestMemoryMmap, Error> {
+        GuestMemoryMmap::from_ranges_with_tracking(regions_summary)
     }
 
     #[test]
@@ -590,6 +632,16 @@ mod tests {
             format!(
                 "{:?}",
                 new_guest_memory_mmap(&regions_summary).err().unwrap()
+            ),
+            format!("{:?}", Error::NoMemoryRegion)
+        );
+
+        assert_eq!(
+            format!(
+                "{:?}",
+                new_guest_memory_mmap_with_tracking(&regions_summary)
+                    .err()
+                    .unwrap()
             ),
             format!("{:?}", Error::NoMemoryRegion)
         );
@@ -643,6 +695,16 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
+                new_guest_memory_mmap_with_tracking(&regions_summary)
+                    .err()
+                    .unwrap()
+            ),
+            format!("{:?}", Error::MemoryRegionOverlap)
+        );
+
+        assert_eq!(
+            format!(
+                "{:?}",
                 new_guest_memory_mmap_with_files(&regions_summary)
                     .err()
                     .unwrap()
@@ -689,6 +751,16 @@ mod tests {
         assert_eq!(
             format!(
                 "{:?}",
+                new_guest_memory_mmap_with_tracking(&regions_summary)
+                    .err()
+                    .unwrap()
+            ),
+            format!("{:?}", Error::UnsortedMemoryRegions)
+        );
+
+        assert_eq!(
+            format!(
+                "{:?}",
                 new_guest_memory_mmap_with_files(&regions_summary)
                     .err()
                     .unwrap()
@@ -728,6 +800,11 @@ mod tests {
         assert_eq!(guest_mem.regions.len(), 0);
 
         check_guest_memory_mmap(new_guest_memory_mmap(&regions_summary), &regions_summary);
+
+        check_guest_memory_mmap(
+            new_guest_memory_mmap_with_tracking(&regions_summary),
+            &regions_summary,
+        );
 
         check_guest_memory_mmap(
             new_guest_memory_mmap_with_files(&regions_summary),
@@ -778,10 +855,13 @@ mod tests {
         let start_addr2 = GuestAddress(0x800);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
-        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
-        ])
+        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let guest_mem_list = vec![guest_mem, guest_mem_backed_by_file];
@@ -804,10 +884,13 @@ mod tests {
         let start_addr2 = GuestAddress(0x800);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
-        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
-        ])
+        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let guest_mem_list = vec![guest_mem, guest_mem_backed_by_file];
@@ -836,10 +919,13 @@ mod tests {
         let start_addr2 = GuestAddress(0x800);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
-        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
-        ])
+        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let guest_mem_list = vec![guest_mem, guest_mem_backed_by_file];
@@ -864,10 +950,13 @@ mod tests {
         let start_addr2 = GuestAddress(0x800);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
-        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
-        ])
+        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x400, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x400, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let guest_mem_list = vec![guest_mem, guest_mem_backed_by_file];
@@ -890,11 +979,10 @@ mod tests {
 
         let start_addr = GuestAddress(0x0);
         let guest_mem = GuestMemoryMmap::from_ranges(&[(start_addr, 0x400)]).unwrap();
-        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[(
-            start_addr,
-            0x400,
-            Some(FileOffset::new(f, 0)),
-        )])
+        let guest_mem_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[(start_addr, 0x400, Some(FileOffset::new(f, 0)))],
+            false,
+        )
         .unwrap();
 
         let guest_mem_list = vec![guest_mem, guest_mem_backed_by_file];
@@ -928,10 +1016,13 @@ mod tests {
 
         let gm =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x1000, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x1000, Some(FileOffset::new(f2, 0))),
-        ])
+        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x1000, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x1000, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let gm_list = vec![gm, gm_backed_by_file];
@@ -967,11 +1058,10 @@ mod tests {
 
         let mut start_addr = GuestAddress(0x1000);
         let gm = GuestMemoryMmap::from_ranges(&[(start_addr, 0x400)]).unwrap();
-        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[(
-            start_addr,
-            0x400,
-            Some(FileOffset::new(f, 0)),
-        )])
+        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[(start_addr, 0x400, Some(FileOffset::new(f, 0)))],
+            false,
+        )
         .unwrap();
 
         let gm_list = vec![gm, gm_backed_by_file];
@@ -998,11 +1088,10 @@ mod tests {
         f.set_len(0x400).unwrap();
 
         let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0x1000), 0x400)]).unwrap();
-        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[(
-            GuestAddress(0x1000),
-            0x400,
-            Some(FileOffset::new(f, 0)),
-        )])
+        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[(GuestAddress(0x1000), 0x400, Some(FileOffset::new(f, 0)))],
+            false,
+        )
         .unwrap();
 
         let gm_list = vec![gm, gm_backed_by_file];
@@ -1065,6 +1154,39 @@ mod tests {
     }
 
     #[test]
+    fn create_vec_with_dirty_tracking() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+
+        // dirty page tracking is disabled
+        let gm = GuestMemoryMmap::from_ranges(&regions).unwrap();
+        let res: guest_memory::Result<()> = gm.with_regions(|_, region| {
+            assert!(region.dirty_bitmap().is_none());
+            Ok(())
+        });
+        assert!(res.is_ok());
+
+        // dirty page tracking is enabled
+        let gm = GuestMemoryMmap::from_ranges_with_tracking(&regions).unwrap();
+        let res: guest_memory::Result<()> = gm.with_regions_mut(|_, region| {
+            // this should not fail
+            let bitmap = region.dirty_bitmap().unwrap();
+            assert_eq!(region.len() as usize, region_size);
+            assert_eq!(bitmap.len(), 1);
+
+            let base_addr = region.guest_base.0 as usize;
+            bitmap.set_addr_range(base_addr, 128);
+            assert!(bitmap.is_addr_set(base_addr));
+
+            Ok(())
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
     fn test_memory() {
         let region_size = 0x400;
         let regions = vec![
@@ -1107,10 +1229,13 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let gm =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(&[
-            (start_addr1, 0x1000, Some(FileOffset::new(f1, 0))),
-            (start_addr2, 0x1000, Some(FileOffset::new(f2, 0))),
-        ])
+        let gm_backed_by_file = GuestMemoryMmap::from_ranges_with_files(
+            &[
+                (start_addr1, 0x1000, Some(FileOffset::new(f1, 0))),
+                (start_addr2, 0x1000, Some(FileOffset::new(f2, 0))),
+            ],
+            false,
+        )
         .unwrap();
 
         let gm_list = vec![gm, gm_backed_by_file];
@@ -1134,11 +1259,10 @@ mod tests {
         let region = gm.find_region(start_addr).unwrap();
         assert!(region.file_offset().is_none());
 
-        let gm = GuestMemoryMmap::from_ranges_with_files(&[(
-            start_addr,
-            0x400,
-            Some(FileOffset::new(f, 0)),
-        )])
+        let gm = GuestMemoryMmap::from_ranges_with_files(
+            &[(start_addr, 0x400, Some(FileOffset::new(f, 0)))],
+            false,
+        )
         .unwrap();
         assert!(gm.find_region(start_addr).is_some());
         let region = gm.find_region(start_addr).unwrap();
@@ -1163,11 +1287,10 @@ mod tests {
         let region = gm.find_region(start_addr).unwrap();
         assert!(region.file_offset().is_none());
 
-        let gm = GuestMemoryMmap::from_ranges_with_files(&[(
-            start_addr,
-            0x400,
-            Some(FileOffset::new(f, offset)),
-        )])
+        let gm = GuestMemoryMmap::from_ranges_with_files(
+            &[(start_addr, 0x400, Some(FileOffset::new(f, offset)))],
+            false,
+        )
         .unwrap();
         assert!(gm.find_region(start_addr).is_some());
         let region = gm.find_region(start_addr).unwrap();
@@ -1186,21 +1309,17 @@ mod tests {
         let mem_orig = gm.memory();
         assert_eq!(mem_orig.num_regions(), 2);
 
-        let mmap = Arc::new(
-            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0x8000)).unwrap(),
-        );
+        let mmap =
+            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0x8000)).unwrap();
         let gm = gm.insert_region(mmap).unwrap();
-        let mmap = Arc::new(
-            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0x4000)).unwrap(),
-        );
+        let mmap =
+            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0x4000)).unwrap();
         let gm = gm.insert_region(mmap).unwrap();
-        let mmap = Arc::new(
-            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0xc000)).unwrap(),
-        );
+        let mmap =
+            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0xc000)).unwrap();
         let gm = gm.insert_region(mmap).unwrap();
-        let mmap = Arc::new(
-            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0xc000)).unwrap(),
-        );
+        let mmap =
+            GuestRegionMmap::new(MmapRegion::new(0x1000).unwrap(), GuestAddress(0xc000)).unwrap();
         gm.insert_region(mmap).unwrap_err();
 
         assert_eq!(mem_orig.num_regions(), 2);
@@ -1233,5 +1352,30 @@ mod tests {
 
         assert_eq!(gm.regions[0].start_addr(), GuestAddress(0x0000));
         assert_eq!(region.start_addr(), GuestAddress(0x10_0000));
+    }
+
+    #[test]
+    fn test_is_dirty_tracking_enabled() {
+        let region_size = 0x100;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x100), region_size),
+            (GuestAddress(0x200), region_size),
+            (GuestAddress(0x300), region_size),
+        ];
+
+        // dirty page tracking is disabled
+        let mut gm = new_guest_memory_mmap(&regions[..2]).unwrap();
+        assert_eq!(gm.regions.len(), 2);
+        assert!(!gm.is_dirty_tracking_enabled());
+
+        // dirty page tracking is enabled
+        let mut dirty_tracking_gm = new_guest_memory_mmap_with_tracking(&regions[2..]).unwrap();
+        assert_eq!(dirty_tracking_gm.regions.len(), 2);
+        assert!(dirty_tracking_gm.is_dirty_tracking_enabled());
+
+        // dirty page tracking not enabled for all
+        gm.regions.append(&mut dirty_tracking_gm.regions);
+        assert!(!gm.is_dirty_tracking_enabled());
     }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.08, "AMD": 84.35}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.41}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Bootstrap implementation for dirty page tracking in vm-memory - #1997

## Description of Changes

- Added a dedicated dirty page bitmap for GuestRegionMap.
- Updated local vm-memory's API with capabilities to enable dirty page tracking.
- Updated dirty page bitmap every time the memory is altered.
- Added unit tests for both GuestRegionMap and GuestMemoryMmap.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
