### PR TITLE
Split MMIO dev manager function

### DIFF
--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -239,7 +239,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                                   event_manager: &mut EventManager|
          -> Result<(), Self::Error> {
             dev_manager
-                .slot_sanity_check(slot)
+                .mmio_device_info_sanity_check(slot)
                 .map_err(Error::DeviceManager)?;
 
             let restore_args = MmioTransportConstructorArgs {


### PR DESCRIPTION
## Reason for This PR
#2014 
Further discussion on [#1921](https://github.com/firecracker-microvm/firecracker/pull/1921#discussion_r442159543)

## Description of Changes

- `MMIODeviceManager`'s `allocate_new_slot` is replaced by two new methods: `allocate_slot` and `allocate_irq`.
  - `allocate_slot` allocates a memory region.
  - `allocate_irq` allocates a single irq and registers it with KVM for the given VM and event.
- This localizes irq allocation and registration.
- This has the side effect of getting rid of `vm.register_irqfd` calls from various other functions.
- Previously, `allocate_new_slot` returned an `MMIODeviceInfo` struct. It is now the responsibility of methods such as `register_mmio_virtio` and `register_new_mmio_rtc` to do direct calls to `allocate_slot` and `allocate_irq` and construct their own instances of `MMIODeviceInfo`
  - You can look at 42c3ea7 to see a possible, more direct`allocate_new_slot` analog (`allocate_new_device_resources`, a configurable method that returns an `MMIODeviceInfo` directly)
  - However, the current solution was the cleanest way I could think of passing information to the `MMIODeviceManager`, since it allows a simple one-to-one between irq and VM/event, rather than having to pass in an optional IRQ registration struct into an `allocate_new_slot` analog.
  - I would appreciate feedback here and a sense of if this choice makes sense given the use cases.
- There are also a few other side effects:
  - Most notably, previously `register_mmio_virtio` used to atomically register IO events with IRQ events. This is no longer the case.
  - Also, `register_mmio_virtio` no longer catches where > 1 IRQs were allocated before registering them since the two are coupled now.
- `test_slot_allocation` was rewritten as `test_irq_allocation`, since it really just tested the bump allocation of irqs. More thorough unit testing can be added for the two new methods if they seem promising.

Otherwise, all these methods were private to the module, so I don't anticipate there being issues in other parts of the code.

The only change not in `mmio.rs` is in `persist.rs`, and that change was simply a naming change for the sanity check method.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

## Contributor Comments
- I used `cargo fmt` for formatting.
- I am not super familiar with virtio and would love any pointers if this code has gaping holes!
- If this seems like a promising approach, I can go ahead and write some unit tests for the two new methods. 
- This is my first attempt at an open source contribution, so any feedback is welcome. :) 
