### PR TITLE
[Balloon] Remove `must_tell_host` device feature

### DIFF
--- a/docs/ballooning.md
+++ b/docs/ballooning.md
@@ -26,12 +26,6 @@ memory. Note that this applies to allocations from guest processes which would
 make the system enter an OOM state. This does not apply to instances when the
 kernel needs memory for its activities (i.e. constructing caches), or when the
 user requests more memory than the amount available through an inflate.
-* `must_tell_host`: if this is set to `true`, the kernel will wait for host
-confirmation before reclaiming memory from the host. This option is not useful
-in Firecracker's implementation of the balloon device because Firecracker does
-not perform any additional operations on returned pages, so it makes no
-difference if the guest waits for the host's approval on returned pages or not.
-Therefore, this option can be safely set to `false`.
 * `stats_polling_interval_s`: unsigned integer value which if set to 0
 disables the virtio balloon statistics and otherwise represents the interval
 of time in seconds at which the balloon statistics are updated.
@@ -102,7 +96,6 @@ Here is an example command on how to install the balloon through the API:
 ```
 socket_location=...
 amount_mb=...
-must_tell_host=...
 deflate_on_oom=...
 polling_interval=...
 
@@ -112,7 +105,6 @@ curl --unix-socket $socket_location -i \
     -H 'Content-Type: application/json' \
     -d "{
         \"amount_mb\": $amount_mb, \
-        \"must_tell_host\": $must_tell_host, \
         \"deflate_on_oom\": $deflate_on_oom, \
         \"stats_polling_interval_s\": $polling_interval \
     }"
@@ -120,10 +112,9 @@ curl --unix-socket $socket_location -i \
 
 To use this, set `socket_location` to the location of the firecracker socket
 (by default, at `/run/firecracker.socket`. Then, set `amount_mb`,
-`must_tell_host`, `deflate_on_oom` and `stats_polling_interval_s` as
-desired: `num_pages` represents the target size of the balloon, and
-`must_tell_host`, `deflate_on_oom` and `stats_polling_interval_s`
-represent the options mentioned before.
+`deflate_on_oom` and `stats_polling_interval_s` as desired: `amount_mb`
+represents the target size of the balloon, and `deflate_on_oom` and
+`stats_polling_interval_s` represent the options mentioned before.
 
 To install the balloon via the JSON config file, insert the following JSON
 object into your configuration file:
@@ -131,7 +122,6 @@ object into your configuration file:
 ```
 "balloon": {
     "amount_mb": 0,
-    "must_tell_host": false,
     "deflate_on_oom": false,
     "stats_polling_interval_s": 1
 },

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -652,9 +652,8 @@ pub(crate) mod tests {
             .write_all(
                 b"PUT /balloon HTTP/1.1\r\n\
                 Content-Type: application/json\r\n\
-                Content-Length: 99\r\n\r\n{ \
+                Content-Length: 74\r\n\r\n{ \
                 \"amount_mb\": 0, \
-                \"must_tell_host\": false, \
                 \"deflate_on_oom\": false, \
                 \"stats_polling_interval_s\": 0 \
                 }",

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -107,8 +107,7 @@ mod tests {
         // PATCH that tries to update something else other than allowed fields.
         let body = r#"{
                 "amount_mb": "dummy_id",
-                "stats_polling_interval_s": "dummy_host",
-                "must_tell_host": false
+                "stats_polling_interval_s": "dummy_host"
               }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
@@ -162,7 +161,6 @@ mod tests {
         // PUT with valid input fields.
         let body = r#"{
                 "amount_mb": 1000,
-                "must_tell_host": true,
                 "deflate_on_oom": true,
                 "stats_polling_interval_s": 0
             }"#;

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -619,7 +619,6 @@ definitions:
     required:
       - amount_mb
       - deflate_on_oom
-      - must_tell_host
     description:
       Balloon device descriptor.
     properties:
@@ -629,9 +628,6 @@ definitions:
       deflate_on_oom:
         type: boolean
         description: Whether the balloon should deflate when the guest has memory pressure.
-      must_tell_host:
-        type: boolean
-        description: Whether the guest should wait for the host to acknowledge deflated pages or not.
       stats_polling_interval_s:
         type: integer
         description: Interval in seconds between refreshing statistics. A non-zero value will enable the statistics. Defaults to 0.

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -140,7 +140,7 @@ pub mod tests {
     #[test]
     fn test_event_handler() {
         let mut event_manager = EventManager::new().unwrap();
-        let mut balloon = Balloon::new(0, true, true, 10, false).unwrap();
+        let mut balloon = Balloon::new(0, true, 10, false).unwrap();
         let mem = default_mem();
         let infq = VirtQueue::new(GuestAddress(0), &mem, 16);
         balloon.set_queue(INFLATE_INDEX, infq.create_queue());

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -35,7 +35,6 @@ pub const DEFLATE_INDEX: usize = 1;
 pub const STATS_INDEX: usize = 2;
 
 // The feature bitmap for virtio balloon.
-const VIRTIO_BALLOON_F_MUST_TELL_HOST: u32 = 0; // Tell before reclaiming pages.
 const VIRTIO_BALLOON_F_STATS_VQ: u32 = 1; // Enable statistics.
 const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u32 = 2; // Deflate balloon on OOM.
 

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -113,7 +113,7 @@ impl Persist<'_> for Balloon {
     ) -> std::result::Result<Self, Self::Error> {
         // We can safely create the balloon with arbitrary flags and
         // num_pages because we will overwrite them after.
-        let mut balloon = Balloon::new(0, false, false, state.stats_polling_interval_s, true)?;
+        let mut balloon = Balloon::new(0, false, state.stats_polling_interval_s, true)?;
 
         let mut num_queues = NUM_QUEUES;
         // As per the virtio 1.1 specification, the statistics queue
@@ -169,7 +169,7 @@ mod tests {
         let version_map = VersionMap::new();
 
         // Create and save the balloon device.
-        let balloon = Balloon::new(0x42, true, false, 2, false).unwrap();
+        let balloon = Balloon::new(0x42, false, 2, false).unwrap();
 
         <Balloon as Persist>::save(&balloon)
             .serialize(&mut mem.as_mut_slice(), &version_map, 1)

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1262,7 +1262,6 @@ pub mod tests {
 
         let balloon_config = BalloonDeviceConfig {
             amount_mb: 0,
-            must_tell_host: false,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -485,7 +485,6 @@ mod tests {
             // Add a balloon device.
             let balloon_cfg = BalloonDeviceConfig {
                 amount_mb: 123,
-                must_tell_host: true,
                 deflate_on_oom: false,
                 stats_polling_interval_s: 1,
             };

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -317,7 +317,6 @@ mod tests {
         // Add a balloon device.
         let balloon_config = BalloonDeviceConfig {
             amount_mb: 0,
-            must_tell_host: false,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -722,7 +722,6 @@ mod tests {
             r#"{{
                     "balloon": {{
                         "amount_mb": 0,
-                        "must_tell_host": false,
                         "deflate_on_oom": false,
                         "stats_polling_interval_s": 0
                     }},
@@ -819,7 +818,6 @@ mod tests {
         vm_resources
             .set_balloon_device(BalloonDeviceConfig {
                 amount_mb: 100,
-                must_tell_host: false,
                 deflate_on_oom: false,
                 stats_polling_interval_s: 0,
             })
@@ -849,7 +847,6 @@ mod tests {
         };
         let mut new_balloon_cfg = BalloonDeviceConfig {
             amount_mb: 100,
-            must_tell_host: false,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };
@@ -860,10 +857,6 @@ mod tests {
 
         let actual_balloon_cfg = vm_resources.balloon.get_config().unwrap();
         assert_eq!(actual_balloon_cfg.amount_mb, new_balloon_cfg.amount_mb);
-        assert_eq!(
-            actual_balloon_cfg.must_tell_host,
-            new_balloon_cfg.must_tell_host
-        );
         assert_eq!(
             actual_balloon_cfg.deflate_on_oom,
             new_balloon_cfg.deflate_on_oom

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -75,9 +75,6 @@ type Result<T> = std::result::Result<T, BalloonConfigError>;
 pub struct BalloonDeviceConfig {
     /// Target balloon size in MB.
     pub amount_mb: u32,
-    /// Option to make the guest obtain permission from the host in
-    /// order to deflate.
-    pub must_tell_host: bool,
     /// Option to deflate the balloon in case the guest is out of memory.
     pub deflate_on_oom: bool,
     /// Interval in seconds between refreshing statistics.
@@ -90,7 +87,6 @@ impl From<BalloonConfig> for BalloonDeviceConfig {
         BalloonDeviceConfig {
             amount_mb: state.amount_mb,
             deflate_on_oom: state.deflate_on_oom,
-            must_tell_host: state.must_tell_host,
             stats_polling_interval_s: state.stats_polling_interval_s,
         }
     }
@@ -140,7 +136,6 @@ impl BalloonBuilder {
         self.inner = Some(Arc::new(Mutex::new(
             Balloon::new(
                 cfg.amount_mb,
-                cfg.must_tell_host,
                 cfg.deflate_on_oom,
                 cfg.stats_polling_interval_s,
                 // `restored` flag is false because this code path
@@ -174,7 +169,6 @@ pub(crate) mod tests {
     pub(crate) fn default_config() -> BalloonDeviceConfig {
         BalloonDeviceConfig {
             amount_mb: 0,
-            must_tell_host: false,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         }
@@ -193,7 +187,6 @@ pub(crate) mod tests {
         let default_balloon_config = default_config();
         let balloon_config = BalloonDeviceConfig {
             amount_mb: 0,
-            must_tell_host: false,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };
@@ -216,14 +209,12 @@ pub(crate) mod tests {
         let expected_balloon_config = BalloonDeviceConfig {
             amount_mb: 5,
             deflate_on_oom: false,
-            must_tell_host: true,
             stats_polling_interval_s: 3,
         };
 
         let actual_balloon_config = BalloonDeviceConfig::from(BalloonConfig {
             amount_mb: 5,
             deflate_on_oom: false,
-            must_tell_host: true,
             stats_polling_interval_s: 3,
         });
 

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -95,7 +95,6 @@ class Balloon():
     def create_json(
             amount_mb=None,
             deflate_on_oom=None,
-            must_tell_host=None,
             stats_polling_interval_s=None
     ):
         """Compose the json associated to this type of API request."""
@@ -106,9 +105,6 @@ class Balloon():
 
         if deflate_on_oom is not None:
             datax['deflate_on_oom'] = deflate_on_oom
-
-        if must_tell_host is not None:
-            datax['must_tell_host'] = must_tell_host
 
         if stats_polling_interval_s is not None:
             datax['stats_polling_interval_s'] = stats_polling_interval_s

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -789,8 +789,7 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     # Adding a memory balloon should be OK.
     response = test_microvm.balloon.put(
         amount_mb=1,
-        deflate_on_oom=True,
-        must_tell_host=False
+        deflate_on_oom=True
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
@@ -798,7 +797,6 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=False,
-        must_tell_host=True,
         stats_polling_interval_s=5
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -808,7 +806,6 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     assert test_microvm.api_session.is_status_ok(response.status_code)
     assert response.json()['amount_mb'] == 0
     assert response.json()['deflate_on_oom'] is False
-    assert response.json()['must_tell_host'] is True
     assert response.json()['stats_polling_interval_s'] == 5
 
     # Updating an existing balloon device is forbidden before boot.
@@ -820,7 +817,6 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     response = test_microvm.balloon.put(
         amount_mb=1024,
         deflate_on_oom=False,
-        must_tell_host=True,
         stats_polling_interval_s=5
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
@@ -836,7 +832,6 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     response = test_microvm.balloon.put(
         amount_mb=3,
         deflate_on_oom=False,
-        must_tell_host=True,
         stats_polling_interval_s=3
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
@@ -863,7 +858,6 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     assert test_microvm.api_session.is_status_ok(response.status_code)
     assert response.json()['amount_mb'] == 4
     assert response.json()['deflate_on_oom'] is False
-    assert response.json()['must_tell_host'] is True
     assert response.json()['stats_polling_interval_s'] == 5
 
     # Check we can't overflow the `num_pages` field in the config space by

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -136,7 +136,6 @@ def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=0
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -190,7 +189,6 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=False,
-        must_tell_host=False,
         stats_polling_interval_s=1
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -235,7 +233,6 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=0
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -277,7 +274,6 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=False,
-        must_tell_host=False,
         stats_polling_interval_s=0
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -315,7 +311,6 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=0
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -388,7 +383,6 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=0
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -434,7 +428,6 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     response = test_microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=1
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
@@ -546,7 +539,6 @@ def _test_balloon_snapshot(context):
     response = basevm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=1
     )
     assert basevm.api_session.is_status_no_content(response.status_code)
@@ -667,7 +659,6 @@ def _test_snapshot_compatibility(context):
     response = microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=1
     )
     assert microvm.api_session.is_status_no_content(response.status_code)
@@ -743,7 +734,6 @@ def _test_memory_scrub(context):
     response = microvm.balloon.put(
         amount_mb=0,
         deflate_on_oom=True,
-        must_tell_host=False,
         stats_polling_interval_s=1
     )
     assert microvm.api_session.is_status_no_content(response.status_code)


### PR DESCRIPTION
## Reason for This PR

The `must_tell_host` feature is not useful to any use case as of now because of the fact that the device does not offer page poisoning functionality. Therefore, since it is not useful, it should be removed.

## Description of Changes

Removed the `must_tell_host` feature of the balloon device.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] Any newly added `unsafe` code is properly documented.~~
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- ~~[ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
