### PR TITLE
Modified queue size in TestContext.

### DIFF
--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -127,7 +127,7 @@ impl TestContext {
     }
 
     pub fn create_event_handler_context(&self) -> EventHandlerContext {
-        const QSIZE: u16 = 2;
+        const QSIZE: u16 = 256;
 
         let guest_rxvq = GuestQ::new(GuestAddress(0x0010_0000), &self.mem, QSIZE as u16);
         let guest_txvq = GuestQ::new(GuestAddress(0x0020_0000), &self.mem, QSIZE as u16);


### PR DESCRIPTION

Signed-off-by: Cihodaru Alexandru <cihodar@amazon.com>

## Reason for This PR

Queue size used in TestContext was different from the one used
in development.

## Description of Changes
Changed value of queue size in TestContext to be the same with the
value used in development(256).

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
