### PR TITLE
CI: add RTC test on aarch64

### DIFF
--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Check the well functioning af the RTC device on aarch64 platforms."""
+import re
+import platform
+import pytest
+
+import framework.utils as utils
+from host_tools.network import SSHConnection
+
+DMESG_LOG_REGEX = r'rtc-pl031\s+(\d+).rtc: setting system clock to'
+
+
+@pytest.mark.skipif(
+    platform.machine() != "aarch64",
+    reason="RTC exists only on aarch64."
+)
+def test_rtc(test_microvm_with_ssh, network_config):
+    """Test RTC functionality on aarch64."""
+    vm = test_microvm_with_ssh
+    vm.spawn()
+    vm.memory_monitor = None
+    vm.basic_config()
+    _tap, _, _ = vm.ssh_network_config(network_config, '1')
+
+    vm.start()
+    conn = SSHConnection(vm.ssh_config)
+
+    # check that the kernel creates an rtcpl031 base device.
+    _, stdout, _ = conn.execute_command("dmesg")
+    rtc_log = re.findall(DMESG_LOG_REGEX, stdout.read())
+    assert rtc_log is not None
+
+    _, stdout, _ = conn.execute_command("stat /dev/rtc0")
+    assert "character special file" in stdout.read()
+
+    _, host_stdout, _ = utils.run_cmd("date +%s")
+    _, guest_stdout, _ = conn.execute_command("date +%s")
+    assert abs(int(guest_stdout.read()) - int(host_stdout)) < 5


### PR DESCRIPTION
Check that the RTC device, which is only
present on aarch64 microVMs, functions properly.

Signed-off-by: Diana Popa <dpopa@amazon.com>

## Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/1117

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
