### PR TITLE
Merge feature/seccomp_audit into master

### DIFF
--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -55,7 +55,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     Cond::new(2, ArgLen::DWORD, Eq, super::FCNTL_FD_CLOEXEC)?,
                 ],],
             ),
-            // Used for drive patching & rescanning
+            // Used for drive patching & rescanning, for reading the local timezone
             allow_syscall(libc::SYS_fstat),
             // Used for snapshotting
             #[cfg(target_arch = "x86_64")]
@@ -96,6 +96,16 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mremap),
             // Used for freeing memory
             allow_syscall(libc::SYS_munmap),
+            // Used for reading the timezone in LocalTime::now()
+            allow_syscall_if(
+                libc::SYS_mmap,
+                or![and![Cond::new(
+                    3,
+                    ArgLen::DWORD,
+                    Eq,
+                    libc::MAP_SHARED as u64
+                )?],],
+            ),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_open),
             #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -20,135 +20,104 @@ const FCNTL_F_SETFD: u64 = 2;
 // See include/uapi/linux/futex.h in the kernel code.
 const FUTEX_WAIT: u64 = 0;
 const FUTEX_WAKE: u64 = 1;
-const FUTEX_REQUEUE: u64 = 3;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE: u64 = 4;
 const FUTEX_PRIVATE_FLAG: u64 = 128;
 const FUTEX_WAIT_PRIVATE: u64 = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
 const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
-const FUTEX_REQUEUE_PRIVATE: u64 = FUTEX_REQUEUE | FUTEX_PRIVATE_FLAG;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
-const TCGETS: u64 = 0x5401;
-const TCSETS: u64 = 0x5402;
-const TIOCGWINSZ: u64 = 0x5413;
-const FIOCLEX: u64 = 0x5451;
 const FIONBIO: u64 = 0x5421;
-
-// Hardcoded here instead of getting values from kvm-ioctls, so that filtered values cannot be
-// mistakenly or intentionally altered from outside our codebase.
-
-// See include/uapi/linux/if_tun.h in the kernel code.
-const KVM_GET_API_VERSION: u64 = 0xae00;
-const KVM_CREATE_VM: u64 = 0xae01;
-const KVM_CHECK_EXTENSION: u64 = 0xae03;
-const KVM_GET_VCPU_MMAP_SIZE: u64 = 0xae04;
-const KVM_CREATE_VCPU: u64 = 0xae41;
-const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
-const KVM_SET_TSS_ADDR: u64 = 0xae47;
-const KVM_CREATE_IRQCHIP: u64 = 0xae60;
-const KVM_RUN: u64 = 0xae80;
-const KVM_SET_MSRS: u64 = 0x4008_ae89;
-const KVM_SET_CPUID2: u64 = 0x4008_ae90;
-const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
-const KVM_IRQFD: u64 = 0x4020_ae76;
-const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
-const KVM_IOEVENTFD: u64 = 0x4040_ae79;
-const KVM_SET_REGS: u64 = 0x4090_ae82;
-const KVM_SET_SREGS: u64 = 0x4138_ae84;
-const KVM_SET_FPU: u64 = 0x41a0_ae8d;
-const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
-const KVM_GET_SREGS: u64 = 0x8138_ae83;
-const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
-const KVM_GET_MSR_INDEX_LIST: u64 = 0xc004_ae02;
-const KVM_GET_MSR_FEATURE_INDEX_LIST: u64 = 0xc004_ae0a;
-const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
-const KVM_GET_IRQCHIP: u64 = 0xc208_ae62;
-const KVM_SET_IRQCHIP: u64 = 0x8208_ae63;
-const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
-const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
-const KVM_GET_PIT2: u64 = 0x8070_ae9f;
-const KVM_SET_PIT2: u64 = 0x4070_aea0;
-const KVM_GET_REGS: u64 = 0x8090_ae81;
-const KVM_GET_MSRS: u64 = 0xc008_ae88;
-const KVM_GET_CPUID2: u64 = 0xc008_ae91;
-const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
-const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
-const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
-const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
-const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
-const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
-const KVM_GET_XSAVE: u64 = 0x9000_aea4;
-const KVM_SET_XSAVE: u64 = 0x5000_aea5;
-const KVM_GET_XCRS: u64 = 0x8188_aea6;
-const KVM_SET_XCRS: u64 = 0x4188_aea7;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
 const TUNSETIFF: u64 = 0x4004_54ca;
 const TUNSETOFFLOAD: u64 = 0x4004_54d0;
 const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
 
-fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
-    Ok(or![
-        and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CHECK_EXTENSION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VM)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_API_VERSION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SUPPORTED_CPUID,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_MMAP_SIZE,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_IRQCHIP,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_PIT2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VCPU)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_TSS_ADDR,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIOCLEX)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],
+// Hardcoded here instead of getting values from kvm-ioctls, so that filtered values cannot be
+// mistakenly or intentionally altered from outside our codebase.
+const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
+const KVM_RUN: u64 = 0xae80;
+const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
+const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
+const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
+const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
+
+// Use this mod to define ioctl params that are architecture specific.
+// To add other architectures, add another module declaration with the right cfg attribute.
+#[cfg(target_arch = "x86_64")]
+mod arch_specific_constants {
+    pub const KVM_SET_MSRS: u64 = 0x4008_ae89;
+    pub const KVM_SET_CPUID2: u64 = 0x4008_ae90;
+    pub const KVM_SET_REGS: u64 = 0x4090_ae82;
+    pub const KVM_SET_SREGS: u64 = 0x4138_ae84;
+    pub const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
+    pub const KVM_GET_SREGS: u64 = 0x8138_ae83;
+    pub const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
+    pub const KVM_GET_IRQCHIP: u64 = 0xc208_ae62;
+    pub const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
+    pub const KVM_GET_PIT2: u64 = 0x8070_ae9f;
+    pub const KVM_GET_REGS: u64 = 0x8090_ae81;
+    pub const KVM_GET_MSRS: u64 = 0xc008_ae88;
+    pub const KVM_GET_CPUID2: u64 = 0xc008_ae91;
+    pub const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
+    pub const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
+    pub const KVM_GET_XSAVE: u64 = 0x9000_aea4;
+    pub const KVM_SET_XSAVE: u64 = 0x5000_aea5;
+    pub const KVM_GET_XCRS: u64 = 0x8188_aea6;
+    pub const KVM_SET_XCRS: u64 = 0x4188_aea7;
+}
+
+fn create_arch_specific_ioctl_conditions() -> Result<Vec<SeccompRule>, Error> {
+    #[cfg(target_arch = "x86_64")]
+    use arch_specific_constants::*;
+
+    #[cfg(target_arch = "x86_64")]
+    return Ok(or![
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SREGS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CPUID2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_SREGS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSR_INDEX_LIST)?],
-        and![Cond::new(
-            1,
-            ArgLen::DWORD,
-            Eq,
-            KVM_GET_MSR_FEATURE_INDEX_LIST
-        )?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_IRQCHIP)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_IRQCHIP)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_PIT2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_PIT2)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CPUID2)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DEBUGREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_DEBUGREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XSAVE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XCRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS)?],
-    ])
+    ]);
+
+    #[cfg(target_arch = "aarch64")]
+    return Ok(or![]);
+}
+
+fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
+    let mut rule = or![
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
+    ];
+
+    rule.append(&mut create_arch_specific_ioctl_conditions()?);
+
+    Ok(rule)
 }
 
 #[cfg(test)]

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -29,6 +29,7 @@ const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
+const TIOCGWINSZ: u64 = 0x5413;
 const FIONBIO: u64 = 0x5421;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
@@ -106,6 +107,9 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
+        // Triggered on microvm shutdown. If you remove it, tests will likely still pass,
+        // because the sigsys_handler exits the process.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -29,6 +29,8 @@ const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
+const TCGETS: u64 = 0x5401;
+const TCSETS: u64 = 0x5402;
 const TIOCGWINSZ: u64 = 0x5413;
 const FIONBIO: u64 = 0x5421;
 
@@ -106,10 +108,15 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
     let mut rule = or![
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
-        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
-        // Triggered on microvm shutdown. If you remove it, tests will likely still pass,
-        // because the sigsys_handler exits the process.
+        // Triggered on shutdown, to restore the initial terminal settings,
+        // only when Firecracker was launched from a shell.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
+        // Triggered on shutdown, to restore the initial terminal settings,
+        // only when Firecracker was launched from a shell.
+        and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
+        // Triggered on shutdown, to restore the initial terminal settings.
         and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -162,6 +162,25 @@ class JailerContext:
             utils.run_cmd(cmd)
         return jailed_p
 
+    def copy_into_root(self, file_path, create_jail=False):
+        """Copy a file in the jail root, owned by uid:gid.
+
+        Copy a file in the jail root, creating the folder path if
+        not existent, then change their owner to uid:gid.
+        """
+        global_path = os.path.join(
+            self.chroot_path(), file_path.strip(os.path.sep))
+        if create_jail:
+            os.makedirs(self.chroot_path(), exist_ok=True)
+
+        os.makedirs(os.path.dirname(global_path), exist_ok=True)
+
+        shutil.copy(file_path, global_path)
+
+        cmd = 'chown {}:{} {}'.format(
+            self.uid, self.gid, global_path)
+        utils.run_cmd(cmd)
+
     def netns_file_path(self):
         """Get the host netns file path for a jailer context.
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -82,6 +82,10 @@ class Microvm:
         )
         self.jailer_clone_pid = None
 
+        # Copy the /etc/localtime file in the jailer root
+        self.jailer.copy_into_root(
+            "/etc/localtime", create_jail=True)
+
         # Now deal with the things specific to the api session used to
         # communicate with this machine.
         self._api_session = None

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -151,7 +151,7 @@ class Microvm:
                     ignore_return_code=True)
         else:
             utils.run_cmd(
-                'screen -XS {} kill'.format(self._session_name))
+                'screen -XS {} kill || true'.format(self._session_name))
 
         if self._memory_monitor and self._memory_monitor.is_alive():
             self._memory_monitor.signal_stop()
@@ -461,9 +461,9 @@ class Microvm:
                 tries=30,
                 delay=1).group(1)
 
-            self.jailer_clone_pid = open('/proc/{0}/task/{0}/children'
-                                         .format(screen_pid)
-                                         ).read().strip()
+            self.jailer_clone_pid = int(open('/proc/{0}/task/{0}/children'
+                                             .format(screen_pid)
+                                             ).read().strip())
 
             # Configure screen to flush stdout to file.
             flush_cmd = 'screen -S {session} -X colon "logfile flush 0^M"'

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -14,6 +14,7 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 def test_reboot(test_microvm_with_ssh, network_config):
     """Test reboot from guest kernel."""
     test_microvm = test_microvm_with_ssh
+    test_microvm.jailer.daemonize = False
     test_microvm.spawn()
 
     # We don't need to monitor the memory for this test because we are

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -3,6 +3,7 @@
 """Tests scenarios for shutting down Firecracker/VM."""
 import os
 import time
+import json
 
 import framework.utils as utils
 
@@ -52,6 +53,7 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # Rebooting Firecracker sends an exit event and should gracefully kill.
     # the instance.
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+
     ssh_connection.execute_command("reboot")
 
     while True:
@@ -65,3 +67,6 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # Consume existing metrics
     lines = metrics_fifo.sequential_reader(100)
     assert len(lines) == 1
+
+    # Make sure that the FC process was not killed by a seccomp fault
+    assert json.loads(lines[0])["seccomp"]["num_faults"] == 0

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -11,6 +11,7 @@ ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -47,6 +48,7 @@ RUN apt-get update \
         python3-venv    \
         zlib1g-dev \
         screen \
+        tzdata \
     && python3 -m pip install \
         setuptools \
         wheel \

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -11,6 +11,7 @@ ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
+ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -47,6 +48,7 @@ RUN apt-get update \
         python3-venv    \
         zlib1g-dev \
         screen \
+        tzdata \
     && python3 -m pip install \
         setuptools \
         wheel \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v19"
+DEVCTR_IMAGE="fcuvm/dev:v20"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

Merge feature/seccomp_audit into master.
The seccomp allowlist audit is done and was properly tested.

Also fixes: #2128 

Note: These commits were already reviewed and approved on the feature branch

## Description of Changes

- Removed unnecessary allowed syscalls.
- Tighten allowed parameters.
- Add arch-specific `ioctl` conditions
- Add descriptive comments where relevant
- Add regression checks for some syscalls/arguments: `mmap(MAP_SHARED)`, `ioctl(TIOCGWINSZ)`, `ioctl(TCGETS)`, `ioctl(TCSETS)`
- Changes `FCNTL_FD_CLOEXEC` param type to be `DWORD`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
