### PR TITLE
tests: changed limit for reusable connections

### DIFF
--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Wrapper over an http session with timed requests."""
 # pylint: disable=unused-import
-import requests_unixsocket
+import requests
+from requests_unixsocket import DEFAULT_SCHEME, UnixAdapter
 
 from framework import decorators
 
 
-class Session(requests_unixsocket.Session):
+class Session(requests.Session):
     """Wrapper over requests_unixsocket.Session limiting the call duration.
 
     Only the API calls relevant to Firecracker (GET, PUT, PATCH) are
@@ -17,6 +18,11 @@ class Session(requests_unixsocket.Session):
     def __init__(self):
         """Create a Session object and set the is_good_response callback."""
         super().__init__()
+
+        # The `pool_connections` argument indicates the maximum number of
+        # open connections allowed at a time. This value is set to 10 for
+        # consistency with the micro-http's `MAX_CONNECTIONS`.
+        self.mount(DEFAULT_SCHEME, UnixAdapter(pool_connections=10))
 
         def is_good_response(response: int):
             """Return `True` for all HTTP 2xx response codes."""


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

The micro-http server holds a HashMap of all opened connections and has a limit for the number of active connections at the same time. The `requests_unixsocket` python package, used by the testing framework for issuing API requests, opens a new connection for every API call and keeps it alive even after receiving the response from the server. These sockets are kept inside the connections HashMap and might very easily end up in exceeding the micro-http's limit, triggering a `503` response from the server. 

## Description of Changes

To prevent this from happening, the `pool_connections` argument was set to 10, consistent with the maximum number of open connections allowed: `MAX_CONNECTIONS`. Attempts to issue a new API request, after this limit has been reached, implies closing and removing the least recently used open fd and then adding a newly opened connection to the pool.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
