### PR TITLE
Add optional 'resume_vm' option to /snapshot/load API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added optional `resume_vm` field to `/snapshot/load` API call.
 - Added support for block rate limiter PATCH.
 - Added devtool test `-c|--cpuset-cpus` flag for cpus confinement when tests
   run.

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -274,7 +274,8 @@ curl --unix-socket /tmp/firecracker.socket -i \
     -d '{
             "snapshot_path": "./snapshot_file",
             "mem_file_path": "./mem_file",
-            "enable_diff_snapshots": true
+            "enable_diff_snapshots": true,
+            "resume_vm": false
     }'
 ```
 
@@ -303,6 +304,7 @@ Details about the required and optional fields can be found in the
   - The file indicated by `snapshot_path`, that is used to load from, is released and no
     longer used by this process.
   - If `enable_diff_snapshots` is set, then diff snapshots can be taken afterwards.
+  - If `resume_vm` is set, the vm is automatically resumed if load is successful.
 - _on failure_: A specific error is reported and then the current Firecracker process
                 is ended (as it might be in an invalid state).
 

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -114,6 +114,7 @@ mod tests {
             snapshot_path: PathBuf::from("foo"),
             mem_file_path: PathBuf::from("bar"),
             enable_diff_snapshots: false,
+            resume_vm: false,
         };
         match vmm_action_from_request(parse_put_snapshot(&Body::new(body), Some(&"load")).unwrap())
         {
@@ -131,6 +132,26 @@ mod tests {
             snapshot_path: PathBuf::from("foo"),
             mem_file_path: PathBuf::from("bar"),
             enable_diff_snapshots: true,
+            resume_vm: false,
+        };
+
+        match vmm_action_from_request(parse_put_snapshot(&Body::new(body), Some(&"load")).unwrap())
+        {
+            VmmAction::LoadSnapshot(cfg) => assert_eq!(cfg, expected_cfg),
+            _ => panic!("Test failed."),
+        }
+
+        body = r#"{
+                "snapshot_path": "foo",
+                "mem_file_path": "bar",
+                "resume_vm": true
+              }"#;
+
+        expected_cfg = LoadSnapshotParams {
+            snapshot_path: PathBuf::from("foo"),
+            mem_file_path: PathBuf::from("bar"),
+            enable_diff_snapshots: false,
+            resume_vm: true,
         };
 
         match vmm_action_from_request(parse_put_snapshot(&Body::new(body), Some(&"load")).unwrap())

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -1005,6 +1005,10 @@ definitions:
       snapshot_path:
         type: string
         description: Path to the file that contains the microVM state to be loaded.
+      resume_vm:
+        type: boolean
+        description:
+          When set to true, the vm is also resumed if the snapshot load is successful.
 
   TokenBucket:
     type: object

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -304,7 +304,7 @@ pub fn validate_x86_64_cpu_vendor(
 }
 
 /// Loads a Microvm snapshot producing a 'paused' Microvm.
-pub fn load_snapshot(
+pub fn restore_from_snapshot(
     event_manager: &mut EventManager,
     seccomp_filter: BpfProgramRef,
     params: &LoadSnapshotParams,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -23,7 +23,7 @@ use crate::device_manager::persist::DeviceStates;
 use crate::memory_snapshot;
 use crate::memory_snapshot::{GuestMemoryState, SnapshotMemory};
 use crate::version_map::FC_VERSION_TO_SNAP_VERSION;
-use crate::Vmm;
+use crate::{Error as VmmError, Vmm};
 use arch::IRQ_BASE;
 use cpuid::common::{get_vendor_id_from_cpuid, get_vendor_id_from_host};
 use logger::{error, info};
@@ -161,6 +161,8 @@ pub enum LoadSnapshotError {
     DeserializeMicrovmState(snapshot::Error),
     /// Failed to open memory backing file.
     MemoryBackingFile(io::Error),
+    /// Failed to resume Vm after loading snapshot.
+    ResumeMicroVm(VmmError),
     /// Failed to open the snapshot backing file.
     SnapshotBackingFile(io::Error),
     /// Failed to retrieve the metadata of the snapshot backing file.
@@ -177,6 +179,7 @@ impl Display for LoadSnapshotError {
             DeserializeMemory(err) => write!(f, "Cannot deserialize memory: {}", err),
             DeserializeMicrovmState(err) => write!(f, "Cannot deserialize MicrovmState: {:?}", err),
             MemoryBackingFile(err) => write!(f, "Cannot open memory file: {}", err),
+            ResumeMicroVm(err) => write!(f, "Failed to resume Vm after loading snapshot: {}", err),
             SnapshotBackingFile(err) => write!(f, "Cannot open snapshot file: {}", err),
             SnapshotBackingFileMetadata(err) => write!(f, "Cannot retrieve file metadata: {}", err),
             CpuVendorMismatch(err) => write!(f, "Snapshot cpu vendor mismatch: {}", err),

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -8,12 +8,12 @@ use std::sync::{Arc, Mutex};
 #[cfg(not(test))]
 use super::{builder::build_microvm_for_boot, resources::VmResources, Vmm};
 #[cfg(all(not(test), target_arch = "x86_64"))]
-use super::{persist::create_snapshot, persist::load_snapshot};
+use super::{persist::create_snapshot, persist::restore_from_snapshot};
 
 #[cfg(test)]
 use tests::{build_microvm_for_boot, MockVmRes as VmResources, MockVmm as Vmm};
 #[cfg(all(test, target_arch = "x86_64"))]
-use tests::{create_snapshot, load_snapshot};
+use tests::{create_snapshot, restore_from_snapshot};
 
 use super::Error as VmmError;
 use crate::builder::StartMicrovmError;
@@ -416,7 +416,7 @@ impl<'a> PrebootApiController<'a> {
             return Err(err);
         }
 
-        let result = load_snapshot(
+        let result = restore_from_snapshot(
             &mut self.event_manager,
             &self.seccomp_filter,
             load_params,
@@ -927,7 +927,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     // Need to redefine this since the non-test one uses real Vmm
     // instead of our mocks.
-    pub fn load_snapshot(
+    pub fn restore_from_snapshot(
         _: &mut EventManager,
         _: BpfProgramRef,
         _: &LoadSnapshotParams,

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1509,6 +1509,7 @@ mod tests {
                 snapshot_path: PathBuf::new(),
                 mem_file_path: PathBuf::new(),
                 enable_diff_snapshots: false,
+                resume_vm: false,
             }),
             VmmActionError::OperationNotSupportedPostBoot,
         );
@@ -1527,6 +1528,7 @@ mod tests {
             snapshot_path: PathBuf::new(),
             mem_file_path: PathBuf::new(),
             enable_diff_snapshots: false,
+            resume_vm: false,
         });
         let err = preboot.handle_preboot_request(req);
         assert_eq!(

--- a/src/vmm/src/vmm_config/snapshot.rs
+++ b/src/vmm/src/vmm_config/snapshot.rs
@@ -52,6 +52,10 @@ pub struct LoadSnapshotParams {
     /// allow taking subsequent incremental snapshots.
     #[serde(default)]
     pub enable_diff_snapshots: bool,
+    /// When set to true, the vm is also resumed if the snapshot load
+    /// is successful.
+    #[serde(default)]
+    pub resume_vm: bool,
 }
 
 /// The microVM state options.

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -149,16 +149,12 @@ class MicrovmBuilder:
                                      netmask_len=DEFAULT_NETMASK,
                                      tapname=DEFAULT_TAP_NAME)
 
-        response = vm.snapshot_load.put(mem_file_path=jailed_mem,
-                                        snapshot_path=jailed_vmstate,
-                                        diff=enable_diff_snapshots)
+        response = vm.snapshot.load(mem_file_path=jailed_mem,
+                                    snapshot_path=jailed_vmstate,
+                                    diff=enable_diff_snapshots,
+                                    resume=resume)
 
         assert vm.api_session.is_status_no_content(response.status_code)
-
-        if resume:
-            # Resume microvm
-            response = vm.vm.patch(state='Resumed')
-            assert vm.api_session.is_status_no_content(response.status_code)
 
         # Reset root path so next microvm is built some place else.
         self.init_root_path()

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.56, "ARM": 82.81}
+COVERAGE_DICT = {"Intel": 85.35, "AMD": 84.63, "ARM": 82.87}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -672,7 +672,7 @@ def _test_snapshot_compatibility(context):
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     # Try to create a snapshot with a balloon on version 0.23.0.
-    response = microvm.snapshot_create.put(
+    response = microvm.snapshot.create(
         mem_file_path='memfile',
         snapshot_path='dummy',
         diff=False,

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -404,8 +404,8 @@ def test_load_snapshot_failure_handling(bin_cloner_path):
     logger.info("FC process time before snapshoat load: %s.", fc_time)
 
     # Load the snapshot
-    response = vm.snapshot_load.put(mem_file_path=jailed_mem,
-                                    snapshot_path=jailed_vmstate)
+    response = vm.snapshot.load(mem_file_path=jailed_mem,
+                                snapshot_path=jailed_vmstate)
 
     logger.info("Response status code %d, content: %s.",
                 response.status_code,

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -210,7 +210,7 @@ def test_create_with_too_many_devices(test_microvm_with_ssh, network_config):
     # v0.23 allowed a maximum of `FC_V0_23_MAX_DEVICES_ATTACHED` virtio
     # devices at a time. This microVM has `FC_V0_23_MAX_DEVICES_ATTACHED`
     # network devices on top of the rootfs, so the limit is exceeded.
-    response = test_microvm.snapshot_create.put(
+    response = test_microvm.snapshot.create(
         mem_file_path="/snapshot/vm.vmstate",
         snapshot_path="/snapshot/vm.mem",
         diff=True,


### PR DESCRIPTION
## Reason for This PR

In order to minimize latency and overhead for starting a vm from snapshot, add option to both load the vm from snapshot and resume running it on the same API call.

## Description of Changes

Added optional `resume_vm` field to `SnapshotLoadParams` which, if `true` will lead to resuming the vm after a successful snapshot load.

The field is optional and takes a `false` default value, so this _API change is backward compatible_.

Added rpc-interface unit test to `LoadSnapshot` command.
Changed snapshot integration tests to use the new functionality to resume vm. The dedicated `resume` api call is still covered by `pause/resume` independent tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
