### PR TITLE
Minor improvements to argument parsing code

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -208,7 +208,7 @@ fn main() {
     // It's safe to unwrap here because the field's been provided with a default value.
     let seccomp_level = arguments.single_value("seccomp-level").unwrap();
     let seccomp_filter = get_seccomp_filter(
-        SeccompLevel::from_string(seccomp_level).unwrap_or_else(|err| {
+        SeccompLevel::from_string(&seccomp_level).unwrap_or_else(|err| {
             panic!("Invalid value for seccomp-level: {}", err);
         }),
     )

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -181,11 +181,11 @@ fn main() {
         app_name: "Firecracker".to_string(),
     };
 
-    LOGGER.set_instance_id(instance_id);
+    LOGGER.set_instance_id(instance_id.to_owned());
 
     if let Some(log) = arguments.single_value("log-path") {
         // It's safe to unwrap here because the field's been provided with a default value.
-        let level = arguments.single_value("level").unwrap();
+        let level = arguments.single_value("level").unwrap().to_owned();
         let logger_level = LoggerLevel::from_string(level).unwrap_or_else(|err| {
             error!("Invalid value for logger level: {}. Possible values: [Error, Warning, Info, Debug]", err);
             process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -326,23 +326,19 @@ fn main() {
             process::exit(1);
         }
         _ => {
-            if let Some(help) = arg_parser.arguments().value_as_bool("help") {
-                if help {
-                    println!("Jailer v{}\n", JAILER_VERSION);
-                    println!("{}\n", arg_parser.formatted_help());
-                    println!(
-                        "Any arguments after the -- separator will be supplied to the jailed \
-                        binary.\n"
-                    );
-                    process::exit(0);
-                }
+            if arg_parser.arguments().flag_present("help") {
+                println!("Jailer v{}\n", JAILER_VERSION);
+                println!("{}\n", arg_parser.formatted_help());
+                println!(
+                    "Any arguments after the -- separator will be supplied to the jailed \
+                    binary.\n"
+                );
+                process::exit(0);
             }
 
-            if let Some(version) = arg_parser.arguments().value_as_bool("version") {
-                if version {
-                    println!("Jailer v{}\n", JAILER_VERSION);
-                    process::exit(0);
-                }
+            if arg_parser.arguments().flag_present("version") {
+                println!("Jailer v{}\n", JAILER_VERSION);
+                process::exit(0);
             }
         }
     }

--- a/src/seccomp/src/lib.rs
+++ b/src/seccomp/src/lib.rs
@@ -1157,7 +1157,7 @@ pub enum SeccompLevel {
 impl SeccompLevel {
     /// Converts from a seccomp level value of type String to the corresponding SeccompLevel variant
     /// or returns an error if the parsing failed.
-    pub fn from_string(seccomp_value: String) -> std::result::Result<Self, SeccompError> {
+    pub fn from_string(seccomp_value: &str) -> std::result::Result<Self, SeccompError> {
         match seccomp_value.parse::<u8>() {
             Ok(0) => Ok(SeccompLevel::None),
             Ok(1) => Ok(SeccompLevel::Basic),
@@ -2019,38 +2019,26 @@ mod tests {
     #[test]
     fn test_parse_seccomp() {
         // Check `from_string()` behaviour for different scenarios.
-        match SeccompLevel::from_string("3".to_string()) {
+        match SeccompLevel::from_string("3") {
             Err(SeccompError::Level(_)) => (),
             _ => panic!("Unexpected result"),
         }
         assert_eq!(
-            format!(
-                "{}",
-                SeccompLevel::from_string("3".to_string()).unwrap_err()
-            ),
+            format!("{}", SeccompLevel::from_string("3").unwrap_err()),
             "'3' isn't a valid value for 'seccomp-level'. Must be 0, 1 or 2."
         );
-        match SeccompLevel::from_string("foo".to_string()) {
+        match SeccompLevel::from_string("foo") {
             Err(SeccompError::Parse(_)) => (),
             _ => panic!("Unexpected result"),
         }
         assert_eq!(
-            format!(
-                "{}",
-                SeccompLevel::from_string("foo".to_string()).unwrap_err()
-            ),
+            format!("{}", SeccompLevel::from_string("foo").unwrap_err()),
             "Could not parse to 'u8': invalid digit found in string"
         );
+        assert_eq!(SeccompLevel::from_string("0").unwrap(), SeccompLevel::None);
+        assert_eq!(SeccompLevel::from_string("1").unwrap(), SeccompLevel::Basic);
         assert_eq!(
-            SeccompLevel::from_string("0".to_string()).unwrap(),
-            SeccompLevel::None
-        );
-        assert_eq!(
-            SeccompLevel::from_string("1".to_string()).unwrap(),
-            SeccompLevel::Basic
-        );
-        assert_eq!(
-            SeccompLevel::from_string("2".to_string()).unwrap(),
+            SeccompLevel::from_string("2").unwrap(),
             SeccompLevel::Advanced
         );
     }

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -240,9 +240,9 @@ pub enum Value {
 }
 
 impl Value {
-    fn as_single_value(&self) -> Option<String> {
+    fn as_single_value(&self) -> Option<&String> {
         match self {
-            Value::Single(s) => Some(s.to_string()),
+            Value::Single(s) => Some(s),
             _ => None,
         }
     }
@@ -254,9 +254,9 @@ impl Value {
         }
     }
 
-    fn as_multiple(&self) -> Option<Vec<String>> {
+    fn as_multiple(&self) -> Option<&[String]> {
         match self {
-            Value::Multiple(v) => Some(v.to_vec()),
+            Value::Multiple(v) => Some(v),
             _ => None,
         }
     }
@@ -299,7 +299,7 @@ impl<'a> Arguments<'a> {
 
     /// Return the value of an argument if the argument exists and has the type
     /// String. Otherwise return None.
-    pub fn single_value(&self, arg_name: &'static str) -> Option<String> {
+    pub fn single_value(&self, arg_name: &'static str) -> Option<&String> {
         self.value_of(arg_name)
             .and_then(|arg_value| arg_value.as_single_value())
     }
@@ -314,7 +314,7 @@ impl<'a> Arguments<'a> {
 
     /// Return the value of an argument if the argument exists and has the type
     /// vector. Otherwise return None.
-    pub fn multiple_values(&self, arg_name: &'static str) -> Option<Vec<String>> {
+    pub fn multiple_values(&self, arg_name: &'static str) -> Option<&[String]> {
         self.value_of(arg_name)
             .and_then(|arg_value| arg_value.as_multiple())
     }
@@ -622,7 +622,7 @@ mod tests {
         let mut value = Value::Flag;
         assert!(Value::as_single_value(&value).is_none());
         value = Value::Single("arg".to_string());
-        assert_eq!(Value::as_single_value(&value).unwrap(), "arg".to_string());
+        assert_eq!(Value::as_single_value(&value).unwrap(), "arg");
 
         value = Value::Single("arg".to_string());
         assert!(!Value::as_flag(&value));


### PR DESCRIPTION
## Reason for This PR

Simplify code.

## Description of Changes

Simplify for flag-type arguments: change `Value::Bool(bool)` to `Value::Flag` since the value only encodes whether an argument with no values (also referred to as a flag) is present or not. The inner bool is redundant (since it is always true) and confusing (because it suggests it could also be false).

Also do a quick rename of `Value::String` and `Value::Vector` to `Value::Single` and `Value::Multiple` to avoid confusion caused by the name collision with the standard types.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
