### PR TITLE
Validate cpu vendor id on snapshot load.

### DIFF
--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -3,11 +3,11 @@ pub mod c3;
 /// Follows a T2 template in setting up the CPUID.
 pub mod t2;
 
-use crate::common::{get_vendor_id, VENDOR_ID_INTEL};
+use crate::common::{get_vendor_id_from_host, VENDOR_ID_INTEL};
 use crate::transformer::Error;
 
 pub fn validate_vendor_id() -> Result<(), Error> {
-    let vendor_id = get_vendor_id().map_err(Error::InternalError)?;
+    let vendor_id = get_vendor_id_from_host().map_err(Error::InternalError)?;
     if &vendor_id != VENDOR_ID_INTEL {
         return Err(Error::InvalidVendor);
     }

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -9,7 +9,7 @@ pub use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 
 use crate::brand_string::BrandString;
 use crate::brand_string::Reg as BsReg;
-use crate::common::get_vendor_id;
+use crate::common::get_vendor_id_from_host;
 
 /// Structure containing the specifications of the VM
 pub struct VmSpec {
@@ -31,7 +31,7 @@ impl VmSpec {
     /// Creates a new instance of VmSpec with the specified parameters
     /// The brand string is deduced from the vendor_id
     pub fn new(cpu_index: u8, cpu_count: u8, ht_enabled: bool) -> Result<VmSpec, Error> {
-        let cpu_vendor_id = get_vendor_id().map_err(Error::InternalError)?;
+        let cpu_vendor_id = get_vendor_id_from_host().map_err(Error::InternalError)?;
 
         Ok(VmSpec {
             cpu_vendor_id,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -260,8 +260,8 @@ pub fn validate_x86_64_cpu_vendor(
         LoadSnapshotError::CpuVendorMismatch("Failed to read vendor from CPUID.".to_owned())
     })?;
 
-    let snapshot_vendor_id =
-        get_vendor_id_from_cpuid(&microvm_state.vcpu_states[0].cpuid).map_err(|_| {
+    let snapshot_vendor_id = get_vendor_id_from_cpuid(&microvm_state.vcpu_states[0].cpuid)
+        .map_err(|_| {
             error!("Snapshot CPU vendor is missing.");
             LoadSnapshotError::CpuVendorMismatch("Failed to read vendor from CPUID.".to_owned())
         })?;

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -379,7 +379,7 @@ impl KvmVcpu {
 /// Structure holding VCPU kvm state.
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct VcpuState {
-    cpuid: CpuId,
+    pub cpuid: CpuId,
     msrs: Msrs,
     debug_regs: kvm_debugregs,
     lapic: kvm_lapic_state,
@@ -399,7 +399,7 @@ mod tests {
 
     use super::*;
     use crate::vstate::vm::{tests::setup_vm, Vm};
-    use cpuid::common::{get_vendor_id, VENDOR_ID_INTEL};
+    use cpuid::common::{get_vendor_id_from_host, VENDOR_ID_INTEL};
 
     impl Default for VcpuState {
         fn default() -> Self {
@@ -462,7 +462,7 @@ mod tests {
             vm.supported_cpuid().clone(),
         );
 
-        match &get_vendor_id().unwrap() {
+        match &get_vendor_id_from_host().unwrap() {
             VENDOR_ID_INTEL => {
                 assert!(t2_res.is_ok());
                 assert!(c3_res.is_ok());

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.51, "ARM": 83.27}
+COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.56, "ARM": 83.27}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Partially implements #2023.

## Description of Changes

Validate cpu vendor id when loading a snapshot. More details in commit messages.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
