### PR TITLE
[NET] Fix rx_fails mismatch

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -575,7 +575,7 @@ impl Net {
                         error!("Failed to read slice: {:?}", e);
                         match e {
                             GuestMemoryError::PartialBuffer { .. } => &METRICS.net.tx_partial_reads,
-                            _ => &METRICS.net.rx_fails,
+                            _ => &METRICS.net.tx_fails,
                         }
                         .inc();
                         read_count = 0;


### PR DESCRIPTION
## Reason for This PR

The main reason is fixing the following: 
[Bug] Network device `rx_fails` metric is incremented on TX path #2175

## Description of Changes

The function where the change occurs is called **process_tx**.
The proper metric to be counted in the case of a failure on line 578 is **tx_fails**. 
Therefore, I have replaced **rx_fails** with **tx_fails**.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
