### PR TITLE
docs update: seccomp is enabled by Firecracker

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -143,7 +143,21 @@ Firecracker microVMs expose access to a minimal MicroVM-Metadata Service
 (MMDS) to the guest through the API endpoint. The metadata stored by the
 service is fully configured by users.
 
-### Jailing
+### Sandboxing
+
+#### __Firecracker process__
+
+##### Seccomp
+
+Seccomp filters are used by default to further limit the system calls Firecracker
+can use. There are 3 possible levels of seccomp filtering, configurable by passing
+a command line argument to Firecracker: 0 (disabled), 1 (whitelists a set of
+trusted system calls by their identifiers) and 2 (whitelists a set of trusted
+system calls with trusted parameter values), the latter being the most
+restrictive and the recommended one. The filters are loaded in the Firecracker
+process, immediately before the execution of the untrusted guest code starts.
+
+#### __Jailer process__
 
 The Firecracker process can be started by another `jailer` process. The jailer
 sets up system resources that require elevated permissions (e.g., cgroup,
@@ -152,15 +166,7 @@ then runs as an unprivileged process. Past this point, Firecracker can only
 access resources that a privileged third-party grants access to (e.g., by
 copying a file into the chroot, or passing a file descriptor).
 
-Seccomp filters are used to further limit the system calls Firecracker can use.
-There are 3 possible levels of seccomp filtering, configurable by passing a
-command line argument to the jailer: 0 (disabled), 1 (whitelists a set of
-trusted system calls by their identifiers) and 2 (whitelists a set of trusted
-system calls with trusted parameter values), the latter being the most
-restrictive and the recommended one. The filters are loaded in the Firecracker
-process, immediately before the execution of the untrusted guest code starts.
-
-#### Cgroups and Quotas
+##### Cgroups and Quotas
 
 Each Firecracker microVM can be further encapsulated into a cgroup. By setting the
 affinity of the Firecracker microVM to a node via the cpuset subsystem, one

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -1,14 +1,26 @@
 # Production Host Setup Recommendations
 
+## Firecracker Configuration
+
+### Seccomp
+
+Firecracker uses
+[seccomp](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
+filters to limit the system calls allowed by the host OS to the required
+minimum.
+
+By default, Firecracker uses advanced filtering, which is the most restrictive
+option, and the recommended setting for production workloads.
+This can also be explicitly requested by supplying `--seccomp-level=2` to the
+Firecracker executable.
+
 ## Jailer Configuration
 
 Using Jailer in a production Firecracker deployment is highly recommended,
 as it provides additional security boundaries for the microVM.
 The Jailer process applies
 [cgroup](https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt),
-namespace,
-[seccomp](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
-isolation and drops privileges of the Firecracker process.
+namespace isolation and drops privileges of the Firecracker process.
 
 To set up the jailer correctly, you'll need to:
 
@@ -130,7 +142,7 @@ It can be enabled by adding the following Linux kernel boot parameter:
 spec_store_bypass_disable=seccomp
 ```
 
-which will apply SSB if seccomp is enabled by Firecracker's jailer.
+which will apply SSB if seccomp is enabled by Firecracker.
 
 Verification can be done by running:
 


### PR DESCRIPTION
## Reason for This PR

Documentation was out of date. Seccomp filters are no longer installed by the Jailer,
they are a default of the Firecracker process.

## Description of Changes

Update statements in `prod-host-setup.md` and `design.md`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
