### PR TITLE
Add unittests to RPC interface

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -360,7 +360,7 @@ mod tests {
 
         to_api
             .send(Box::new(Err(VmmActionError::StartMicrovm(
-                StartMicrovmError::MicroVMAlreadyRunning,
+                StartMicrovmError::MissingKernelConfig,
             ))))
             .unwrap();
         let response = api_server.serve_vmm_action_request(Box::new(VmmAction::StartMicroVm), 0);
@@ -551,7 +551,7 @@ mod tests {
         .unwrap();
         to_api
             .send(Box::new(Err(VmmActionError::StartMicrovm(
-                StartMicrovmError::MicroVMAlreadyRunning,
+                StartMicrovmError::MissingKernelConfig,
             ))))
             .unwrap();
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -62,8 +62,6 @@ pub enum StartMicrovmError {
     KernelLoader(kernel::loader::Error),
     /// Cannot load command line string.
     LoadCommandline(kernel::cmdline::Error),
-    /// The start command was issued more than once.
-    MicroVMAlreadyRunning,
     /// Cannot start the VM because the kernel was not configured.
     MissingKernelConfig,
     /// Cannot start the VM because the size of the guest memory  was not specified.
@@ -132,7 +130,6 @@ impl Display for StartMicrovmError {
                 err_msg = err_msg.replace("\"", "");
                 write!(f, "Cannot load command line string. {}", err_msg)
             }
-            MicroVMAlreadyRunning => write!(f, "Microvm already running."),
             MissingKernelConfig => write!(f, "Cannot start microvm without kernel configuration."),
             MissingMemSizeConfig => {
                 write!(f, "Cannot start microvm without guest mem_size config.")
@@ -1237,9 +1234,6 @@ pub mod tests {
         let _ = format!("{}{:?}", err, err);
 
         let err = LoadCommandline(kernel::cmdline::Error::TooLarge);
-        let _ = format!("{}{:?}", err, err);
-
-        let err = MicroVMAlreadyRunning;
         let _ = format!("{}{:?}", err, err);
 
         let err = MissingKernelConfig;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -501,7 +501,7 @@ impl Vmm {
 
     /// Updates the path of the host file backing the emulated block device with id `drive_id`.
     /// We update the disk image on the device and its virtio configuration.
-    fn update_block_device_path(&mut self, drive_id: &str, path_on_host: String) -> Result<()> {
+    pub fn update_block_device_path(&mut self, drive_id: &str, path_on_host: String) -> Result<()> {
         self.mmio_device_manager
             .with_virtio_device_with_id(TYPE_BLOCK, drive_id, |block: &mut Block| {
                 block

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -395,12 +395,10 @@ impl RuntimeApiController {
             | InsertNetworkDevice(_)
             | SetVsockDevice(_)
             | SetMmdsConfiguration(_)
-            | SetVmConfiguration(_) => Err(VmmActionError::OperationNotSupportedPostBoot),
+            | SetVmConfiguration(_)
+            | StartMicroVm => Err(VmmActionError::OperationNotSupportedPostBoot),
             #[cfg(target_arch = "x86_64")]
             LoadSnapshot(_) => Err(VmmActionError::OperationNotSupportedPostBoot),
-            StartMicroVm => Err(VmmActionError::StartMicrovm(
-                StartMicrovmError::MicroVMAlreadyRunning,
-            )),
         }
     }
 

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -10,7 +10,7 @@ use std::net::Ipv4Addr;
 #[serde(deny_unknown_fields)]
 pub struct MmdsConfig {
     /// MMDS IPv4 configured address.
-    ipv4_address: Option<Ipv4Addr>,
+    pub ipv4_address: Option<Ipv4Addr>,
 }
 
 impl MmdsConfig {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.9, "AMD": 84.08, "ARM": 82.44}
+COVERAGE_DICT = {"Intel": 85.93, "AMD": 85.11, "ARM": 83.47}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

RPC interface had no unit-test coverage.

Fixes #2060 - Loading snapshot is allowed after configuration of kernel and rootfs

## Description of Changes

The RPC interface code has the purpose of transforming locally defined RPC commands (VmmActions) to programmatic API calls to the underlying components.

In order to efficiently test the RPC interface code we could create mock objects for these underlying components and make use of these mock objects to control and validate expected RPC interface behavior.

Adds `struct MockVmRes` which, when under config(test), is exported as `VmResources`.
With a mock VmResources struct we can easily test most of the PrebootApiController.

Adds `struct MockVmm` which, when under config(test), is exported as `Vmm`.
With a mock Vmm struct we can easily test the RuntimeApiController, as well as the the transition between the two stages (preboot/runtime).

Adds unittests to validate both the happy and error paths of VmmActions received in each stage (preboot, then runtime).

Adds code to disallow LoadSnapshot after configuring boot-specific resources.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
