### PR TITLE
Added warning comments for version bumping

### DIFF
--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -21,12 +21,14 @@ use crate::virtio::persist::VirtioDeviceState;
 use crate::virtio::{DeviceState, TYPE_BALLOON};
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct BalloonConfigSpaceState {
     num_pages: u32,
     actual_pages: u32,
 }
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct BalloonStatsState {
     swap_in: Option<u64>,
     swap_out: Option<u64>,
@@ -77,6 +79,7 @@ impl BalloonStatsState {
 }
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct BalloonState {
     stats_polling_interval_s: u16,
     stats_desc_index: Option<u16>,

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -20,6 +20,7 @@ use crate::virtio::persist::VirtioDeviceState;
 use crate::virtio::{DeviceState, TYPE_BLOCK};
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct BlockState {
     id: String,
     partuuid: Option<String>,

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -22,11 +22,13 @@ use crate::virtio::persist::{Error as VirtioStateError, VirtioDeviceState};
 use crate::virtio::{DeviceState, TYPE_NET};
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct NetConfigSpaceState {
     guest_mac: [u8; MAC_ADDR_LEN],
 }
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct NetState {
     id: String,
     tap_if_name: String,

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -21,6 +21,7 @@ pub enum Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct QueueState {
     /// The maximal size in elements offered by the device
     max_size: u16,
@@ -81,6 +82,7 @@ impl Persist<'_> for Queue {
 
 /// State of a VirtioDevice.
 #[derive(Clone, Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VirtioDeviceState {
     pub device_type: u32,
     pub avail_features: u64,
@@ -149,6 +151,7 @@ impl VirtioDeviceState {
 }
 
 #[derive(Clone, Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct MmioTransportState {
     // The register where feature bits are stored.
     features_select: u32,

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -16,6 +16,7 @@ use crate::virtio::persist::VirtioDeviceState;
 use crate::virtio::{DeviceState, TYPE_VSOCK};
 
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VsockState {
     pub backend: VsockBackendState,
     pub frontend: VsockFrontendState,
@@ -23,6 +24,7 @@ pub struct VsockState {
 
 /// The Vsock serializable state.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VsockFrontendState {
     pub cid: u64,
     virtio_state: VirtioDeviceState,
@@ -30,12 +32,14 @@ pub struct VsockFrontendState {
 
 /// An enum for the serializable backend state types.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub enum VsockBackendState {
     Uds(VsockUdsState),
 }
 
 /// The Vsock Unix Backend serializable state.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VsockUdsState {
     /// The path for the UDS socket.
     pub(crate) path: String,

--- a/src/mmds/src/persist.rs
+++ b/src/mmds/src/persist.rs
@@ -14,6 +14,7 @@ use super::ns::MmdsNetworkStack;
 
 /// State of a MmdsNetworkStack.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct MmdsNetworkStackState {
     mac_addr: [u8; MAC_ADDR_LEN],
     ipv4_addr: u32,

--- a/src/rate_limiter/src/persist.rs
+++ b/src/rate_limiter/src/persist.rs
@@ -10,6 +10,7 @@ use versionize_derive::Versionize;
 
 /// State for saving a TokenBucket.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct TokenBucketState {
     size: u64,
     one_time_burst: u64,
@@ -52,6 +53,7 @@ impl Persist<'_> for TokenBucket {
 
 /// State for saving a RateLimiter.
 #[derive(Clone, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct RateLimiterState {
     ops: Option<TokenBucketState>,
     bandwidth: Option<TokenBucketState>,

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -77,6 +77,7 @@ const MMIO_LEN: u64 = 0x1000;
 
 /// Stores the address range and irq allocated to this device.
 #[derive(Clone, Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct MMIODeviceInfo {
     /// Mmio address at which the device is registered.
     pub addr: u64,

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -46,6 +46,7 @@ pub enum Error {
 
 #[derive(Clone, Versionize)]
 /// Holds the state of a balloon device connected to the MMIO space.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct ConnectedBalloonState {
     /// Device identifier.
     pub device_id: String,
@@ -59,6 +60,7 @@ pub struct ConnectedBalloonState {
 
 #[derive(Clone, Versionize)]
 /// Holds the state of a block device connected to the MMIO space.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct ConnectedBlockState {
     /// Device identifier.
     pub device_id: String,
@@ -72,6 +74,7 @@ pub struct ConnectedBlockState {
 
 #[derive(Clone, Versionize)]
 /// Holds the state of a net device connected to the MMIO space.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct ConnectedNetState {
     /// Device identifier.
     pub device_id: String,
@@ -85,6 +88,7 @@ pub struct ConnectedNetState {
 
 #[derive(Clone, Versionize)]
 /// Holds the state of a vsock device connected to the MMIO space.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct ConnectedVsockState {
     /// Device identifier.
     pub device_id: String,
@@ -98,6 +102,7 @@ pub struct ConnectedVsockState {
 
 #[derive(Clone, Versionize)]
 /// Holds the device states.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct DeviceStates {
     /// Block device states.
     pub block_devices: Vec<ConnectedBlockState>,

--- a/src/vmm/src/memory_snapshot.rs
+++ b/src/vmm/src/memory_snapshot.rs
@@ -21,6 +21,7 @@ use crate::DirtyBitmap;
 
 /// State of a guest memory region saved to file/buffer.
 #[derive(Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct GuestMemoryRegionState {
     /// Base address.
     pub base_address: u64,
@@ -32,6 +33,7 @@ pub struct GuestMemoryRegionState {
 
 /// Guest memory state.
 #[derive(Debug, Default, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct GuestMemoryState {
     /// List of regions.
     pub regions: Vec<GuestMemoryRegionState>,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -33,6 +33,7 @@ use crate::Vmm;
 
 /// Holds information related to the VM that is not part of VmState.
 #[derive(Debug, PartialEq, Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VmInfo {
     /// Guest memory size.
     pub mem_size_mib: u64,
@@ -40,6 +41,7 @@ pub struct VmInfo {
 
 /// Contains the necesary state for saving/restoring a microVM.
 #[derive(Versionize)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct MicrovmState {
     /// Miscellaneous VM info.
     pub vm_info: VmInfo,

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -377,6 +377,7 @@ impl KvmVcpu {
 
 #[derive(Clone, Versionize)]
 /// Structure holding VCPU kvm state.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VcpuState {
     cpuid: CpuId,
     msrs: Msrs,

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -290,6 +290,7 @@ impl Vm {
 #[cfg(target_arch = "x86_64")]
 #[derive(Versionize)]
 /// Structure holding VM kvm state.
+// NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VmState {
     pitstate: kvm_pit_state2,
     clock: kvm_clock_data,


### PR DESCRIPTION
Added warning comments to #[derive(Versionize)]
structures that require snapshot version bumps.

## Reason for This PR

Fixes #2089

## Description of Changes

Added warning comments to remind developers to bump the snapshot version when changing structures with the versionize trait. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
