### PR TITLE
RFC: Add support for pausing and resuming emulation

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -117,6 +117,7 @@ pub struct Balloon {
     pub(crate) device_state: DeviceState,
 
     // Implementation specific fields.
+    pub(crate) events_registered: bool,
     pub(crate) restored: bool,
     pub(crate) stats_polling_interval_s: u16,
     pub(crate) stats_timer: TimerFd,
@@ -172,6 +173,7 @@ impl Balloon {
             queues,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(BalloonError::EventFd)?,
+            events_registered: false,
             restored,
             stats_polling_interval_s,
             stats_timer,

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -145,6 +145,7 @@ pub struct Block {
     pub(crate) partuuid: Option<String>,
     pub(crate) root_device: bool,
     pub(crate) rate_limiter: RateLimiter,
+    pub(crate) events_registered: bool,
 }
 
 impl Block {
@@ -186,6 +187,7 @@ impl Block {
             queues,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK)?,
+            events_registered: false,
         })
     }
 

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -1,13 +1,15 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use std::os::unix::io::AsRawFd;
+use std::result::Result;
+use std::sync::{Arc, Mutex};
 
 use logger::{debug, error, warn};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 
 use crate::virtio::block::device::Block;
-use crate::virtio::VirtioDevice;
+use crate::virtio::device::VirtioDevice;
 
 impl Block {
     fn process_activate_event(&self, event_manager: &mut EventManager) {
@@ -95,6 +97,39 @@ impl Subscriber for Block {
                 self.activate_evt.as_raw_fd() as u64,
             )]
         }
+    }
+
+    fn stop(&mut self, evmgr: &mut EventManager) -> Result<(), String> {
+        if self.events_registered {
+            for event in self.interest_list() {
+                evmgr
+                    .unregister(event.data() as i32)
+                    .map_err(|e| format!("Failed to unregister events: {:?}", e))?;
+            }
+            self.events_registered = false;
+        }
+        self.disk.file_mut().sync_all().unwrap_or_else(|e| {
+            error!("Block {} failed to fsync backing file: {}", self.id, e);
+        });
+        Ok(())
+    }
+
+    fn start(
+        &mut self,
+        self_subscriber: Arc<Mutex<dyn Subscriber>>,
+        evmgr: &mut EventManager,
+    ) -> Result<(), String> {
+        if !self.events_registered {
+            for event in self.interest_list() {
+                evmgr
+                    .register(event.data() as i32, event, self_subscriber.clone())
+                    .map_err(|e| format!("Failed to re-register events: {:?}", e))?;
+                // Kick the device to make up for lost, in-flight events.
+                self.process(&event, evmgr);
+            }
+            self.events_registered = true;
+        }
+        Ok(())
     }
 }
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -123,6 +123,7 @@ pub struct Net {
     pub(crate) activate_evt: EventFd,
 
     pub(crate) mmds_ns: Option<MmdsNetworkStack>,
+    pub(crate) events_registered: bool,
 
     #[cfg(test)]
     pub(crate) mocks: Mocks,
@@ -200,6 +201,7 @@ impl Net {
             config_space,
             mmds_ns,
             guest_mac: guest_mac.copied(),
+            events_registered: false,
 
             #[cfg(test)]
             mocks: Mocks::default(),

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::os::unix::io::AsRawFd;
+use std::result::Result;
+use std::sync::{Arc, Mutex};
 
 use logger::{debug, error, warn, Metric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
@@ -50,7 +52,7 @@ impl Subscriber for Net {
 
         // TODO: also check for errors. Pending high level discussions on how we want
         // to handle errors in devices.
-        let supported_events = EventSet::IN;
+        let supported_events = EventSet::IN | EventSet::EDGE_TRIGGERED;
         if !supported_events.contains(event_set) {
             warn!(
                 "Received unknown event: {:?} from source: {:?}",
@@ -110,6 +112,36 @@ impl Subscriber for Net {
                 self.activate_evt.as_raw_fd() as u64,
             )]
         }
+    }
+
+    fn stop(&mut self, evmgr: &mut EventManager) -> Result<(), String> {
+        if self.events_registered {
+            for event in self.interest_list() {
+                evmgr
+                    .unregister(event.data() as i32)
+                    .map_err(|e| format!("Failed to unregister events: {:?}", e))?;
+            }
+            self.events_registered = false;
+        }
+        Ok(())
+    }
+
+    fn start(
+        &mut self,
+        self_subscriber: Arc<Mutex<dyn Subscriber>>,
+        evmgr: &mut EventManager,
+    ) -> Result<(), String> {
+        if !self.events_registered {
+            for event in self.interest_list() {
+                evmgr
+                    .register(event.data() as i32, event, self_subscriber.clone())
+                    .map_err(|e| format!("Failed to re-register events: {:?}", e))?;
+                // Kick the device to make up for lost, in-flight events.
+                self.process(&event, evmgr);
+            }
+            self.events_registered = true;
+        }
+        Ok(())
     }
 }
 

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -64,6 +64,7 @@ pub struct Vsock<B> {
     // continuous triggers from happening before the device gets activated.
     pub(crate) activate_evt: EventFd,
     pub(crate) device_state: DeviceState,
+    pub(crate) events_registered: bool,
 }
 
 // TODO: Detect / handle queue deadlock:
@@ -96,6 +97,7 @@ where
             interrupt_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VsockError::EventFd)?,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(VsockError::EventFd)?,
             device_state: DeviceState::Inactive,
+            events_registered: false,
         })
     }
 

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -61,14 +61,14 @@ impl ApiServerAdapter {
 }
 impl Subscriber for ApiServerAdapter {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, evmgr: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
         if source == self.api_event_fd.as_raw_fd() && event_set == EventSet::IN {
             match self.from_api.try_recv() {
                 Ok(api_request) => {
-                    let response = self.controller.handle_request(*api_request);
+                    let response = self.controller.handle_request(*api_request, evmgr);
                     // Send back the result.
                     self.to_api
                         .send(Box::new(response))

--- a/src/polly/src/event_manager.rs
+++ b/src/polly/src/event_manager.rs
@@ -61,6 +61,24 @@ pub trait Subscriber {
 
     /// Returns a list of `EpollEvent` that this subscriber is interested in.
     fn interest_list(&self) -> Vec<EpollEvent>;
+
+    /// Callback for the `Subscriber` to handle stopping/pausing its event handling.
+    ///
+    /// The `Subscriber` is also responsible for unregistering its events from `EventManager`.
+    fn stop(&mut self, _: &mut EventManager) -> std::result::Result<(), String> {
+        Ok(())
+    }
+
+    /// Callback for the Subscriber to handle starting/resuming its event handling.
+    ///
+    /// The `Subscriber` is also responsible for registering its events from `EventManager`.
+    fn start(
+        &mut self,
+        _: Arc<Mutex<dyn Subscriber>>,
+        _: &mut EventManager,
+    ) -> std::result::Result<(), String> {
+        Ok(())
+    }
 }
 
 /// Manages I/O notifications using epoll mechanism.

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -57,6 +57,8 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             ),
             // Used for drive patching & rescanning, for reading the local timezone
             allow_syscall(libc::SYS_fstat),
+            // Used for flushing drive to backing storage on pause
+            allow_syscall(libc::SYS_fsync),
             // Used for snapshotting
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_ftruncate),

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -319,6 +319,27 @@ impl MMIODeviceManager {
         }
         None
     }
+
+    #[cfg(target_arch = "x86_64")]
+    /// Run fn for each registered device.
+    pub fn for_each_device<F, E>(&self, mut f: F) -> std::result::Result<(), E>
+    where
+        F: FnMut(
+            &DeviceType,
+            &String,
+            &MMIODeviceInfo,
+            &Mutex<dyn BusDevice>,
+        ) -> std::result::Result<(), E>,
+    {
+        for ((device_type, device_id), device_info) in self.get_device_info().iter() {
+            let bus_device = self
+                .get_device(*device_type, device_id)
+                // Safe to unwrap() because we know the device exists.
+                .unwrap();
+            f(device_type, device_id, device_info, bus_device)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -297,18 +297,17 @@ mod tests {
     use crate::vmm_config::vsock::tests::default_config;
     use crate::Vmm;
 
-    use polly::event_manager::EventManager;
     use snapshot::Persist;
     use utils::{errno, tempfile::TempFile};
 
-    fn default_vmm_with_devices(event_manager: &mut EventManager) -> Vmm {
+    fn default_vmm_with_devices() -> Vmm {
         let mut vmm = default_vmm();
         let mut cmdline = default_kernel_cmdline();
 
         // Add a block device.
         let drive_id = String::from("root");
         let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
-        insert_block_devices(&mut vmm, &mut cmdline, event_manager, block_configs);
+        insert_block_devices(&mut vmm, &mut cmdline, block_configs);
 
         // Add net device.
         let network_interface = NetworkInterfaceConfig {
@@ -319,22 +318,21 @@ mod tests {
             tx_rate_limiter: None,
             allow_mmds_requests: true,
         };
-        insert_net_device(&mut vmm, &mut cmdline, event_manager, network_interface);
+        insert_net_device(&mut vmm, &mut cmdline, network_interface);
 
         // Add vsock device.
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
 
-        insert_vsock_device(&mut vmm, &mut cmdline, event_manager, vsock_config);
+        insert_vsock_device(&mut vmm, &mut cmdline, vsock_config);
 
         vmm
     }
 
     #[test]
     fn test_microvmstate_versionize() {
-        let mut event_manager = EventManager::new().expect("Cannot create EventManager");
-        let vmm = default_vmm_with_devices(&mut event_manager);
+        let vmm = default_vmm_with_devices();
         let states = vmm.mmio_device_manager.save();
 
         // Only checking that all devices are saved, actual device state

--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -76,9 +76,7 @@ class CpuLoadMonitor(Thread):
         """
         clock_ticks_cmd = 'getconf CLK_TCK'
         try:
-            stdout = utils.cmd_run(
-                    clock_ticks_cmd,
-                ).stdout.decode('utf-8')
+            _, stdout, _ = utils.run_cmd(clock_ticks_cmd)
         except ChildProcessError:
             return
         try:


### PR DESCRIPTION
## Reason for This PR

Fixes #2193 
Alternate fix: #2213 

## Draft/RFC status

Currently RFC to get early feedback. Still needs unit-tests and integ-tests to promote to full PR.

## Description of Changes

When pausing or resuming the VM, alongside vcpus device emulation is now also paused or resumed.
    
For reduced complexity and runtime overhead, this change only affects virtio devices. Legacy devices are controlled by vcpus (which get paused) and use no resources external to firecracker so their state remains consistent even if they're not explicitly paused.

### Implementation details:

    We want to be able to pause and resume event handling.
    Usually this boils down to unregistering from event handling on
    pause, and re-registering on resume.
    
    At the very least we need an 'update()' function in the Subscriber
    trait to allow on-demand updates to EventManager for said subscriber.
    
    I've chosen instead to add pause and resume specific functions with
    default implementations to minimize boiler-plate code across all
    Subscribers that don't need custom implementations.
    To keep an unified model for both fresh booting a VM and restoring
    one from snapshot, we follow the same pattern with devices as with
    vcpus: devices start off in the paused state and they are resumed
    alongside vcpus.

    In devices, override default implementation of Subscriber functions that
    control when events are registered and unregistered.
    
    The resulting behaviour is:
     * (pause):  on paused->paused nothing happens,
     * (pause):  on running->paused transition device events are
                 unregistered from EventManager, effectively
                 removing the device from the emulation thread,
     * (resume): on running->running nothing happens,
     * (resume): on paused->running transition device events are
                 re-registered with EventManager.
    
    The MMIODeviceManager was enhanced with a list of subscribers to be
    able to directly access the Subscriber trait functions on the devices
    without having to downcast BusDevices all the way down to their
    concrete types then upcast back to Arc<Mutex<dyn Subscriber>>.
    
    Device events registration is moved from device attachment to Vmm,
    to device resume path since `resume_emulation()` is called on both
    boot path and snapshot load path.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~Any newly added `unsafe` code is properly documented.~
- [ ] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [ ] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [ ] All added/changed functionality is tested.
