### PR TITLE
Avoid hard-coded sleep() calls in balloon driver functional tests

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -9,12 +9,13 @@ import subprocess
 import time
 
 import pytest
+from retry import retry
 
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.matrix import TestMatrix, TestContext
-from framework.utils import get_free_mem_ssh
+from framework.utils import get_free_mem_ssh, run_cmd
 
 import host_tools.network as net_tools  # pylint: disable=import-error
 
@@ -22,10 +23,27 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 MB_TO_PAGES = 256
 
 
-def get_rss_mem_by_pid(pid):
-    """Get the RSS memory that a guest uses, given the pid of the guest."""
-    output = subprocess.check_output("pmap -X {}".format(pid), shell=True)
-    return int(output.decode('utf-8').split('\n')[-2].split()[1], 10)
+@retry(delay=0.5, tries=10)
+def get_stable_rss_mem_by_pid(pid, percentage_delta=0.5):
+    """
+    Get the RSS memory that a guest uses, given the pid of the guest.
+
+    Wait till the fluctuations in RSS drop below percentage_delta. If timeout
+    is reached before the fluctuations drop, raise an exception.
+    """
+
+    def get_rss_from_pmap():
+        _, output, _ = run_cmd("pmap -X {}".format(pid))
+        return int(output.split('\n')[-2].split()[1], 10)
+
+    first_rss = get_rss_from_pmap()
+    time.sleep(1)
+    second_rss = get_rss_from_pmap()
+
+    delta = (abs(first_rss - second_rss)/float(first_rss)) * 100
+    assert delta < percentage_delta
+
+    return second_rss
 
 
 def make_guest_dirty_memory(ssh_connection, should_oom=False, amount=8192):
@@ -127,15 +145,15 @@ def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
     # Using deflate_on_oom, get the RSS as low as possible
     response = test_microvm.balloon.patch(amount_mb=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
 
     # Get initial rss consumption.
-    init_rss = get_rss_mem_by_pid(firecracker_pid)
+    init_rss = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get the balloon back to 0.
     response = test_microvm.balloon.patch(amount_mb=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(2)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Dirty memory, then inflate balloon and get ballooned rss consumption.
     make_guest_dirty_memory(ssh_connection)
@@ -143,8 +161,7 @@ def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
     response = test_microvm.balloon.patch(amount_mb=200)
 
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
-    balloon_rss = get_rss_mem_by_pid(firecracker_pid)
+    balloon_rss = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Check that the ballooning reclaimed the memory.
     assert balloon_rss - init_rss <= 15000
@@ -176,6 +193,7 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
     test_microvm.start()
 
     # Get and open an ssh connection.
+    firecracker_pid = test_microvm.jailer_clone_pid
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Get the free memory before ballooning.
@@ -184,7 +202,8 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
     # Inflate 64 MB == 16384 page balloon.
     response = test_microvm.balloon.patch(amount_mb=64)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get the free memory after ballooning.
     available_mem_inflated = get_free_mem_ssh(ssh_connection)
@@ -219,12 +238,14 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
     test_microvm.start()
 
     # Get an ssh connection to the microvm.
+    firecracker_pid = test_microvm.jailer_clone_pid
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon
     response = test_microvm.balloon.patch(amount_mb=172)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Check that using memory doesn't lead to an out of memory error.
     # Note that due to `test_deflate_on_oom_false`, we know that
@@ -259,12 +280,14 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
     test_microvm.start()
 
     # Get an ssh connection to the microvm.
+    firecracker_pid = test_microvm.jailer_clone_pid
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon.
     response = test_microvm.balloon.patch(amount_mb=172)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Check that using memory does lead to an out of memory error.
     make_guest_dirty_memory(ssh_connection, should_oom=True)
@@ -303,35 +326,37 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
     # the memory.
     response = test_microvm.balloon.patch(amount_mb=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
+
     response = test_microvm.balloon.patch(amount_mb=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(2)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get the guest to dirty memory.
     make_guest_dirty_memory(ssh_connection)
-    first_reading = get_rss_mem_by_pid(firecracker_pid)
+    first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon.
     response = test_microvm.balloon.patch(amount_mb=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
-    second_reading = get_rss_mem_by_pid(firecracker_pid)
+    second_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
-    # Now inflate the balloon again.
+    # Now deflate the balloon.
     response = test_microvm.balloon.patch(amount_mb=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(2)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now have the guest dirty memory again.
     make_guest_dirty_memory(ssh_connection)
-    third_reading = get_rss_mem_by_pid(firecracker_pid)
+    third_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon again.
     response = test_microvm.balloon.patch(amount_mb=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
-    fourth_reading = get_rss_mem_by_pid(firecracker_pid)
+    fourth_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Check that the memory used is the same after regardless of the previous
     # inflate history of the balloon (with the third reading being allowed
@@ -370,7 +395,7 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Check memory usage.
-    first_reading = get_rss_mem_by_pid(firecracker_pid)
+    first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Have the guest drop its caches.
     ssh_connection.execute_command('sync; echo 3 > /proc/sys/vm/drop_caches')
@@ -379,10 +404,9 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
     # Now inflate the balloon.
     response = test_microvm.balloon.patch(amount_mb=40)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
 
     # Check memory usage again.
-    second_reading = get_rss_mem_by_pid(firecracker_pid)
+    second_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # There should be a reduction of at least 10MB.
     assert first_reading - second_reading >= 10000
@@ -413,6 +437,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     test_microvm.start()
 
     # Open an ssh connection to the microvm.
+    firecracker_pid = test_microvm.jailer_clone_pid
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Get an initial reading of the stats.
@@ -421,6 +446,8 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     # Dirty 10MB of pages.
     make_guest_dirty_memory(ssh_connection, amount=(10 * MB_TO_PAGES))
     time.sleep(1)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Make sure that the stats catch the page faults.
     after_workload_stats = test_microvm.balloon.get_stats().json()
@@ -430,7 +457,8 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     # Now inflate the balloon with 10MB of pages.
     response = test_microvm.balloon.patch(amount_mb=10)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(1)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get another reading of the stats after the polling interval has passed.
     inflated_stats = test_microvm.balloon.get_stats().json()
@@ -449,7 +477,8 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     # available memory.
     response = test_microvm.balloon.patch(amount_mb=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(1)
+    # This call will internally wait for rss to become stable.
+    _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get another reading of the stats after the polling interval has passed.
     deflated_stats = test_microvm.balloon.get_stats().json()
@@ -527,15 +556,14 @@ def _test_balloon_snapshot(context):
     firecracker_pid = basevm.jailer_clone_pid
 
     # Check memory usage.
-    first_reading = get_rss_mem_by_pid(firecracker_pid)
+    first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon with 20MB of pages.
     response = basevm.balloon.patch(amount_mb=20)
     assert basevm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
 
     # Check memory usage again.
-    second_reading = get_rss_mem_by_pid(firecracker_pid)
+    second_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # There should be a reduction in RSS, but it's inconsistent.
     # We only test that the reduction happens.
@@ -564,23 +592,21 @@ def _test_balloon_snapshot(context):
     firecracker_pid = microvm.jailer_clone_pid
 
     # Check memory usage.
-    third_reading = get_rss_mem_by_pid(firecracker_pid)
+    third_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Dirty 60MB of pages.
     make_guest_dirty_memory(ssh_connection, amount=(60 * MB_TO_PAGES))
-    time.sleep(1)
 
     # Check memory usage.
-    fourth_reading = get_rss_mem_by_pid(firecracker_pid)
+    fourth_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     assert fourth_reading > third_reading
 
     # Inflate the balloon with another 20MB of pages.
     response = microvm.balloon.patch(amount_mb=40)
     assert microvm.api_session.is_status_no_content(response.status_code)
-    time.sleep(5)
 
-    fifth_reading = get_rss_mem_by_pid(firecracker_pid)
+    fifth_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # There should be a reduction in RSS, but it's inconsistent.
     # We only test that the reduction happens.


### PR DESCRIPTION
Currently, tests in test_balloon.py use sleep() calls with hard coded values to
wait until the RSS of the microvm reaches a stable value for reading.

The behavior is changed and the test now waits until the percentage change in
RSS falls under a specified threshold. Right now 0.5% is used as the threshold.

## Reason for This PR

Tests in test_balloon.py use hard-coded sleep() calls. Fixing that to make tests more robust.
The hard-coded sleep() calls results in failure of tests on aarch64.

## Description of Changes

The hard-coded sleep calls are removed and the test now waits until the percentage change in
RSS falls under a specified threshold. Right now 0.5% is used as the threshold.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
