### PR TITLE
Change visibility of pub fun in api_server crate

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -314,7 +314,7 @@ impl ApiServer {
     }
 
     /// An HTTP response which also includes a body.
-    pub fn json_response<T: Into<String>>(status: StatusCode, body: T) -> Response {
+    pub(crate) fn json_response<T: Into<String>>(status: StatusCode, body: T) -> Response {
         let mut response = Response::new(Version::Http11, status);
         response.set_body(Body::new(body.into()));
         response

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -26,7 +26,7 @@ use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use logger::{error, info};
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 
-pub enum ParsedRequest {
+pub(crate) enum ParsedRequest {
     GetInstanceInfo,
     GetMMDS,
     PatchMMDS(Value),
@@ -35,7 +35,7 @@ pub enum ParsedRequest {
 }
 
 impl ParsedRequest {
-    pub fn try_from_request(request: &Request) -> Result<ParsedRequest, Error> {
+    pub(crate) fn try_from_request(request: &Request) -> Result<ParsedRequest, Error> {
         let request_uri = request.uri().get_abs_path().to_string();
         log_received_api_request(describe(
             request.method(),
@@ -92,7 +92,7 @@ impl ParsedRequest {
         }
     }
 
-    pub fn convert_to_response(
+    pub(crate) fn convert_to_response(
         request_outcome: &std::result::Result<VmmData, VmmActionError>,
     ) -> Response {
         match request_outcome {
@@ -135,7 +135,7 @@ impl ParsedRequest {
     }
 
     /// Helper function to avoid boiler-plate code.
-    pub fn new_sync(vmm_action: VmmAction) -> ParsedRequest {
+    pub(crate) fn new_sync(vmm_action: VmmAction) -> ParsedRequest {
         ParsedRequest::Sync(Box::new(vmm_action))
     }
 }
@@ -170,7 +170,7 @@ fn describe(method: Method, path: &str, body: Option<&Body>) -> String {
 }
 
 /// Generates a `GenericError` for each request method.
-pub fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
+pub(crate) fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
     match method {
         Method::Get => Err(Error::Generic(
             StatusCode::BadRequest,
@@ -188,7 +188,7 @@ pub fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
 }
 
 #[derive(Debug)]
-pub enum Error {
+pub(crate) enum Error {
     // A generic error, with a given status code and message to be turned into a fault message.
     Generic(StatusCode, String),
     // The resource ID is empty.
@@ -240,7 +240,7 @@ impl Into<Response> for Error {
 }
 
 // This function is supposed to do id validation for requests.
-pub fn checked_id(id: &str) -> Result<&str, Error> {
+pub(crate) fn checked_id(id: &str) -> Result<&str, Error> {
     // todo: are there any checks we want to do on id's?
     // not allow them to be empty strings maybe?
     // check: ensure string is not empty

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -28,7 +28,7 @@ struct ActionBody {
     action_type: ActionType,
 }
 
-pub fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.actions_count.inc();
     let action_body = serde_json::from_slice::<ActionBody>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.actions_fails.inc();

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -9,7 +9,7 @@ use vmm::vmm_config::balloon::{
     BalloonDeviceConfig, BalloonUpdateConfig, BalloonUpdateStatsConfig,
 };
 
-pub fn parse_get_balloon(path_second_token: Option<&&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_balloon(path_second_token: Option<&&str>) -> Result<ParsedRequest, Error> {
     match path_second_token {
         Some(stats_path) => match *stats_path {
             "statistics" => Ok(ParsedRequest::new_sync(VmmAction::GetBalloonStats)),
@@ -22,13 +22,13 @@ pub fn parse_get_balloon(path_second_token: Option<&&str>) -> Result<ParsedReque
     }
 }
 
-pub fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::SetBalloonDevice(
         serde_json::from_slice::<BalloonDeviceConfig>(body.raw()).map_err(Error::SerdeJson)?,
     )))
 }
 
-pub fn parse_patch_balloon(
+pub(crate) fn parse_patch_balloon(
     body: &Body,
     path_second_token: Option<&&str>,
 ) -> Result<ParsedRequest, Error> {

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -7,7 +7,7 @@ use crate::request::Body;
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::boot_source::BootSourceConfig;
 
-pub fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.boot_source_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
         serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|e| {

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -7,7 +7,10 @@ use crate::request::{Body, StatusCode};
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::drive::{BlockDeviceConfig, BlockDeviceUpdateConfig};
 
-pub fn parse_put_drive(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_drive(
+    body: &Body,
+    id_from_path: Option<&&str>,
+) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.drive_count.inc();
     let id = if let Some(id) = id_from_path {
         checked_id(id)?
@@ -34,7 +37,10 @@ pub fn parse_put_drive(body: &Body, id_from_path: Option<&&str>) -> Result<Parse
     }
 }
 
-pub fn parse_patch_drive(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_drive(
+    body: &Body,
+    id_from_path: Option<&&str>,
+) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.drive_count.inc();
     let id = if let Some(id) = id_from_path {
         checked_id(id)?

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -4,7 +4,7 @@
 use crate::parsed_request::{Error, ParsedRequest};
 use logger::{IncMetric, METRICS};
 
-pub fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.instance_info_count.inc();
     Ok(ParsedRequest::GetInstanceInfo)
 }

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -7,7 +7,7 @@ use crate::request::Body;
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::logger::LoggerConfig;
 
-pub fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.logger_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureLogger(
         serde_json::from_slice::<LoggerConfig>(body.raw()).map_err(|e| {

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -7,12 +7,12 @@ use crate::request::{Body, Method, StatusCode};
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::machine_config::VmConfig;
 
-pub fn parse_get_machine_config() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_machine_config() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.machine_cfg_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::GetVmConfiguration))
 }
 
-pub fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.machine_cfg_count.inc();
     let vm_config = serde_json::from_slice::<VmConfig>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.machine_cfg_fails.inc();
@@ -36,7 +36,7 @@ pub fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
     )))
 }
 
-pub fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.machine_cfg_count.inc();
     let vm_config = serde_json::from_slice::<VmConfig>(body.raw()).map_err(|e| {
         METRICS.patch_api_requests.machine_cfg_fails.inc();

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -7,7 +7,7 @@ use crate::request::Body;
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::metrics::MetricsConfig;
 
-pub fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.metrics_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureMetrics(
         serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|e| {

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -7,11 +7,11 @@ use micro_http::StatusCode;
 use vmm::rpc_interface::VmmAction::SetMmdsConfiguration;
 use vmm::vmm_config::mmds::MmdsConfig;
 
-pub fn parse_get_mmds() -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_get_mmds() -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::GetMMDS)
 }
 
-pub fn parse_put_mmds(
+pub(crate) fn parse_put_mmds(
     body: &Body,
     path_second_token: Option<&&str>,
 ) -> Result<ParsedRequest, Error> {
@@ -31,7 +31,7 @@ pub fn parse_put_mmds(
     }
 }
 
-pub fn parse_patch_mmds(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_mmds(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::PatchMMDS(
         serde_json::from_slice(body.raw()).map_err(Error::SerdeJson)?,
     ))

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -7,7 +7,10 @@ use crate::request::{Body, StatusCode};
 use logger::{IncMetric, METRICS};
 use vmm::vmm_config::net::{NetworkInterfaceConfig, NetworkInterfaceUpdateConfig};
 
-pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_net(
+    body: &Body,
+    id_from_path: Option<&&str>,
+) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.network_count.inc();
     let id = if let Some(id) = id_from_path {
         checked_id(id)?
@@ -32,7 +35,10 @@ pub fn parse_put_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedR
     )))
 }
 
-pub fn parse_patch_net(body: &Body, id_from_path: Option<&&str>) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_net(
+    body: &Body,
+    id_from_path: Option<&&str>,
+) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.network_count.inc();
     let id = if let Some(id) = id_from_path {
         checked_id(id)?

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -11,7 +11,7 @@ use vmm::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams};
 use vmm::vmm_config::snapshot::{Vm, VmState};
 
 #[cfg(target_arch = "x86_64")]
-pub fn parse_put_snapshot(
+pub(crate) fn parse_put_snapshot(
     body: &Body,
     request_type_from_path: Option<&&str>,
 ) -> Result<ParsedRequest, Error> {
@@ -37,7 +37,7 @@ pub fn parse_put_snapshot(
     }
 }
 
-pub fn parse_patch_vm_state(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_patch_vm_state(body: &Body) -> Result<ParsedRequest, Error> {
     let vm = serde_json::from_slice::<Vm>(body.raw()).map_err(Error::SerdeJson)?;
 
     match vm.state {

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -6,7 +6,7 @@ use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
-pub fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
+pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::SetVsockDevice(
         serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(Error::SerdeJson)?,
     )))


### PR DESCRIPTION
Reduce visibility of public functions. Functions which are visible only
with the crate are marked as pub(crate). Functions which are visible only
within the mod are marked as private.

Signed-off-by: kumargu <kumargu@amazon.com>

## Reason for This PR

https://github.com/firecracker-microvm/firecracker/issues/607

## Description of Changes

Reduce visibility of public functions. Functions which are visible only with the crate are marked as pub(crate).
Functions which are visible only within the mod are marked as private.


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
