### PR TITLE
Added command line parameter to retrieve supported snapshot versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Removed the jailer `--extra-args` parameter. It was a noop, having been
   replaced by the `--` separator for extra arguments.
+- Changed the output of the `--version` command line parameter to include a list
+  of supported snapshot data format versions for the firecracker binary.
 
 ## [0.23.0]
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -19,6 +19,7 @@ use utils::validators::validate_instance_id;
 use vmm::default_syscalls::get_seccomp_filter;
 use vmm::resources::VmResources;
 use vmm::signal_handler::register_signal_handlers;
+use vmm::version_map::FC_VERSION_TO_SNAP_VERSION;
 use vmm::vmm_config::instance_info::InstanceInfo;
 use vmm::vmm_config::logger::{init_logger, LoggerConfig, LoggerLevel};
 
@@ -140,7 +141,7 @@ fn main() {
         .arg(
             Argument::new("version")
                 .takes_value(false)
-                .help("Print the binary version number.")
+                .help("Print the binary version number and a list of supported snapshot data format versions.")
         );
 
     let arguments = match arg_parser.parse_from_cmdline() {
@@ -164,6 +165,7 @@ fn main() {
             if let Some(version) = arg_parser.arguments().value_as_bool("version") {
                 if version {
                     println!("Firecracker v{}\n", FIRECRACKER_VERSION);
+                    print_supported_snapshot_versions();
                     process::exit(i32::from(vmm::FC_EXIT_CODE_OK));
                 }
             }
@@ -258,6 +260,22 @@ fn main() {
             boot_timer_enabled,
         );
     }
+}
+
+// Print supported snapshot data format versions.
+fn print_supported_snapshot_versions() {
+    let mut snapshot_versions_str = "Supported snapshot data format versions:".to_string();
+    let mut snapshot_versions: Vec<String> = FC_VERSION_TO_SNAP_VERSION
+        .iter()
+        .map(|(key, _)| key.clone())
+        .collect();
+    snapshot_versions.sort();
+
+    snapshot_versions
+        .iter()
+        .for_each(|v| snapshot_versions_str.push_str(format!(" v{},", v).as_str()));
+    snapshot_versions_str.pop();
+    println!("{}\n", snapshot_versions_str);
 }
 
 // Configure and start a microVM as described by the command-line JSON.

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -136,6 +136,11 @@ fn main() {
             Argument::new("boot-timer")
                 .takes_value(false)
                 .help("Whether or not to load boot timer device for logging elapsed time since InstanceStart command.")
+        )
+        .arg(
+            Argument::new("version")
+                .takes_value(false)
+                .help("Print the binary version number.")
         );
 
     let arguments = match arg_parser.parse_from_cmdline() {

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -270,6 +270,11 @@ pub fn build_arg_parser() -> ArgParser<'static> {
              <cgroup_file>=<value> (e.g cpu.shares=10). This argument can be used
              multiple times to add multiple cgroups.",
         ))
+        .arg(
+            Argument::new("version")
+                .takes_value(false)
+                .help("Print the binary version number."),
+        )
 }
 
 fn sanitize_process() {

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -362,7 +362,7 @@ impl<'a> Arguments<'a> {
         // command line arguments by adding just the version argument to the parsed list and
         // returning.
         if args.contains(&VERSION_ARG.to_string()) {
-            let mut version_arg = Argument::new("version").help("Print the binary version number.");
+            let mut version_arg = Argument::new("version");
             version_arg.user_value = Some(Value::Bool(true));
             self.insert_arg(version_arg);
             return Ok(());

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2102728,
+        "FC_BINARY_SIZE_TARGET": 2212120,
         "JAILER_BINARY_SIZE_TARGET": 1439512,
-        "FC_BINARY_SIZE_LIMIT": 2207864,
+        "FC_BINARY_SIZE_LIMIT": 2322726,
         "JAILER_BINARY_SIZE_LIMIT": 1511488,
     },
     "aarch64": {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.72, "AMD": 84.94, "ARM": 83.47}
+COVERAGE_DICT = {"Intel": 85.60, "AMD": 84.83, "ARM": 83.47}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

This is a draft PR meant to solve [#2063](https://github.com/firecracker-microvm/firecracker/issues/2063).

## Description of Changes

An added functionality to display an ordered list of the current supported snapshot data format versions to the `--version` command line parameter. 
The updated `./firecracker --version` command will print the information in the format below:

> Firecracker v0.x.0
> 
> Supported snapshot data format versions: v0.y.0, v0.z.0

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
