### PR TITLE
RFC: Cascaded EventManager for pausing and resuming emulation

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -168,16 +168,11 @@ pub fn run_with_api(
 
     // Configure, build and start the microVM.
     let (vm_resources, vmm) = match config_json {
-        Some(json) => super::build_microvm_from_json(
-            seccomp_filter,
-            &mut event_manager,
-            json,
-            &instance_info,
-            boot_timer_enabled,
-        ),
+        Some(json) => {
+            super::build_microvm_from_json(seccomp_filter, json, &instance_info, boot_timer_enabled)
+        }
         None => PrebootApiController::build_microvm_from_requests(
             seccomp_filter,
-            &mut event_manager,
             instance_info,
             || {
                 let req = from_api
@@ -198,6 +193,10 @@ pub fn run_with_api(
             boot_timer_enabled,
         ),
     };
+    let vmm = Arc::new(Mutex::new(vmm));
+    event_manager
+        .add_subscriber(vmm.clone())
+        .expect("Cannot register the vmm to the events manager.");
 
     // Start the metrics.
     firecracker_metrics

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -61,14 +61,14 @@ impl ApiServerAdapter {
 }
 impl Subscriber for ApiServerAdapter {
     /// Handle a read event (EPOLLIN).
-    fn process(&mut self, event: &EpollEvent, _: &mut EventManager) {
+    fn process(&mut self, event: &EpollEvent, evmgr: &mut EventManager) {
         let source = event.fd();
         let event_set = event.event_set();
 
         if source == self.api_event_fd.as_raw_fd() && event_set == EventSet::IN {
             match self.from_api.try_recv() {
                 Ok(api_request) => {
-                    let response = self.controller.handle_request(*api_request);
+                    let response = self.controller.handle_request(*api_request, evmgr);
                     // Send back the result.
                     self.to_api
                         .send(Box::new(response))

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -258,11 +258,10 @@ fn main() {
 // Configure and start a microVM as described by the command-line JSON.
 fn build_microvm_from_json(
     seccomp_filter: BpfProgram,
-    event_manager: &mut EventManager,
     config_json: String,
     instance_info: &InstanceInfo,
     boot_timer_enabled: bool,
-) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
+) -> (VmResources, vmm::Vmm) {
     let mut vm_resources =
         VmResources::from_json(&config_json, instance_info).unwrap_or_else(|err| {
             error!(
@@ -272,14 +271,15 @@ fn build_microvm_from_json(
             process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
         });
     vm_resources.boot_timer = boot_timer_enabled;
-    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, event_manager, &seccomp_filter)
-        .unwrap_or_else(|err| {
+    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, &seccomp_filter).unwrap_or_else(
+        |err| {
             error!(
                 "Building VMM configured from cmdline json failed: {:?}",
                 err
             );
             process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
-        });
+        },
+    );
     info!("Successfully started microvm that was configured from one single json");
 
     (vm_resources, vmm)
@@ -302,14 +302,16 @@ fn run_without_api(
     // Build the microVm. We can ignore the returned values here because:
     // - VmResources is not used without api,
     // - An `Arc` reference of the built `Vmm` is plugged in the `EventManager` by the builder.
-    build_microvm_from_json(
+    let (_, vmm) = build_microvm_from_json(
         seccomp_filter,
-        &mut event_manager,
         // Safe to unwrap since '--no-api' requires this to be set.
         config_json.unwrap(),
         instance_info,
         bool_timer_enabled,
     );
+    event_manager
+        .add_subscriber(Arc::new(Mutex::new(vmm)))
+        .expect("Cannot register the vmm to the events manager.");
 
     // Start the metrics.
     firecracker_metrics

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -319,6 +319,26 @@ impl MMIODeviceManager {
         }
         None
     }
+
+    /// Run fn for each registered device.
+    pub fn for_each_device<F, E>(&self, mut f: F) -> std::result::Result<(), E>
+    where
+        F: FnMut(
+            &DeviceType,
+            &String,
+            &MMIODeviceInfo,
+            &Mutex<dyn BusDevice>,
+        ) -> std::result::Result<(), E>,
+    {
+        for ((device_type, device_id), device_info) in self.get_device_info().iter() {
+            let bus_device = self
+                .get_device(*device_type, device_id)
+                // Safe to unwrap() because we know the device exists.
+                .unwrap();
+            f(device_type, device_id, device_info, bus_device)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -228,7 +228,7 @@ pub struct Vmm {
     pio_device_manager: PortIODeviceManager,
 
     // Emulation event manager.
-    emu_evmgr: EventManager,
+    pub(crate) emu_evmgr: EventManager,
 }
 
 impl Vmm {

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -297,18 +297,17 @@ mod tests {
     use crate::vmm_config::vsock::tests::default_config;
     use crate::Vmm;
 
-    use polly::event_manager::EventManager;
     use snapshot::Persist;
     use utils::{errno, tempfile::TempFile};
 
-    fn default_vmm_with_devices(event_manager: &mut EventManager) -> Vmm {
+    fn default_vmm_with_devices() -> Vmm {
         let mut vmm = default_vmm();
         let mut cmdline = default_kernel_cmdline();
 
         // Add a block device.
         let drive_id = String::from("root");
         let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
-        insert_block_devices(&mut vmm, &mut cmdline, event_manager, block_configs);
+        insert_block_devices(&mut vmm, &mut cmdline, block_configs);
 
         // Add net device.
         let network_interface = NetworkInterfaceConfig {
@@ -319,22 +318,21 @@ mod tests {
             tx_rate_limiter: None,
             allow_mmds_requests: true,
         };
-        insert_net_device(&mut vmm, &mut cmdline, event_manager, network_interface);
+        insert_net_device(&mut vmm, &mut cmdline, network_interface);
 
         // Add vsock device.
         let mut tmp_sock_file = TempFile::new().unwrap();
         tmp_sock_file.remove().unwrap();
         let vsock_config = default_config(&tmp_sock_file);
 
-        insert_vsock_device(&mut vmm, &mut cmdline, event_manager, vsock_config);
+        insert_vsock_device(&mut vmm, &mut cmdline, vsock_config);
 
         vmm
     }
 
     #[test]
     fn test_microvmstate_versionize() {
-        let mut event_manager = EventManager::new().expect("Cannot create EventManager");
-        let vmm = default_vmm_with_devices(&mut event_manager);
+        let vmm = default_vmm_with_devices();
         let states = vmm.mmio_device_manager.save();
 
         // Only checking that all devices are saved, actual device state

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -422,6 +422,10 @@ impl RuntimeApiController {
             .register(emu_evmgr_fd, event, vmm_subscriber)
             .map_err(VmmActionError::VmmResume)?;
 
+        // FIXME: If we're coming off a snapshot we may have lost pending events, so
+        // It's not enough to register the emulation event manager, we also need to
+        // kick all of its Subscribers.
+
         vmm.resume_vcpus().map_err(VmmActionError::InternalVmm)?;
 
         let elapsed_time_us =

--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -76,9 +76,7 @@ class CpuLoadMonitor(Thread):
         """
         clock_ticks_cmd = 'getconf CLK_TCK'
         try:
-            stdout = utils.cmd_run(
-                    clock_ticks_cmd,
-                ).stdout.decode('utf-8')
+            _, stdout, _ = utils.run_cmd(clock_ticks_cmd)
         except ChildProcessError:
             return
         try:


### PR DESCRIPTION
## Reason for This PR

Fixes #2193 
Alternative to #2208 

## Description of Changes

Use two cascaded `EventManagers` with API in the top one and emulation in the bottom one. On VMM pause, un-register the bottom `EventManager` from the top one. On VMM resume, re-register the emulation `EventManager` under the main/top one.

### The good

I like this approach because it also separates `vmm` and emulation from other app-specific logic like API handling, metrics, etc.

The `vmm` owns its emulation `EventManager` which is unregistered or re-registered for running by the runtime-controller (the api controller) on vmm pause and respectively vmm resume.

There are a lot of line changes mainly because `builder`, `snapshot` and `tests` don't need to carry around the main `&mut EventManager`, the `Vmm` simply works with its internal evmgr and only exposes the FD for registering it under the main evmgr. The builder now builds a simple `Vmm` instead of an `Arc<Mutex<Vmm>>` already registered to an `EventManager`. The top layers use the `Vmm` whichever way they like.

Also we're not touching the `EventManager/Subscriber` interface - which is interpreted as good by some, irrelevant for others.

### The bad

Emulation goes through two layers of `EventManager` syscalls, lookups and dynamic dispatches. From a few rounds of simple tests, it looks like performance impact is visible:

| iperf3: guest as: |    Original    | Cascaded EvMgr |
|-------------------|:--------------:|----------------|
| client run 1      | 20.4 Gbits/sec | 20.1 Gbits/sec |
| client run 2      | 20.5 Gbits/sec | 19.4 Gbits/sec |
| server run 1      | 24.7 Gbits/sec | 21.5 Gbits/sec |
| server run 2      | 21.7 Gbits/sec | 20.2 Gbits/sec |

### The ugly

The current code in this PR is not enough.
If we're coming off a snapshot we may have lost pending events, so it's not enough to register the emulation event manager, we also need to kick all of its Subscribers.

This means, on resume, we either:
 - add a `.kick()` to `trait VirtioDevice` and go thru all `BusDevices` and `kick()` the `type == Virtio` ones,
 - add a `.kick()` to `trait Subscriber` and keep a list of subscribers like in the other RFC and just run thru them and kick them,
    or
 - (uglyish, but works) go through all `BusDevices`, dynamic cast them down to their concrete types, manually call `kick()/process()`

L.E. we might also need to do some device specific things on pause as well: block devices could be flushed for example (but I don't think that's mandatory), in the future we might identify corner cases with mandatory actions.