### PR TITLE
[Balloon] Added GET call for balloon device state

### DIFF
--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use super::VmmData;
 use crate::request::actions::parse_put_actions;
-use crate::request::balloon::{parse_get_balloon_stats, parse_patch_balloon, parse_put_balloon};
+use crate::request::balloon::{parse_get_balloon, parse_patch_balloon, parse_put_balloon};
 use crate::request::boot_source::parse_put_boot_source;
 use crate::request::drive::{parse_patch_drive, parse_put_drive};
 use crate::request::instance_info::parse_get_instance_info;
@@ -51,7 +51,7 @@ impl ParsedRequest {
 
         match (request.method(), path, request.body.as_ref()) {
             (Method::Get, "", None) => parse_get_instance_info(),
-            (Method::Get, "balloon", None) => parse_get_balloon_stats(),
+            (Method::Get, "balloon", None) => parse_get_balloon(path_tokens.get(1)),
             (Method::Get, "machine-config", None) => parse_get_machine_config(),
             (Method::Get, "mmds", None) => parse_get_mmds(),
             (Method::Get, _, Some(_)) => method_to_error(Method::Get),
@@ -98,6 +98,12 @@ impl ParsedRequest {
                     info!("The request was executed successfully. Status code: 200 OK.");
                     let mut response = Response::new(Version::Http11, StatusCode::OK);
                     response.set_body(Body::new(vm_config.to_string()));
+                    response
+                }
+                VmmData::BalloonConfig(balloon_config) => {
+                    info!("The request was executed successfully. Status code: 200 OK.");
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    response.set_body(Body::new(serde_json::to_string(balloon_config).unwrap()));
                     response
                 }
                 VmmData::BalloonStats(stats) => {
@@ -553,10 +559,22 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_try_from_get_balloon_stats() {
+    fn test_try_from_get_balloon() {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
         sender.write_all(b"GET /balloon HTTP/1.1\r\n\r\n").unwrap();
+        assert!(connection.try_read().is_ok());
+        let req = connection.pop_parsed_request().unwrap();
+        assert!(ParsedRequest::try_from_request(&req).is_ok());
+    }
+
+    #[test]
+    fn test_try_from_get_balloon_stats() {
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        let mut connection = HttpConnection::new(receiver);
+        sender
+            .write_all(b"GET /balloon/statistics HTTP/1.1\r\n\r\n")
+            .unwrap();
         assert!(connection.try_read().is_ok());
         let req = connection.pop_parsed_request().unwrap();
         assert!(ParsedRequest::try_from_request(&req).is_ok());

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -60,6 +60,115 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /balloon:
+    get:
+      summary: Returns the current balloon device configuration.
+      operationId: describeBalloonConfig
+      responses:
+        200:
+          description: The balloon device configuration
+          schema:
+            $ref: "#/definitions/Balloon"
+        400:
+          description: Balloon device not configured.
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/Error"
+    put:
+      summary: Creates or updates a balloon device.
+      description:
+        Creates a new balloon device if one does not already exist, otherwise updates it, before machine startup.
+        This will fail after machine startup.
+        Will fail if update is not possible.
+      operationId: putBalloon
+      parameters:
+      - name: body
+        in: body
+        description: Balloon properties
+        required: true
+        schema:
+          $ref: "#/definitions/Balloon"
+      responses:
+        204:
+          description: Balloon device created/updated
+        400:
+          description: Balloon device cannot be created/updated due to bad input
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+    patch:
+      summary: Updates a balloon device.
+      description:
+        Updates an existing balloon device, before or after machine startup.
+        Will fail if update is not possible.
+      operationId: patchBalloon
+      parameters:
+      - name: body
+        in: body
+        description: Balloon properties
+        required: true
+        schema:
+          $ref: "#/definitions/BalloonUpdate"
+      responses:
+        204:
+          description: Balloon device updated
+        400:
+          description: Balloon device cannot be updated due to bad input
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+              
+  /balloon/statistics:
+    get:
+      summary: Returns the latest balloon device statistics, only if enabled pre-boot.
+      operationId: describeBalloonStats
+      responses:
+        200:
+          description: The balloon device statistics
+          schema:
+            $ref: "#/definitions/BalloonStats"
+        400:
+          description: The balloon device statistics were not enabled when the device was configured.
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/Error"
+    patch:
+      summary: Updates a balloon device statistics polling interval.
+      description:
+        Updates an existing balloon device statistics interval, before or after machine startup.
+        Will fail if update is not possible.
+      operationId: patchBalloonStatsInterval
+      parameters:
+      - name: body
+        in: body
+        description: Balloon properties
+        required: true
+        schema:
+          $ref: "#/definitions/BalloonStatsUpdate"
+      responses:
+        204:
+          description: Balloon statistics interval updated
+        400:
+          description: Balloon statistics interval cannot be updated due to bad input
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+
   /boot-source:
     put:
       summary: Creates or updates the boot source. Pre-boot only.
@@ -505,6 +614,113 @@ paths:
             $ref: "#/definitions/Error"
 
 definitions:
+  Balloon:
+    type: object
+    required:
+      - amount_mb
+      - deflate_on_oom
+      - must_tell_host
+    description:
+      Balloon device descriptor.
+    properties:
+      amount_mb:
+        type: integer
+        description: Target balloon size in MB.
+      deflate_on_oom:
+        type: boolean
+        description: Whether the balloon should deflate when the guest has memory pressure.
+      must_tell_host:
+        type: boolean
+        description: Whether the guest should wait for the host to acknowledge deflated pages or not.
+      stats_polling_interval_s:
+        type: integer
+        description: Interval in seconds between refreshing statistics. A non-zero value will enable the statistics. Defaults to 0.
+  
+  BalloonUpdate:
+    type: object
+    required:
+      - amount_mb
+    description:
+      Balloon device descriptor.
+    properties:
+      amount_mb:
+        type: integer
+        description: Target balloon size in MB.
+  
+  BalloonStats:
+    type: object
+    description:
+      Describes the balloon device statistics.
+    required:
+      - target_pages
+      - actual_pages
+      - target_mb
+      - actual_mb
+    properties:
+      target_pages:
+        description: Target number of pages the device aims to hold.
+        type: integer
+      actual_pages:
+        description: Actual number of pages the device is holding.
+        type: integer
+      target_mb:
+        description: Target amount of memory (in MB) the device aims to hold.
+        type: integer
+      actual_mb:
+        description: Actual amount of memory (in MB) the device is holding.
+        type: integer
+      swap_in:
+        description: The amount of memory that has been swapped in (in bytes).
+        type: integer
+        format: int64
+      swap_out:
+        description: The amount of memory that has been swapped out to disk (in bytes).
+        type: integer
+        format: int64
+      major_faults:
+        description: The number of major page faults that have occurred.
+        type: integer
+        format: int64
+      minor_faults:
+        description: The number of minor page faults that have occurred.
+        type: integer
+        format: int64
+      free_memory:
+        description: The amount of memory not being used for any purpose (in bytes).
+        type: integer
+        format: int64
+      total_memory:
+        description: The total amount of memory available (in bytes).
+        type: integer
+        format: int64
+      available_memory:
+        description: An estimate of how much memory is available (in bytes) for starting new applications, without pushing the system to swap.
+        type: integer
+        format: int64
+      disk_caches:
+        description: The amount of memory, in bytes, that can be quickly reclaimed without additional I/O. Typically these pages are used for caching files from disk.
+        type: integer
+        format: int64
+      hugetlb_allocations:
+        description: The number of successful hugetlb page allocations in the guest.
+        type: integer
+        format: int64
+      hugetlb_failures:
+        description: The number of failed hugetlb page allocations in the guest.
+        type: integer
+        format: int64
+        
+  BalloonStatsUpdate:
+    type: object
+    required:
+      - stats_polling_interval_s
+    description:
+      Update the statistics polling interval. Statistics cannot be turned on/off after boot.
+    properties:
+      stats_polling_interval_s:
+        type: integer
+        description: Interval in seconds between refreshing statistics.
+
   BootSource:
     type: object
     required:

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -75,6 +75,15 @@ unsafe impl ByteValued for BalloonStat {}
 
 // BalloonStats holds statistics returned from the stats_queue.
 #[derive(Clone, Default, Debug, PartialEq, Serialize)]
+pub struct BalloonConfig {
+    pub amount_mb: u32,
+    pub deflate_on_oom: bool,
+    pub must_tell_host: bool,
+    pub stats_polling_interval_s: u16,
+}
+
+// BalloonStats holds statistics returned from the stats_queue.
+#[derive(Clone, Default, Debug, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BalloonStats {
     pub target_pages: u32,
@@ -421,6 +430,18 @@ impl Balloon {
         pages_to_mb(self.config_space.num_pages)
     }
 
+    pub fn deflate_on_oom(&self) -> bool {
+        self.avail_features & (1u64 << VIRTIO_BALLOON_F_DEFLATE_ON_OOM) != 0
+    }
+
+    pub fn must_tell_host(&self) -> bool {
+        self.avail_features & (1u64 << VIRTIO_BALLOON_F_MUST_TELL_HOST) != 0
+    }
+
+    pub fn stats_polling_interval_s(&self) -> u16 {
+        self.stats_polling_interval_s
+    }
+
     pub fn latest_stats(&mut self) -> Option<&BalloonStats> {
         if self.stats_enabled() {
             self.latest_stats.target_pages = self.config_space.num_pages;
@@ -430,6 +451,15 @@ impl Balloon {
             Some(&self.latest_stats)
         } else {
             None
+        }
+    }
+
+    pub fn config(&self) -> BalloonConfig {
+        BalloonConfig {
+            amount_mb: self.size_mb(),
+            deflate_on_oom: self.deflate_on_oom(),
+            must_tell_host: self.must_tell_host(),
+            stats_polling_interval_s: self.stats_polling_interval_s(),
         }
     }
 
@@ -699,6 +729,14 @@ pub(crate) mod tests {
     #[test]
     fn test_virtio_read_config() {
         let balloon = Balloon::new(0x10, true, true, 0, false).unwrap();
+
+        let cfg = BalloonConfig {
+            amount_mb: 16,
+            deflate_on_oom: true,
+            must_tell_host: true,
+            stats_polling_interval_s: 0,
+        };
+        assert_eq!(balloon.config(), cfg);
 
         let mut actual_config_space = [0u8; CONFIG_SPACE_SIZE];
         balloon.read_config(0, &mut actual_config_space);

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -9,6 +9,7 @@ mod utils;
 use vm_memory::GuestMemoryError;
 
 pub use self::device::Balloon;
+pub use self::device::BalloonConfig;
 pub use self::device::BalloonStats;
 pub use self::event_handler::*;
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -55,6 +55,8 @@ pub enum VmmAction {
     /// after the microVM has booted and only when the microVM is in `Paused` state.
     #[cfg(target_arch = "x86_64")]
     CreateSnapshot(CreateSnapshotParams),
+    /// Get the balloon device configuration.
+    GetBalloonConfig,
     /// Get the ballon device latest statistics.
     GetBalloonStats,
     /// Get the configuration of the microVM.
@@ -187,6 +189,8 @@ impl Display for VmmActionError {
 /// empty, when no data needs to be sent, or an internal VMM structure.
 #[derive(Debug)]
 pub enum VmmData {
+    /// The balloon device configuration.
+    BalloonConfig(BalloonDeviceConfig),
     /// The latest balloon device statistics.
     BalloonStats(BalloonStats),
     /// No data is sent on the channel.
@@ -282,6 +286,12 @@ impl<'a> PrebootApiController<'a> {
             ConfigureMetrics(metrics_cfg) => vmm_config::metrics::init_metrics(metrics_cfg)
                 .map(|_| VmmData::Empty)
                 .map_err(VmmActionError::Metrics),
+            GetBalloonConfig => self
+                .vm_resources
+                .balloon
+                .get_config()
+                .map(VmmData::BalloonConfig)
+                .map_err(VmmActionError::BalloonConfig),
             GetVmConfiguration => Ok(VmmData::MachineConfiguration(
                 self.vm_resources.vm_config().clone(),
             )),
@@ -388,6 +398,13 @@ impl RuntimeApiController {
                 .create_snapshot(&snapshot_create_cfg)
                 .map(|_| VmmData::Empty),
             FlushMetrics => self.flush_metrics().map(|_| VmmData::Empty),
+            GetBalloonConfig => self
+                .vmm
+                .lock()
+                .expect("Poisoned lock")
+                .balloon_state()
+                .map(|state| VmmData::BalloonConfig(BalloonDeviceConfig::from(state)))
+                .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
             GetBalloonStats => self
                 .vmm
                 .lock()

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -80,9 +80,15 @@ class Balloon():
         )
 
     def get(self):
-        """Get the response of specifying the balloon statistics."""
+        """Get the response of specifying the balloon configuration."""
         return self._api_session.get(
             self._balloon_cfg_url
+        )
+
+    def get_stats(self):
+        """Get the response of specifying the balloon statistics."""
+        return self._api_session.get(
+            "{}".format(self._balloon_cfg_url + "/statistics")
         )
 
     @staticmethod

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.89, "AMD": 84.81}
+COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.69}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -773,6 +773,14 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
+    # Getting the device configuration should be available pre-boot.
+    response = test_microvm.balloon.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json()['amount_mb'] == 0
+    assert response.json()['deflate_on_oom'] is False
+    assert response.json()['must_tell_host'] is True
+    assert response.json()['stats_polling_interval_s'] == 5
+
     # Updating an existing balloon device is forbidden before boot.
     response = test_microvm.balloon.patch(amount_mb=2)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
@@ -805,6 +813,14 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     # We can, however, change the interval to a non-zero value.
     response = test_microvm.balloon.patch_stats(stats_polling_interval_s=5)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Getting the device configuration should be available post-boot.
+    response = test_microvm.balloon.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json()['amount_mb'] == 4
+    assert response.json()['deflate_on_oom'] is False
+    assert response.json()['must_tell_host'] is True
+    assert response.json()['stats_polling_interval_s'] == 5
 
     # Check we can't overflow the `num_pages` field in the config space by
     # requesting too many MB. There are 256 4K pages in a MB. Here, we are

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -397,14 +397,14 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Get an initial reading of the stats.
-    initial_stats = test_microvm.balloon.get().json()
+    initial_stats = test_microvm.balloon.get_stats().json()
 
     # Dirty 10MB of pages.
     make_guest_dirty_memory(ssh_connection, amount=(10 * MB_TO_PAGES))
     time.sleep(1)
 
     # Make sure that the stats catch the page faults.
-    after_workload_stats = test_microvm.balloon.get().json()
+    after_workload_stats = test_microvm.balloon.get_stats().json()
     assert initial_stats['minor_faults'] < after_workload_stats['minor_faults']
     assert initial_stats['major_faults'] < after_workload_stats['major_faults']
 
@@ -414,7 +414,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     time.sleep(1)
 
     # Get another reading of the stats after the polling interval has passed.
-    inflated_stats = test_microvm.balloon.get().json()
+    inflated_stats = test_microvm.balloon.get_stats().json()
 
     # Ensure the stats reflect inflating the balloon.
     assert (
@@ -433,7 +433,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     time.sleep(1)
 
     # Get another reading of the stats after the polling interval has passed.
-    deflated_stats = test_microvm.balloon.get().json()
+    deflated_stats = test_microvm.balloon.get_stats().json()
 
     # Ensure the stats reflect deflating the balloon.
     assert (


### PR DESCRIPTION
## Reason for This PR

We need an API call to poll the state of the balloon device.

## Description of Changes

Added an API call to poll the state of the balloon device.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
