### PR TITLE
[Balloon] Fix snap load crashes with invalid input

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -992,6 +992,14 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_process_balloon_queues() {
+        let mut balloon = Balloon::new(0x10, true, true, 0, false).unwrap();
+        let mem = default_mem();
+        balloon.activate(mem).unwrap();
+        balloon.process_virtio_queues()
+    }
+
+    #[test]
     fn test_update_stats_interval() {
         let mut balloon = Balloon::new(0, true, true, 0, false).unwrap();
         assert_eq!(

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -71,6 +71,8 @@ pub enum Error {
     MalformedDescriptor,
     /// Guest gave us a malformed payload.
     MalformedPayload,
+    /// Error restoring the balloon device queues.
+    QueueRestoreError,
     /// Received stats querry when stats are disabled.
     StatisticsDisabled,
     /// Statistics cannot be enabled/disabled after activation.


### PR DESCRIPTION
## Reason for This PR

We introduced sanity checks for virtqueues on snapshot restore, but they were not used in the balloon device.

## Description of Changes

Applied the sanity checks on the virtio queues in the balloon restore function.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
