### PR TITLE
Fixes around statistics functions

### DIFF
--- a/tests/framework/statistics/function.py
+++ b/tests/framework/statistics/function.py
@@ -77,7 +77,7 @@ class Stddev(StatisticFunction):
     ...observations.
     """
 
-    def call(self) -> Any:
+    def __call__(self) -> Any:
         """Get the stddev."""
         assert len(self.results) > 0
         # pylint: disable=R0123
@@ -98,7 +98,7 @@ class Percentile(StatisticFunction):
         super().__init__(results)
         self.k = k
 
-    def __call__(self, results) -> Any:
+    def __call__(self) -> Any:
         """Get the kth percentile of the statistical exercise."""
         # pylint: disable=R0123
         if len(self.results) is 1:


### PR DESCRIPTION
##  Reason for This PR

* Stddev function has an implementation for `call` instead of `__call__`.
* Percentile `__call__` has a redundant extra argument.

## Description of Changes

* Renamed `call` to `__call__` for Stddev function.
* Removed the percentile `__call__` extra arg.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~~- [] Any required documentation changes (code and docs) are included in this PR.~~
~~- [] Any newly added `unsafe` code is properly documented.~~
~~- [] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [] All added/changed functionality is tested.~~
