### PR TITLE
seccomp_audit: allow ioctl TCGETS & TCSETS

### DIFF
--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -29,6 +29,8 @@ const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
+const TCGETS: u64 = 0x5401;
+const TCSETS: u64 = 0x5402;
 const TIOCGWINSZ: u64 = 0x5413;
 const FIONBIO: u64 = 0x5421;
 
@@ -106,10 +108,15 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
     let mut rule = or![
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
-        // Triggered on microvm shutdown. If you remove it, tests will likely still pass,
-        // because the sigsys_handler exits the process.
+        // Triggered on shutdown, to restore the initial terminal settings,
+        // only when Firecracker was launched from a shell.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
+        // Triggered on shutdown, to restore the initial terminal settings,
+        // only when Firecracker was launched from a shell.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
+        // Triggered on shutdown, to restore the initial terminal settings.
         and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -151,7 +151,7 @@ class Microvm:
                     ignore_return_code=True)
         else:
             utils.run_cmd(
-                'screen -XS {} kill'.format(self._session_name))
+                'screen -XS {} kill || true'.format(self._session_name))
 
         if self._memory_monitor and self._memory_monitor.is_alive():
             self._memory_monitor.signal_stop()
@@ -461,9 +461,9 @@ class Microvm:
                 tries=30,
                 delay=1).group(1)
 
-            self.jailer_clone_pid = open('/proc/{0}/task/{0}/children'
-                                         .format(screen_pid)
-                                         ).read().strip()
+            self.jailer_clone_pid = int(open('/proc/{0}/task/{0}/children'
+                                             .format(screen_pid)
+                                             ).read().strip())
 
             # Configure screen to flush stdout to file.
             flush_cmd = 'screen -S {session} -X colon "logfile flush 0^M"'

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -14,6 +14,7 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 def test_reboot(test_microvm_with_ssh, network_config):
     """Test reboot from guest kernel."""
     test_microvm = test_microvm_with_ssh
+    test_microvm.jailer.daemonize = False
     test_microvm.spawn()
 
     # We don't need to monitor the memory for this test because we are


### PR DESCRIPTION
## Reason for This PR

The following `ioctl` parameters were removed from the allowlist after the audit: `TCSETS` and `TCGETS`.
These calls are triggered on microVM shutdown, if Firecracker was launched from a shell, in order to restore the calling terminal settings.
This was not triggered by our integration tests, because in `test_shut_down.py` we were using the jailer to `exec` into Firecracker.

## Description of Changes

 - Add `ioctl` `TCGETS` & `TCSETS` to seccomp allowlist
 - Add regression test, by launching Firecracker from a `screen` session in the shutdown test.
 - Modified the `microvm.kill` method in the test framework to ignore errors from `screen kill`. Otherwise the command would return an error, since the process was already killed by the reboot.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
