### PR TITLE
Firecracker exits before returning API response FIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added devtool test `-m|--cpuset-mems` flag for memory confinement when tests
   run.
 - Added the virtio traditional memory ballooning device.
+- Added a mechanism to handle vCPU/VMM errors that result in process termination.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ name = "micro_http"
 version = "0.1.0"
 dependencies = [
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.1.0",
  "utils 0.1.0",
 ]
 

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+libc = ">=0.2.39"
 
 logger = { path = "../logger" }
 micro_http = { path = "../micro_http" }

--- a/src/micro_http/Cargo.toml
+++ b/src/micro_http/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 libc = ">=0.2.39"
 
 utils = { path = "../utils" }
+logger = { path = "../logger" }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -463,13 +463,7 @@ impl Vmm {
         for response in vcpu_responses.into_iter() {
             match response {
                 VcpuResponse::RestoredState => (),
-                VcpuResponse::Error(e) => {
-                    error!("Fatal error: {}", e);
-                    // Stop all vCPUs and exit.
-                    let _ = self.exit_vcpus();
-                    self.stop(i32::from(FC_EXIT_CODE_BAD_CONFIGURATION));
-                    unreachable!()
-                }
+                VcpuResponse::Error(e) => return Err(MicrovmStateError::RestoreVcpuState(e)),
                 VcpuResponse::NotAllowed(reason) => {
                     return Err(MicrovmStateError::NotAllowed(reason))
                 }
@@ -679,6 +673,12 @@ impl Vmm {
         } else {
             Err(BalloonError::DeviceNotFound)
         }
+    }
+}
+
+impl Drop for Vmm {
+    fn drop(&mut self) {
+        let _ = self.exit_vcpus();
     }
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,12 @@ To run tests from specific directories and/or files:
 tools/devtool test -- <test_dir_or_file_path>...
 ```
 
+To run a single specific test from a file:
+
+``` sh
+tools/devtool test -- <test_file_path>::<test_name>
+```
+
 The testing system is built around [pytest](https://docs.pytest.org/en/latest/).
 Any parameters passed to `tools/devtool test --` are passed to the `pytest`
 command. `devtool` is used to automate fetching of test dependencies (useful
@@ -247,6 +253,11 @@ local image cache.
 *Is there a way to speed up integration tests execution time?*
 `A5:`
 You can speed up tests execution time with any of these:
+
+`Q6:`
+*How can I get live logger output from the tests?*
+`A6:`
+Accessing **pytest.ini** will allow you to modify logger settings.
 
 1. Run the tests from inside the container and set the environment variable
    `KEEP_TEST_SESSION` to a non-empty value.

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -138,7 +138,7 @@ class MicrovmBuilder:
         # Hardlink all the snapshot files into the microvm jail.
         jailed_mem = vm.create_jailed_resource(snapshot.mem)
         jailed_vmstate = vm.create_jailed_resource(snapshot.vmstate)
-        assert len(snapshot.disks) > 0, "Snapshot requiures at least one disk."
+        assert len(snapshot.disks) > 0, "Snapshot requires at least one disk."
         _jailed_disks = []
         for disk in snapshot.disks:
             _jailed_disks.append(vm.create_jailed_resource(disk))
@@ -165,6 +165,11 @@ class MicrovmBuilder:
 
         # Return a resumed microvm.
         return vm, metrics_fifo
+
+    def create_basevm(self):
+        """Create a clean VM in an initial state."""
+        return init_microvm(self.root_path, self.bin_cloner_path,
+                            self._fc_binary, self._jailer_binary)
 
 
 class SnapshotBuilder:  # pylint: disable=too-few-public-methods

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.30, "AMD": 84.53, "ARM": 83.27}
+COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.51, "ARM": 83.27}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -5,8 +5,11 @@
 import filecmp
 import logging
 import os
+import subprocess
 import platform
 import tempfile
+from pathlib import Path
+import time
 import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
@@ -350,6 +353,77 @@ def test_5_inc_snapshots(network_config,
                              ])
 
     test_matrix.run_test(_test_seq_snapshots)
+
+
+def _get_process_start_time(p_pid):
+    # Helper function returning:
+    # - start time of process with provided PID
+    # - return code of stat -c%X /proc/$$ command
+    proc = subprocess.Popen(["stat -c%X /proc/{}".format(p_pid)],
+                            stdout=subprocess.PIPE,
+                            shell=True,
+                            encoding='ascii')
+    out = proc.communicate()[0].strip('\n')
+    return out, proc.returncode
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_load_snapshot_failure_handling(bin_cloner_path):
+    """
+    Test scenario.
+
+    1. Create two empty files representing snapshot memory and
+    microvm state
+    2. Try to load a VM snapshot out of the empty files.
+    3. Verify that an error was shown and the FC process is terminated.
+    """
+    logger = logging.getLogger("snapshot_load_failure")
+    vm = MicrovmBuilder(bin_cloner_path).create_basevm()
+    vm.spawn(log_level='Info')
+
+    # Create two empty files for snapshot state and snapshot memory
+    chroot_path = vm.jailer.chroot_path()
+    snapshot_dir = os.path.join(chroot_path, "snapshot")
+    Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
+
+    snapshot_mem = os.path.join(snapshot_dir, "snapshot_mem")
+    open(snapshot_mem, "w+").close()
+    snapshot_vmstate = os.path.join(snapshot_dir, "snapshot_vmstate")
+    open(snapshot_vmstate, "w+").close()
+
+    # Hardlink the snapshot files into the microvm jail.
+    jailed_mem = vm.create_jailed_resource(snapshot_mem)
+    jailed_vmstate = vm.create_jailed_resource(snapshot_vmstate)
+
+    # Get the Firecracker process starting time
+    fc_time, err = _get_process_start_time(vm.jailer_clone_pid)
+    assert err == 0
+    logger.info("FC process time before snapshoat load: %s.", fc_time)
+
+    # Load the snapshot
+    response = vm.snapshot_load.put(mem_file_path=jailed_mem,
+                                    snapshot_path=jailed_vmstate)
+
+    logger.info("Response status code %d, content: %s.",
+                response.status_code,
+                response.text)
+    assert vm.api_session.is_status_bad_request(response.status_code)
+
+    # Check if FC process is closed
+    pid_time, ret = _get_process_start_time(vm.jailer_clone_pid)
+    while True:
+        if ret != 0 or fc_time != pid_time:
+            break
+        time.sleep(0.1)
+        pid_time, ret = _get_process_start_time(vm.jailer_clone_pid)
+    # Check that either:
+    #  - pid no longer exists, or
+    #  - pid exists but is a different process (different process start time)
+    assert ret != 0 or fc_time != pid_time, "Firecracker process should \
+     have ended with error!"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Reason for This PR

This PR addresses the following [bug](https://github.com/firecracker-microvm/firecracker/issues/2116). For now, the status is RFC since integration tests have to be added.

## Description of Changes

The important points of this change are the following:

- the VCPU errors that killed the process before, are now allowed to return to the API
thread.
- the API thread decides if an error is considered **fatal** or not. New errors can be added in the future which are deemed fatal
- in case of a **fatal** error, the Firecracker process is killed by the API thread,
since the VMM thread is already compromised
- this mechanism abides by the rules of the [Snapshotting specification](https://github.com/firecracker-microvm/firecracker/blob/master/docs/snapshotting/snapshot-support.md) which says that,
in the case of an error when _loading a snapshot_, _"a specific error is reported and then the current Firecracker process is ended"_

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
