### PR TITLE
whitelist FUTEX_WAIT_BITSET_PRIVATE argument for futex syscalls for g…

### DIFF
--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -73,6 +73,13 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                         Eq,
                         super::FUTEX_CMP_REQUEUE_PRIVATE
                     )?],
+                    #[cfg(target_env = "gnu")]
+                    and![Cond::new(
+                        1,
+                        ArgLen::DWORD,
+                        Eq,
+                        super::FUTEX_WAIT_BITSET_PRIVATE
+                    )?],
                 ],
             ),
             // Used by glibc's tgkill

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -22,11 +22,15 @@ const FUTEX_WAIT: u64 = 0;
 const FUTEX_WAKE: u64 = 1;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE: u64 = 4;
+#[cfg(target_env = "gnu")]
+const FUTEX_WAIT_BITSET: u64 = 9;
 const FUTEX_PRIVATE_FLAG: u64 = 128;
 const FUTEX_WAIT_PRIVATE: u64 = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
 const FUTEX_WAKE_PRIVATE: u64 = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 #[cfg(target_env = "gnu")]
 const FUTEX_CMP_REQUEUE_PRIVATE: u64 = FUTEX_CMP_REQUEUE | FUTEX_PRIVATE_FLAG;
+#[cfg(target_env = "gnu")]
+const FUTEX_WAIT_BITSET_PRIVATE: u64 = FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG;
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
 const TCGETS: u64 = 0x5401;


### PR DESCRIPTION
…nu libc

Signed-off-by: Mikhail Gordeev <obirvalger@altlinux.org>

## Reason for This PR

Using firectl with firecracker build with gnu libc fails. Error message: "Shutting down VM after intercepting a bad syscall (202)."

## Description of Changes

Allow FUTEX_WAIT_BITSET_PRIVATE argument for futex syscall for gnu libc.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
