### PR TITLE
virtio: sync data on virtio flush request

### DIFF
--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -230,7 +230,6 @@ impl Request {
             RequestType::Flush => {
                 diskfile.sync_all().map_err(ExecuteError::SyncAll)?;
                 METRICS.block.flush_count.inc();
-                return Ok(0);
             }
             RequestType::GetDeviceID => {
                 let disk_id = disk.image_id();

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -109,6 +109,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_timerfd_settime),
             allow_syscall(libc::SYS_write),
             allow_syscall(libc::SYS_writev),
+            allow_syscall(libc::SYS_fsync),
         ]
         .into_iter()
         .collect(),


### PR DESCRIPTION
When the virtio block device receives a flush (VIRTIO_BLK_T_FLUSH)
it must ensure that the data in the host page cache is actually
flushed out to media. Otherwise, data can be lost in the event of
a power fail.

This commit changes the underlying request from a flush() to a
sync_all(), forcing the data to be flushed to disk. This has
been verified by running a 'fio' test with sync_on_close in the
VM and verifying via 'perf' that fsync() on the host is actually
invoked. The bandwidth in the VM is also now in line with the
underlying hardware.

The invocation of sync_all() has been refactored to be in accordance
with other function invocations in the request handler.

This change also requires that the sys_fsync system call is in the
list of approved seccomp calls.

Signed-off-by:	Peter Lawthers <peter.lawthers@esrlabs.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
