### PR TITLE
Add mmap with MAP_SHARED to allowlist.

### DIFF
--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -55,7 +55,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     Cond::new(2, ArgLen::DWORD, Eq, super::FCNTL_FD_CLOEXEC)?,
                 ],],
             ),
-            // Used for drive patching & rescanning
+            // Used for drive patching & rescanning, for reading the local timezone
             allow_syscall(libc::SYS_fstat),
             // Used for snapshotting
             #[cfg(target_arch = "x86_64")]
@@ -96,6 +96,16 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mremap),
             // Used for freeing memory
             allow_syscall(libc::SYS_munmap),
+            // Used for reading the timezone in LocalTime::now()
+            allow_syscall_if(
+                libc::SYS_mmap,
+                or![and![Cond::new(
+                    3,
+                    ArgLen::DWORD,
+                    Eq,
+                    libc::MAP_SHARED as u64
+                )?],],
+            ),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_open),
             #[cfg(target_arch = "aarch64")]

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -162,6 +162,25 @@ class JailerContext:
             utils.run_cmd(cmd)
         return jailed_p
 
+    def copy_into_root(self, file_path, create_jail=False):
+        """Copy a file in the jail root, owned by uid:gid.
+
+        Copy a file in the jail root, creating the folder path if
+        not existent, then change their owner to uid:gid.
+        """
+        global_path = os.path.join(
+            self.chroot_path(), file_path.strip(os.path.sep))
+        if create_jail:
+            os.makedirs(self.chroot_path(), exist_ok=True)
+
+        os.makedirs(os.path.dirname(global_path), exist_ok=True)
+
+        shutil.copy(file_path, global_path)
+
+        cmd = 'chown {}:{} {}'.format(
+            self.uid, self.gid, global_path)
+        utils.run_cmd(cmd)
+
     def netns_file_path(self):
         """Get the host netns file path for a jailer context.
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -82,6 +82,10 @@ class Microvm:
         )
         self.jailer_clone_pid = None
 
+        # Copy the /etc/localtime file in the jailer root
+        self.jailer.copy_into_root(
+            "/etc/localtime", create_jail=True)
+
         # Now deal with the things specific to the api session used to
         # communicate with this machine.
         self._api_session = None

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -11,6 +11,7 @@ ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -47,6 +48,7 @@ RUN apt-get update \
         python3-venv    \
         zlib1g-dev \
         screen \
+        tzdata \
     && python3 -m pip install \
         setuptools \
         wheel \

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -11,6 +11,7 @@ ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -47,6 +48,7 @@ RUN apt-get update \
         python3-venv    \
         zlib1g-dev \
         screen \
+        tzdata \
     && python3 -m pip install \
         setuptools \
         wheel \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v19"
+DEVCTR_IMAGE="fcuvm/dev:v20"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

The [previous similar PR](https://github.com/firecracker-microvm/firecracker/pull/2147) was closed because I needed to do a rebase from mainline first. 

With the previous allowlist, Firecracker raised a SIGSYS when running non-jailed.
This was because the `/etc/localtime` was getting memory mapped by the `localtime_r` musl implementation, used in the logger.
It was not caught by our CI because we don't mount the `/etc/localtime` in the jailer.

## Description of Changes

- Allowed the `mmap` syscall with the `MAP_SHARED` flag.
 - Added a new docker container tag that installs the `tzdata` package - `fcuvm/dev:v20` - in order to have access to the `/etc/localtime` file in the container.
 - Modified the test framework to mount `/etc/localtime` in the jailer root so that this error will not reappear in the future.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
