### PR TITLE
CI: enable kcov on aarch64

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.56, "ARM": 83.27}
+COVERAGE_DICT = {"Intel": 85.28, "AMD": 84.56, "ARM": 82.81}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05
@@ -41,10 +41,6 @@ KCOV_TOTAL_LINES_REGEX = r'"total_lines" : "(\d+)"'
 
 
 @pytest.mark.timeout(400)
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="unstable on aarch64 as of right now"
-)
 def test_coverage(test_session_root_path, test_session_tmp_path):
     """Test line coverage with kcov.
 


### PR DESCRIPTION
## Reason for This PR

We tried replicating the variations seen in first phase by spawning multiple m6g and obtaining the coverage, however the value was always the same. We decided to enable the kcov test for the moment and solve the variations if/when the issue replicates again.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
