### PR TITLE
Add snapshot load latency baseline for v0.24.0

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -287,14 +287,12 @@ def test_older_snapshot_resume_latency(bin_cloner_path):
             exit_code, _, _ = ssh_connection.execute_command("sync")
             assert exit_code == 0
 
-            # Create a snapshot builder from a microvm.
-            snapshot_builder = SnapshotBuilder(vm_instance.vm)
-
             # The snapshot builder expects disks as paths, not artifacts.
             disks = []
             for disk in vm_instance.disks:
                 disks.append(disk.local_path())
 
+            # Create a snapshot builder from a microvm.
             snapshot_builder = SnapshotBuilder(vm_instance.vm)
             snapshot = snapshot_builder.create(disks,
                                                vm_instance.ssh_key,

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -39,9 +39,6 @@ CREATE_LATENCY_BASELINES = {
 LOAD_LATENCY_BASELINES = {
     '2vcpu_256mb.json': 8,
     '2vcpu_512mb.json': 8,
-    # We are also tracking restore from older version latency.
-    # Snapshot properties: 2vCPU, 512MB RAM, 1 disk, 1 network iface.
-    '0.23.0': 80,
 }
 
 
@@ -319,7 +316,7 @@ def test_older_snapshot_resume_latency(bin_cloner_path):
                     value = cur_value / USEC_IN_MSEC
                     break
 
-            baseline = LOAD_LATENCY_BASELINES[fc_version]
+            baseline = LOAD_LATENCY_BASELINES['2vcpu_512mb.json']
             logger.info("Latency %s/%s: %s ms", i + 1, SAMPLE_COUNT, value)
             assert baseline > value, "LoadSnapshot latency degraded."
             microvm.kill()


### PR DESCRIPTION
## Reason for This PR

Latency baseline for snapshot resume in v0.24.0 must be present in the baselines map of the CI.

## Description of Changes

- Add snapshot load latency baseline for v0.24.0.
- Removed redundant builder creation.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
