### PR TITLE
use upstream kvm-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "arch_gen 0.1.0",
  "device_tree 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)",
- "kvm-ioctls 0.6.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.6.0-3)",
+ "kvm-ioctls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
  "vm-memory 0.1.0",
@@ -129,7 +129,7 @@ name = "cpuid"
 version = "0.1.0"
 dependencies = [
  "kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)",
- "kvm-ioctls 0.6.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.6.0-3)",
+ "kvm-ioctls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
 ]
 
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.6.0"
-source = "git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.6.0-3#503b85e453f13c36bd7eae96fad139496ad10f64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -809,7 +809,7 @@ dependencies = [
  "devices 0.1.0",
  "kernel 0.1.0",
  "kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)",
- "kvm-ioctls 0.6.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.6.0-3)",
+ "kvm-ioctls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
@@ -976,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum js-sys 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)" = "<none>"
-"checksum kvm-ioctls 0.6.0 (git+https://github.com/firecracker-microvm/kvm-ioctls?tag=v0.6.0-3)" = "<none>"
+"checksum kvm-ioctls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158d15da895bddca8223fa31dc9e8b9317bdc2fbc4635dea8dd575fc40dae37f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 lto = true
+
+[patch.crates-io]
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.3.0-3", features = ["fam-wrappers"] }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["The Chromium OS Authors"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.3.0-3", features = ["fam-wrappers"] }
-kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.6.0-3" }
+kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
+kvm-ioctls = { version = "0.6.0" }
 libc = ">=0.2.39"
 vm-memory = { path = "../vm-memory" }
 arch_gen = { path = "../arch_gen" }

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.3.0-3", features = ["fam-wrappers"] }
-kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.6.0-3" }
+kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
+kvm-ioctls = { version = "0.6.0" }
 
 utils = { path = "../utils"}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -16,8 +16,8 @@ vm-memory = { path = "../vm-memory" }
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.3.0-3", features = ["fam-wrappers"] }
-kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.6.0-3" }
+kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
+kvm-ioctls = { version = "0.6.0" }
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
 polly = { path = "../polly" }

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -302,7 +302,9 @@ pub struct VmState {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
     use crate::vstate::system::KvmContext;
+    use std::os::unix::io::FromRawFd;
     use vm_memory::GuestAddress;
 
     // Auxiliary function being used throughout the tests.
@@ -321,9 +323,8 @@ pub(crate) mod tests {
         use std::os::unix::io::AsRawFd;
         use utils::tempfile::TempFile;
         // Testing an error case.
-        let vm = Vm::new(&unsafe {
-            Kvm::new_with_fd_number(TempFile::new().unwrap().as_file().as_raw_fd())
-        });
+        let vm =
+            Vm::new(&unsafe { Kvm::from_raw_fd(TempFile::new().unwrap().as_file().as_raw_fd()) });
         assert!(vm.is_err());
 
         // Testing with a valid /dev/kvm descriptor.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.35, "AMD": 84.63, "ARM": 82.87}
+COVERAGE_DICT = {"Intel": 85.35, "AMD": 84.63, "ARM": 82.81}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

This purpose of this PR is to reduce the overhead needed for maintaining, and releasing the firecracker-microvm/kvm-ioctls fork. The changes enable using the upstream kvm-ioctls, while still keeping the kvm-bindings + versionize support.

## Description of Changes

This should reduce the burden of maintaining forks of both kvm-ioctls
and kvm-bindings, and allows us to use the upsream kvm-ioctls while only
replacing the kvm-bindings dependency with one that supports versionize.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
