### PR TITLE
CI: adjust the boot time and process startup time to m6g's performances

### DIFF
--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -1,11 +1,6 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests that ensure the boot time to init process is within spec.
-
-The boot time tests use the minimal kernel image and root file system found in
-the S3 bucket at https://s3.amazonaws.com/spec.ccfc.min/img/minimal.
-For boot time testing the serial console is not enabled.
-"""
+"""Tests that ensure the boot time to init process is within spec."""
 
 import re
 import time
@@ -23,7 +18,7 @@ TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
 
 def test_no_boottime(test_microvm_with_api):
-    """Check boottimer not present by default."""
+    """Check that boot timer device not present by default."""
     _ = _configure_and_run_vm(test_microvm_with_api)
     time.sleep(0.4)
     timestamps = re.findall(TIMESTAMP_LOG_REGEX,
@@ -32,7 +27,7 @@ def test_no_boottime(test_microvm_with_api):
 
 
 def test_boottime_no_network(test_microvm_with_boottime_timer):
-    """Check guest boottime of microvm without network."""
+    """Check boot time of microVM without network."""
     test_microvm_with_boottime_timer.jailer.extra_args.update(
         {'boot-timer': None}
     )
@@ -47,7 +42,7 @@ def test_boottime_with_network(
         test_microvm_with_boottime_timer,
         network_config
 ):
-    """Check guest boottime of microvm with network."""
+    """Check boot time of microVM with network."""
     test_microvm_with_boottime_timer.jailer.extra_args.update(
         {'boot-timer': None}
     )
@@ -62,7 +57,7 @@ def test_boottime_with_network(
 
 def test_initrd_boottime(
         test_microvm_with_initrd_timer):
-    """Check guest boottime of microvm with initrd."""
+    """Check boot time of microVM when using an initrd."""
     test_microvm_with_initrd_timer.jailer.extra_args.update(
         {'boot-timer': None}
     )
@@ -75,10 +70,7 @@ def test_initrd_boottime(
 
 
 def _test_microvm_boottime(log_fifo_data, max_time_us=MAX_BOOT_TIME_US):
-    """Assert that we meet the minimum boot time.
-
-    TODO: Should use a microVM with the `boottime` capability.
-    """
+    """Auxiliary function for asserting the expected boot time."""
     boot_time_us = 0
     timestamps = re.findall(TIMESTAMP_LOG_REGEX, log_fifo_data)
     if timestamps:

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -11,7 +11,7 @@ MAX_BOOT_TIME_US = 150000
 # NOTE: for aarch64 most of the boot time is spent by the kernel to unpack the
 # initramfs in RAM. This time is influenced by the size and the compression
 # method of the used initrd image.
-INITRD_BOOT_TIME_US = 160000 if platform.machine() == "x86_64" else 500000
+INITRD_BOOT_TIME_US = 160000 if platform.machine() == "x86_64" else 200000
 # TODO: Keep a `current` boot time in S3 and validate we don't regress
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -9,7 +9,7 @@ import time
 
 import host_tools.logging as log_tools
 
-MAX_STARTUP_TIME_CPU_US = {'x86_64': 8000, 'aarch64': 12000}
+MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2500}
 """ The maximum acceptable startup time in CPU us. """
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 


### PR DESCRIPTION
## Reason for This PR

We recently switched our CI to run on m6g instances.

## Description of Changes

Adjusted boot time for initrd and process startup time.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
