### PR TITLE
Improve device update operations

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -15,6 +15,7 @@ use crate::virtio::{
     ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_NET, VIRTIO_MMIO_INT_VRING,
 };
 use crate::{report_net_event_fail, Error as DeviceError};
+
 use dumbo::pdu::ethernet::EthernetFrame;
 use libc::EAGAIN;
 use logger::{error, warn, Metric, METRICS};

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -479,7 +479,8 @@ impl RuntimeApiController {
             .lock()
             .expect("Poisoned lock")
             .update_block_device_path(drive_id, path_on_host)
-            .map_err(|_| VmmActionError::DriveConfig(DriveError::InvalidBlockDeviceID))
+            .map_err(DriveError::DeviceUpdate)
+            .map_err(VmmActionError::DriveConfig)
     }
 
     /// Updates configuration for an emulated net device as described in `new_cfg`.
@@ -494,6 +495,7 @@ impl RuntimeApiController {
                 new_cfg.tx_bytes(),
                 new_cfg.tx_ops(),
             )
-            .map_err(|_| VmmActionError::NetworkConfig(NetworkInterfaceError::DeviceIdNotFound))
+            .map_err(NetworkInterfaceError::DeviceUpdate)
+            .map_err(VmmActionError::NetworkConfig)
     }
 }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -10,6 +10,7 @@ use std::result;
 use std::sync::{Arc, Mutex};
 
 use super::RateLimiterConfig;
+use crate::Error as VmmError;
 use devices::virtio::Block;
 
 use serde::Deserialize;
@@ -26,8 +27,8 @@ pub enum DriveError {
     CreateBlockDevice(io::Error),
     /// Failed to create a `RateLimiter` object.
     CreateRateLimiter(io::Error),
-    /// The block device ID is invalid.
-    InvalidBlockDeviceID,
+    /// Error during drive update (patch).
+    DeviceUpdate(VmmError),
     /// The block device path is invalid.
     InvalidBlockDevicePath,
     /// Cannot open block device due to invalid permissions or path.
@@ -48,7 +49,7 @@ impl Display for DriveError {
             ),
             BlockDeviceUpdateFailed(e) => write!(f, "The update operation failed: {}", e),
             CreateRateLimiter(e) => write!(f, "Cannot create RateLimiter: {}", e),
-            InvalidBlockDeviceID => write!(f, "Invalid block device ID!"),
+            DeviceUpdate(e) => write!(f, "Error during drive update (patch): {}", e),
             InvalidBlockDevicePath => write!(f, "Invalid block device path!"),
             OpenBlockDevice(e) => write!(
                 f,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -691,7 +691,7 @@ def _drive_patch(test_microvm):
         path_on_host='foo.bar'
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert "The update operation failed: No such file or directory" \
+    assert "drive update (patch): device error: No such file or directory" \
            in response.text
 
     fs = drive_tools.FilesystemFile(


### PR DESCRIPTION
## Reason for This PR

Cleans up some device-specific and vmm-internal logic from `RPC interface` and breaks that code into separate pieces, each working at the appropriate layer/component.

Also de-dups device downcasting code - currently only two operations:
1. update net rate limiters
2. update block device path

But going further we plan to add others such as:
- update block rate limiters
- get balloon config
- get balloon stats

This PR paves the way for them.

## Description of Changes

- Created helper `device_manager::on_virtio_device_with_id()` to de-duplicate code that needs to find a specific virtio device then downcast it to its concrete type to call one of its methods. The helper function can be given a closure that directly works with a `&mut T` where T is the concrete type.

- Vmm exposes programmatic interface to update net devices based on their IDs. It internally uses the above helper to call
`update_rate_limiters()` on a specific `Net` device.

- `Block::update_disk_image()` not only updates its internal config space, but now also notifies the guest driver of the configuration change. This is inline with other device config updates and also offers better containment of device config space update operations.

- Vmm exposes programmatic interface to update block devices based on their IDs. It internally uses `on_virtio_device_with_id()` to call `update_disk_image()` on a specific `Block` device.

- RPC interface only calls the Vmm interface without needing to understand Vmm internal data (such as device topology, device concrete types, etc).

- Rework the errors a bit so the actual bottom error is propagated. This provides callers with the complete error context.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
