### PR TITLE
arm: fix possible load-load data inconsistency

### DIFF
--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -288,6 +288,9 @@ impl Queue {
             return None;
         }
 
+        // This fence ensures all subsequent reads see the updated driver writes.
+        fence(Ordering::Acquire);
+
         // We'll need to find the first available descriptor, that we haven't yet popped.
         // In a naive notation, that would be:
         // `descriptor_table[avail_ring[next_avail]]`.


### PR DESCRIPTION
Fixed a bug in the virtio mechansim which could lead to the virtqueue reading stale data. Specifically, the virtqueue pop() function reads the index of the available ring tail from the driver in order to check for new descriptors made available.
Based on that, it goes on to read the location of the available virtq descriptors. This introduces a load-load control dependency for which we need to protect against with a full memory barrier on weak memory models like arm.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

The Firecracker virtqueue implementation does not take into account Arm's weak ordering, which requires barriers to ensure that data from the guest is not stale. The current implementation does not include this barrier so it is possible for an emulated device to lose customer data from the guest OS on Arm platforms. Because this issue depends on run time non-determinism, this problem may only appear intermittently. 

## Description of Changes

Added an `Acquire` fence for consumer threads of the virtio queue available descriptors. Producers threads - the driver - must `Release` fence the writes to the memory.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
