### PR TITLE
Fix release_policy.md link

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -11,7 +11,7 @@ guest workload at that particular point in time.
 
 ### Supported platforms
 
-The Firecracker snapshot feature is in [developer preview](docs/RELEASE_POLICY.md) 
+The Firecracker snapshot feature is in [developer preview](../RELEASE_POLICY.md) 
 on all CPU micro-architectures listed in [README](../README.md#supported-platforms) 
 except ARM which is not supported.
 


### PR DESCRIPTION
## Reason for This PR

This commit fixes a broken link pointing to RELEASE_POLICY.md, inside snapshot-support.md file.

## Description of Changes

Change the link pointing to RELEASE_POLICY.md to the correct one,
to guide the readers into the right location.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
