### PR TITLE
[Balloon] Added checks for invalid target sizes on balloon config updates

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::builder::{self, StartMicrovmError};
 use crate::device_manager::persist::Error as DevicePersistError;
+use crate::mem_size_mib;
 use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
 use crate::vstate::{self, vcpu::VcpuState, vm::VmState};
 
@@ -26,7 +27,7 @@ use seccomp::BpfProgramRef;
 use snapshot::Snapshot;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::GuestMemoryMmap;
 
 use crate::Vmm;
 
@@ -242,10 +243,6 @@ fn snapshot_memory_to_file(
         }
         SnapshotType::Full => vmm.guest_memory().dump(&mut file).map_err(Memory),
     }
-}
-
-pub(crate) fn mem_size_mib(guest_memory: &GuestMemoryMmap) -> u64 {
-    guest_memory.map_and_fold(0, |(_, region)| region.len(), |a, b| a + b) >> 20
 }
 
 /// Loads a Microvm snapshot producing a 'paused' Microvm.


### PR DESCRIPTION
## Reason for This PR

Previously, when users set the target size of the balloon device, the request would succeed even if the target size was greater than the total amount of memory the VM had.

## Description of Changes

Added checks to ensure users cannot request more memory from the balloon than the total amount of VM memory.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
