### PR TITLE
snapshot: changed atomic ordering for bitmap functions

### DIFF
--- a/src/vm-memory/src/bitmap.rs
+++ b/src/vm-memory/src/bitmap.rs
@@ -3,10 +3,6 @@
 //
 //! Atomic bitmap implementation.
 
-// Temporarly disable unused warnings.
-// TODO: remove these once the Bitmap integration is completed.
-#![allow(dead_code)]
-
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// `Bitmap` implements a simple bit map on the page level with test and set operations. It is
@@ -42,7 +38,7 @@ impl Bitmap {
     #[inline]
     pub fn is_bit_set(&self, n: usize) -> bool {
         if n <= self.size {
-            (self.map[n >> 6].load(Ordering::SeqCst) & (1 << (n & 63))) != 0
+            (self.map[n >> 6].load(Ordering::Acquire) & (1 << (n & 63))) != 0
         } else {
             // Out-of-range bits are always unset.
             false
@@ -96,7 +92,7 @@ impl Clone for Bitmap {
         let map = self
             .map
             .iter()
-            .map(|i| i.load(Ordering::SeqCst))
+            .map(|i| i.load(Ordering::Acquire))
             .map(AtomicU64::new)
             .collect();
         Bitmap {


### PR DESCRIPTION
Optimized bitmap functions by changing atomic ordering types
and deleted attribute which allowed dead code.

Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

Addressed extra comments here: https://github.com/firecracker-microvm/firecracker/pull/2259.

## Description of Changes

Relaxed atomic ordering types for the bitmap functions and forbade dead code for the bitmap file.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
