### PR TITLE
devtool: remove cargo update from prepare_release

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -749,7 +749,7 @@ cmd_fmt() {
 }
 
 
-# Prepare a Firecracker release by updating the version, crate dependencies
+# Prepare a Firecracker release by updating the version, changelog
 # and credits.
 # Example: `devtool release 0.42.0`
 #
@@ -791,14 +791,15 @@ cmd_prepare_release() {
         rm -f "${file}="
     done
 
-    # Update crate dependencies.
-    say "Updating crate dependencies..."
+    # Run `cargo check` to update firecracker and jailer versions in 
+    # `Cargo.lock`.
+    say "Updating lockfile..."
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
-        cargo update
-    ok_or_die "cargo update failed."
+        cargo check
+    ok_or_die "cargo check failed."
 
     # Update credits.
     say "Updating credits..."


### PR DESCRIPTION
## Reason for This PR

Resolves #2225.

## Description of Changes

Replace `cargo update` with `cargo check` in `devtool prepare_release`.
The `cargo check` command updates in the lockfile the new firecracker and jailer versions, while also checking that all the code compiles.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
