### PR TITLE
Changed visibility of pub functions in firecracker crate

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -119,7 +119,7 @@ impl Subscriber for ApiServerAdapter {
     }
 }
 
-pub fn run_with_api(
+pub(crate) fn run_with_api(
     seccomp_filter: BpfProgram,
     config_json: Option<String>,
     bind_path: PathBuf,

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -10,10 +10,10 @@ use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 use utils::epoll::{EpollEvent, EventSet};
 
 /// Metrics reporting period.
-pub const WRITE_METRICS_PERIOD_MS: u64 = 60000;
+pub(crate) const WRITE_METRICS_PERIOD_MS: u64 = 60000;
 
 /// Object to drive periodic reporting of metrics.
-pub struct PeriodicMetrics {
+pub(crate) struct PeriodicMetrics {
     write_metrics_event_fd: TimerFd,
     #[cfg(test)]
     flush_counter: u64,
@@ -32,7 +32,7 @@ impl PeriodicMetrics {
     }
 
     /// Start the periodic metrics engine which will flush metrics every `interval_ms` millisecs.
-    pub fn start(&mut self, interval_ms: u64) {
+    pub(crate) fn start(&mut self, interval_ms: u64) {
         // Arm the log write timer.
         let timer_state = TimerState::Periodic {
             current: Duration::from_millis(interval_ms),


### PR DESCRIPTION
Signed-off-by: kumargu <kumargu@amazon.com>

## Reason for This PR

#607

## Description of Changes

Changed visibility of pub fun in crate-firecracker. Public functions which are accessible only within crate are now changed to pub(crate).

This reduces the visibility of pub functions in the crate-firecracker.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
