### PR TITLE
Enabled describeInstance to show VM pause/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Changed
 
+- Change the information provided in `DescribeInstance` command to provide microVM
+  state information (Not started/Running/Paused) instead of whether it's started or not.
 - Removed the jailer `--extra-args` parameter. It was a noop, having been
   replaced by the `--` separator for extra arguments.
 - Changed the output of the `--version` command line parameter to include a list

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -5,7 +5,7 @@ mod request;
 
 use serde_json::json;
 use std::path::PathBuf;
-use std::sync::{mpsc, Arc, Mutex, RwLock};
+use std::sync::{mpsc, Arc, Mutex};
 use std::{fmt, io};
 
 use crate::parsed_request::ParsedRequest;
@@ -60,8 +60,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct ApiServer {
     /// MMDS info directly accessible from the API thread.
     mmds_info: Arc<Mutex<Mmds>>,
-    /// VMM instance info directly accessible from the API thread.
-    vmm_shared_info: Arc<RwLock<InstanceInfo>>,
+    /// Firecracker instance info exposed through API.
+    instance_info: InstanceInfo,
     /// Sender which allows passing messages to the VMM.
     api_request_sender: mpsc::Sender<ApiRequest>,
     /// Receiver which collects messages from the VMM.
@@ -77,14 +77,14 @@ pub struct ApiServer {
 impl ApiServer {
     pub fn new(
         mmds_info: Arc<Mutex<Mmds>>,
-        vmm_shared_info: Arc<RwLock<InstanceInfo>>,
+        instance_info: InstanceInfo,
         api_request_sender: mpsc::Sender<ApiRequest>,
         vmm_response_receiver: mpsc::Receiver<ApiResponse>,
         to_vmm_fd: EventFd,
     ) -> Result<Self> {
         Ok(ApiServer {
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -222,6 +222,12 @@ impl ApiServer {
             _ => None,
         };
 
+        let vmm_new_state = match *vmm_action {
+            VmmAction::StartMicroVm => "Running".to_string(),
+            VmmAction::Pause => "Paused".to_string(),
+            VmmAction::Resume => "Running".to_string(),
+            _ => self.instance_info.state.clone(),
+        };
         self.api_request_sender
             .send(vmm_action)
             .expect("Failed to send VMM message");
@@ -232,6 +238,7 @@ impl ApiServer {
         let response = ParsedRequest::convert_to_response(&vmm_outcome);
 
         if vmm_outcome.is_ok() {
+            self.instance_info.state = vmm_new_state;
             if let Some((metric, action)) = metric_with_action {
                 let elapsed_time_us =
                     update_metric_with_elapsed_time(metric, request_processing_start_us);
@@ -250,11 +257,9 @@ impl ApiServer {
     }
 
     fn get_instance_info(&self) -> Response {
-        let shared_info_lock = self.vmm_shared_info.clone();
-        // expect() to crash if the other thread poisoned this lock
-        let shared_info = shared_info_lock.read().expect("Poisoned lock");
+        let shared_info = self.instance_info.clone();
         // Serialize it to a JSON string.
-        let body_result = serde_json::to_string(&(*shared_info));
+        let body_result = serde_json::to_string(&shared_info);
         match body_result {
             Ok(body) => ApiServer::json_response(StatusCode::OK, body),
             Err(e) => {
@@ -375,12 +380,12 @@ mod tests {
 
     #[test]
     fn test_serve_vmm_action_request() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_serve_action_req".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -389,7 +394,7 @@ mod tests {
 
         let mut api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -449,13 +454,12 @@ mod tests {
 
     #[test]
     fn test_get_instance_info() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_get_instance_info".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
-
+        };
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -463,7 +467,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -476,12 +480,12 @@ mod tests {
 
     #[test]
     fn test_get_mmds() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_get_mmds".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -490,7 +494,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -503,12 +507,12 @@ mod tests {
 
     #[test]
     fn test_put_mmds() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_put_mmds".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -517,7 +521,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -530,12 +534,12 @@ mod tests {
 
     #[test]
     fn test_patch_mmds() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_patch_mmds".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -544,7 +548,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -566,12 +570,12 @@ mod tests {
 
     #[test]
     fn test_handle_request() {
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_handle_request".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -580,7 +584,7 @@ mod tests {
 
         let mut api_server = ApiServer::new(
             mmds_info,
-            vmm_shared_info,
+            instance_info,
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -671,12 +675,12 @@ mod tests {
         let path_to_socket = tmp_socket.as_path().to_str().unwrap().to_owned();
         let api_thread_path_to_socket = path_to_socket.clone();
 
-        let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo {
-            started: false,
+        let instance_info = InstanceInfo {
+            state: "Not started".to_string(),
             id: "test_handle_request".to_string(),
             vmm_version: "version 0.1.0".to_string(),
             app_name: "app name".to_string(),
-        }));
+        };
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
@@ -688,7 +692,7 @@ mod tests {
             .spawn(move || {
                 ApiServer::new(
                     mmds_info,
-                    vmm_shared_info,
+                    instance_info,
                     api_request_sender,
                     vmm_response_receiver,
                     to_vmm_fd,

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -799,7 +799,7 @@ definitions:
     required:
       - app_name
       - id
-      - started
+      - state
       - vmm_version
     properties:
       app_name:
@@ -808,11 +808,15 @@ definitions:
       id:
         description: MicroVM / instance ID.
         type: string
-      started:
+      state:
         description:
-          The current detailed state of the Firecracker instance.
+          The current detailed state (Not started, Running, Paused) of the Firecracker instance.
           This value is read-only for the control-plane.
-        type: boolean
+        type: string
+        enum:
+          - Not started
+          - Running
+          - Paused
       vmm_version:
         description: MicroVM hypervisor build version.
         type: string

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
 
     let instance_info = InstanceInfo {
         id: instance_id.clone(),
-        started: false,
+        state: "Not started".to_string(),
         vmm_version: FIRECRACKER_VERSION.to_string(),
         app_name: "Firecracker".to_string(),
     };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -462,7 +462,7 @@ mod tests {
 
         let default_instance_info = InstanceInfo {
             id: "".to_string(),
-            started: false,
+            state: "Not started".to_string(),
             vmm_version: "SOME_VERSION".to_string(),
             app_name: "".to_string(),
         };

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -942,7 +942,7 @@ mod tests {
     ) -> PrebootApiController<'a> {
         let instance_info = InstanceInfo {
             id: String::new(),
-            started: false,
+            state: "Not started".to_string(),
             vmm_version: String::new(),
             app_name: String::new(),
         };
@@ -1277,7 +1277,7 @@ mod tests {
             &mut EventManager::new().unwrap(),
             InstanceInfo {
                 id: String::new(),
-                started: false,
+                state: "Not started".to_string(),
                 vmm_version: String::new(),
                 app_name: String::new(),
             },

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -7,8 +7,8 @@ use serde::Serialize;
 pub struct InstanceInfo {
     /// The ID of the microVM.
     pub id: String,
-    /// Whether the microVM has been started.
-    pub started: bool,
+    /// Whether the microVM is not started/running/paused.
+    pub state: String,
     /// The version of the VMM that runs the microVM.
     pub vmm_version: String,
     /// The name of the application that runs the microVM.

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -165,7 +165,7 @@ mod tests {
     fn test_init_logger() {
         let default_instance_info = InstanceInfo {
             id: "".to_string(),
-            started: false,
+            state: "Not started".to_string(),
             vmm_version: "some_version".to_string(),
             app_name: "".to_string(),
         };

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -254,8 +254,16 @@ class Microvm:
         return self._memory_monitor
 
     @property
+    def state(self):
+        """Get the InstanceInfo property and return the state field."""
+        return json.loads(self.desc_inst.get().content)["state"]
+
+    @property
     def started(self):
-        """Get the InstanceInfo property and return the started field."""
+        """Get the InstanceInfo property and return the started field.
+
+        This is kept for legacy snapshot support.
+        """
         return json.loads(self.desc_inst.get().content)["started"]
 
     @memory_monitor.setter
@@ -694,13 +702,19 @@ class Microvm:
         This function has asserts to validate that the microvm boot success.
         """
         # Check that the VM has not started yet
-        assert self.started is False
+        try:
+            assert self.state == "Not started"
+        except KeyError:
+            assert self.started is False
 
         response = self.actions.put(action_type='InstanceStart')
         assert self._api_session.is_status_no_content(response.status_code)
 
         # Check that the VM has started
-        assert self.started is True
+        try:
+            assert self.state == "Running"
+        except KeyError:
+            assert self.started is True
 
     def pause_to_snapshot(self,
                           mem_file_path=None,


### PR DESCRIPTION
DescribeInstance command now provides information about microVM state
(Stopped, Running, Paused) instead of a boolean of whether it's started
or not.

Signed-off-by: HQ01 <qh384@nyu.edu>

## Reason for This PR

#2285

## Description of Changes

DescribeInstance command now provides information about microVM state
(Stopped, Running, Paused) instead of a boolean of whether it's started
or not.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
