### PR TITLE
Update Rust toolchain to 1.46.0

### DIFF
--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -519,7 +519,7 @@ fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildH
     }
 
     // Sort out virtio devices by address from low to high and insert them into fdt table.
-    ordered_virtio_device.sort_by(|a, b| a.addr().cmp(&b.addr()));
+    ordered_virtio_device.sort_by_key(|&a| a.addr());
     for ordered_device_info in ordered_virtio_device.drain(..) {
         create_virtio_node(fdt, ordered_device_info)?;
     }

--- a/src/arch/src/x86_64/msr.rs
+++ b/src/arch/src/x86_64/msr.rs
@@ -253,10 +253,7 @@ mod tests {
     fn test_msr_whitelist() {
         for range in WHITELISTED_MSR_RANGES.iter() {
             for msr in range.base..(range.base + range.nmsrs) {
-                let should = match msr {
-                    MSR_IA32_FEATURE_CONTROL | MSR_IA32_MCG_CTL => false,
-                    _ => true,
-                };
+                let should = !matches!(msr, MSR_IA32_FEATURE_CONTROL | MSR_IA32_MCG_CTL);
                 assert_eq!(msr_should_serialize(msr), should);
             }
         }

--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -18,7 +18,7 @@ pub(crate) fn compact_page_frame_numbers(v: &mut Vec<u32>) -> Vec<(u32, u32)> {
     // received at once from a single descriptor is `MAX_PAGES_IN_DESC`,
     // this sort does not change the complexity of handling
     // an inflation.
-    v.sort();
+    v.sort_unstable();
 
     // Since there are at most `MAX_PAGES_IN_DESC` pages, setting the
     // capacity of `result` to this makes sense.
@@ -108,10 +108,7 @@ mod tests {
     /// This asserts that $lhs matches $rhs.
     macro_rules! assert_match {
         ($lhs:expr, $rhs:pat) => {{
-            assert!(match $lhs {
-                $rhs => true,
-                _ => false,
-            })
+            assert!(matches!($lhs, $rhs))
         }};
     }
 

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -344,20 +344,20 @@ mod tests {
             let request_header = RequestHeader::new(VIRTIO_BLK_T_OUT, 114);
             m.write_obj::<RequestHeader>(request_header, GuestAddress(0x1000))
                 .unwrap();
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::UnexpectedWriteOnlyDescriptor) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::UnexpectedWriteOnlyDescriptor)
+            ));
         }
 
         {
             let mut q = vq.create_queue();
             // Chain too short: no data_descriptor.
             vq.dtable[request_type_descriptor].flags.set(0);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::DescriptorChainTooShort) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::DescriptorChainTooShort)
+            ));
         }
 
         {
@@ -367,10 +367,10 @@ mod tests {
                 .flags
                 .set(VIRTQ_DESC_F_NEXT);
             vq.dtable[data_descriptor].set(0x2000, 0x1000, 0, 2);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::DescriptorChainTooShort) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::DescriptorChainTooShort)
+            ));
         }
 
         {
@@ -380,10 +380,10 @@ mod tests {
                 .flags
                 .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
             vq.dtable[status_descriptor].set(0x3000, 0, 0, 0);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::UnexpectedWriteOnlyDescriptor) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::UnexpectedWriteOnlyDescriptor)
+            ));
         }
 
         {
@@ -392,10 +392,10 @@ mod tests {
             m.write_obj::<u32>(VIRTIO_BLK_T_GET_ID, GuestAddress(0x1000))
                 .unwrap();
             vq.dtable[data_descriptor].flags.set(VIRTQ_DESC_F_NEXT);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::UnexpectedReadOnlyDescriptor) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::UnexpectedReadOnlyDescriptor)
+            ));
         }
 
         {
@@ -404,10 +404,10 @@ mod tests {
             m.write_obj::<u32>(VIRTIO_BLK_T_IN, GuestAddress(0x1000))
                 .unwrap();
             vq.dtable[data_descriptor].flags.set(VIRTQ_DESC_F_NEXT);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::UnexpectedReadOnlyDescriptor) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::UnexpectedReadOnlyDescriptor)
+            ));
         }
 
         {
@@ -416,20 +416,20 @@ mod tests {
             vq.dtable[data_descriptor]
                 .flags
                 .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::UnexpectedReadOnlyDescriptor) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::UnexpectedReadOnlyDescriptor)
+            ));
         }
 
         {
             let mut q = vq.create_queue();
             // Status descriptor too small.
             vq.dtable[status_descriptor].flags.set(VIRTQ_DESC_F_WRITE);
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::DescriptorLengthTooSmall) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::DescriptorLengthTooSmall)
+            ));
         }
 
         {
@@ -440,10 +440,10 @@ mod tests {
             vq.dtable[status_descriptor]
                 .addr
                 .set(m.last_addr().raw_value());
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_))) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_)))
+            ));
         }
 
         {
@@ -454,10 +454,10 @@ mod tests {
             vq.dtable[data_descriptor]
                 .addr
                 .set(m.last_addr().raw_value());
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_))) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                Request::parse(&q.pop(m).unwrap(), m),
+                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_)))
+            ));
         }
 
         {

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -404,11 +404,10 @@ impl Net {
 
         // Check for guest MAC spoofing.
         if let Some(mac) = guest_mac {
-            let _ = EthernetFrame::from_bytes(checked_frame(frame_buf)?).and_then(|eth_frame| {
+            let _ = EthernetFrame::from_bytes(checked_frame(frame_buf)?).map(|eth_frame| {
                 if mac != eth_frame.src_mac() {
                     METRICS.net.tx_spoofed_mac_count.inc();
                 }
-                Ok(())
             });
         }
 

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -310,10 +310,7 @@ impl Connection {
             return false;
         }
 
-        match parse_mss_option(segment) {
-            Ok(mss) if mss == self.mss => true,
-            _ => false,
-        }
+        matches!(parse_mss_option(segment), Ok(mss) if mss == self.mss)
     }
 
     fn reset_for_segment<T: NetworkBytes>(&mut self, s: &TcpSegment<T>) {
@@ -334,10 +331,7 @@ impl Connection {
     // has been ACKed by the other endpoint, and no FIN has been previously sent.
     fn can_send_first_fin(&self) -> bool {
         !self.fin_sent()
-            && match self.send_fin {
-                Some(fin_seq) if fin_seq == self.highest_ack_received => true,
-                _ => false,
-            }
+            && matches!(self.send_fin, Some(fin_seq) if fin_seq == self.highest_ack_received)
     }
 
     // Returns the window size which should be written to an outgoing segment. This is going to be

--- a/src/kernel/src/cmdline/mod.rs
+++ b/src/kernel/src/cmdline/mod.rs
@@ -49,10 +49,7 @@ impl fmt::Display for Error {
 pub type Result<T> = result::Result<T, Error>;
 
 fn valid_char(c: char) -> bool {
-    match c {
-        ' '..='~' => true,
-        _ => false,
-    }
+    matches!(c, ' '..='~')
 }
 
 fn valid_str(s: &str) -> Result<()> {

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -248,10 +248,7 @@ impl Value {
     }
 
     fn as_flag(&self) -> bool {
-        match self {
-            Value::Flag => true,
-            _ => false,
-        }
+        matches!(self, Value::Flag)
     }
 
     fn as_multiple(&self) -> Option<&[String]> {

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -177,7 +177,7 @@ pub fn get_seccomp_filter(seccomp_level: SeccompLevel) -> Result<BpfProgram, Sec
     match seccomp_level {
         SeccompLevel::None => Ok(vec![]),
         SeccompLevel::Basic => default_filter()
-            .and_then(|filter| Ok(filter.allow_all()))
+            .map(|filter| filter.allow_all())
             .and_then(|filter| filter.try_into())
             .map_err(SeccompError::SeccompFilter),
         SeccompLevel::Advanced => default_filter()

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2212120,
+        "FC_BINARY_SIZE_TARGET": 2067944,
         "JAILER_BINARY_SIZE_TARGET": 1439512,
-        "FC_BINARY_SIZE_LIMIT": 2322726,
+        "FC_BINARY_SIZE_LIMIT": 2171516,
         "JAILER_BINARY_SIZE_LIMIT": 1511488,
     },
     "aarch64": {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.25, "AMD": 84.50, "ARM": 82.72}
+COVERAGE_DICT = {"Intel": 85.04, "AMD": 84.27, "ARM": 82.98}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_malicious.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_malicious.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 fn main() {
     unsafe {
-        // In this example, the malicious component is outputing to standard input.
+        // In this example, the malicious component is outputting to standard input.
         libc::syscall(libc::SYS_write, libc::STDIN_FILENO, "Hello, world!\n", 14);
     }
 }

--- a/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
@@ -18,6 +18,7 @@ pub fn jailer_required_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_rt_sigaction),
         allow_syscall(libc::SYS_execve),
         allow_syscall(libc::SYS_mmap),
+        allow_syscall(libc::SYS_mprotect),
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_arch_prctl),
         allow_syscall(libc::SYS_set_tid_address),

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.43.1"
+ARG RUST_TOOLCHAIN="1.46.0"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -4,8 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.43.1"
-ARG RUST_TOOLCHAIN_AUDIT="1.47.0"
+ARG RUST_TOOLCHAIN="1.46.0"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG FIRECRACKER_SRC_DIR="/firecracker"
@@ -78,10 +77,10 @@ RUN mkdir "$TMP_BUILD_DIR" \
         && rustup target add x86_64-unknown-linux-musl \
         && rustup component add rustfmt \
         && rustup component add clippy-preview \
-        && rustup install "$RUST_TOOLCHAIN_AUDIT" \
+        && rustup install "stable" \
         && cd "$TMP_BUILD_DIR" \
             && cargo install cargo-kcov \
-            && cargo +"$RUST_TOOLCHAIN_AUDIT" install cargo-audit \
+            && cargo +"stable" install cargo-audit \
             && cargo kcov --print-install-kcov-sh | sh \
         && rm -rf "$CARGO_HOME/registry" \
         && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v23"
+DEVCTR_IMAGE="fcuvm/dev:v24"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Description of Changes

Ideally we would update to the latest stable which is `1.48.0` - which has also promoted `aarch64-unknown-linux-musl` to _Tier 2_.

Unfortunately that's not possible because of compiler and linker issues https://github.com/rust-lang/rust/issues/79789 and https://github.com/rust-lang/rust/issues/79791.

Latest stable we can use now is `1.46.0` - the version targeted by this PR.

**Binary size** decreases along with covered lines because of aggressive LTO code deduplication.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
