### PR TITLE
[Balloon] Add integration test for memory scrubbing

### DIFF
--- a/tests/host_tools/readmem.c
+++ b/tests/host_tools/readmem.c
@@ -1,0 +1,69 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a balloon device helper tool, which allocates an amount of
+// memory, given as the first starting parameter, and then tries to find
+// 4 consecutive occurences of an integer, given as the second starting
+// parameter, in that memory chunk. The program returns 1 if it succeeds
+// in finding these occurences, 0 otherwise. After performing a deflate
+// operation on the balloon device, we run this program with the second
+// starting parameter equal to `1`, which is the value we are using to
+// write in memory when dirtying it with `fillmem`. If the memory is
+// indeed scrubbed, we won't be able to find any 4 consecutive occurences
+// of the integer `1` in newly allocated memory.
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#define MB (1024 * 1024)
+
+
+int read_mem(int mb_count, int value) {
+    int i;
+    char *ptr = NULL;
+    int *cur = NULL;
+    int buf[4] = { value };
+
+    do {
+        ptr = mmap(
+            NULL,
+            mb_count * MB * sizeof(char),
+            PROT_READ | PROT_WRITE,
+            MAP_ANONYMOUS | MAP_PRIVATE,
+            -1,
+            0
+        );
+    } while (ptr == MAP_FAILED);
+        
+    cur = (int *) ptr;
+    // We will go through all the memory allocated with an `int` pointer,
+    // so we have to divide the amount of bytes available by the size of
+    // `int`. Furthermore, we compare 4 `int`s at a time, so we will
+    // divide the upper limit of the loop by 4 and also increment the index
+    // by 4.
+    for (i = 0; i < (mb_count * MB * sizeof(char)) / (4 * sizeof(int)); i += 4) {
+        if (memcmp(cur, buf, 4 * sizeof(int)) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+int main(int argc, char *const argv[]) {
+
+    if (argc != 3) {
+        printf("Usage: ./readmem mb_count value\n");
+        return -1;
+    }
+    
+    int mb_count = atoi(argv[1]);
+    int value = atoi(argv[2]);
+
+    return read_mem(mb_count, value);
+}


### PR DESCRIPTION
## Reason for This PR

We needed an integration test to ensure memory allocated after an inflate/deflate cycle is indeed zeroed out.

## Description of Changes

Added a test for the ballon device that ensures the memory after a deflate is zeroed out.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
