### PR TITLE
Return error when setting CPU template on aarch64

### DIFF
--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -746,12 +746,11 @@ pub(crate) mod tests {
             .write_all(
                 b"PUT /machine-config HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
-                Content-Length: 80\r\n\r\n{ \
-                \"vcpu_count\": 0, \
-                \"mem_size_mib\": 0, \
-                \"ht_enabled\": true, \
-                \"cpu_template\": \"C3\" \
-            }",
+                Content-Length: 58\r\n\r\n{ \
+                    \"vcpu_count\": 0, \
+                    \"mem_size_mib\": 0, \
+                    \"ht_enabled\": true \
+                }",
             )
             .unwrap();
         assert!(connection.try_read().is_ok());
@@ -981,6 +980,21 @@ pub(crate) mod tests {
             .write_all(
                 b"PATCH /machine-config HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
+                Content-Length: 58\r\n\r\n{ \
+                \"vcpu_count\": 0, \
+                \"mem_size_mib\": 0, \
+                \"ht_enabled\": true \
+            }",
+            )
+            .unwrap();
+        assert!(connection.try_read().is_ok());
+        let req = connection.pop_parsed_request().unwrap();
+        assert!(ParsedRequest::try_from_request(&req).is_ok());
+
+        sender
+            .write_all(
+                b"PATCH /machine-config HTTP/1.1\r\n\
+                Content-Type: application/json\r\n\
                 Content-Length: 80\r\n\r\n{ \
                 \"vcpu_count\": 0, \
                 \"mem_size_mib\": 0, \
@@ -991,7 +1005,10 @@ pub(crate) mod tests {
             .unwrap();
         assert!(connection.try_read().is_ok());
         let req = connection.pop_parsed_request().unwrap();
+        #[cfg(target_arch = "x86_64")]
         assert!(ParsedRequest::try_from_request(&req).is_ok());
+        #[cfg(target_arch = "aarch64")]
+        assert!(ParsedRequest::try_from_request(&req).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Reason for This PR

Fixes #2165 

## Description of Changes

* Return an error when trying to set cpu_template on aarch64 since it is not supported.
* Add to unit tests of parsing PUT machine configuration to make sure the error is returned on aarch64.
* Modify unit tests that test setting machine config making them platform-specific.

Now trying to set the `cpu_template` on aarch64 by running:
```bash 
curl --unix-socket /tmp/firecracker.socket -i  -X PUT "http://localhost/machine-config"  -H "accept: application/json"  -H "Content-Type: application/json"  -d "{ \"vcpu_count\": 1, \"mem_size_mib\": 32, \"ht_enabled\": false, \"cpu_template\": \"T2\" }"
```
will return the following error:
```bash
{"fault_message":"cpu_template is not supported on aarch64"}
```
While running the same request on an x86 machine will work normally.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
