### PR TITLE
vmm: kick devices on resume-vm instead of load-snaphot

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -366,7 +366,7 @@ pub fn build_microvm_for_boot(
         .map_err(Internal)?;
 
     // The vcpus start off in the `Paused` state, let them run.
-    vmm.resume_vcpus().map_err(Internal)?;
+    vmm.resume_vm().map_err(Internal)?;
 
     let vmm = Arc::new(Mutex::new(vmm));
     event_manager

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -13,10 +13,14 @@ use std::{fmt, io};
 use arch::aarch64::DeviceInfoForFDT;
 use arch::DeviceType;
 use devices::pseudo::BootTimer;
-use devices::virtio::VirtioDevice;
-use devices::{virtio::MmioTransport, BusDevice};
+use devices::virtio::{
+    Balloon, Block, MmioTransport, Net, VirtioDevice, TYPE_BALLOON, TYPE_BLOCK, TYPE_NET,
+    TYPE_VSOCK,
+};
+use devices::BusDevice;
 use kernel::cmdline as kernel_cmdline;
 use kvm_ioctls::{IoEventAddress, VmFd};
+use logger::info;
 #[cfg(target_arch = "aarch64")]
 use utils::eventfd::EventFd;
 use versionize::{VersionMap, Versionize, VersionizeResult};
@@ -325,7 +329,6 @@ impl MMIODeviceManager {
         None
     }
 
-    #[cfg(target_arch = "x86_64")]
     /// Run fn for each registered device.
     pub fn for_each_device<F, E>(&self, mut f: F) -> std::result::Result<(), E>
     where
@@ -370,6 +373,62 @@ impl MMIODeviceManager {
             return Err(Error::DeviceNotFound);
         }
         Ok(())
+    }
+
+    /// Artificially kick devices as if they had external events.
+    pub fn kick_devices(&self) {
+        info!("Artificially kick devices.");
+        let _: Result<()> = self.for_each_device(|devtype, id, _, bus_dev| {
+            // We only kick virtio devices for now.
+            if let DeviceType::Virtio(virtio_type) = *devtype {
+                let bus_dev = bus_dev.lock().expect("Poisoned lock");
+                // Virtio devices are guaranteed MmioTransport.
+                let mmio_dev = bus_dev.as_any().downcast_ref::<MmioTransport>().unwrap();
+                let mut virtio = mmio_dev.locked_device();
+                match virtio_type {
+                    TYPE_BALLOON => {
+                        info!("kick balloon {}.", id);
+                        let balloon = virtio.as_mut_any().downcast_mut::<Balloon>().unwrap();
+                        // If device is activated, kick the balloon queue(s) to make up for any
+                        // pending or in-flight epoll events we may have not captured in snapshot.
+                        // Stats queue doesn't need kicking as it is notified via a `timer_fd`.
+                        if balloon.is_activated() {
+                            balloon.process_virtio_queues();
+                        }
+                    }
+                    TYPE_BLOCK => {
+                        info!("kick block {}.", id);
+                        let block = virtio.as_mut_any().downcast_mut::<Block>().unwrap();
+                        // If device is activated, kick the block queue(s) to make up for any
+                        // pending or in-flight epoll events we may have not captured in snapshot.
+                        // No need to kick Ratelimiters because they are restored 'unblocked' so
+                        // any inflight `timer_fd` events can be safely discarded.
+                        if block.is_activated() {
+                            block.process_virtio_queues();
+                        }
+                    }
+                    TYPE_NET => {
+                        info!("kick net {}.", id);
+                        let net = virtio.as_mut_any().downcast_mut::<Net>().unwrap();
+                        // If device is activated, kick the net queue(s) to make up for any
+                        // pending or in-flight epoll events we may have not captured in snapshot.
+                        // No need to kick Ratelimiters because they are restored 'unblocked' so
+                        // any inflight `timer_fd` events can be safely discarded.
+                        if net.is_activated() {
+                            net.process_virtio_queues();
+                        }
+                    }
+                    TYPE_VSOCK => {
+                        // Vsock has complicated protocol that isn't resilient to any packet loss,
+                        // so for Vsock we don't support connection persistence through snapshot.
+                        // Any in-flight packets or events are simply lost.
+                        // Vsock is restored 'empty'.
+                    }
+                    _ => (),
+                }
+            };
+            Ok(())
+        });
     }
 }
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -263,20 +263,12 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
             restore_helper(
                 device.clone(),
-                device.clone(),
+                device,
                 &balloon_state.device_id,
                 &balloon_state.transport_state,
                 &balloon_state.mmio_slot,
                 constructor_args.event_manager,
             )?;
-
-            // If device is activated, kick the balloon queue(s) to make up for any
-            // pending or in-flight epoll events we may have not captured in snapshot.
-            // Stats queue doesn't need kicking as it is notified via a `timer_fd`.
-            let mut dev = device.lock().expect("Poisoned lock");
-            if dev.is_activated() {
-                dev.process_virtio_queues();
-            }
         }
 
         for block_state in &state.block_devices {
@@ -290,21 +282,12 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
             restore_helper(
                 device.clone(),
-                device.clone(),
+                device,
                 &block_state.device_id,
                 &block_state.transport_state,
                 &block_state.mmio_slot,
                 constructor_args.event_manager,
             )?;
-
-            // If device is activated, kick the block queue(s) to make up for any
-            // pending or in-flight epoll events we may have not captured in snapshot.
-            // No need to kick Ratelimiters because they are restored 'unblocked' so
-            // any inflight `timer_fd` events can be safely discarded.
-            let mut dev = device.lock().expect("Poisoned lock");
-            if dev.is_activated() {
-                dev.process_virtio_queues();
-            }
         }
         for net_state in &state.net_devices {
             let device = Arc::new(Mutex::new(
@@ -317,21 +300,12 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
             restore_helper(
                 device.clone(),
-                device.clone(),
+                device,
                 &net_state.device_id,
                 &net_state.transport_state,
                 &net_state.mmio_slot,
                 constructor_args.event_manager,
             )?;
-
-            // If device is activated, kick the net queue(s) to make up for any
-            // pending or in-flight epoll events we may have not captured in snapshot.
-            // No need to kick Ratelimiters because they are restored 'unblocked' so
-            // any inflight `timer_fd` events can be safely discarded.
-            let mut dev = device.lock().expect("Poisoned lock");
-            if dev.is_activated() {
-                dev.process_virtio_queues();
-            }
         }
         if let Some(vsock_state) = &state.vsock_device {
             let ctor_args = VsockUdsConstructorArgs {
@@ -358,10 +332,6 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 &vsock_state.mmio_slot,
                 constructor_args.event_manager,
             )?;
-
-            // Vsock has complicated protocol that isn't resilient to any packet loss,
-            // so for Vsock we don't support connection persistence through snapshot.
-            // Any in-flight packets or events are simply lost. Vsock is restored 'empty'.
         }
 
         Ok(dev_manager)

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -55,9 +55,9 @@ use crate::vstate::{
 use arch::DeviceType;
 use devices::virtio::balloon::Error as BalloonError;
 use devices::virtio::{
-    Balloon, BalloonConfig, BalloonStats, MmioTransport, BALLOON_DEV_ID, TYPE_BALLOON,
+    Balloon, BalloonConfig, BalloonStats, Block, MmioTransport, Net, BALLOON_DEV_ID, TYPE_BALLOON,
+    TYPE_BLOCK, TYPE_NET,
 };
-use devices::virtio::{Block, Net, TYPE_BLOCK, TYPE_NET};
 use devices::BusDevice;
 use logger::{error, info, warn, LoggerError, MetricsError, METRICS};
 use polly::event_manager::{EventManager, Subscriber};
@@ -301,13 +301,14 @@ impl Vmm {
     }
 
     /// Sends a resume command to the vCPUs.
-    pub fn resume_vcpus(&mut self) -> Result<()> {
+    pub fn resume_vm(&mut self) -> Result<()> {
+        self.mmio_device_manager.kick_devices();
         self.broadcast_vcpu_event(VcpuEvent::Resume, VcpuResponse::Resumed)
             .map_err(|_| Error::VcpuResume)
     }
 
     /// Sends a pause command to the vCPUs.
-    pub fn pause_vcpus(&mut self) -> Result<()> {
+    pub fn pause_vm(&mut self) -> Result<()> {
         self.broadcast_vcpu_event(VcpuEvent::Pause, VcpuResponse::Paused)
             .map_err(|_| Error::VcpuPause)
     }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -518,7 +518,7 @@ impl RuntimeApiController {
         self.vmm
             .lock()
             .expect("Poisoned lock")
-            .pause_vcpus()
+            .pause_vm()
             .map_err(VmmActionError::InternalVmm)?;
 
         let elapsed_time_us =
@@ -535,7 +535,7 @@ impl RuntimeApiController {
         self.vmm
             .lock()
             .expect("Poisoned lock")
-            .resume_vcpus()
+            .resume_vm()
             .map_err(VmmActionError::InternalVmm)?;
 
         let elapsed_time_us =
@@ -789,7 +789,7 @@ mod tests {
     }
 
     impl MockVmm {
-        pub fn resume_vcpus(&mut self) -> Result<(), VmmError> {
+        pub fn resume_vm(&mut self) -> Result<(), VmmError> {
             if self.force_errors {
                 return Err(VmmError::VcpuResume);
             }
@@ -797,7 +797,7 @@ mod tests {
             Ok(())
         }
 
-        pub fn pause_vcpus(&mut self) -> Result<(), VmmError> {
+        pub fn pause_vm(&mut self) -> Result<(), VmmError> {
             if self.force_errors {
                 return Err(VmmError::VcpuPause);
             }

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -209,11 +209,11 @@ fn test_pause_resume_microvm() {
 
             // There's a race between this thread and the vcpu thread, but this thread
             // should be able to pause vcpu thread before it finishes running its test-binary.
-            assert!(vmm.lock().unwrap().pause_vcpus().is_ok());
+            assert!(vmm.lock().unwrap().pause_vm().is_ok());
             // Pausing again the microVM should not fail (microVM remains in the
             // `Paused` state).
-            assert!(vmm.lock().unwrap().pause_vcpus().is_ok());
-            assert!(vmm.lock().unwrap().resume_vcpus().is_ok());
+            assert!(vmm.lock().unwrap().pause_vm().is_ok());
+            assert!(vmm.lock().unwrap().resume_vm().is_ok());
 
             let _ = event_manager.run_with_timeout(500).unwrap();
 
@@ -314,7 +314,7 @@ fn test_disallow_snapshots_without_pausing() {
             };
 
             // Pause microVM.
-            vmm.lock().unwrap().pause_vcpus().unwrap();
+            vmm.lock().unwrap().pause_vm().unwrap();
             // It is now allowed.
             vmm.lock().unwrap().save_state().unwrap();
             // Stop.
@@ -343,7 +343,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
             thread::sleep(Duration::from_millis(200));
 
             // Pause microVM.
-            vmm.lock().unwrap().pause_vcpus().unwrap();
+            vmm.lock().unwrap().pause_vm().unwrap();
 
             // Create snapshot.
             let snapshot_type = match is_diff {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.60, "AMD": 84.83, "ARM": 83.47}
+COVERAGE_DICT = {"Intel": 85.52, "AMD": 84.75, "ARM": 83.47}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Fixes bug where, following a snapshot load, device emulation takes place while VM is _Paused_.

## Description of Changes

Kicking the devices after loading snapshot but _before_ resuming vm, breaks the assumption that vm state does not change while paused.

Fix this by moving device kicking from 'load snapshot' to 'vm resume'.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [ ] ~All added/changed functionality is tested.~
