### PR TITLE
jailer: remove useless --extra-args param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   run.
 - Added the virtio traditional memory ballooning device.
 
+### Changed
+
+- Removed the jailer `--extra-args` parameter. It was a noop, having been
+  replaced by the `--` separator for extra arguments.
+
 ## [0.23.0]
 
 ### Added

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -265,11 +265,6 @@ pub fn build_arg_parser() -> ArgParser<'static> {
             "Daemonize the jailer before exec, by invoking setsid(), and redirecting \
              the standard I/O file descriptors to /dev/null.",
         ))
-        .arg(
-            Argument::new("extra-args")
-                .takes_value(true)
-                .help("Arguments that will be passed verbatim to the exec file."),
-        )
         .arg(Argument::new("cgroup").allow_multiple(true).help(
             "Cgroup and value to be set by the jailer. It must follow this format: \
              <cgroup_file>=<value> (e.g cpu.shares=10). This argument can be used
@@ -329,7 +324,11 @@ fn main() {
             if let Some(help) = arg_parser.arguments().value_as_bool("help") {
                 if help {
                     println!("Jailer v{}\n", JAILER_VERSION);
-                    println!("{}", arg_parser.formatted_help());
+                    println!("{}\n", arg_parser.formatted_help());
+                    println!(
+                        "Any arguments after the -- separator will be supplied to the jailed \
+                        binary.\n"
+                    );
                     process::exit(0);
                 }
             }


### PR DESCRIPTION
##  Reason for This PR

Jailer's `--extra-args` parameter is basically a noop. It is not parsed and its value is not used by the jailer.
The supported mechanism for passing arguments to Firecracker, which is also documented in the jailer docs is using the `--` separator.

## Description of Changes

- Removed the `--extra-args` param from jailer.
- Updated the `--help` information of the jailer.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
