### PR TITLE
increase the number of IRQs on x86_64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   replaced by the `--` separator for extra arguments.
 - Changed the output of the `--version` command line parameter to include a list
   of supported snapshot data format versions for the firecracker binary.
+- Increased the maximum number of virtio devices from 11 to 19.
+- Added a new check that prevents creating v0.23 snapshots when more than 11
+  devices are attached.
 
 ### Fixed
 

--- a/src/arch/src/x86_64/layout.rs
+++ b/src/arch/src/x86_64/layout.rs
@@ -18,11 +18,11 @@ pub const CMDLINE_MAX_SIZE: usize = 0x10000;
 /// Start of the high memory.
 pub const HIMEM_START: u64 = 0x0010_0000; //1 MB.
 
-// Typically, on x86 systems 16 IRQs are used (0-15).
+// Typically, on x86 systems 24 IRQs are used (0-23).
 /// First usable IRQ ID for virtio device interrupts on x86_64.
 pub const IRQ_BASE: u32 = 5;
 /// Last usable IRQ ID for virtio device interrupts on x86_64.
-pub const IRQ_MAX: u32 = 15;
+pub const IRQ_MAX: u32 = 23;
 
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -314,6 +314,17 @@ impl MMIODeviceManager {
         &self.id_to_dev_info
     }
 
+    #[cfg(target_arch = "x86_64")]
+    /// Gets the number of interrupts used by the devices registered.
+    pub fn used_irqs_count(&self) -> usize {
+        let mut irq_number = 0;
+        let _: Result<()> = self.for_each_device(|_, _, device_info, _| {
+            irq_number += device_info.irqs.len();
+            Ok(())
+        });
+        irq_number
+    }
+
     /// Gets the the specified device.
     pub fn get_device(
         &self,
@@ -723,6 +734,7 @@ mod tests {
                 Ok(())
             });
             assert_eq!(count, 3);
+            assert_eq!(device_manager.used_irqs_count(), 2);
         }
     }
 

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests scenario for adding the maximum number of devices to a microVM."""
+
+import platform
+import pytest
+import host_tools.network as net_tools
+
+# IRQs are available from 5 to 23, so the maximum number of devices
+# supported at the same time is 19.
+MAX_DEVICES_ATTACHED = 19
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Firecracker supports 24 IRQs on x86_64."
+)
+def test_attach_maximum_devices(test_microvm_with_ssh, network_config):
+    """Test attaching maximum number of devices to the microVM."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+
+    # Set up a basic microVM.
+    test_microvm.basic_config()
+
+    # Add (`MAX_DEVICES_ATTACHED` - 1) devices because the rootfs
+    # has already been configured in the `basic_config()`function.
+    guest_ips = []
+    for i in range(MAX_DEVICES_ATTACHED - 1):
+        # Create tap before configuring interface.
+        _tap, _host_ip, guest_ip = test_microvm.ssh_network_config(
+            network_config,
+            str(i)
+        )
+        guest_ips.append(guest_ip)
+
+    test_microvm.start()
+
+    # Test that network devices attached are operational.
+    for i in range(MAX_DEVICES_ATTACHED - 1):
+        test_microvm.ssh_config['hostname'] = guest_ips[i]
+        ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+        # Verify if guest can run commands.
+        exit_code, _, _ = ssh_connection.execute_command("sync")
+        assert exit_code == 0
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Firecracker supports 24 IRQs on x86_64."
+)
+def test_attach_too_many_devices(test_microvm_with_ssh, network_config):
+    """Test attaching to a microVM more devices than available IRQs."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+
+    # Set up a basic microVM.
+    test_microvm.basic_config()
+
+    # Add `MAX_DEVICES_ATTACHED` network devices on top of the
+    # already configured rootfs.
+    for i in range(MAX_DEVICES_ATTACHED):
+        # Create tap before configuring interface.
+        _tap, _host_ip, _guest_ip = test_microvm.ssh_network_config(
+            network_config,
+            str(i)
+        )
+
+    # Attempting to start a microVM with more than
+    # `MAX_DEVICES_ATTACHED` devices should fail.
+    response = test_microvm.actions.put(action_type='InstanceStart')
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "no more IRQs are available" in response.text

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -11,6 +11,35 @@ from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.microvms import VMMicro
 import host_tools.network as net_tools  # pylint: disable=import-error
 
+# Firecracker v0.23 used 16 IRQ lines. For virtio devices,
+# IRQs are available from 5 to 23, so the maximum number
+# of devices allowed at the same time was 11.
+FC_V0_23_MAX_DEVICES_ATTACHED = 11
+
+
+def _create_and_start_microvm_with_net_devices(test_microvm,
+                                               network_config,
+                                               devices_no):
+    test_microvm.spawn()
+    # Set up a basic microVM: configure the boot source and
+    # add a root device.
+    test_microvm.basic_config(track_dirty_pages=True)
+
+    # Add network devices on top of the already configured rootfs for a
+    # total of (`devices_no` + 1) devices.
+    for i in range(devices_no):
+        # Create tap before configuring interface.
+        _tap, _host_ip, _guest_ip = test_microvm.ssh_network_config(
+            network_config,
+            str(i)
+        )
+    test_microvm.start()
+
+    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    # Verify if guest can run commands.
+    exit_code, _, _ = ssh_connection.execute_command("sync")
+    assert exit_code == 0
+
 
 @pytest.mark.skipif(
     platform.machine() != "x86_64",
@@ -50,7 +79,7 @@ def test_restore_from_past_versions(bin_cloner_path):
 
 def create_512mb_full_snapshot(bin_cloner_path, target_version: str = None,
                                fc_binary=None, jailer_binary=None):
-    """Create a snapshoft from a 2vcpu 512MB microvm."""
+    """Test scenario: create a snapshot from a 2vcpu 512MB microvm."""
     vm_instance = VMMicro.spawn(bin_cloner_path, True,
                                 fc_binary, jailer_binary)
     # Attempt to connect to the fresh microvm.
@@ -123,3 +152,69 @@ def test_restore_in_past_versions(bin_cloner_path):
 
         exit_code, _, _ = ssh_connection.execute_command("sleep 1 && sync")
         assert exit_code == 0
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_create_with_past_version(test_microvm_with_ssh, network_config):
+    """Test scenario: restore in previous versions with too many devices."""
+    test_microvm = test_microvm_with_ssh
+
+    # Create and start a microVM with (`FC_V0_23_MAX_DEVICES_ATTACHED` - 1)
+    # network devices.
+    devices_no = FC_V0_23_MAX_DEVICES_ATTACHED - 1
+    _create_and_start_microvm_with_net_devices(test_microvm,
+                                               network_config,
+                                               devices_no)
+
+    snapshot_builder = SnapshotBuilder(test_microvm)
+    # Create directory and files for saving snapshot state and memory.
+    _snapshot_dir = snapshot_builder.create_snapshot_dir()
+    # Pause and create a snapshot of the microVM. Firecracker v0.23 allowed a
+    # maximum of `FC_V0_23_MAX_DEVICES_ATTACHED` virtio devices at a time.
+    # This microVM has `FC_V0_23_MAX_DEVICES_ATTACHED` devices, including the
+    # rootfs, so snapshotting should succeed.
+    test_microvm.pause_to_snapshot(
+        mem_file_path="/snapshot/vm.mem",
+        snapshot_path="/snapshot/vm.vmstate",
+        diff=True,
+        version="0.23.0")
+
+
+@pytest.mark.skipif(
+    platform.machine() != "x86_64",
+    reason="Not supported yet."
+)
+def test_create_with_too_many_devices(test_microvm_with_ssh, network_config):
+    """Test scenario: restore in previous versions with too many devices."""
+    test_microvm = test_microvm_with_ssh
+
+    # Create and start a microVM with `FC_V0_23_MAX_DEVICES_ATTACHED`
+    # network devices.
+    devices_no = FC_V0_23_MAX_DEVICES_ATTACHED
+    _create_and_start_microvm_with_net_devices(test_microvm,
+                                               network_config,
+                                               devices_no)
+
+    snapshot_builder = SnapshotBuilder(test_microvm)
+    # Create directory and files for saving snapshot state and memory.
+    _snapshot_dir = snapshot_builder.create_snapshot_dir()
+
+    # Pause microVM for snapshot.
+    response = test_microvm.vm.patch(state='Paused')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Attempt to create a snapshot with version: `0.23.0`. Firecracker
+    # v0.23 allowed a maximum of `FC_V0_23_MAX_DEVICES_ATTACHED` virtio
+    # devices at a time. This microVM has `FC_V0_23_MAX_DEVICES_ATTACHED`
+    # network devices on top of the rootfs, so the limit is exceeded.
+    response = test_microvm.snapshot_create.put(
+        mem_file_path="/snapshot/vm.vmstate",
+        snapshot_path="/snapshot/vm.mem",
+        diff=True,
+        version="0.23.0"
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "Too many devices attached" in response.text


### PR DESCRIPTION
## Reason for This PR

increase the number of IRQs on x86_64

## Description of Changes

increase the number of IRQs on x86_64

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
