### PR TITLE
Fixed function naming in mmio device registration

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -730,7 +730,7 @@ fn attach_virtio_device<T: 'static + VirtioDevice + Subscriber>(
     // The device mutex mustn't be locked here otherwise it will deadlock.
     let device = MmioTransport::new(vmm.guest_memory().clone(), device);
     vmm.mmio_device_manager
-        .register_new_virtio_mmio_device(vmm.vm.fd(), id, device, cmdline)
+        .register_mmio_virtio_for_boot(vmm.vm.fd(), id, device, cmdline)
         .map_err(RegisterMmioDevice)
         .map(|_| ())
 }
@@ -744,7 +744,7 @@ pub(crate) fn attach_boot_timer_device(
     let boot_timer = devices::pseudo::BootTimer::new(request_ts);
 
     vmm.mmio_device_manager
-        .register_new_mmio_boot_timer(boot_timer)
+        .register_mmio_boot_timer(boot_timer)
         .map_err(RegisterMmioDevice)?;
 
     Ok(())

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -172,6 +172,7 @@ impl MMIODeviceManager {
         self.irqs.check(&slot.irqs)
     }
 
+    /// Register a device at some MMIO address.
     fn register_mmio_device(
         &mut self,
         identifier: (DeviceType, String),
@@ -186,7 +187,7 @@ impl MMIODeviceManager {
     }
 
     /// Register a virtio-over-MMIO device to be used via MMIO transport at a specific slot.
-    pub fn register_virtio_mmio_device(
+    pub fn register_mmio_virtio(
         &mut self,
         vm: &VmFd,
         device_id: String,
@@ -236,7 +237,7 @@ impl MMIODeviceManager {
 
     /// Allocate slot and register an already created virtio-over-MMIO device. Also Adds the device
     /// to the boot cmdline.
-    pub fn register_new_virtio_mmio_device(
+    pub fn register_mmio_virtio_for_boot(
         &mut self,
         vm: &VmFd,
         device_id: String,
@@ -244,7 +245,7 @@ impl MMIODeviceManager {
         _cmdline: &mut kernel_cmdline::Cmdline,
     ) -> Result<MMIODeviceInfo> {
         let mmio_slot = self.allocate_new_slot(1)?;
-        self.register_virtio_mmio_device(vm, device_id, mmio_device, &mmio_slot)?;
+        self.register_mmio_virtio(vm, device_id, mmio_device, &mmio_slot)?;
         #[cfg(target_arch = "x86_64")]
         Self::add_virtio_device_to_cmdline(_cmdline, &mmio_slot)?;
         Ok(mmio_slot)
@@ -294,9 +295,9 @@ impl MMIODeviceManager {
         self.register_mmio_device(identifier, slot, Arc::new(Mutex::new(device)))
     }
 
-    /// Create and register a boot timer device.
-    pub fn register_new_mmio_boot_timer(&mut self, device: BootTimer) -> Result<()> {
-        // Create and attach a new boot timer device.
+    /// Register a boot timer device.
+    pub fn register_mmio_boot_timer(&mut self, device: BootTimer) -> Result<()> {
+        // Attach a new boot timer device.
         let slot = self.allocate_new_slot(0)?;
 
         let identifier = (DeviceType::BootTimer, DeviceType::BootTimer.to_string());
@@ -410,7 +411,7 @@ mod tests {
         ) -> Result<u64> {
             let mmio_device = MmioTransport::new(guest_mem, device);
             let mmio_slot =
-                self.register_new_virtio_mmio_device(vm, dev_id.to_string(), mmio_device, cmdline)?;
+                self.register_mmio_virtio_for_boot(vm, dev_id.to_string(), mmio_device, cmdline)?;
             Ok(mmio_slot.addr)
         }
     }

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -244,7 +244,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
             let mmio_transport =
                 MmioTransport::restore(restore_args, state).map_err(|()| Error::MmioTransport)?;
             dev_manager
-                .register_virtio_mmio_device(vm, id.clone(), mmio_transport, slot)
+                .register_mmio_virtio(vm, id.clone(), mmio_transport, slot)
                 .map_err(Error::DeviceManager)?;
 
             event_manager


### PR DESCRIPTION
Fixed unnatural naming of functions relating to mmio device
registration. 

Signed-off-by: HQ01 <qh384@nyu.edu>

## Reason for This PR

Fixes #2015 

## Description of Changes

Renamed "register_new_virtio_mmio-device" to
"register_mmio_virtio_add_cmdline", "register_virtio_mmio_device" to
"register_mmio_virtio", and "register_new_mmio_boot_timer" to
"register_mmio_boot_timer". New function names are more consistent with
other mmio device registration functions. "New" is now only present in
names of functions that create the corresponding device. Functions that
register a new virtio device now have names better reflecting their
jobs.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
