### PR TITLE
Add prototype support for macvtap interfaces

### DIFF
--- a/src/utils/src/net/macvtap.rs
+++ b/src/utils/src/net/macvtap.rs
@@ -1,0 +1,160 @@
+// Copyright 2021 Geoff Johnstone. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains support for detecting macvtap interfaces.
+use std::ffi::CString;
+use std::io::{Error, ErrorKind, Result};
+use std::os::unix::{ffi::OsStrExt, fs::FileTypeExt};
+use std::path::{Path, PathBuf};
+
+use crate::syscall::SyscallReturnCode;
+
+/// Represents a macvtap interface.
+pub struct MacVTap {
+    /// Interface name, as seen in 'ip addr' output.
+    pub if_name: String,
+    /// Host tap device node name in /dev.
+    pub tap_name: String,
+    /// Device major number.
+    pub major: u32,
+    /// Device minor number.
+    pub minor: u32,
+}
+
+impl MacVTap {
+    /// Returns the device node for the given macvtap interface.
+    pub fn get_device_node(if_name: &str) -> Result<PathBuf> {
+        // If this is run with jailer, we expect /dev/net/<if_name> to be a valid char device;
+        // If run without jailer, try /dev/tapXX.
+        is_char_device(Path::new("/dev/net").join(if_name))
+            .or_else(|_| is_char_device(Path::new("/dev").join(Self::by_name(if_name)?.tap_name)))
+    }
+
+    /// Returns a MacVTap instance for the given network interface name.
+    /// This function looks into /sys/devices/virtual/net/{if_name}/macvtap/ and expects to find
+    /// the name of the /dev/tapXX associated with it.
+    /// It will look further to find out the major and minor numbers in the
+    /// /sys/devices/virtual/net/{if_name}/macvtap/tapXX/dev
+    pub fn by_name(if_name: &str) -> Result<Self> {
+        // Need to convert if_name into a device node. There should be one
+        // directory under /sys/.../<if_name>/macvtap, which is the name of
+        // the device node in /dev. Within that, dev gives major:minor\n
+        if !is_normal_path_component(if_name) {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Invalid macvtap interface name: {}", if_name),
+            ));
+        }
+
+        let macvtap_dir = Path::new("/sys/devices/virtual/net")
+            .join(if_name)
+            .join("macvtap");
+        let dirents = macvtap_dir.read_dir()?.collect::<Vec<_>>();
+        if dirents.len() != 1 {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "Found {} dirents in {}",
+                    dirents.len(),
+                    macvtap_dir.display()
+                ),
+            ));
+        }
+
+        // unwrap() is safe because there is one element in dirents and we already checked for that.
+        let dirent = dirents.into_iter().next().unwrap();
+        let dev_name = dirent?.file_name(); // e.g. tap42
+
+        // Read /sys/.../<if_name>/macvtap/<dev_name>/dev
+        let dev_file_path = macvtap_dir.join(&dev_name).join("dev");
+        let dev_str = std::fs::read_to_string(&dev_file_path)?;
+
+        // Trim trailing newline, split on ':', parse major and minor numbers
+        let mut cpts = dev_str.trim_end().splitn(2, ':');
+        let major = parse_dev(&mut cpts);
+        let minor = parse_dev(&mut cpts);
+
+        if major.is_none() || minor.is_none() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid {} contents: {}", dev_file_path.display(), dev_str),
+            ));
+        }
+
+        Ok(Self {
+            if_name: if_name.to_string(),
+            tap_name: dev_name.into_string().unwrap(),
+            major: major.unwrap(),
+            minor: minor.unwrap(),
+        })
+    }
+
+    /// Creates a device node for the given network MacVTap instance at the given path with
+    /// the given owner and group.
+    pub fn mknod<P: AsRef<Path>>(&self, path: P, uid: u32, gid: u32) -> Result<()> {
+        let osstr = path.as_ref().as_os_str();
+        let cstr =
+            CString::new(osstr.as_bytes()).map_err(|x| Error::new(ErrorKind::InvalidInput, x))?;
+
+        // Safety: path is a C-compatible pointer to memory that is in scope
+        SyscallReturnCode(unsafe {
+            libc::mknod(
+                cstr.as_ptr(),
+                libc::S_IFCHR | libc::S_IRUSR | libc::S_IWUSR,
+                libc::makedev(self.major, self.minor),
+            )
+        })
+        .into_empty_result()?;
+
+        // Safety: path is a C-compatible pointer to memory that is in scope
+        SyscallReturnCode(unsafe { libc::chown(cstr.as_ptr(), uid, gid) }).into_empty_result()
+    }
+}
+
+fn parse_dev<'a, It: Iterator<Item = &'a str>>(it: &mut It) -> Option<u32> {
+    it.next().and_then(|s| s.parse().ok())
+}
+
+fn is_normal_path_component(if_name: &str) -> bool {
+    // Mustn't be empty, "." or ".."; mustn't contain / or \.
+    if_name != ""
+        && if_name != "."
+        && if_name != ".."
+        && if_name.as_bytes().iter().all(|b| *b != b'/' && *b != b'\\')
+}
+
+fn is_char_device(dev_path: PathBuf) -> Result<PathBuf> {
+    dev_path.metadata().and_then(|md| {
+        if !md.file_type().is_char_device() {
+            Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("{} is not a character device", dev_path.display()),
+            ))
+        } else {
+            Ok(dev_path)
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_normal_path_component() {
+        assert!(!is_normal_path_component(""));
+        assert!(!is_normal_path_component("."));
+        assert!(!is_normal_path_component(".."));
+        assert!(!is_normal_path_component("/"));
+        assert!(!is_normal_path_component("./x"));
+        assert!(!is_normal_path_component("../x"));
+        assert!(!is_normal_path_component("x/./x"));
+        assert!(!is_normal_path_component("x/"));
+        assert!(!is_normal_path_component("x/y"));
+        assert!(!is_normal_path_component("/.."));
+        assert!(!is_normal_path_component("../"));
+        assert!(is_normal_path_component("x"));
+        assert!(is_normal_path_component(".x"));
+        assert!(is_normal_path_component("..x"));
+    }
+}

--- a/src/utils/src/net/mod.rs
+++ b/src/utils/src/net/mod.rs
@@ -14,3 +14,4 @@
 /// Provides IPv4 address utility methods.
 pub mod ipv4addr;
 pub mod mac;
+pub mod macvtap;

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -35,6 +35,7 @@ class JailerContext:
     extra_args = None
     api_socket_name = None
     cgroups = None
+    macvtaps = None
 
     def __init__(
             self,
@@ -47,6 +48,7 @@ class JailerContext:
             netns=None,
             daemonize=True,
             cgroups=None,
+            macvtaps=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -66,6 +68,7 @@ class JailerContext:
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
+        self.macvtaps = macvtaps
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -106,6 +109,9 @@ class JailerContext:
         if self.cgroups is not None:
             for cgroup in self.cgroups:
                 jailer_param_list.extend(['--cgroup', str(cgroup)])
+        if self.macvtaps is not None:
+            for vtap in self.macvtaps:
+                jailer_param_list.extend(['--macvtap', str(vtap)])
         # applying neccessory extra args if needed
         if len(self.extra_args) > 0:
             jailer_param_list.append('--')
@@ -199,14 +205,14 @@ class JailerContext:
             return 'ip netns exec {} '.format(self.netns)
         return ''
 
-    def setup(self):
+    def setup(self, create_netns):
         """Set up this jailer context."""
         os.makedirs(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
             exist_ok=True
         )
-        if self.netns:
+        if self.netns and create_netns:
             utils.run_cmd('ip netns add {}'.format(self.netns))
 
     def cleanup(self):

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -407,10 +407,11 @@ class Microvm:
             return True
         return False
 
-    def spawn(self, create_logger=True, log_file='log_fifo', log_level='Info'):
+    def spawn(self, create_netns=True, create_logger=True,
+              log_file='log_fifo', log_level='Info'):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
-        self._jailer.setup()
+        self._jailer.setup(create_netns)
         self._api_socket = self._jailer.api_socket_path()
         self._api_session = Session()
 
@@ -640,6 +641,23 @@ class Microvm:
         )
         assert self.api_session.is_status_no_content(response.status_code)
 
+    def put_network(
+            self, iface_id, tapname, guest_mac,
+            allow_mmds_requests=False,
+            tx_rate_limiter=None,
+            rx_rate_limiter=None
+    ):
+        """Attach a network device."""
+        response = self.network.put(
+            iface_id=iface_id,
+            host_dev_name=tapname,
+            guest_mac=guest_mac,
+            allow_mmds_requests=allow_mmds_requests,
+            tx_rate_limiter=tx_rate_limiter,
+            rx_rate_limiter=rx_rate_limiter
+        )
+        assert self._api_session.is_status_no_content(response.status_code)
+
     def ssh_network_config(
             self,
             network_config,
@@ -673,15 +691,8 @@ class Microvm:
                                              tapname)
         guest_mac = net_tools.mac_from_ip(guest_ip)
 
-        response = self.network.put(
-            iface_id=iface_id,
-            host_dev_name=tapname,
-            guest_mac=guest_mac,
-            allow_mmds_requests=allow_mmds_requests,
-            tx_rate_limiter=tx_rate_limiter,
-            rx_rate_limiter=rx_rate_limiter
-        )
-        assert self._api_session.is_status_no_content(response.status_code)
+        self.put_network(iface_id, tapname, guest_mac, allow_mmds_requests,
+                         tx_rate_limiter, rx_rate_limiter)
 
         return tap, host_ip, guest_ip
 

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -353,6 +353,13 @@ class Bridge:
 
     def __init__(self, br_name):
         """Set up a bridge containing macvtap interfaces."""
+        # We first check that the device does not exist.
+        # If it exists, ip addr will return no error and we try to
+        # tear it down.
+        _, _, stderr = utils.run_cmd('ip addr show dev {}'.format(br_name),
+                                     ignore_return_code=True)
+        if stderr == "":
+            utils.run_cmd('ip link delete {}'.format(br_name))
         utils.run_cmd('ip link add {} type dummy'.format(br_name))
         utils.run_cmd('ip link set {} up'.format(br_name))
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.38, "AMD": 84.65, "ARM": 83.46}
+COVERAGE_DICT = {"Intel": 84.80, "AMD": 84.12, "ARM": 83.12}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -9,7 +9,7 @@ import time
 
 import host_tools.logging as log_tools
 
-MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2800}
+MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2900}
 """ The maximum acceptable startup time in CPU us. """
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -30,6 +30,12 @@ ALIBABA_COPYRIGHT = (
 ALIBABA_LICENSE = (
     "SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause"
 )
+GEOFF_COPYRIGHT = (
+    "Copyright 2021 Geoff Johnstone. All Rights Reserved."
+)
+GEOFF_LICENSE = (
+    "SPDX-License-Identifier: Apache-2.0"
+)
 
 
 def _has_amazon_copyright(string):
@@ -81,11 +87,16 @@ def _validate_license(filename):
             ALIBABA_COPYRIGHT in copyright_info and
             _look_for_license(file, ALIBABA_LICENSE)
         )
+        has_geoff_copyright = (
+                GEOFF_COPYRIGHT in copyright_info and
+                _look_for_license(file, GEOFF_LICENSE)
+        )
         return (
             has_amazon_copyright or
             has_chromium_copyright or
             has_tuntap_copyright or
-            has_alibaba_copyright
+            has_alibaba_copyright or
+            has_geoff_copyright
         )
     return True
 


### PR DESCRIPTION
Firecracker uses /dev/net/tun to open/create tap interfaces. On the host these are typically bridged, using the standard Linux bridge implementation.

Linux macvtap interfaces are similar to bridges but simpler: the kernel doesn't snoop frames to maintain a FIB to map MAC addresses to interfaces and doesn't need to use flooding, because the full topology is known to the kernel.

However, macvtap interfaces are exposed to userland as /dev/tap%d device nodes, which Firecracker doesn't support. This commit adds support by checking whether the `host_dev_name` in the network configuration looks like a path name, and opening the device node if it does.

Tested thus:

```bash
    # Create a dummy interface to host the macvtap interfaces, plus two macvtap interfaces in bridge mode
    sudo ip link add dummy0 type dummy
    sudo ip link add link dummy0 name vtap0 type macvtap mode bridge
    sudo ip link add link dummy0 name vtap1 type macvtap mode bridge
    sudo ip link set dummy0 up
    sudo ip link set vtap0 up
    sudo ip link set vtap1 up
    sudo chmod 660 /dev/tap*             # For proof-of-concept purposes only
    sudo chown root:$(id -g) /dev/tap*   # For proof-of-concept purposes only
```
Configure two VMs thus; look in `/dev` for device node names; use `ip link` to get tap MAC address etc:
```
    {
        ...
            "network-interfaces" [
                {
                    ...
                    "host_dev_name: "/dev/tapXX",
                    "guest_mac": "<see host's ip link output>"
                }
            ]
        ...
    }
```
Start the VMs, give them IP addresses on the same subnet; they can then ping each other etc.

You must use the correct MAC address in the VM configuration, i.e. the MAC address that the host kernel has assigned to the tap interface.

## Reason for This PR

macvtap (see #1933) allows VMs on a host to be networked without using the Linux bridge code; it is simpler and not prone to ARP spoofing.

The implementation in the commit proves that macvtap-based networking works; I'm after feedback please as to whether macvtap support would be considered for merging. If so then I'd look at configuring properly rather than leeching off the existing /dev/net/tun configuration code.

Alternatively, a more flexible approach would be to allow Firecracker to adopt a file descriptor as a network interface and read/write frames to it. (In other words, in this case, open /dev/tapXX as e.g. FD 3, then exec() firecracker and have it treat FD 3 as the tap interface). This would let me do other useful things on the host, but would require a jailer change to keep the relevant FD[s] open.

## Description of Changes

Extend `Tap::open_named()` in `virtio/net/tap.rs` to support opening `/dev/tapXX` directly, rather than using `/dev/net/tun` to open/create tap interfaces. This allows Firecracker to use tap interfaces create via `macvtap` on the host.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## PR Checklist

I haven't looked at these as this is an RFC; if macvtap (or passing in FDs) is acceptable then I'll submit a PR that meets them.

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
