### PR TITLE
Handle kvm system events on aarch64

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.35, "AMD": 84.63, "ARM": 82.81}
+COVERAGE_DICT = {"Intel": 85.25, "AMD": 84.50, "ARM": 82.72}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -4,6 +4,7 @@
 import os
 import time
 import json
+import platform
 
 import framework.utils as utils
 
@@ -68,6 +69,11 @@ def test_reboot(test_microvm_with_ssh, network_config):
     # Consume existing metrics
     lines = metrics_fifo.sequential_reader(100)
     assert len(lines) == 1
+
+    if platform.machine() != "x86_64":
+        log_data = test_microvm.log_data
+        assert "Received KVM_SYSTEM_EVENT: type: 2, event: 0" in log_data
+        assert "Vmm is stopping." in log_data
 
     # Make sure that the FC process was not killed by a seccomp fault
     assert json.loads(lines[0])["seccomp"]["num_faults"] == 0


### PR DESCRIPTION
Signed-off-by: Alexandru Cihodaru <cihodar@amazon.com>

## Reason for This PR

Kvm system events were not handled and they caused `unexpected`
errors.

## Description of Changes

Added handler for KVM_SYSTEM_EVENT_SHUTDOWN
KVM_SYSTEM_EVENT_CRASH and KVM_SYSTEM_EVENT_RESET
on aarch64

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist
- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
