### PR TITLE
metrics: fix bug triggered by memory reordering casualties

### DIFF
--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -6,7 +6,7 @@ use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
 #[cfg(target_arch = "aarch64")]
 use crate::request::StatusCode;
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -4,7 +4,7 @@
 use super::super::VmmAction;
 use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::boot_source::BootSourceConfig;
 
 pub fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use super::super::VmmAction;
 use crate::parsed_request::{checked_id, Error, ParsedRequest};
 use crate::request::{Body, StatusCode};
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::drive::BlockDeviceConfig;
 
 struct PatchDrivePayload {

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::parsed_request::{Error, ParsedRequest};
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 
 pub fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.instance_info_count.inc();

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -4,7 +4,7 @@
 use super::super::VmmAction;
 use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::logger::LoggerConfig;
 
 pub fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -4,7 +4,7 @@
 use super::super::VmmAction;
 use crate::parsed_request::{method_to_error, Error, ParsedRequest};
 use crate::request::{Body, Method, StatusCode};
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::machine_config::VmConfig;
 
 pub fn parse_get_machine_config() -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -4,7 +4,7 @@
 use super::super::VmmAction;
 use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::metrics::MetricsConfig;
 
 pub fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -4,7 +4,7 @@
 use super::super::VmmAction;
 use crate::parsed_request::{checked_id, Error, ParsedRequest};
 use crate::request::{Body, StatusCode};
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 
 pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {

--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use logger::{error, warn, Metric, METRICS};
+use logger::{error, warn, IncMetric, METRICS};
 use std::fmt;
 use std::num::Wrapping;
 use std::{io, result};

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use std::{io, result};
 
 use crate::BusDevice;
-use logger::{warn, Metric, METRICS};
+use logger::{warn, IncMetric, METRICS};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 //use bus::Error;

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use logger::{error, warn, Metric, METRICS};
+use logger::{error, warn, IncMetric, METRICS};
 use polly::event_manager::{EventManager, Pollable, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -15,7 +15,7 @@ pub mod virtio;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};
 use crate::virtio::QueueError;
-use logger::{error, Metric, METRICS};
+use logger::{error, IncMetric, METRICS};
 
 // Function used for reporting error in terms of logging
 // but also in terms of METRICS net event fails.

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use ::timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 
-use ::logger::{error, Metric, METRICS};
+use ::logger::{error, IncMetric, METRICS};
 use ::utils::eventfd::EventFd;
 use ::versionize::{VersionMap, Versionize, VersionizeResult};
 use ::versionize_derive::Versionize;

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -15,7 +15,7 @@ use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use logger::{error, warn, Metric, METRICS};
+use logger::{error, warn, IncMetric, METRICS};
 use rate_limiter::{RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::*;

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -10,7 +10,7 @@ use std::io::{self, Seek, SeekFrom, Write};
 use std::mem;
 use std::result;
 
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use virtio_gen::virtio_blk::*;
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -18,7 +18,7 @@ use crate::{report_net_event_fail, Error as DeviceError};
 
 use dumbo::pdu::ethernet::EthernetFrame;
 use libc::EAGAIN;
-use logger::{error, warn, Metric, METRICS};
+use logger::{error, warn, IncMetric, METRICS};
 use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 #[cfg(not(test))]
@@ -852,7 +852,7 @@ pub mod tests {
     };
     use dumbo::pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
     use dumbo::pdu::ethernet::ETHERTYPE_ARP;
-    use logger::{Metric, METRICS};
+    use logger::{IncMetric, METRICS};
     use rate_limiter::{RateLimiter, TokenBucket, TokenType};
     use virtio_gen::virtio_net::{
         virtio_net_hdr_v1, VIRTIO_F_VERSION_1, VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM,

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -3,7 +3,7 @@
 
 use std::os::unix::io::AsRawFd;
 
-use logger::{debug, error, warn, Metric, METRICS};
+use logger::{debug, error, warn, IncMetric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 
@@ -118,7 +118,7 @@ pub mod tests {
     use crate::check_metric_after_block;
     use crate::virtio::net::test_utils::test::TestHelper;
     use crate::virtio::net::test_utils::{NetEvent, NetQueue};
-    use logger::{Metric, METRICS};
+    use logger::{IncMetric, METRICS};
 
     #[test]
     fn test_event_handler() {

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -304,7 +304,7 @@ pub mod test {
         Net, VirtioDevice, MAX_BUFFER_SIZE, RX_INDEX, TX_INDEX, VIRTQ_DESC_F_NEXT,
         VIRTQ_DESC_F_WRITE,
     };
-    use logger::{Metric, METRICS};
+    use logger::{IncMetric, METRICS};
     use net_gen::ETH_HLEN;
     use polly::event_manager::{EventManager, Subscriber};
     use std::cmp;

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -83,7 +83,7 @@ use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use logger::{debug, error, info, warn, Metric, METRICS};
+use logger::{debug, error, info, warn, IncMetric, METRICS};
 use utils::epoll::EventSet;
 
 use super::super::defs::uapi;

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -23,7 +23,7 @@ use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use logger::{debug, error, warn, Metric, METRICS};
+use logger::{debug, error, warn, IncMetric, METRICS};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 use vm_memory::GuestMemoryMmap;

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -24,7 +24,7 @@
 ///   - again, attempt to fetch any incoming packets queued by the backend into virtio RX buffers.
 use std::os::unix::io::AsRawFd;
 
-use logger::{debug, error, warn, Metric, METRICS};
+use logger::{debug, error, warn, IncMetric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -35,7 +35,7 @@ use std::io::Read;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 
-use logger::{debug, error, info, warn, Metric, METRICS};
+use logger::{debug, error, info, warn, IncMetric, METRICS};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 
 use super::super::csm::ConnState;

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -18,7 +18,7 @@ use crate::tcp::{
     connection::{Connection, PassiveOpenError, RecvStatusFlags},
     seq_after, NextSegmentStatus, MAX_WINDOW_SIZE,
 };
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use micro_http::{Body, Request, RequestError, Response, StatusCode, Version};
 use utils::time::timestamp_cycles;
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::process;
 use std::sync::{Arc, Mutex};
 
-use logger::{error, info, Metric, LOGGER, METRICS};
+use logger::{error, info, IncMetric, LOGGER, METRICS};
 use polly::event_manager::EventManager;
 use seccomp::{BpfProgram, SeccompLevel};
 use utils::arg_parser::{ArgParser, Argument};

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -4,7 +4,7 @@
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
-use logger::{error, warn, Metric, METRICS};
+use logger::{error, warn, IncMetric, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 use utils::epoll::{EpollEvent, EventSet};

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -7,7 +7,9 @@ mod metrics;
 use std::sync::LockResult;
 
 pub use crate::logger::{LoggerError, LOGGER};
-pub use crate::metrics::{Metric, MetricsError, SharedMetric, METRICS};
+pub use crate::metrics::{
+    IncMetric, MetricsError, SharedIncMetric, SharedStoreMetric, StoreMetric, METRICS,
+};
 pub use log::Level::*;
 pub use log::*;
 
@@ -20,7 +22,7 @@ fn extract_guard<G>(lock_result: LockResult<G>) -> G {
     }
 }
 
-pub fn update_metric_with_elapsed_time(metric: &SharedMetric, start_time_us: u64) -> u64 {
+pub fn update_metric_with_elapsed_time(metric: &SharedStoreMetric, start_time_us: u64) -> u64 {
     let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time_us;
     metric.store(delta_us as usize);
     delta_us

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -84,7 +84,7 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, RwLock};
 
-use crate::metrics::{Metric, METRICS};
+use crate::metrics::{IncMetric, METRICS};
 use lazy_static::lazy_static;
 use log::{max_level, set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
 use utils::time::LocalTime;

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -44,9 +44,14 @@
 //! * Since all metrics start at 0, we implement the `Default` trait via derive for all of them,
 //!   to avoid having to initialize everything by hand.
 //!
-//! Moreover, the value of a metric is currently NOT reset to 0 each time it's being written. The
-//! current approach is to store two values (current and previous) and compute the delta between
-//! them each time we do a flush (i.e by serialization). There are a number of advantages
+//! The system implements 2 types of metrics:
+//! * Shared Incremental Metrics (SharedIncMetrics) - dedicated for the metrics which need a counter
+//! (i.e the number of times an API request failed). These metrics are reset upon flush.
+//! * Shared Store Metrics (SharedStoreMetrics) - are targeted at keeping a persistent value, it is not
+//! intended to act as a counter (i.e for measure the process start up time for example).
+//!
+//! The current approach for the `SharedIncMetrics` type is to store two values (current and previous)
+//! and compute the delta between them each time we do a flush (i.e by serialization). There are a number of advantages
 //! to this approach, including:
 //! * We don't have to introduce an additional write (to reset the value) from the thread which
 //!   does to actual writing, so less synchronization effort is required.
@@ -181,11 +186,9 @@ impl fmt::Display for MetricsError {
     }
 }
 
-/// Used for defining new types of metrics that can be either incremented with an unit
-/// or an arbitrary amount of units.
-// This trait helps with writing less code. It has to be in scope (via an use directive) in order
-// for its methods to be available to call on structs that implement it.
-pub trait Metric {
+/// Used for defining new types of metrics that act as a counter (i.e they are continuously updated by
+/// incrementing their value).
+pub trait IncMetric {
     /// Adds `value` to the current counter.
     fn add(&self, value: usize);
     /// Increments by 1 unit the current counter.
@@ -194,6 +197,12 @@ pub trait Metric {
     }
     /// Returns current value of the counter.
     fn count(&self) -> usize;
+}
+
+/// Used for defining new types of metrics that do not need a counter and act as a persistent indicator.
+pub trait StoreMetric {
+    /// Returns current value of the counter.
+    fn fetch(&self) -> usize;
     /// Stores `value` to the current counter.
     fn store(&self, value: usize);
 }
@@ -204,14 +213,17 @@ pub trait Metric {
 // to have one instance of every metric for each thread, and to
 // aggregate them when writing. However this probably overkill unless we have a lot of vCPUs
 // incrementing metrics very often. Still, it's there if we ever need it :-s
-#[derive(Default)]
 // We will be keeping two values for each metric for being able to reset
 // counters on each metric.
 // 1st member - current value being updated
 // 2nd member - old value that gets the current value whenever metrics is flushed to disk
-pub struct SharedMetric(AtomicUsize, AtomicUsize);
+#[derive(Default)]
+pub struct SharedIncMetric(AtomicUsize, AtomicUsize);
 
-impl Metric for SharedMetric {
+#[derive(Default)]
+pub struct SharedStoreMetric(AtomicUsize);
+
+impl IncMetric for SharedIncMetric {
     // While the order specified for this operation is still Relaxed, the actual instruction will
     // be an asm "LOCK; something" and thus atomic across multiple threads, simply because of the
     // fetch_and_add (as opposed to "store(load() + 1)") implementation for atomics.
@@ -223,16 +235,19 @@ impl Metric for SharedMetric {
     fn count(&self) -> usize {
         self.0.load(Ordering::Relaxed)
     }
+}
 
-    // It is necessary to also reset the old value in order to flush later the correct one,
-    // which is `value` (see the `Serialize` implementation for SharedMetric a few lines below).
+impl StoreMetric for SharedStoreMetric {
+    fn fetch(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+
     fn store(&self, value: usize) {
         self.0.store(value, Ordering::Relaxed);
-        self.1.store(0, Ordering::Relaxed)
     }
 }
 
-impl Serialize for SharedMetric {
+impl Serialize for SharedIncMetric {
     /// Reset counters of each metrics. Here we suppose that Serialize's goal is to help with the
     /// flushing of metrics.
     /// !!! Any print of the metrics will also reset them. Use with caution !!!
@@ -248,6 +263,12 @@ impl Serialize for SharedMetric {
     }
 }
 
+impl Serialize for SharedStoreMetric {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(self.0.load(Ordering::Relaxed) as u64)
+    }
+}
+
 // The following structs are used to define a certain organization for the set of metrics we
 // are interested in. Whenever the name of a field differs from its ideal textual representation
 // in the serialized form, we can use the #[serde(rename = "name")] attribute to, well, rename it.
@@ -256,246 +277,246 @@ impl Serialize for SharedMetric {
 #[derive(Default, Serialize)]
 pub struct ApiServerMetrics {
     /// Measures the process's startup time in microseconds.
-    pub process_startup_time_us: SharedMetric,
+    pub process_startup_time_us: SharedStoreMetric,
     /// Measures the cpu's startup time in microseconds.
-    pub process_startup_time_cpu_us: SharedMetric,
+    pub process_startup_time_cpu_us: SharedStoreMetric,
     /// Number of failures on API requests triggered by internal errors.
-    pub sync_response_fails: SharedMetric,
+    pub sync_response_fails: SharedIncMetric,
     /// Number of timeouts during communication with the VMM.
-    pub sync_vmm_send_timeout_count: SharedMetric,
+    pub sync_vmm_send_timeout_count: SharedIncMetric,
 }
 
 /// Metrics specific to GET API Requests for counting user triggered actions and/or failures.
 #[derive(Default, Serialize)]
 pub struct GetRequestsMetrics {
     /// Number of GETs for getting information on the instance.
-    pub instance_info_count: SharedMetric,
+    pub instance_info_count: SharedIncMetric,
     /// Number of failures when obtaining information on the current instance.
-    pub instance_info_fails: SharedMetric,
+    pub instance_info_fails: SharedIncMetric,
     /// Number of GETs for getting status on attaching machine configuration.
-    pub machine_cfg_count: SharedMetric,
+    pub machine_cfg_count: SharedIncMetric,
     /// Number of failures during GETs for getting information on the instance.
-    pub machine_cfg_fails: SharedMetric,
+    pub machine_cfg_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PUT API Requests for counting user triggered actions and/or failures.
 #[derive(Default, Serialize)]
 pub struct PutRequestsMetrics {
     /// Number of PUTs triggering an action on the VM.
-    pub actions_count: SharedMetric,
+    pub actions_count: SharedIncMetric,
     /// Number of failures in triggering an action on the VM.
-    pub actions_fails: SharedMetric,
+    pub actions_fails: SharedIncMetric,
     /// Number of PUTs for attaching source of boot.
-    pub boot_source_count: SharedMetric,
+    pub boot_source_count: SharedIncMetric,
     /// Number of failures during attaching source of boot.
-    pub boot_source_fails: SharedMetric,
+    pub boot_source_fails: SharedIncMetric,
     /// Number of PUTs triggering a block attach.
-    pub drive_count: SharedMetric,
+    pub drive_count: SharedIncMetric,
     /// Number of failures in attaching a block device.
-    pub drive_fails: SharedMetric,
+    pub drive_fails: SharedIncMetric,
     /// Number of PUTs for initializing the logging system.
-    pub logger_count: SharedMetric,
+    pub logger_count: SharedIncMetric,
     /// Number of failures in initializing the logging system.
-    pub logger_fails: SharedMetric,
+    pub logger_fails: SharedIncMetric,
     /// Number of PUTs for configuring the machine.
-    pub machine_cfg_count: SharedMetric,
+    pub machine_cfg_count: SharedIncMetric,
     /// Number of failures in configuring the machine.
-    pub machine_cfg_fails: SharedMetric,
+    pub machine_cfg_fails: SharedIncMetric,
     /// Number of PUTs for initializing the metrics system.
-    pub metrics_count: SharedMetric,
+    pub metrics_count: SharedIncMetric,
     /// Number of failures in initializing the metrics system.
-    pub metrics_fails: SharedMetric,
+    pub metrics_fails: SharedIncMetric,
     /// Number of PUTs for creating a new network interface.
-    pub network_count: SharedMetric,
+    pub network_count: SharedIncMetric,
     /// Number of failures in creating a new network interface.
-    pub network_fails: SharedMetric,
+    pub network_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PATCH API Requests for counting user triggered actions and/or failures.
 #[derive(Default, Serialize)]
 pub struct PatchRequestsMetrics {
     /// Number of tries to PATCH a block device.
-    pub drive_count: SharedMetric,
+    pub drive_count: SharedIncMetric,
     /// Number of failures in PATCHing a block device.
-    pub drive_fails: SharedMetric,
+    pub drive_fails: SharedIncMetric,
     /// Number of tries to PATCH a net device.
-    pub network_count: SharedMetric,
+    pub network_count: SharedIncMetric,
     /// Number of failures in PATCHing a net device.
-    pub network_fails: SharedMetric,
+    pub network_fails: SharedIncMetric,
     /// Number of PATCHs for configuring the machine.
-    pub machine_cfg_count: SharedMetric,
+    pub machine_cfg_count: SharedIncMetric,
     /// Number of failures in configuring the machine.
-    pub machine_cfg_fails: SharedMetric,
+    pub machine_cfg_fails: SharedIncMetric,
 }
 
 /// Balloon Device associated metrics.
 #[derive(Default, Serialize)]
 pub struct BalloonDeviceMetrics {
     /// Number of times when activate failed on a balloon device.
-    pub activate_fails: SharedMetric,
+    pub activate_fails: SharedIncMetric,
     /// Number of balloon device inflations.
-    pub inflate_count: SharedMetric,
+    pub inflate_count: SharedIncMetric,
     // Number of balloon statistics updates from the driver.
-    pub stats_updates_count: SharedMetric,
+    pub stats_updates_count: SharedIncMetric,
     // Number of balloon statistics update failures.
-    pub stats_update_fails: SharedMetric,
+    pub stats_update_fails: SharedIncMetric,
     /// Number of balloon device deflations.
-    pub deflate_count: SharedMetric,
+    pub deflate_count: SharedIncMetric,
     /// Number of times when handling events on a balloon device failed.
-    pub event_fails: SharedMetric,
+    pub event_fails: SharedIncMetric,
 }
 
 /// Block Device associated metrics.
 #[derive(Default, Serialize)]
 pub struct BlockDeviceMetrics {
     /// Number of times when activate failed on a block device.
-    pub activate_fails: SharedMetric,
+    pub activate_fails: SharedIncMetric,
     /// Number of times when interacting with the space config of a block device failed.
-    pub cfg_fails: SharedMetric,
+    pub cfg_fails: SharedIncMetric,
     /// No available buffer for the block queue.
-    pub no_avail_buffer: SharedMetric,
+    pub no_avail_buffer: SharedIncMetric,
     /// Number of times when handling events on a block device failed.
-    pub event_fails: SharedMetric,
+    pub event_fails: SharedIncMetric,
     /// Number of failures in executing a request on a block device.
-    pub execute_fails: SharedMetric,
+    pub execute_fails: SharedIncMetric,
     /// Number of invalid requests received for this block device.
-    pub invalid_reqs_count: SharedMetric,
+    pub invalid_reqs_count: SharedIncMetric,
     /// Number of flushes operation triggered on this block device.
-    pub flush_count: SharedMetric,
+    pub flush_count: SharedIncMetric,
     /// Number of events triggerd on the queue of this block device.
-    pub queue_event_count: SharedMetric,
+    pub queue_event_count: SharedIncMetric,
     /// Number of events ratelimiter-related.
-    pub rate_limiter_event_count: SharedMetric,
+    pub rate_limiter_event_count: SharedIncMetric,
     /// Number of update operation triggered on this block device.
-    pub update_count: SharedMetric,
+    pub update_count: SharedIncMetric,
     /// Number of failures while doing update on this block device.
-    pub update_fails: SharedMetric,
+    pub update_fails: SharedIncMetric,
     /// Number of bytes read by this block device.
-    pub read_bytes: SharedMetric,
+    pub read_bytes: SharedIncMetric,
     /// Number of bytes written by this block device.
-    pub write_bytes: SharedMetric,
+    pub write_bytes: SharedIncMetric,
     /// Number of successful read operations.
-    pub read_count: SharedMetric,
+    pub read_count: SharedIncMetric,
     /// Number of successful write operations.
-    pub write_count: SharedMetric,
+    pub write_count: SharedIncMetric,
     /// Number of rate limiter throttling events.
-    pub rate_limiter_throttled_events: SharedMetric,
+    pub rate_limiter_throttled_events: SharedIncMetric,
 }
 
 /// Metrics specific to the i8042 device.
 #[derive(Default, Serialize)]
 pub struct I8042DeviceMetrics {
     /// Errors triggered while using the i8042 device.
-    pub error_count: SharedMetric,
+    pub error_count: SharedIncMetric,
     /// Number of superfluous read intents on this i8042 device.
-    pub missed_read_count: SharedMetric,
+    pub missed_read_count: SharedIncMetric,
     /// Number of superfluous write intents on this i8042 device.
-    pub missed_write_count: SharedMetric,
+    pub missed_write_count: SharedIncMetric,
     /// Bytes read by this device.
-    pub read_count: SharedMetric,
+    pub read_count: SharedIncMetric,
     /// Number of resets done by this device.
-    pub reset_count: SharedMetric,
+    pub reset_count: SharedIncMetric,
     /// Bytes written by this device.
-    pub write_count: SharedMetric,
+    pub write_count: SharedIncMetric,
 }
 
 /// Metrics for the logging subsystem.
 #[derive(Default, Serialize)]
 pub struct LoggerSystemMetrics {
     /// Number of misses on flushing metrics.
-    pub missed_metrics_count: SharedMetric,
+    pub missed_metrics_count: SharedIncMetric,
     /// Number of errors during metrics handling.
-    pub metrics_fails: SharedMetric,
+    pub metrics_fails: SharedIncMetric,
     /// Number of misses on logging human readable content.
-    pub missed_log_count: SharedMetric,
+    pub missed_log_count: SharedIncMetric,
     /// Number of errors while trying to log human readable content.
-    pub log_fails: SharedMetric,
+    pub log_fails: SharedIncMetric,
 }
 
 /// Metrics for the MMDS functionality.
 #[derive(Default, Serialize)]
 pub struct MmdsMetrics {
     /// Number of frames rerouted to MMDS.
-    pub rx_accepted: SharedMetric,
+    pub rx_accepted: SharedIncMetric,
     /// Number of errors while handling a frame through MMDS.
-    pub rx_accepted_err: SharedMetric,
+    pub rx_accepted_err: SharedIncMetric,
     /// Number of uncommon events encountered while processing packets through MMDS.
-    pub rx_accepted_unusual: SharedMetric,
+    pub rx_accepted_unusual: SharedIncMetric,
     /// The number of buffers which couldn't be parsed as valid Ethernet frames by the MMDS.
-    pub rx_bad_eth: SharedMetric,
+    pub rx_bad_eth: SharedIncMetric,
     /// The total number of successful receive operations by the MMDS.
-    pub rx_count: SharedMetric,
+    pub rx_count: SharedIncMetric,
     /// The total number of bytes sent by the MMDS.
-    pub tx_bytes: SharedMetric,
+    pub tx_bytes: SharedIncMetric,
     /// The total number of successful send operations by the MMDS.
-    pub tx_count: SharedMetric,
+    pub tx_count: SharedIncMetric,
     /// The number of errors raised by the MMDS while attempting to send frames/packets/segments.
-    pub tx_errors: SharedMetric,
+    pub tx_errors: SharedIncMetric,
     /// The number of frames sent by the MMDS.
-    pub tx_frames: SharedMetric,
+    pub tx_frames: SharedIncMetric,
     /// The number of connections successfully accepted by the MMDS TCP handler.
-    pub connections_created: SharedMetric,
+    pub connections_created: SharedIncMetric,
     /// The number of connections cleaned up by the MMDS TCP handler.
-    pub connections_destroyed: SharedMetric,
+    pub connections_destroyed: SharedIncMetric,
 }
 
 /// Network-related metrics.
 #[derive(Default, Serialize)]
 pub struct NetDeviceMetrics {
     /// Number of times when activate failed on a network device.
-    pub activate_fails: SharedMetric,
+    pub activate_fails: SharedIncMetric,
     /// Number of times when interacting with the space config of a network device failed.
-    pub cfg_fails: SharedMetric,
+    pub cfg_fails: SharedIncMetric,
     //// Number of times the mac address was updated through the config space.
-    pub mac_address_updates: SharedMetric,
+    pub mac_address_updates: SharedIncMetric,
     /// No available buffer for the net device rx queue.
-    pub no_rx_avail_buffer: SharedMetric,
+    pub no_rx_avail_buffer: SharedIncMetric,
     /// No available buffer for the net device tx queue.
-    pub no_tx_avail_buffer: SharedMetric,
+    pub no_tx_avail_buffer: SharedIncMetric,
     /// Number of times when handling events on a network device failed.
-    pub event_fails: SharedMetric,
+    pub event_fails: SharedIncMetric,
     /// Number of events associated with the receiving queue.
-    pub rx_queue_event_count: SharedMetric,
+    pub rx_queue_event_count: SharedIncMetric,
     /// Number of events associated with the rate limiter installed on the receiving path.
-    pub rx_event_rate_limiter_count: SharedMetric,
+    pub rx_event_rate_limiter_count: SharedIncMetric,
     /// Number of RX partial writes to guest.
-    pub rx_partial_writes: SharedMetric,
+    pub rx_partial_writes: SharedIncMetric,
     /// Number of RX rate limiter throttling events.
-    pub rx_rate_limiter_throttled: SharedMetric,
+    pub rx_rate_limiter_throttled: SharedIncMetric,
     /// Number of events received on the associated tap.
-    pub rx_tap_event_count: SharedMetric,
+    pub rx_tap_event_count: SharedIncMetric,
     /// Number of bytes received.
-    pub rx_bytes_count: SharedMetric,
+    pub rx_bytes_count: SharedIncMetric,
     /// Number of packets received.
-    pub rx_packets_count: SharedMetric,
+    pub rx_packets_count: SharedIncMetric,
     /// Number of errors while receiving data.
-    pub rx_fails: SharedMetric,
+    pub rx_fails: SharedIncMetric,
     /// Number of successful read operations while receiving data.
-    pub rx_count: SharedMetric,
+    pub rx_count: SharedIncMetric,
     /// Number of times reading from TAP failed.
-    pub tap_read_fails: SharedMetric,
+    pub tap_read_fails: SharedIncMetric,
     /// Number of times writing to TAP failed.
-    pub tap_write_fails: SharedMetric,
+    pub tap_write_fails: SharedIncMetric,
     /// Number of transmitted bytes.
-    pub tx_bytes_count: SharedMetric,
+    pub tx_bytes_count: SharedIncMetric,
     /// Number of malformed TX frames.
-    pub tx_malformed_frames: SharedMetric,
+    pub tx_malformed_frames: SharedIncMetric,
     /// Number of errors while transmitting data.
-    pub tx_fails: SharedMetric,
+    pub tx_fails: SharedIncMetric,
     /// Number of successful write operations while transmitting data.
-    pub tx_count: SharedMetric,
+    pub tx_count: SharedIncMetric,
     /// Number of transmitted packets.
-    pub tx_packets_count: SharedMetric,
+    pub tx_packets_count: SharedIncMetric,
     /// Number of TX partial reads from guest.
-    pub tx_partial_reads: SharedMetric,
+    pub tx_partial_reads: SharedIncMetric,
     /// Number of events associated with the transmitting queue.
-    pub tx_queue_event_count: SharedMetric,
+    pub tx_queue_event_count: SharedIncMetric,
     /// Number of events associated with the rate limiter installed on the transmitting path.
-    pub tx_rate_limiter_event_count: SharedMetric,
+    pub tx_rate_limiter_event_count: SharedIncMetric,
     /// Number of RX rate limiter throttling events.
-    pub tx_rate_limiter_throttled: SharedMetric,
+    pub tx_rate_limiter_throttled: SharedIncMetric,
     /// Number of packets with a spoofed mac, sent by the guest.
-    pub tx_spoofed_mac_count: SharedMetric,
+    pub tx_spoofed_mac_count: SharedIncMetric,
 }
 
 /// Performance metrics related for the moment only to snapshots.
@@ -510,155 +531,155 @@ pub struct NetDeviceMetrics {
 pub struct PerformanceMetrics {
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot full create time, at the API (user) level, in microseconds.
-    pub full_create_snapshot: SharedMetric,
+    pub full_create_snapshot: SharedStoreMetric,
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot diff create time, at the API (user) level, in microseconds.
-    pub diff_create_snapshot: SharedMetric,
+    pub diff_create_snapshot: SharedStoreMetric,
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot load time, at the API (user) level, in microseconds.
-    pub load_snapshot: SharedMetric,
+    pub load_snapshot: SharedStoreMetric,
     /// Measures the microVM pausing duration, at the API (user) level, in microseconds.
-    pub pause_vm: SharedMetric,
+    pub pause_vm: SharedStoreMetric,
     /// Measures the microVM resuming duration, at the API (user) level, in microseconds.
-    pub resume_vm: SharedMetric,
+    pub resume_vm: SharedStoreMetric,
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot full create time, at the VMM level, in microseconds.
-    pub vmm_full_create_snapshot: SharedMetric,
+    pub vmm_full_create_snapshot: SharedStoreMetric,
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot diff create time, at the VMM level, in microseconds.
-    pub vmm_diff_create_snapshot: SharedMetric,
+    pub vmm_diff_create_snapshot: SharedStoreMetric,
     #[cfg(target_arch = "x86_64")]
     /// Measures the snapshot load time, at the VMM level, in microseconds.
-    pub vmm_load_snapshot: SharedMetric,
+    pub vmm_load_snapshot: SharedStoreMetric,
     /// Measures the microVM pausing duration, at the VMM level, in microseconds.
-    pub vmm_pause_vm: SharedMetric,
+    pub vmm_pause_vm: SharedStoreMetric,
     /// Measures the microVM resuming duration, at the VMM level, in microseconds.
-    pub vmm_resume_vm: SharedMetric,
+    pub vmm_resume_vm: SharedStoreMetric,
 }
 
 /// Metrics specific to the RTC device.
 #[derive(Default, Serialize)]
 pub struct RTCDeviceMetrics {
     /// Errors triggered while using the RTC device.
-    pub error_count: SharedMetric,
+    pub error_count: SharedIncMetric,
     /// Number of superfluous read intents on this RTC device.
-    pub missed_read_count: SharedMetric,
+    pub missed_read_count: SharedIncMetric,
     /// Number of superfluous write intents on this RTC device.
-    pub missed_write_count: SharedMetric,
+    pub missed_write_count: SharedIncMetric,
 }
 
 /// Metrics for the seccomp filtering.
 #[derive(Default, Serialize)]
 pub struct SeccompMetrics {
     /// Number of errors inside the seccomp filtering.
-    pub num_faults: SharedMetric,
+    pub num_faults: SharedIncMetric,
 }
 
 /// Metrics specific to the UART device.
 #[derive(Default, Serialize)]
 pub struct SerialDeviceMetrics {
     /// Errors triggered while using the UART device.
-    pub error_count: SharedMetric,
+    pub error_count: SharedIncMetric,
     /// Number of flush operations.
-    pub flush_count: SharedMetric,
+    pub flush_count: SharedIncMetric,
     /// Number of read calls that did not trigger a read.
-    pub missed_read_count: SharedMetric,
+    pub missed_read_count: SharedIncMetric,
     /// Number of write calls that did not trigger a write.
-    pub missed_write_count: SharedMetric,
+    pub missed_write_count: SharedIncMetric,
     /// Number of succeeded read calls.
-    pub read_count: SharedMetric,
+    pub read_count: SharedIncMetric,
     /// Number of succeeded write calls.
-    pub write_count: SharedMetric,
+    pub write_count: SharedIncMetric,
 }
 
 /// Metrics related to signals.
 #[derive(Default, Serialize)]
 pub struct SignalMetrics {
     /// Number of times that SIGBUS was handled.
-    pub sigbus: SharedMetric,
+    pub sigbus: SharedIncMetric,
     /// Number of times that SIGSEGV was handled.
-    pub sigsegv: SharedMetric,
+    pub sigsegv: SharedIncMetric,
     /// Number of times that SIGXFSZ was handled.
-    pub sigxfsz: SharedMetric,
+    pub sigxfsz: SharedIncMetric,
     /// Number of times that SIGXCPU was handled.
-    pub sigxcpu: SharedMetric,
+    pub sigxcpu: SharedIncMetric,
     /// Number of times that SIGPIPE was handled.
-    pub sigpipe: SharedMetric,
+    pub sigpipe: SharedIncMetric,
     /// Number of times that SIGHUP was handled.
-    pub sighup: SharedMetric,
+    pub sighup: SharedIncMetric,
     /// Number of times that SIGILL was handled.
-    pub sigill: SharedMetric,
+    pub sigill: SharedIncMetric,
 }
 
 /// Metrics specific to VCPUs' mode of functioning.
 #[derive(Default, Serialize)]
 pub struct VcpuMetrics {
     /// Number of KVM exits for handling input IO.
-    pub exit_io_in: SharedMetric,
+    pub exit_io_in: SharedIncMetric,
     /// Number of KVM exits for handling output IO.
-    pub exit_io_out: SharedMetric,
+    pub exit_io_out: SharedIncMetric,
     /// Number of KVM exits for handling MMIO reads.
-    pub exit_mmio_read: SharedMetric,
+    pub exit_mmio_read: SharedIncMetric,
     /// Number of KVM exits for handling MMIO writes.
-    pub exit_mmio_write: SharedMetric,
+    pub exit_mmio_write: SharedIncMetric,
     /// Number of errors during this VCPU's run.
-    pub failures: SharedMetric,
+    pub failures: SharedIncMetric,
     /// Failures in configuring the CPUID.
-    pub filter_cpuid: SharedMetric,
+    pub filter_cpuid: SharedIncMetric,
 }
 
 /// Metrics specific to the machine manager as a whole.
 #[derive(Default, Serialize)]
 pub struct VmmMetrics {
     /// Number of device related events received for a VM.
-    pub device_events: SharedMetric,
+    pub device_events: SharedIncMetric,
     /// Metric for signaling a panic has occurred.
-    pub panic_count: SharedMetric,
+    pub panic_count: SharedIncMetric,
 }
 
 /// Vsock-related metrics.
 #[derive(Default, Serialize)]
 pub struct VsockDeviceMetrics {
     /// Number of times when activate failed on a vsock device.
-    pub activate_fails: SharedMetric,
+    pub activate_fails: SharedIncMetric,
     /// Number of times when interacting with the space config of a vsock device failed.
-    pub cfg_fails: SharedMetric,
+    pub cfg_fails: SharedIncMetric,
     /// Number of times when handling RX queue events on a vsock device failed.
-    pub rx_queue_event_fails: SharedMetric,
+    pub rx_queue_event_fails: SharedIncMetric,
     /// Number of times when handling TX queue events on a vsock device failed.
-    pub tx_queue_event_fails: SharedMetric,
+    pub tx_queue_event_fails: SharedIncMetric,
     /// Number of times when handling event queue events on a vsock device failed.
-    pub ev_queue_event_fails: SharedMetric,
+    pub ev_queue_event_fails: SharedIncMetric,
     /// Number of times when handling muxer events on a vsock device failed.
-    pub muxer_event_fails: SharedMetric,
+    pub muxer_event_fails: SharedIncMetric,
     /// Number of times when handling connection events on a vsock device failed.
-    pub conn_event_fails: SharedMetric,
+    pub conn_event_fails: SharedIncMetric,
     /// Number of events associated with the receiving queue.
-    pub rx_queue_event_count: SharedMetric,
+    pub rx_queue_event_count: SharedIncMetric,
     /// Number of events associated with the transmitting queue.
-    pub tx_queue_event_count: SharedMetric,
+    pub tx_queue_event_count: SharedIncMetric,
     /// Number of bytes received.
-    pub rx_bytes_count: SharedMetric,
+    pub rx_bytes_count: SharedIncMetric,
     /// Number of transmitted bytes.
-    pub tx_bytes_count: SharedMetric,
+    pub tx_bytes_count: SharedIncMetric,
     /// Number of packets received.
-    pub rx_packets_count: SharedMetric,
+    pub rx_packets_count: SharedIncMetric,
     /// Number of transmitted packets.
-    pub tx_packets_count: SharedMetric,
+    pub tx_packets_count: SharedIncMetric,
     /// Number of added connections.
-    pub conns_added: SharedMetric,
+    pub conns_added: SharedIncMetric,
     /// Number of killed connections.
-    pub conns_killed: SharedMetric,
+    pub conns_killed: SharedIncMetric,
     /// Number of removed connections.
-    pub conns_removed: SharedMetric,
+    pub conns_removed: SharedIncMetric,
     /// How many times the killq has been resynced.
-    pub killq_resync: SharedMetric,
+    pub killq_resync: SharedIncMetric,
     /// How many flush fails have been seen.
-    pub tx_flush_fails: SharedMetric,
+    pub tx_flush_fails: SharedIncMetric,
     /// How many write fails have been seen.
-    pub tx_write_fails: SharedMetric,
+    pub tx_write_fails: SharedIncMetric,
     /// Number of times read() has failed.
-    pub rx_read_fails: SharedMetric,
+    pub rx_read_fails: SharedIncMetric,
 }
 
 // The sole purpose of this struct is to produce an UTC timestamp when an instance is serialized.
@@ -723,6 +744,7 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
+    use std::sync::atomic::fence;
     use utils::tempfile::TempFile;
 
     #[test]
@@ -744,9 +766,8 @@ mod tests {
     }
 
     #[test]
-    fn test_metric() {
-        // Test SharedMetric.
-        let m2 = Arc::new(SharedMetric::default());
+    fn test_shared_inc_metric() {
+        let metric = Arc::new(SharedIncMetric::default());
 
         // We're going to create a number of threads that will attempt to increase this metric
         // in parallel. If everything goes fine we still can't be sure the synchronization works,
@@ -756,12 +777,12 @@ mod tests {
         const NUM_INCREMENTS_PER_THREAD: usize = 10_0000;
         const M2_INITIAL_COUNT: usize = 123;
 
-        m2.add(M2_INITIAL_COUNT);
+        metric.add(M2_INITIAL_COUNT);
 
         let mut v = Vec::with_capacity(NUM_THREADS_TO_SPAWN);
 
         for _ in 0..NUM_THREADS_TO_SPAWN {
-            let r = m2.clone();
+            let r = metric.clone();
             v.push(thread::spawn(move || {
                 for _ in 0..NUM_INCREMENTS_PER_THREAD {
                     r.inc();
@@ -774,16 +795,17 @@ mod tests {
         }
 
         assert_eq!(
-            m2.count(),
+            metric.count(),
             M2_INITIAL_COUNT + NUM_THREADS_TO_SPAWN * NUM_INCREMENTS_PER_THREAD
         );
+    }
 
-        // Trying to store multiple values in the metric will result in keeping only the last
-        // value there.
-        m2.store(1);
-        m2.store(2);
-        assert_eq!(m2.0.load(Ordering::Relaxed), 2);
-        assert_eq!(m2.1.load(Ordering::Relaxed), 0);
+    #[test]
+    fn test_shared_store_metric() {
+        let m1 = Arc::new(SharedStoreMetric::default());
+        m1.store(1);
+        fence(Ordering::SeqCst);
+        assert_eq!(1, m1.fetch());
     }
 
     #[test]

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -22,7 +22,7 @@ use dumbo::pdu::tcp::Error as TcpSegmentError;
 use dumbo::pdu::Incomplete;
 use dumbo::tcp::handler::{self, RecvEvent, TcpIPv4Handler, WriteEvent};
 use dumbo::tcp::NextSegmentStatus;
-use logger::{Metric, METRICS};
+use logger::{IncMetric, METRICS};
 use utils::net::mac::MacAddr;
 use utils::time::timestamp_cycles;
 

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -6,7 +6,7 @@ use libc::{
     SIGXFSZ,
 };
 
-use logger::{error, Metric, METRICS};
+use logger::{error, IncMetric, METRICS};
 use utils::signal::register_signal_handler;
 
 // The offset of `si_syscall` (offending syscall identifier) within the siginfo structure

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::vstate::{vcpu::VcpuEmulation, vm::Vm};
 use kvm_ioctls::*;
-use logger::{error, Metric, METRICS};
+use logger::{error, IncMetric, METRICS};
 use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
 
 /// Errors associated with the wrappers over KVM ioctls.

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     FC_EXIT_CODE_OK,
 };
 use kvm_ioctls::VcpuExit;
-use logger::{error, info, Metric, METRICS};
+use logger::{error, info, IncMetric, METRICS};
 use seccomp::{BpfProgram, SeccompFilter};
 use utils::{
     eventfd::EventFd,

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -21,7 +21,7 @@ use kvm_bindings::{
     kvm_xsave, CpuId, MsrList, Msrs,
 };
 use kvm_ioctls::{VcpuExit, VcpuFd};
-use logger::{error, Metric, METRICS};
+use logger::{error, IncMetric, METRICS};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{Address, GuestAddress, GuestMemoryMmap};

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 1955168,
+        "FC_BINARY_SIZE_TARGET": 2059824,
         "JAILER_BINARY_SIZE_TARGET": 1439512,
-        "FC_BINARY_SIZE_LIMIT": 2052927,
+        "FC_BINARY_SIZE_LIMIT": 2100000,
         "JAILER_BINARY_SIZE_LIMIT": 1511488,
     },
     "aarch64": {


### PR DESCRIPTION
With the passing of the time in Firecracker started
to shape out 2 types of metrics:
* the types of metrics needed for counting purposes -> they
are represented by 2 values, one of them is the active counter while
the other one is the value that was last flushed. With each flush, we would
 compute the delta between them
* the types of metrics needed for storing persistent values of a specific
measurement, for example the ones used for obtaining the process start up
time. This type of metric does not need to keep around a second value
since the value being flushed is always the one the system updates.

This approach also rids us of any memory reordering that may happen on weak
memory models.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

The first are of code that needs to check out first thing when starting the review is `src/logger/metrics.rs`.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
