### PR TITLE
Gdb server #2168

### DIFF
--- a/docs/gdb-server.md
+++ b/docs/gdb-server.md
@@ -1,45 +1,71 @@
 # GDB Server Runbook
 
-The GDB server on Firecracker wears the purpose of providing the necessary means for debugging any type of guests running on top of the VMM, without being limited to the kernel version, whether it represents a type of unikernel or simply a Linux kernel.
+The GDB server on Firecracker wears the purpose of providing the necessary
+means for debugging any type of guests running on top of the VMM, without
+being limited to the kernel version, whether it represents a type of unikernel
+or simply a Linux kernel.
 
-The current version may only be run on top of microVMs configured with 1 vCPU on a x86 architecture. The behavior is otherwise undefined.
+The current version may only be run on top of microVMs configured with 1 vCPU
+on a x86 architecture. The behavior is otherwise undefined.
 
 ## Server Side
 
-Enabling the debugging process is independent of the way in which the user chooses to configure the microVM for boot and it can be done through a command line option passed to the Firecracker executable: --debugger. Therefore, whether you choose to run:
+Enabling the debugging process is independent of the way in which the user
+chooses to configure the microVM for boot and it can be done through a command
+line option passed to the Firecracker executable: --debugger.Therefore, whether
+you choose to run:
+
+```bash
+./firecracker --api-sock /tmp/firecracker.socket --config-file \
+ <path_to_config_file> --debugger
 ```
-./firecracker --api-sock /tmp/firecracker.socket --config-file <path_to_config_file> --debugger
-```
+
 or
+
+```bash
+./firecracker --api-sock /tmp/firecracker.socket --debugger, followed
+by the specific API requests,
 ```
-./firecracker --api-sock /tmp/firecracker.socket --debugger, followed by the specific API requests,
-```
+
 you will be greeted by the following prompt:
-```
+
+```console
 Waiting for a GDB connection on "0.0.0.0:8443"...
 ```
-Now the server waits for a GDB client - found either on the same machine or a remote one - to initiate the communication.
+
+Now the server waits for a GDB client - found either on the same machine or a
+remote one - to initiate the communication.
 
 ## Client Side
 
-Assuming we are on the same machine, from a different terminal, we can now launch the GDB client, specifying the path to the kernel image file (not stripped) that was used for microVM configuration:
+Assuming we are on the same machine, from a different terminal, we can now
+launch the GDB client, specifying the path to the kernel image
+file (not stripped) that was used for microVM configuration:
 
-**_ubuntu@host:~$ gdb \<path\_to\_kernel\_image\>_**
+### _ubuntu@host:~$ gdb \<path\_to\_kernel\_image\>_
 
 In order to attach to the running GDB server session, we use the target remote mode:
 
-**_(gdb) target remote 127.0.0.1:8443_**
+#### _(gdb) target remote 127.0.0.1:8443_
 
-In the command line interface, the first command after establishing the connection should be:
+In the command line interface, the first command after establishing
+the connection should be:
 
-**_(gdb) continue_**
+#### _(gdb) continue_
 
-At this point, the guest is hanging at the entry point of the executable. Typically, that is, on Linux kernels with default memory layout, the entry point coincides with address 0x1000000.
+At this point, the guest is hanging at the entry point of the executable.
+Typically, that is, on Linux kernels with default memory layout, the entry
+point coincides with address 0x1000000.
 
-**The default behavior in an IDE like Eclipse or VSCode is to automatically issue a continue command at the beginning of the session, therefore this last step can be skipped in those environments.**
+The default behavior in an IDE like Eclipse or VSCode is to automatically
+issue a continue command at the beginning of the session, therefore this last
+step can be skipped in those environments.
 
-In this mode, commands like run and attach are not supported. Now you can simply start debugging as you normally would when attached to a user-space process. A list of known supported commands is:
-```
+In this mode, commands like run and attach are not supported. Now you can
+simply start debugging as you normally would when attached to a user-space
+process. A list of known supported commands is:
+
+```console
 (gdb) continue
 (gdb) break <address>/<function symbol>
 (gdb) clear <address>/<function symbol>
@@ -53,39 +79,65 @@ In this mode, commands like run and attach are not supported. Now you can simply
 (gdb) print/<format> $<register>
 (gdb) disassemble
 ```
-The list is not exhaustive; other commands and variants may be usable as the client performs a great deal of processing on its own based on the data it extracts from the executable and the primitives exposed by the server.
 
-_When using a command which takes an address as argument (e.g., break, clear, examine) you must take into consideration a slight limitation of a kernel in the early boot process: up until the moment when the kernel properly sets up the page tables, it doesn’t have the notion of virtual addresses, therefore, when using/accessing a location in the early stages of the kernel boot, make sure you use a physical address, not a linear/virtual one. This drawback also affects the use of commands like next or finish, and binary-to-sources mapping. These may not properly function before switching the page tables. Generally, on a Linux kernel, this stage is bounded by the setting of the CR3 register, shortly after the call of the \_\_startup\_64 routine. Once execution reaches this point, you will be able to use symbols or virtual addresses._
+The list is not exhaustive; other commands and variants may be usable as the
+client performs a great deal of processing on its own based on the data it
+extracts from the executable and the primitives exposed by the server.
 
-_A simple way of figuring out the physical address is by looking at the program headers of the kernel image; these can be obtained with the following command:_
+_When using a command which takes an address as argument
+(e.g., break, clear, examine) you must take into consideration a slight
+limitation of a kernel in the early boot process: up until the moment when
+the kernel properly sets up the page tables, it doesn’t have the notion of
+virtual addresses, therefore, when using/accessing a location in the early
+stages of the kernel boot, make sure you use a physical address, not a
+linear/virtual one. This drawback also affects the use of commands like
+next or finish, and binary-to-sources mapping. These may not properly function
+before switching the page tables. Generally, on a Linux kernel, this stage is
+bounded by the setting of the CR3 register, shortly after the call of the
+\_\_startup\_64 routine. Once execution reaches this point, you will be able
+to use symbols or virtual addresses._
 
-**_readelf -l \<path\_to\_kernel\_image>_**
+_A simple way of figuring out the physical address is by looking at the program
+headers of the kernel image; these can be obtained with the following command:_
 
-_You will find that obtaining the corresponding physical address only requires subtracting an offset from the linear one. For example, by default, a Linux kernel is loaded at address 0x1000000 (physical), while the virtual address (the one you will see in the binary dump) is 0xffffffff81000000._
+#### _readelf -l \<path\_to\_kernel\_image>_
 
-_A breakpoint set at a virtual address in the early boot code will be ignored; same applies for breakpoints set at physical addresses later in the boot/execution stages._
+_You will find that obtaining the corresponding physical address only requires
+subtracting an offset from the linear one. For example, by default, a Linux
+kernel is loaded at address 0x1000000 (physical), while the virtual
+address (the one you will see in the binary dump) is 0xffffffff81000000._
 
-Below we are taking a look at an example session showcasing the various aspects of the above-mentioned limitation:
+_A breakpoint set at a virtual address in the early boot code will be ignored;
+same applies for breakpoints set at physical addresses later in the
+boot/execution stages._
 
-```
+Below we are taking a look at an example session showcasing the various aspects
+of the above-mentioned limitation:
+
+```console
 (gdb) target remote 127.0.0.1:8443
 0x0000000000000000 in ?? ()
 
 (gdb) continue
 0x0000000001000000 in ?? ()
 
-# Setting a breakpoint at the physical address corresponding to the __startup_64 function symbol
+# Setting a breakpoint at the physical address corresponding to the __startup_64
+function symbol
 (gdb) b *0x10001f0
 Breakpoint 1 at 0x10001f0
 
 (gdb) next
 Cannot find bounds of current function
 
-# Setting a breakpoint at a location right after the page tables have been set up; we must use the virtual address
+# Setting a breakpoint at a location right after the page tables have been
+set up; we must use the virtual address
+
 (gdb) b *0xffffffff8100005d
 Breakpoint 2 at 0xffffffff8100005d
 
-# Setting a breakpoint directly at a symbol. This is only possible because boot_cpu_init is called much later in the boot #process
+# Setting a breakpoint directly at a symbol. This is only possible because
+boot_cpu_init is called much later in the boot #process
+
 (gdb) b boot_cpu_init
 Breakpoint 3 at 0xffffffff81cde9b1
 
@@ -93,7 +145,9 @@ Breakpoint 3 at 0xffffffff81cde9b1
 (gdb) continue
 Breakpoint 1, 0x00000000010001f0 in ?? ()
 
-# We passed the border; symbol information becomes available. From this point on, it is safe to use virtual addresses #or symbols only
+# We passed the border; symbol information becomes available. From this point
+on, it is safe to use virtual addresses #or symbols only
+
 (gdb) continue
 Breakpoint 2, 0xffffffff8100005d in secondary_startup_64 ()
 
@@ -107,4 +161,5 @@ Breakpoint 3, 0xffffffff81cde9b1 in boot_cpu_init ()
 (gdb) quit
 ```
 
-In order to have a binary-to-sources mapping you may use command _directory \<path\_to\_kernel\_sources\>_
+In order to have a binary-to-sources mapping you may use command
+_directory \<path\_to\_kernel\_sources\>_

--- a/docs/gdb-server.md
+++ b/docs/gdb-server.md
@@ -1,0 +1,110 @@
+# GDB Server Runbook
+
+The GDB server on Firecracker wears the purpose of providing the necessary means for debugging any type of guests running on top of the VMM, without being limited to the kernel version, whether it represents a type of unikernel or simply a Linux kernel.
+
+The current version may only be run on top of microVMs configured with 1 vCPU on a x86 architecture. The behavior is otherwise undefined.
+
+## Server Side
+
+Enabling the debugging process is independent of the way in which the user chooses to configure the microVM for boot and it can be done through a command line option passed to the Firecracker executable: --debugger. Therefore, whether you choose to run:
+```
+./firecracker --api-sock /tmp/firecracker.socket --config-file <path_to_config_file> --debugger
+```
+or
+```
+./firecracker --api-sock /tmp/firecracker.socket --debugger, followed by the specific API requests,
+```
+you will be greeted by the following prompt:
+```
+Waiting for a GDB connection on "0.0.0.0:8443"...
+```
+Now the server waits for a GDB client - found either on the same machine or a remote one - to initiate the communication.
+
+## Client Side
+
+Assuming we are on the same machine, from a different terminal, we can now launch the GDB client, specifying the path to the kernel image file (not stripped) that was used for microVM configuration:
+
+**_ubuntu@host:~$ gdb \<path\_to\_kernel\_image\>_**
+
+In order to attach to the running GDB server session, we use the target remote mode:
+
+**_(gdb) target remote 127.0.0.1:8443_**
+
+In the command line interface, the first command after establishing the connection should be:
+
+**_(gdb) continue_**
+
+At this point, the guest is hanging at the entry point of the executable. Typically, that is, on Linux kernels with default memory layout, the entry point coincides with address 0x1000000.
+
+**The default behavior in an IDE like Eclipse or VSCode is to automatically issue a continue command at the beginning of the session, therefore this last step can be skipped in those environments.**
+
+In this mode, commands like run and attach are not supported. Now you can simply start debugging as you normally would when attached to a user-space process. A list of known supported commands is:
+```
+(gdb) continue
+(gdb) break <address>/<function symbol>
+(gdb) clear <address>/<function symbol>
+(gdb) next/nexti
+(gdb) step/stepi
+(gdb) finish
+(gdb) info breakpoints
+(gdb) info registers
+(gdb) backtrace/where
+(gdb) x/<count><format><size> <address>
+(gdb) print/<format> $<register>
+(gdb) disassemble
+```
+The list is not exhaustive; other commands and variants may be usable as the client performs a great deal of processing on its own based on the data it extracts from the executable and the primitives exposed by the server.
+
+_When using a command which takes an address as argument (e.g., break, clear, examine) you must take into consideration a slight limitation of a kernel in the early boot process: up until the moment when the kernel properly sets up the page tables, it doesn’t have the notion of virtual addresses, therefore, when using/accessing a location in the early stages of the kernel boot, make sure you use a physical address, not a linear/virtual one. This drawback also affects the use of commands like next or finish, and binary-to-sources mapping. These may not properly function before switching the page tables. Generally, on a Linux kernel, this stage is bounded by the setting of the CR3 register, shortly after the call of the \_\_startup\_64 routine. Once execution reaches this point, you will be able to use symbols or virtual addresses._
+
+_A simple way of figuring out the physical address is by looking at the program headers of the kernel image; these can be obtained with the following command:_
+
+**_readelf -l \<path\_to\_kernel\_image>_**
+
+_You will find that obtaining the corresponding physical address only requires subtracting an offset from the linear one. For example, by default, a Linux kernel is loaded at address 0x1000000 (physical), while the virtual address (the one you will see in the binary dump) is 0xffffffff81000000._
+
+_A breakpoint set at a virtual address in the early boot code will be ignored; same applies for breakpoints set at physical addresses later in the boot/execution stages._
+
+Below we are taking a look at an example session showcasing the various aspects of the above-mentioned limitation:
+
+```
+(gdb) target remote 127.0.0.1:8443
+0x0000000000000000 in ?? ()
+
+(gdb) continue
+0x0000000001000000 in ?? ()
+
+# Setting a breakpoint at the physical address corresponding to the __startup_64 function symbol
+(gdb) b *0x10001f0
+Breakpoint 1 at 0x10001f0
+
+(gdb) next
+Cannot find bounds of current function
+
+# Setting a breakpoint at a location right after the page tables have been set up; we must use the virtual address
+(gdb) b *0xffffffff8100005d
+Breakpoint 2 at 0xffffffff8100005d
+
+# Setting a breakpoint directly at a symbol. This is only possible because boot_cpu_init is called much later in the boot #process
+(gdb) b boot_cpu_init
+Breakpoint 3 at 0xffffffff81cde9b1
+
+# While in early boot, symbol information will not be available
+(gdb) continue
+Breakpoint 1, 0x00000000010001f0 in ?? ()
+
+# We passed the border; symbol information becomes available. From this point on, it is safe to use virtual addresses #or symbols only
+(gdb) continue
+Breakpoint 2, 0xffffffff8100005d in secondary_startup_64 ()
+
+(gdb) continue
+
+Breakpoint 3, 0xffffffff81cde9b1 in boot_cpu_init ()
+
+(gdb) next
+0xffffffff8104b8e0 in cpumask_set_cpu ()
+
+(gdb) quit
+```
+
+In order to have a binary-to-sources mapping you may use command _directory \<path\_to\_kernel\_sources\>_

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -16,3 +16,4 @@ polly = { path = "../polly" }
 seccomp = { path = "../seccomp" }
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
+gdb_server = { path = "../gdb_server" }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -128,6 +128,7 @@ pub(crate) fn run_with_api(
     start_time_us: Option<u64>,
     start_time_cpu_us: Option<u64>,
     boot_timer_enabled: bool,
+    debugger_enabled: bool,
 ) {
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
@@ -209,6 +210,7 @@ pub(crate) fn run_with_api(
             json,
             &instance_info,
             boot_timer_enabled,
+            debugger_enabled,
         ),
         None => PrebootApiController::build_microvm_from_requests(
             seccomp_filter,
@@ -231,6 +233,7 @@ pub(crate) fn run_with_api(
                     .expect("one-shot channel closed")
             },
             boot_timer_enabled,
+            debugger_enabled,
         ),
     };
 

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -120,6 +120,7 @@ impl Subscriber for ApiServerAdapter {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_with_api(
     seccomp_filter: BpfProgram,
     config_json: Option<String>,

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -137,6 +137,11 @@ fn main() {
             Argument::new("version")
                 .takes_value(false)
                 .help("Print the binary version number and a list of supported snapshot data format versions.")
+        )
+        .arg(
+            Argument::new("debugger")
+                .takes_value(false)
+                .help("Whether or not to launch the guest microvm under GDB")
         );
 
     let arguments = match arg_parser.parse_from_cmdline() {
@@ -218,6 +223,7 @@ fn main() {
 
     let boot_timer_enabled = arguments.flag_present("boot-timer");
     let api_enabled = !arguments.flag_present("no-api");
+    let debugger_enabled = arguments.flag_present("debugger").unwrap_or(false);
 
     if api_enabled {
         let bind_path = arguments
@@ -242,6 +248,7 @@ fn main() {
             start_time_us,
             start_time_cpu_us,
             boot_timer_enabled,
+            debugger_enabled,
         );
     } else {
         run_without_api(
@@ -249,6 +256,7 @@ fn main() {
             vmm_config_json,
             &instance_info,
             boot_timer_enabled,
+            debugger_enabled,
         );
     }
 }
@@ -276,6 +284,7 @@ fn build_microvm_from_json(
     config_json: String,
     instance_info: &InstanceInfo,
     boot_timer_enabled: bool,
+    debugger_enabled: bool,
 ) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
     let mut vm_resources =
         VmResources::from_json(&config_json, instance_info).unwrap_or_else(|err| {
@@ -286,7 +295,7 @@ fn build_microvm_from_json(
             process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
         });
     vm_resources.boot_timer = boot_timer_enabled;
-    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, event_manager, &seccomp_filter)
+    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, event_manager, &seccomp_filter, debugger_enabled)
         .unwrap_or_else(|err| {
             error!(
                 "Building VMM configured from cmdline json failed: {:?}",
@@ -304,6 +313,7 @@ fn run_without_api(
     config_json: Option<String>,
     instance_info: &InstanceInfo,
     bool_timer_enabled: bool,
+    debugger_enabled: bool,
 ) {
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");
 
@@ -335,6 +345,7 @@ fn run_without_api(
         config_json.unwrap(),
         instance_info,
         bool_timer_enabled,
+        debugger_enabled,
     );
 
     // Start the metrics.

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -295,14 +295,19 @@ fn build_microvm_from_json(
             process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
         });
     vm_resources.boot_timer = boot_timer_enabled;
-    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, event_manager, &seccomp_filter, debugger_enabled)
-        .unwrap_or_else(|err| {
-            error!(
-                "Building VMM configured from cmdline json failed: {:?}",
-                err
-            );
-            process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
-        });
+    let vmm = vmm::builder::build_microvm_for_boot(
+        &vm_resources,
+        event_manager,
+        &seccomp_filter,
+        debugger_enabled,
+    )
+    .unwrap_or_else(|err| {
+        error!(
+            "Building VMM configured from cmdline json failed: {:?}",
+            err
+        );
+        process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
+    });
     info!("Successfully started microvm that was configured from one single json");
 
     (vm_resources, vmm)

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -223,7 +223,7 @@ fn main() {
 
     let boot_timer_enabled = arguments.flag_present("boot-timer");
     let api_enabled = !arguments.flag_present("no-api");
-    let debugger_enabled = arguments.flag_present("debugger").unwrap_or(false);
+    let debugger_enabled = arguments.flag_present("debugger");
 
     if api_enabled {
         let bind_path = arguments

--- a/src/gdb_server/Cargo.toml
+++ b/src/gdb_server/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gdb_server"
+version = "0.1.0"
+authors = ["Marius-Cristian Baciu <baciumar@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+gdbstub = "0.2.0"

--- a/src/gdb_server/Cargo.toml
+++ b/src/gdb_server/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gdbstub = "0.2.0"
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
+kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
+gdbstub = "0.3.0"

--- a/src/gdb_server/Cargo.toml
+++ b/src/gdb_server/Cargo.toml
@@ -9,5 +9,7 @@ edition = "2018"
 [dependencies]
 vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
+kernel = { path = "../kernel" }
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 gdbstub = "0.3.0"
+vmm-sys-util = ">=0.2.1"

--- a/src/gdb_server/Cargo.toml
+++ b/src/gdb_server/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
-kvm-ioctls = { git = "https://github.com/firecracker-microvm/kvm-ioctls", tag = "v0.5.0-2" }
+vm-memory = { path = "../vm-memory" }
+kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
+kvm-ioctls = { version = "0.6.0" }
 kernel = { path = "../kernel" }
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 gdbstub = "0.3.0"
 vmm-sys-util = ">=0.2.1"
 arch = { path = "../arch" }

--- a/src/gdb_server/Cargo.toml
+++ b/src/gdb_server/Cargo.toml
@@ -13,3 +13,4 @@ kernel = { path = "../kernel" }
 kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.2.0-2", features = ["fam-wrappers"] }
 gdbstub = "0.3.0"
 vmm-sys-util = ">=0.2.1"
+arch = { path = "../arch" }

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,7 +1,9 @@
 use std::net::{TcpListener, TcpStream};
 
 pub use arch;
+#[cfg(target_arch = "x86_64")]
 pub use arch::x86_64::regs::setup_sregs;
+#[cfg(target_arch = "x86_64")]
 pub use kernel::loader::elf::{Elf64_Phdr, PT_LOAD};
 pub use kvm_bindings;
 pub use kvm_ioctls::VcpuFd;
@@ -11,20 +13,26 @@ pub use vm_memory::{
 };
 
 pub use gdbstub::GdbStubError;
+#[allow(unused_imports)]
 use gdbstub::{Connection, DisconnectReason, GdbStub, ResumeAction};
 
 extern crate vm_memory;
 
+#[allow(dead_code, unused_imports)]
 mod target;
+#[allow(dead_code, unused_imports)]
 mod util;
 
+#[allow(unused_imports)]
 use target::*;
 pub use util::*;
 
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 
+#[allow(dead_code)]
 const PORT_NUM: u16 = 8443;
 
+#[allow(dead_code)]
 fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     let sockaddr = format!("0.0.0.0:{}", port);
     eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
@@ -35,6 +43,7 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     Ok(stream)
 }
 
+#[cfg(target_arch = "x86_64")]
 pub fn run_gdb_server(
     vmm_gm: GuestMemoryMmap,
     entry_addr: GuestAddress,

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -32,7 +32,7 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     Ok(stream)
 }
 
-pub fn run_gdb_server<'a>(
+pub fn run_gdb_server(
     vmm_gm: GuestMemoryMmap,
     entry_addr: GuestAddress,
     e_phdrs: Vec<Elf64_Phdr>,

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,5 +1,6 @@
 use std::net::{TcpListener, TcpStream};
 
+pub use arch;
 pub use kernel::loader::{Elf64_Phdr, PT_LOAD};
 pub use kvm_bindings;
 pub use kvm_ioctls::VcpuFd;

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::net::{TcpListener, TcpStream};
 
 pub use arch;

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,13 +1,13 @@
 use std::net::{TcpListener, TcpStream};
 
-#[cfg(unix)]
-use std::os::unix::net::{UnixListener, UnixStream};
 pub use std::sync::mpsc::{Receiver, Sender};
 pub use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, ByteValued};
 pub use kvm_ioctls::VcpuFd;
 pub use kvm_bindings;
+pub use kernel::loader::{Elf64_Phdr, PT_LOAD};
 
 use gdbstub::{Connection, DisconnectReason, GdbStub, ResumeAction};
+pub use gdbstub::GdbStubError;
 
 extern crate vm_memory;
 
@@ -29,52 +29,41 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     Ok(stream) 
 }
 
-#[cfg(unix)]
-fn wait_for_uds(path: &str) -> DynResult<UnixStream> {
-    match std::fs::remove_file(path) {
-        Ok(_) => {}
-        Err(e) => match e.kind() {
-            std::io::ErrorKind::NotFound => {}
-            _ => return Err(e.into()),
-        },
+pub fn run_gdb_server<'a>(vmm_gm: GuestMemoryMmap, entry_addr: GuestAddress, e_phdrs: Vec<Elf64_Phdr>,
+                     vcpu_event_receiver: Receiver<DebugEvent>, vcpu_event_sender: Sender<DebugEvent>) -> DynResult<()> {
+    let mut target = FirecrackerGDBServer::new(vmm_gm,
+        vcpu_event_receiver, vcpu_event_sender, e_phdrs)?;
+
+    if target.insert_bp(entry_addr.0).is_err() {
+        return Err("GDB server error".into());
     }
 
-    eprintln!("Waiting for a GDB connection on {}...", path);
-
-    let sock = UnixListener::bind(path)?;
-    let (stream, addr) = sock.accept()?;
-    eprintln!("Debugger connected from {:?}", addr);
-
-    Ok(stream)
-}
-
-pub fn run_gdb_server<'a>(vmm_gm: GuestMemoryMmap,
-                     vcpu_event_receiver: Receiver<DebugEvent>, vcpu_event_sender: Sender<DebugEvent>) -> DynResult<()> {
-    let mut target = FirecrackerGDBServer::new(vmm_gm, vcpu_event_receiver, vcpu_event_sender)?;
-
-    let entry_addr: u64 = 0x1000000;
-    target.insert_bp(entry_addr);
-
     // This signals the main thread it is ok to start the vcpus
-    target.vcpu_event_sender.send(DebugEvent::START).expect("Failed notifying Firecracker");
+    if target.vcpu_event_sender.send(DebugEvent::START).is_err() {
+        return Err("GDB server - main thread communication error".into());
+    }
     // Guarantees that the vcpus are in a waiting state at the entry point of the kernel
-    target.vcpu_event_receiver.recv().expect("Communication with the Firecracker process failed");
+    if target.vcpu_event_receiver.recv().is_err() {
+        return Err("GDB server - main thread communication error".into());
+    }
 
-    target.remove_bp(entry_addr);
+    if target.remove_bp(entry_addr.0).is_err() {
+        return Err("GDB server error".into());
+    }
+
+    // Retrieving the guest state. We will not be doing this again until
+    // after the first continue/single-step
+    if target.vcpu_event_sender.send(DebugEvent::GET_REGS).is_err() {
+        return Err("GDB server - main thread communication error".into());
+    }
+    if let Ok(DebugEvent::PEEK_REGS(state)) = target.vcpu_event_receiver.recv() {
+        target.guest_state = state;
+    } else {
+        return Err("GDB server - main thread communication error".into());
+    }
 
     let connection: Box<dyn Connection<Error = std::io::Error>> = {
-        if std::env::args().nth(1) == Some("--uds".to_string()) {
-            #[cfg(not(unix))]
-            {
-                return Err("Unix Domain Sockets can only be used on Unix".into());
-            }
-            #[cfg(unix)]
-            {
-                Box::new(wait_for_uds("/tmp/armv4t_gdb")?)
-            }
-        } else {
             Box::new(wait_for_tcp(9001)?)
-        }
     };
     let mut debugger = GdbStub::new(connection);
     match debugger.run(&mut target)? {
@@ -92,11 +81,3 @@ pub fn run_gdb_server<'a>(vmm_gm: GuestMemoryMmap,
     Ok(())
 }
 
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,13 +1,15 @@
 use std::net::{TcpListener, TcpStream};
 
-pub use std::sync::mpsc::{Receiver, Sender};
-pub use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, ByteValued};
-pub use kvm_ioctls::VcpuFd;
-pub use kvm_bindings;
 pub use kernel::loader::{Elf64_Phdr, PT_LOAD};
+pub use kvm_bindings;
+pub use kvm_ioctls::VcpuFd;
+pub use std::sync::mpsc::{Receiver, Sender};
+pub use vm_memory::{
+    ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion,
+};
 
-use gdbstub::{Connection, DisconnectReason, GdbStub, ResumeAction};
 pub use gdbstub::GdbStubError;
+use gdbstub::{Connection, DisconnectReason, GdbStub, ResumeAction};
 
 extern crate vm_memory;
 
@@ -19,20 +21,25 @@ pub use util::*;
 
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-fn wait_for_tcp(port: u16) -> DynResult<TcpStream> { 
+fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
     let sockaddr = format!("127.0.0.1:{}", port);
     eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
 
     let sock = TcpListener::bind(sockaddr)?;
     let (stream, addr) = sock.accept()?;
     eprintln!("Debugger connected from {}", addr);
-    Ok(stream) 
+    Ok(stream)
 }
 
-pub fn run_gdb_server<'a>(vmm_gm: GuestMemoryMmap, entry_addr: GuestAddress, e_phdrs: Vec<Elf64_Phdr>,
-                     vcpu_event_receiver: Receiver<DebugEvent>, vcpu_event_sender: Sender<DebugEvent>) -> DynResult<()> {
-    let mut target = FirecrackerGDBServer::new(vmm_gm,
-        vcpu_event_receiver, vcpu_event_sender, e_phdrs)?;
+pub fn run_gdb_server<'a>(
+    vmm_gm: GuestMemoryMmap,
+    entry_addr: GuestAddress,
+    e_phdrs: Vec<Elf64_Phdr>,
+    vcpu_event_receiver: Receiver<DebugEvent>,
+    vcpu_event_sender: Sender<DebugEvent>,
+) -> DynResult<()> {
+    let mut target =
+        FirecrackerGDBServer::new(vmm_gm, vcpu_event_receiver, vcpu_event_sender, e_phdrs)?;
 
     if target.insert_bp(entry_addr.0, false).is_err() {
         return Err("GDB server error".into());
@@ -53,23 +60,19 @@ pub fn run_gdb_server<'a>(vmm_gm: GuestMemoryMmap, entry_addr: GuestAddress, e_p
         return Err("GDB server error".into());
     }
 
-    let connection: Box<dyn Connection<Error = std::io::Error>> = {
-            Box::new(wait_for_tcp(9001)?)
-    };
+    let connection: Box<dyn Connection<Error = std::io::Error>> = { Box::new(wait_for_tcp(9001)?) };
     let mut debugger = GdbStub::new(connection);
     match debugger.run(&mut target)? {
-       DisconnectReason::Disconnect => {
+        DisconnectReason::Disconnect => {
             println!("Disconnected from GDB.");
-                return Ok(());
-       }
-       DisconnectReason::TargetHalted => println!("Target halted!"),
-       DisconnectReason::Kill => {
-           println!("GDB sent a kill command!");
-           return Ok(());
-       }
+            return Ok(());
+        }
+        DisconnectReason::TargetHalted => println!("Target halted!"),
+        DisconnectReason::Kill => {
+            println!("GDB sent a kill command!");
+            return Ok(());
+        }
     }
 
     Ok(())
 }
-
-

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -30,6 +30,7 @@ mod walker;
 #[allow(unused_imports)]
 use target::*;
 pub use util::*;
+pub  use walker::Walker;
 
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,0 +1,82 @@
+use std::net::{TcpListener, TcpStream};
+
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use gdbstub::{Connection, DisconnectReason, GdbStub};
+
+mod target;
+use target::FirecrackerGDBServer;
+
+pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+fn wait_for_tcp(port: u16) -> DynResult<TcpStream> { 
+    let sockaddr = format!("127.0.0.1:{}", port);
+    eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
+
+    let sock = TcpListener::bind(sockaddr)?;
+    let (stream, addr) = sock.accept()?;
+    eprintln!("Debugger connected from {}", addr);
+    Ok(stream) 
+}
+
+#[cfg(unix)]
+fn wait_for_uds(path: &str) -> DynResult<UnixStream> {
+    match std::fs::remove_file(path) {
+        Ok(_) => {}
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::NotFound => {}
+            _ => return Err(e.into()),
+        },
+    }
+
+    eprintln!("Waiting for a GDB connection on {}...", path);
+
+    let sock = UnixListener::bind(path)?;
+    let (stream, addr) = sock.accept()?;
+    eprintln!("Debugger connected from {:?}", addr);
+
+    Ok(stream)
+}
+
+pub fn run_gdb_server() -> DynResult<()> {
+    let mut target = FirecrackerGDBServer::new()?;
+
+    let connection: Box<dyn Connection<Error = std::io::Error>> = {
+        if std::env::args().nth(1) == Some("--uds".to_string()) {
+            #[cfg(not(unix))]
+            {
+                return Err("Unix Domain Sockets can only be used on Unix".into());
+            }
+            #[cfg(unix)]
+            {
+                Box::new(wait_for_uds("/tmp/armv4t_gdb")?)
+            }
+        } else {
+            Box::new(wait_for_tcp(9001)?)
+        }
+    };
+    let mut debugger = GdbStub::new(connection);
+    match debugger.run(&mut target)? {
+       DisconnectReason::Disconnect => {
+            println!("Disconnected from GDB.");
+                return Ok(());
+       }
+       DisconnectReason::TargetHalted => println!("Target halted!"),
+       DisconnectReason::Kill => {
+           println!("GDB sent a kill command!");
+           return Ok(());
+       }
+    }
+
+    Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -25,6 +25,7 @@ extern crate vm_memory;
 mod target;
 #[allow(dead_code, unused_imports)]
 mod util;
+mod walker;
 
 #[allow(unused_imports)]
 use target::*;

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -1,7 +1,8 @@
 use std::net::{TcpListener, TcpStream};
 
 pub use arch;
-pub use kernel::loader::{Elf64_Phdr, PT_LOAD};
+pub use arch::x86_64::regs::setup_sregs;
+pub use kernel::loader::elf::{Elf64_Phdr, PT_LOAD};
 pub use kvm_bindings;
 pub use kvm_ioctls::VcpuFd;
 pub use std::sync::mpsc::{Receiver, Sender};

--- a/src/gdb_server/src/lib.rs
+++ b/src/gdb_server/src/lib.rs
@@ -23,7 +23,7 @@ pub use util::*;
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
-    let sockaddr = format!("127.0.0.1:{}", port);
+    let sockaddr = format!("0.0.0.0:{}", port);
     eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
 
     let sock = TcpListener::bind(sockaddr)?;
@@ -51,7 +51,7 @@ pub fn run_gdb_server<'a>(
         return Err("GDB server error".into());
     }
 
-    let connection: Box<dyn Connection<Error = std::io::Error>> = { Box::new(wait_for_tcp(9001)?) };
+    let connection: Box<dyn Connection<Error = std::io::Error>> = { Box::new(wait_for_tcp(8443)?) };
     let mut debugger = GdbStub::new(connection);
     match debugger.run(&mut target)? {
         DisconnectReason::Disconnect => {

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -1,9 +1,9 @@
 use gdbstub::{
-    arch, BreakOp, OptResult, StopReason, Target, Tid, WatchKind, SINGLE_THREAD_TID,
+    arch, BreakOp, OptResult, StopReason, Target, Tid, TidSelector, WatchKind, SINGLE_THREAD_TID, Actions,
 };
 
-use super::{Debugger, DebugEvent, Receiver, Sender, ResumeAction};
-use super::{Bytes, GuestAddress, GuestMemoryMmap};
+use super::{DebuggerError, Debugger, DebugEvent, Receiver, Sender, ResumeAction, FullVcpuState};
+use super::{Bytes, GuestAddress, GuestMemoryMmap, Elf64_Phdr};
 use crate::DynResult;
 
 pub struct FirecrackerGDBServer {
@@ -11,134 +11,210 @@ pub struct FirecrackerGDBServer {
 
     pub vcpu_event_receiver: Receiver<DebugEvent>,
     pub vcpu_event_sender: Sender<DebugEvent>,
-
+    // Stores (real opcode, linear address)
     pub breakpoints: Vec<(u8, u64)>,
-
+    pub guest_state: FullVcpuState,
     pub single_step_en: bool,
+
+    pub e_phdrs: Vec<Elf64_Phdr>,
 }
 
 impl FirecrackerGDBServer {
     pub fn new(guest_memory: GuestMemoryMmap,
         vcpu_event_receiver: Receiver<DebugEvent>,
-        vcpu_event_sender: Sender<DebugEvent>) -> DynResult <FirecrackerGDBServer > {
-        Ok(FirecrackerGDBServer{guest_memory, vcpu_event_receiver,
-            vcpu_event_sender, breakpoints: Vec::new(), single_step_en: false})
+        vcpu_event_sender: Sender<DebugEvent>,
+        e_phdrs: Vec<Elf64_Phdr>) -> DynResult <FirecrackerGDBServer > {
+        Ok(FirecrackerGDBServer{guest_memory, vcpu_event_receiver, vcpu_event_sender,
+            breakpoints: Vec::new(), guest_state: Default::default(), single_step_en: false, e_phdrs})
     }
 
-    pub fn remove_bp(&mut self, addr : u64) {
+    pub fn remove_bp(&mut self, phys_addr: u64) -> Result<(), DebuggerError> {
         for (idx, it) in self.breakpoints.iter().enumerate() {
-            if it.1 == addr {
-                self.guest_memory.write_obj(it.0, GuestAddress(addr))
-                        .expect("Failed removing interrupt");
+            if it.1 == phys_addr {
+                if self.guest_memory.write_obj(it.0, GuestAddress(phys_addr)).is_err() {
+                    return Err(DebuggerError::MemoryError);
+                }
 
                 self.breakpoints.remove(idx);
                 break;
             }
         }
-    }
-    pub fn insert_bp(&mut self, phys_addr: u64) {
-        let int3: u8 = 0xCC;
-        let entry_addr: u64 = 0x1000000;
 
-        if phys_addr != entry_addr {
-            self.vcpu_event_sender.send(DebugEvent::BREAKPOINT).unwrap();
+        Ok(())
+    }
+    pub fn insert_bp(&mut self, phys_addr: u64) -> Result<(), DebuggerError>{
+        // Opcode specific to x86 architecture that triggers a trap when
+        // encountered during cpu execution
+        let int3: u8 = 0xCC;
+
+        let opcode: u8;
+        if let Ok(byte) = self.guest_memory.read_obj(GuestAddress(phys_addr)) {
+            opcode = byte;
+        } else {
+            return Err(DebuggerError::MemoryError);
         }
 
-        let opcode: u8 = self.guest_memory.read_obj(GuestAddress(phys_addr)).unwrap();
         self.breakpoints.push((opcode, phys_addr));
-        self.guest_memory.write_obj(int3, GuestAddress(phys_addr))
-                        .expect("Failed inserting interrupt");
+
+        if self.guest_memory.write_obj(int3, GuestAddress(phys_addr)).is_err() {
+            return Err(DebuggerError::MemoryError);
+        }
+
+        Ok(())
+    }
+
+    /// Normally, when a continue/single-step packet is received from the client,
+    /// no breakpoint should exist at the current address, as it would cause an
+    /// unwanted trap. The client takes care of this by removing the breakpoint
+    /// each time right after using it and re-inserting it after the current
+    /// instruction was executed.
+    /// A problem occurs when the client is not aware of a breakpoint existing
+    /// (during early boot, the breakpoint may be set at linear address 0xffffffff81000007,
+    /// but the eip would show 0x1000007 - the physical address). In this case,
+    ///  we solve the problem on the server side.
+    fn invalid_state(&self, rip: u64) -> bool {
+        for it in self.breakpoints.iter() {
+            if it.1 == rip {
+                return true;
+            }
+        }
+        return false;
     }
 }
 
 impl Target for FirecrackerGDBServer {
     type Arch = arch::x86::X86_64;
-    type Error = &'static str;
+    type Error = DebuggerError;
     
+    /// Function that is called when a continue/single-step packet is received from client
     fn resume(
         &mut self,
-        actions: gdbstub::Actions,
+        actions: Actions,
         check_gdb_interrupt: &mut dyn FnMut() -> bool,
     ) -> Result<(Tid, StopReason<u64>), Self::Error> {
+        let mut ret: Option<StopReason<u64>> = None;
+
         for item in actions {
+            let invalid_state = self.invalid_state(self.guest_state.regular_regs.rip);
+            let prev_bp_addr = Debugger::virt_to_phys(self.guest_state.regular_regs.rip, 
+                &self, &self.guest_state).unwrap();
             match item.1 {
                 ResumeAction::Continue => {
-                    self.vcpu_event_sender.send(DebugEvent::CONTINUE(self.single_step_en)).unwrap();
-                    self.single_step_en = false;
-                    while !check_gdb_interrupt() {
-                        match self.vcpu_event_receiver.try_recv() {
-                            Ok(DebugEvent::PRINT_PTs(cr3)) => {
-                                println!("Printing PTs...");
-                                for i in 0..512 {
-                                    let addr: u64 = cr3 & 0x000ffffffffff000u64;
-                                    let data: u64 = self.guest_memory.read_obj(GuestAddress(addr + i * 8)).unwrap();
-                                    println!("{:x?} : {:x?}", addr + i * 8, data);
-                                }
-                                // A better return value would probably be SwBreak, but
-                                // there are some problems regarding the thread id that
-                                // gdbstub chooses to return for that case
-                                return Ok((SINGLE_THREAD_TID, StopReason::GdbInterrupt));
+                    // Client has failed in removing the bp before continuing
+                    if invalid_state {
+                        if let Err(e) = self.remove_bp(prev_bp_addr) {
+                            return Err(e);
+                        }
+                        if self.vcpu_event_sender.send(DebugEvent::STEP_INTO(self.single_step_en)).is_err() {
+                            return Err(Self::Error::ChannelError);
+                        }
+                        self.single_step_en = true;
+
+                        if let Ok(DebugEvent::NOTIFY) = self.vcpu_event_receiver.recv() {
+                            if let Err(e) = self.insert_bp(prev_bp_addr) {
+                                return Err(e);
                             }
-                            Ok(_) => { println!("Wrong message type"); break; }
-                            Err(_) => {}
+                        } else {
+                            return Err(Self::Error::ChannelError);
                         }
                     }
-                    // This can be reached either by a 0x03 signal from the client or by a
-                    // connection error occurring. It is not clear for now what the return
-                    // value should be
+                    if self.vcpu_event_sender.send(DebugEvent::CONTINUE(self.single_step_en)).is_err() {
+                        return Err(Self::Error::ChannelError);
+                    }
+                    self.single_step_en = false;
+                    while !check_gdb_interrupt() {
+                        if let Ok(DebugEvent::NOTIFY) = self.vcpu_event_receiver.try_recv() {
+                            // A better return value would probably be SwBreak, but
+                            // there are some problems regarding the thread id that
+                            // gdbstub chooses to return for that case
+                            ret = Some(StopReason::GdbInterrupt);
+                            break;
+                        }
+                    }
+                    if ret.is_some() {
+                        continue;
+                    }
+                    // This can be reached only as a result of a Ctrl-C signal
                     return Ok((SINGLE_THREAD_TID, StopReason::Halted));
                 }
                 ResumeAction::Step => {
-                    self.vcpu_event_sender.send(DebugEvent::STEP_INTO(self.single_step_en)).unwrap();
+                    if invalid_state {
+                        if let Err(e) = self.remove_bp(prev_bp_addr) {
+                            return Err(e);
+                        }
+                    }
+                    if self.vcpu_event_sender.send(DebugEvent::STEP_INTO(self.single_step_en)).is_err() {
+                        return Err(Self::Error::ChannelError);
+                    }
                     // Main thread will take care of what it means enabling/disabling single-stepping
                     self.single_step_en = true;
-                    loop {
-                        match self.vcpu_event_receiver.try_recv() {
-                            Ok(DebugEvent::PRINT_PTs(cr3)) =>
-                                return Ok((SINGLE_THREAD_TID, StopReason::DoneStep)),
-                            Ok(_) => { println!("Wrong message type"); break;}
-                            Err(_) => {}
+                    while !check_gdb_interrupt() {
+                        if let Ok(DebugEvent::NOTIFY) = self.vcpu_event_receiver.try_recv() {
+                            if invalid_state {
+                                if let Err(e) = self.insert_bp(prev_bp_addr) {
+                                    return Err(e);
+                                }
+                            }
+                            ret = Some(StopReason::DoneStep);
+                            break;
                         }
+                    }
+                    if ret.is_some() {
+                        continue;
                     }
                     return Ok((SINGLE_THREAD_TID, StopReason::Halted));
                 }
             }
         }
-        Err("Continue/Step op failed")
+        if ret.is_some() {
+            // Guest registers' values are needed throughout the entire execution and
+            // the state can be requested by the client at any point in time.
+            // In order to reduce the number of ioctl calls and channel messages,
+            // we only perform this operation once after each continue/single-step.
+            // Since the guest is not the only one that alters its state (the GDB client
+            // can do it too), when this happens, we must also ensure that our local
+            // "cache" is also properly updated
+            if self.vcpu_event_sender.send(DebugEvent::GET_REGS).is_err() {
+                return Err(Self::Error::ChannelError);
+            }
+            if let Ok(DebugEvent::PEEK_REGS(state)) = self.vcpu_event_receiver.recv() {
+                self.guest_state = state;
+                return Ok((SINGLE_THREAD_TID, ret.unwrap()));
+            } else {
+                return Err(Self::Error::ChannelError);
+            }
+        }
+
+        Err(Self::Error::InvalidState)
     }
 
+    /// Function that is called when the user or the GDB client requests the guest state
     fn read_registers(
         &mut self,
         regs: &mut arch::x86::reg::X86_64CoreRegs,
     ) -> Result<(), Self::Error> {
-        self.vcpu_event_sender.send(DebugEvent::GET_REGS).unwrap();
-        match self.vcpu_event_receiver.recv() {
-            Ok(DebugEvent::PEEK_REGS(state)) => {
-                regs.regs[0] = state.regular_regs.rax;
-                regs.regs[1] = state.regular_regs.rbx;
-                regs.regs[2] = state.regular_regs.rcx;
-                regs.regs[3] = state.regular_regs.rdx;
-                regs.regs[4] = state.regular_regs.rsi;
-                regs.regs[5] = state.regular_regs.rdi;
-                regs.regs[6] = state.regular_regs.rbp;
-                regs.regs[7] = state.regular_regs.rsp;
+        regs.regs[0] = self.guest_state.regular_regs.rax;
+        regs.regs[1] = self.guest_state.regular_regs.rbx;
+        regs.regs[2] = self.guest_state.regular_regs.rcx;
+        regs.regs[3] = self.guest_state.regular_regs.rdx;
+        regs.regs[4] = self.guest_state.regular_regs.rsi;
+        regs.regs[5] = self.guest_state.regular_regs.rdi;
+        regs.regs[6] = self.guest_state.regular_regs.rbp;
+        regs.regs[7] = self.guest_state.regular_regs.rsp;
 
-                regs.regs[8] = state.regular_regs.r8;
-                regs.regs[9] = state.regular_regs.r9;
-                regs.regs[10] = state.regular_regs.r10;
-                regs.regs[11] = state.regular_regs.r11;
-                regs.regs[12] = state.regular_regs.r12;
-                regs.regs[13] = state.regular_regs.r13;
-                regs.regs[14] = state.regular_regs.r14;
-                regs.regs[15] = state.regular_regs.r15;
+        regs.regs[8] = self.guest_state.regular_regs.r8;
+        regs.regs[9] = self.guest_state.regular_regs.r9;
+        regs.regs[10] = self.guest_state.regular_regs.r10;
+        regs.regs[11] = self.guest_state.regular_regs.r11;
+        regs.regs[12] = self.guest_state.regular_regs.r12;
+        regs.regs[13] = self.guest_state.regular_regs.r13;
+        regs.regs[14] = self.guest_state.regular_regs.r14;
+        regs.regs[15] = self.guest_state.regular_regs.r15;
 
-                regs.rip = state.regular_regs.rip;
-                regs.eflags = state.regular_regs.rflags as u32;
-            }
-            Ok(_) => println!("Error! Expecting PEEK_REGS packet"),
-            Err(_) => println!("Error receiving regs"),
-        }
-        Ok(())
+        regs.rip = self.guest_state.regular_regs.rip;
+        regs.eflags = self.guest_state.regular_regs.rflags as u32;
+
+        return Ok(());
     }
 
     fn write_registers(
@@ -148,17 +224,24 @@ impl Target for FirecrackerGDBServer {
         Ok(())
     }
 
+    /// Function that is called when the user or the GDB client requests a number of val.len
+    /// bytes from the guest memory at address 'addrs'
     fn read_addrs(
         &mut self,
         addrs: u64,
         val: &mut [u8],
     ) -> Result<bool, Self::Error> {
-        // The address passed to the "m" packet can be of the form 0x1000000
-        // or 0xffffff.... so u have to be prepared
-        for i in 0..val.len() {
-            val[i] = self.guest_memory.read_obj(GuestAddress((addrs & 0xfffffff) + (i as u64))).unwrap();
-        }
-        Ok(true)
+        return Debugger::virt_to_phys(addrs, &self, &self.guest_state)
+            .and_then(|phys_addr: u64| -> Result<bool, Self::Error> {
+                for i in 0..val.len() {
+                    if let Ok(byte) = self.guest_memory.read_obj(GuestAddress(phys_addr + (i as u64))) {
+                        val[i] = byte;
+                    } else {
+                        return Err(Self::Error::MemoryError);
+                    }
+                }
+                Ok(true)
+            } );
     }
 
     fn write_addrs(
@@ -169,20 +252,20 @@ impl Target for FirecrackerGDBServer {
         Ok(true)
     }
 
+    /// Function called when the user or the GDB client request the insertion/removal of a
+    /// software breakpoint
     fn update_sw_breakpoint(
         &mut self,
         addr: u64,
         op: BreakOp,
     ) -> Result<bool, Self::Error> {
-        //let phys_addr = Debugger::virt_to_phys(linear_addr, &self).unwrap();
-        let phys_addr = addr & 0xfffffff;
-
-        match op {
-            BreakOp::Add => self.insert_bp(phys_addr),
-            BreakOp::Remove => self.remove_bp(phys_addr),
-        }
-        
-        Ok(true)
+        return Debugger::virt_to_phys(addr, &self, &self.guest_state)
+            .and_then(|phys_addr: u64| -> Result<bool, Self::Error>{
+                match op {
+                    BreakOp::Add => self.insert_bp(phys_addr),
+                    BreakOp::Remove => self.remove_bp(phys_addr),
+                }.map(|_| true)
+            });
     }
 
     fn update_hw_breakpoint(

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use gdbstub::{arch, Actions, BreakOp, StopReason, Target, Tid, SINGLE_THREAD_TID};
 
-use super::{Bytes, Elf64_Phdr, GuestAddress, GuestMemoryMmap};
+use super::{Bytes, GuestAddress, GuestMemoryMmap};
 use super::{DebugEvent, Debugger, DebuggerError, FullVcpuState, Receiver, ResumeAction, Sender};
 use crate::DynResult;
+pub use kernel::loader::elf::Elf64_Phdr;
 
 pub struct FirecrackerGDBServer {
     pub guest_memory: GuestMemoryMmap,

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 
-use gdbstub::{
-    arch, Actions, BreakOp, StopReason, Target, Tid, SINGLE_THREAD_TID,
-};
+use gdbstub::{arch, Actions, BreakOp, StopReason, Target, Tid, SINGLE_THREAD_TID};
 
 use super::{Bytes, Elf64_Phdr, GuestAddress, GuestMemoryMmap};
 use super::{DebugEvent, Debugger, DebuggerError, FullVcpuState, Receiver, ResumeAction, Sender};

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -5,6 +5,7 @@ use gdbstub::{arch, Actions, BreakOp, StopReason, Target, Tid, SINGLE_THREAD_TID
 use super::{Bytes, GuestAddress, GuestMemoryMmap};
 use super::{DebugEvent, Debugger, DebuggerError, FullVcpuState, Receiver, ResumeAction, Sender};
 use crate::DynResult;
+#[cfg(target_arch = "x86_64")]
 pub use kernel::loader::elf::Elf64_Phdr;
 
 pub struct FirecrackerGDBServer {
@@ -24,10 +25,12 @@ pub struct FirecrackerGDBServer {
     pub guest_state: FullVcpuState,
     pub single_step_en: bool,
 
+    #[cfg(target_arch = "x86_64")]
     pub e_phdrs: Vec<Elf64_Phdr>,
     pub entry_addr: GuestAddress,
 }
 
+#[cfg(target_arch = "x86_64")]
 impl FirecrackerGDBServer {
     pub fn new(
         guest_memory: GuestMemoryMmap,
@@ -179,6 +182,7 @@ impl FirecrackerGDBServer {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 impl Target for FirecrackerGDBServer {
     type Arch = arch::x86::X86_64;
     type Error = DebuggerError;
@@ -307,6 +311,7 @@ impl Target for FirecrackerGDBServer {
     }
 
     /// Called when the user or the GDB client requests the guest state
+    #[cfg(target_arch = "x86_64")]
     fn read_registers(
         &mut self,
         regs: &mut arch::x86::reg::X86_64CoreRegs,
@@ -335,6 +340,7 @@ impl Target for FirecrackerGDBServer {
         Ok(())
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn write_registers(
         &mut self,
         regs: &arch::x86::reg::X86_64CoreRegs,

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -1,0 +1,96 @@
+use gdbstub::{
+    arch, BreakOp, OptResult, ResumeAction, StopReason, Target, Tid, TidSelector, WatchKind, SINGLE_THREAD_TID,
+};
+
+use crate::DynResult;
+pub struct FirecrackerGDBServer {
+}
+
+impl FirecrackerGDBServer {
+    pub fn new() -> DynResult<FirecrackerGDBServer> {
+        Ok(FirecrackerGDBServer{})
+    }
+}
+
+impl Target for FirecrackerGDBServer {
+    type Arch = arch::x86::X86_64;
+    type Error = &'static str;
+    
+    fn resume(
+        &mut self,
+        actions: &mut dyn Iterator<Item = (TidSelector, ResumeAction)>,
+        check_gdb_interrupt: &mut dyn FnMut() -> bool,
+    ) -> Result<(Tid, StopReason<u64>), Self::Error> {
+        Ok((SINGLE_THREAD_TID, StopReason::Halted))
+    }
+
+    fn read_registers(
+        &mut self,
+        regs: &mut arch::x86::reg::X86_64CoreRegs,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &arch::x86::reg::X86_64CoreRegs,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn read_addrs(
+        &mut self,
+        addrs: std::ops::Range<u64>,
+        val: &mut dyn FnMut(u8),
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: u64,
+        data: &[u8],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn update_sw_breakpoint(
+        &mut self,
+        addr: u64,
+        op: BreakOp,
+    ) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+
+    fn update_hw_breakpoint(
+        &mut self,
+        addr: u64,
+        op: BreakOp,
+    ) -> OptResult<bool, Self::Error> {
+        Ok(false)
+    }
+
+    fn update_hw_watchpoint(
+        &mut self,
+        addr: u64,
+        op: BreakOp,
+        kind: WatchKind,
+    ) -> OptResult<bool, Self::Error> {
+        Ok(false)
+    }
+
+    fn list_active_threads(
+        &mut self,
+        thread_is_active: &mut dyn FnMut(Tid),
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_current_thread(&mut self, tid: Tid) -> OptResult<(), Self::Error> {
+        Ok(())
+    }
+
+    fn is_thread_alive(&mut self, tid: Tid) -> OptResult<bool, Self::Error> {
+        Ok(false)
+    }
+}

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use gdbstub::{arch, Actions, BreakOp, StopReason, Target, Tid, SINGLE_THREAD_TID};

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -2,26 +2,49 @@ use gdbstub::{
     arch, BreakOp, OptResult, ResumeAction, StopReason, Target, Tid, TidSelector, WatchKind, SINGLE_THREAD_TID,
 };
 
+use super::{kvm_translation, kvm_sregs};
+use super::{Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, ByteValued};
+use super::VcpuFd;
 use crate::DynResult;
-pub struct FirecrackerGDBServer {
+
+const CR0_PG : u64 = 0x80000000;
+const CR4_PAE : u64 = 0x00000020;
+const CR4_LA57 : u64 = 0x00001000;
+const CR4_PSE : u64 = 0x00000010;
+const EFER_LME : u64 = 0x00000100;
+const EFER_LMA : u64 = 0x00000400;
+const PDPTE_PS : u64 = 0x00000080;
+const PDE_PS : u64 = 0x00000080;
+#[derive(PartialEq, Eq, Debug)]
+enum PAGING_TYPE {
+    NONE,
+    _32BIT,
+    PAE,
+    _4LVL,
+    _5LVL,
 }
 
-impl FirecrackerGDBServer {
-    pub fn new() -> DynResult<FirecrackerGDBServer> {
-        Ok(FirecrackerGDBServer{})
+pub struct FirecrackerGDBServer<'a> {
+    guest_memory : &'a GuestMemoryMmap,
+    vcpu : &'a VcpuFd,
+}
+
+impl<'a> FirecrackerGDBServer<'a> {
+    pub fn new<'b>(guest_memory: &'b GuestMemoryMmap, vcpu: &'b VcpuFd) -> DynResult <FirecrackerGDBServer<'b>> {
+        Ok(FirecrackerGDBServer{guest_memory, vcpu})
     }
 }
 
-impl Target for FirecrackerGDBServer {
+impl<'a> Target for FirecrackerGDBServer<'a> {
     type Arch = arch::x86::X86_64;
     type Error = &'static str;
     
     fn resume(
         &mut self,
-        actions: &mut dyn Iterator<Item = (TidSelector, ResumeAction)>,
+        actions: gdbstub::target::Actions,
         check_gdb_interrupt: &mut dyn FnMut() -> bool,
     ) -> Result<(Tid, StopReason<u64>), Self::Error> {
-        Ok((SINGLE_THREAD_TID, StopReason::Halted))
+        Ok((SINGLE_THREAD_TID, StopReason::DoneStep))
     }
 
     fn read_registers(
@@ -40,18 +63,18 @@ impl Target for FirecrackerGDBServer {
 
     fn read_addrs(
         &mut self,
-        addrs: std::ops::Range<u64>,
-        val: &mut dyn FnMut(u8),
-    ) -> Result<(), Self::Error> {
-        Ok(())
+        addrs: u64,
+        val: &mut [u8],
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
     }
 
     fn write_addrs(
         &mut self,
         start_addr: u64,
         data: &[u8],
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
     }
 
     fn update_sw_breakpoint(
@@ -59,7 +82,160 @@ impl Target for FirecrackerGDBServer {
         addr: u64,
         op: BreakOp,
     ) -> Result<bool, Self::Error> {
-        Ok(false)
+        let int3: u8 = 0xCC;
+        let mut linear_addr : u64 = addr;
+
+        /*
+        match self.vcpu.translate(new_addr) {
+            Ok(t) => println!("...Linear address {:x?} -> Physical address {:x?}", new_addr, t.physical_address),
+            Err(_) => println!("Translation failed"),
+        }
+        */
+
+        let context : kvm_sregs;
+        let mut pt_level = PAGING_TYPE::NONE;
+        match self.vcpu.get_sregs() {
+            Ok(sregs) => context = sregs,
+            Err(_) => return Err("Error retrieving registers"),
+        }
+        // Paging enabled
+        if context.cr0 & CR0_PG == 0 {
+
+        // Determine the type of paging
+        } else {
+            // See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual
+            pt_level = 
+            if context.cr4 & CR4_LA57 != 0 {
+                PAGING_TYPE::_5LVL
+            } else {
+                if context.efer & EFER_LME != 0 {
+                    PAGING_TYPE::_4LVL
+                } else {
+                    if context.cr4 & CR4_PAE != 0 {
+                        PAGING_TYPE::PAE
+                    } else {
+                        PAGING_TYPE::_32BIT
+                    }
+                }
+            }
+        }
+        println!("cr4 = {:x?}; cr3 = {:x?} efer={:x?}", context.cr4, context.cr3, context.efer);
+        println!("Paging type: {:?}", pt_level);
+
+        let mut paddr: u64 = 0;
+        let mut mask : u64 = 0;
+        let mut movem = 0;
+        if pt_level == PAGING_TYPE::PAE {
+            linear_addr &= 0x00000000ffffffffu64;
+            mask =  0x0000007fc0000000u64;
+
+            paddr = context.cr3 & 0x00000000ffffffe0u64;
+        } else {
+            if pt_level == PAGING_TYPE::_4LVL {
+                // Translation from 48 bits linear address
+                // to 52 bits physical address
+                linear_addr &= 0x0000ffffffffffffu64;
+                mask =  0x0000ff8000000000u64;
+
+                paddr = context.cr3 & 0x000ffffffffff000u64;
+                movem = 36;
+            } else {
+                // Performs a translation from 32 bits linear address
+                // to a 40 bits physical address
+                if pt_level == PAGING_TYPE::_32BIT {
+                    // The PDE physical address contains
+                    // on 31:12 -> bits 31:12 from cr3
+                    // on 11:2 -> bits 31:22 from the linear address
+                    // on 1:0 -> 0
+                    linear_addr &= 0x00000000ffffffffu64;
+                    mask =  0x00000000ffc00000u64;
+
+                    paddr = context.cr3 & 0x00000000fffff000u64;
+                    movem = 20;
+                }
+            }
+        }
+        println!("Linear address: {:x?}", linear_addr);
+        let mut d : u64; 
+        let mut add : u64 = 0x9000;
+        for i in 1..512 {
+            d = self.guest_memory.read_obj(GuestAddress(add)).unwrap();
+            println!("{:x?} : {:x?}", add, d);
+            add += 8;
+        }
+        paddr += (linear_addr & mask) >> movem;
+        let mut table_entry: u64 = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("PML4={:x?} and PML4E content={:x?}", paddr, table_entry);
+
+        mask >>= 9;
+        movem -= 9;
+        paddr = table_entry & 0x000ffffffffff000u64;
+        paddr += (linear_addr & mask) >> movem;
+        table_entry = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("PDPT={:x?} and PDPTE content={:x?}", paddr, table_entry);
+
+        if table_entry & PDPTE_PS != 0 {
+            // translation to 1GB page
+            println!("Translation to 1GB page");
+            paddr = table_entry & 0x000fffffc0000000u64;
+            // Final address
+            paddr += linear_addr & 0x3fffffffu64;
+        } else {
+            // translation to 2MB page
+            println!("Translation to 2MB page");
+            mask >>= 9;
+            movem -= 9;
+            paddr = table_entry & 0x000ffffffffff000u64;
+            paddr += (linear_addr & mask) >> movem;
+
+            table_entry = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+            println!("Page directory addr: {:x?} and PDE: {:x?}", paddr, table_entry);
+            if table_entry & PDE_PS != 0 {
+                // Final address
+                paddr = table_entry & 0x000ffffffff00000u64;
+                paddr += linear_addr & 0xfffff;
+            } else {
+                mask >>= 9;
+                movem -= 9;
+                paddr = table_entry & 0x000ffffffffff000u64;
+                paddr += (linear_addr & mask) >> movem;
+
+                table_entry = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+                println!("2MB page addr: {:x?} and the entry: {:x?}", paddr, table_entry);
+                // Final address
+                paddr = table_entry & 0x000ffffffffff000u64;
+                paddr += linear_addr & 0xfff;
+            }
+        }
+        let data: u64 = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("Final address: {:x?} and data: {:x?}", paddr, data);
+        //if context.cr4 & CR4_PSE == 0 {
+            
+            // The PTE physical address contains
+            // on 31:12 -> 31:12 from pde
+            // on 11:2 -> 21:12 from the linear address
+            // on 1:0 -> 0
+        
+        /*    mask >>= 10;
+            paddr = pde & (!0xfffu64);
+            paddr += (linear_addr & mask) >> 10;
+            let raw_pte: u32 = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+            let pte: u64 = raw_pte.into();
+            println!("PTE address: {:x?} and content: {}", paddr, pte);
+        */    
+            // The final physical address contains
+            // on 31:12 -> 31:12 from pte
+            // on 11:0 -> 11:0 from the linear address
+        /*    mask = 0xfff;
+            paddr = pte & (!0xfffu64);
+            paddr += linear_addr & mask;
+            let data: u32 = self.guest_memory.read_obj(GuestAddress(0x1000000 + paddr)).unwrap();
+            println!("At address {:x?} it's {}", paddr, data);
+        */
+        //}
+
+        //self.guest_memory.write_obj(int3, GuestAddress(new_addr));
+        Ok(true)
     }
 
     fn update_hw_breakpoint(
@@ -76,21 +252,6 @@ impl Target for FirecrackerGDBServer {
         op: BreakOp,
         kind: WatchKind,
     ) -> OptResult<bool, Self::Error> {
-        Ok(false)
-    }
-
-    fn list_active_threads(
-        &mut self,
-        thread_is_active: &mut dyn FnMut(Tid),
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn set_current_thread(&mut self, tid: Tid) -> OptResult<(), Self::Error> {
-        Ok(())
-    }
-
-    fn is_thread_alive(&mut self, tid: Tid) -> OptResult<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/src/gdb_server/src/target.rs
+++ b/src/gdb_server/src/target.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use gdbstub::{
-    arch, BreakOp, OptResult, StopReason, Target, Tid, WatchKind, SINGLE_THREAD_TID, Actions,
+    arch, Actions, BreakOp, OptResult, StopReason, Target, Tid, WatchKind, SINGLE_THREAD_TID,
 };
 
-use super::{DebuggerError, Debugger, DebugEvent, Receiver, Sender, ResumeAction, FullVcpuState};
-use super::{Bytes, GuestAddress, GuestMemoryMmap, Elf64_Phdr};
+use super::{Bytes, Elf64_Phdr, GuestAddress, GuestMemoryMmap};
+use super::{DebugEvent, Debugger, DebuggerError, FullVcpuState, Receiver, ResumeAction, Sender};
 use crate::DynResult;
 
 pub struct FirecrackerGDBServer {
@@ -29,19 +29,36 @@ pub struct FirecrackerGDBServer {
 }
 
 impl FirecrackerGDBServer {
-    pub fn new(guest_memory: GuestMemoryMmap,
+    pub fn new(
+        guest_memory: GuestMemoryMmap,
         vcpu_event_receiver: Receiver<DebugEvent>,
         vcpu_event_sender: Sender<DebugEvent>,
-        e_phdrs: Vec<Elf64_Phdr>) -> DynResult <FirecrackerGDBServer > {
-        Ok(FirecrackerGDBServer{guest_memory, vcpu_event_receiver, vcpu_event_sender,
-            breakpoints_linear: HashMap::new(), breakpoints_phys: HashMap::new(),
-            guest_state: Default::default(), single_step_en: false, e_phdrs})
+        e_phdrs: Vec<Elf64_Phdr>,
+    ) -> DynResult<FirecrackerGDBServer> {
+        Ok(FirecrackerGDBServer {
+            guest_memory,
+            vcpu_event_receiver,
+            vcpu_event_sender,
+            breakpoints_linear: HashMap::new(),
+            breakpoints_phys: HashMap::new(),
+            guest_state: Default::default(),
+            single_step_en: false,
+            e_phdrs,
+        })
     }
 
-    pub fn remove_bp(&mut self, linear_addr: u64, phys_addr: Option<u64>) -> Result<(), DebuggerError> {
+    pub fn remove_bp(
+        &mut self,
+        linear_addr: u64,
+        phys_addr: Option<u64>,
+    ) -> Result<(), DebuggerError> {
         if phys_addr.is_some() && self.breakpoints_phys.contains_key(&phys_addr.unwrap()) {
             let val = self.breakpoints_phys.get_mut(&phys_addr.unwrap()).unwrap();
-            if self.guest_memory.write_obj(val.0, GuestAddress(phys_addr.unwrap())).is_err() {
+            if self
+                .guest_memory
+                .write_obj(val.0, GuestAddress(phys_addr.unwrap()))
+                .is_err()
+            {
                 return Err(DebuggerError::MemoryError);
             }
             val.1 = false;
@@ -51,7 +68,11 @@ impl FirecrackerGDBServer {
         if phys_addr.is_none() && self.breakpoints_linear.contains_key(&linear_addr) {
             let val = self.breakpoints_linear.get_mut(&linear_addr).unwrap();
             if val.2 {
-                if self.guest_memory.write_obj(val.0, GuestAddress(val.1)).is_err() {
+                if self
+                    .guest_memory
+                    .write_obj(val.0, GuestAddress(val.1))
+                    .is_err()
+                {
                     return Err(DebuggerError::MemoryError);
                 }
                 val.2 = false;
@@ -60,7 +81,7 @@ impl FirecrackerGDBServer {
 
         Ok(())
     }
-    pub fn insert_bp(&mut self, linear_addr: u64, translate: bool) -> Result<(), DebuggerError>{
+    pub fn insert_bp(&mut self, linear_addr: u64, translate: bool) -> Result<(), DebuggerError> {
         // Opcode specific to x86 architecture that triggers a trap when
         // encountered during cpu execution
         let int3: u8 = 0xCC;
@@ -68,12 +89,16 @@ impl FirecrackerGDBServer {
         if self.breakpoints_linear.contains_key(&linear_addr) {
             let val = self.breakpoints_linear.get_mut(&linear_addr).unwrap();
             if !val.2 {
-                if self.guest_memory.write_obj(int3, GuestAddress(val.1)).is_err() {
+                if self
+                    .guest_memory
+                    .write_obj(int3, GuestAddress(val.1))
+                    .is_err()
+                {
                     return Err(DebuggerError::MemoryError);
                 }
                 val.2 = true;
             }
-            return Ok(())
+            return Ok(());
         }
         let mut phys_addr = linear_addr;
         // Breakpoint has never been set until now
@@ -84,7 +109,9 @@ impl FirecrackerGDBServer {
                 }
                 // We dont want to interrupt the whole debugging process because of an invalid address
                 // This breakpoint simply wont be hit
-                Err(_) => { return Ok(()); }
+                Err(_) => {
+                    return Ok(());
+                }
             }
         }
         // A breakpoint at the same physical address has already been placed
@@ -102,13 +129,19 @@ impl FirecrackerGDBServer {
                 return Err(DebuggerError::MemoryError);
             }
 
-            if self.guest_memory.write_obj(int3, GuestAddress(phys_addr)).is_err() {
+            if self
+                .guest_memory
+                .write_obj(int3, GuestAddress(phys_addr))
+                .is_err()
+            {
                 return Err(DebuggerError::MemoryError);
             }
         }
 
-        self.breakpoints_linear.insert(linear_addr, (opcode.unwrap(), phys_addr, true));
-        self.breakpoints_phys.insert(phys_addr, (opcode.unwrap(), true));
+        self.breakpoints_linear
+            .insert(linear_addr, (opcode.unwrap(), phys_addr, true));
+        self.breakpoints_phys
+            .insert(phys_addr, (opcode.unwrap(), true));
 
         Ok(())
     }
@@ -129,8 +162,9 @@ impl FirecrackerGDBServer {
     /// it would confuse the client.
     fn invalid_state(&self, rip: u64) -> bool {
         if self.breakpoints_linear.contains_key(&rip)
-            && self.breakpoints_linear.get(&rip).unwrap().2 {
-            return  false;
+            && self.breakpoints_linear.get(&rip).unwrap().2
+        {
+            return false;
         }
         return true;
     }
@@ -139,14 +173,13 @@ impl FirecrackerGDBServer {
 impl Target for FirecrackerGDBServer {
     type Arch = arch::x86::X86_64;
     type Error = DebuggerError;
-    
+
     /// Function that is called when a continue/single-step packet is received from client
     fn resume(
         &mut self,
         actions: Actions,
         check_gdb_interrupt: &mut dyn FnMut() -> bool,
     ) -> Result<(Tid, StopReason<u64>), Self::Error> {
-
         for item in actions {
             match item.1 {
                 ResumeAction::Continue => {
@@ -154,26 +187,38 @@ impl Target for FirecrackerGDBServer {
                     // valid breakpoint being hit
                     let mut valid_bp_not_reached = true;
                     while valid_bp_not_reached {
-                        if self.vcpu_event_sender.send(DebugEvent::CONTINUE(self.single_step_en)).is_err() {
+                        if self
+                            .vcpu_event_sender
+                            .send(DebugEvent::CONTINUE(self.single_step_en))
+                            .is_err()
+                        {
                             return Err(Self::Error::ChannelError);
                         }
                         self.single_step_en = false;
                         let mut interrupted = false;
                         while !check_gdb_interrupt() {
-                            if let Ok(DebugEvent::NOTIFY(state)) = self.vcpu_event_receiver.try_recv() {
+                            if let Ok(DebugEvent::NOTIFY(state)) =
+                                self.vcpu_event_receiver.try_recv()
+                            {
                                 interrupted = true;
                                 self.guest_state = state;
-                                valid_bp_not_reached = self.invalid_state(self.guest_state.regular_regs.rip);
+                                valid_bp_not_reached =
+                                    self.invalid_state(self.guest_state.regular_regs.rip);
                                 if valid_bp_not_reached {
                                     // Normally we shouldn't have to translate an address in order
                                     // to remove a breakpoint, but in early boot the virtual
                                     // address that EIP stores may not be the same one with
                                     // the address the user is thinking of, which would be, indeed,
                                     // an invalid one
-                                    match Debugger::virt_to_phys(self.guest_state.regular_regs.rip, &self) {
+                                    match Debugger::virt_to_phys(
+                                        self.guest_state.regular_regs.rip,
+                                        &self,
+                                    ) {
                                         Ok(phys_addr) => {
-                                            if let Err(e)
-                                                = self.remove_bp(self.guest_state.regular_regs.rip, Some(phys_addr)) {
+                                            if let Err(e) = self.remove_bp(
+                                                self.guest_state.regular_regs.rip,
+                                                Some(phys_addr),
+                                            ) {
                                                 return Err(e);
                                             }
                                         }
@@ -196,14 +241,20 @@ impl Target for FirecrackerGDBServer {
                 ResumeAction::Step => {
                     let prev_rip = self.guest_state.regular_regs.rip;
                     loop {
-                        if self.vcpu_event_sender.send(DebugEvent::STEP_INTO(self.single_step_en)).is_err() {
+                        if self
+                            .vcpu_event_sender
+                            .send(DebugEvent::STEP_INTO(self.single_step_en))
+                            .is_err()
+                        {
                             return Err(Self::Error::ChannelError);
                         }
                         // Main thread will take care of what it means enabling/disabling single-stepping
                         self.single_step_en = true;
                         let mut interrupted = false;
                         while !check_gdb_interrupt() {
-                            if let Ok(DebugEvent::NOTIFY(state)) = self.vcpu_event_receiver.try_recv() {
+                            if let Ok(DebugEvent::NOTIFY(state)) =
+                                self.vcpu_event_receiver.try_recv()
+                            {
                                 interrupted = true;
                                 self.guest_state = state;
                                 break;
@@ -259,7 +310,7 @@ impl Target for FirecrackerGDBServer {
         regs.rip = self.guest_state.regular_regs.rip;
         regs.eflags = self.guest_state.regular_regs.rflags as u32;
 
-        return Ok(());
+        Ok(())
     }
 
     fn write_registers(
@@ -271,14 +322,13 @@ impl Target for FirecrackerGDBServer {
 
     /// Function that is called when the user or the GDB client requests a number of val.len
     /// bytes from the guest memory at address 'addrs'
-    fn read_addrs(
-        &mut self,
-        addrs: u64,
-        val: &mut [u8],
-    ) -> Result<bool, Self::Error> {
+    fn read_addrs(&mut self, addrs: u64, val: &mut [u8]) -> Result<bool, Self::Error> {
         if let Ok(phys_addr) = Debugger::virt_to_phys(addrs, &self) {
             for i in 0..val.len() {
-                if let Ok(byte) = self.guest_memory.read_obj(GuestAddress(phys_addr + (i as u64))) {
+                if let Ok(byte) = self
+                    .guest_memory
+                    .read_obj(GuestAddress(phys_addr + (i as u64)))
+                {
                     val[i] = byte;
                 } else {
                     return Err(Self::Error::MemoryError);
@@ -289,33 +339,21 @@ impl Target for FirecrackerGDBServer {
         Ok(false)
     }
 
-    fn write_addrs(
-        &mut self,
-        start_addr: u64,
-        data: &[u8],
-    ) -> Result<bool, Self::Error> {
+    fn write_addrs(&mut self, start_addr: u64, data: &[u8]) -> Result<bool, Self::Error> {
         Ok(true)
     }
 
     /// Function called when the user or the GDB client request the insertion/removal of a
     /// software breakpoint
-    fn update_sw_breakpoint(
-        &mut self,
-        addr: u64,
-        op: BreakOp,
-    ) -> Result<bool, Self::Error> {
-        return
-            match op {
-                BreakOp::Add => self.insert_bp(addr, true),
-                BreakOp::Remove => self.remove_bp(addr, None),
-            }.map(|_| true);
+    fn update_sw_breakpoint(&mut self, addr: u64, op: BreakOp) -> Result<bool, Self::Error> {
+        return match op {
+            BreakOp::Add => self.insert_bp(addr, true),
+            BreakOp::Remove => self.remove_bp(addr, None),
+        }
+        .map(|_| true);
     }
 
-    fn update_hw_breakpoint(
-        &mut self,
-        addr: u64,
-        op: BreakOp,
-    ) -> OptResult<bool, Self::Error> {
+    fn update_hw_breakpoint(&mut self, addr: u64, op: BreakOp) -> OptResult<bool, Self::Error> {
         Ok(false)
     }
 

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -97,6 +97,7 @@ pub enum DebuggerError {
     IoctlError(Error),
     InvalidLinearAddress,
     UnsupportedPagingStrategy,
+    PageNotFound,
 }
 
 impl Display for DebuggerError {
@@ -180,7 +181,6 @@ impl Debugger {
     ) -> Result<u64, DebuggerError> {
         let mut linear_addr = addr;
         let pt_level = Debugger::get_paging_strategy(&guest_state.special_regs);
-
         let mut paddr: u64;
         let mut mask: u64;
         let mut movem;

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -2,9 +2,11 @@ use std::fmt::{Display, Formatter};
 use vm_memory::Bytes;
 use vmm_sys_util::errno::Error;
 
-pub use super::arch::x86_64::regs::setup_sregs;
+pub use arch::x86_64::regs::setup_sregs;
+pub use kernel::loader::elf::{Elf64_Phdr, PT_LOAD};
+
 use super::kvm_bindings::*;
-use super::{Elf64_Phdr, GuestAddress, GuestMemoryMmap, VcpuFd, PT_LOAD};
+use super::{GuestAddress, GuestMemoryMmap, VcpuFd};
 
 // See Chapter 2.5 (Control Registers), Volume 3A in Intel Arch SW Developer's Manual.
 // Bit 0 of CR0 register on x86 architecture

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -4,23 +4,60 @@ use vmm_sys_util::errno::Error;
 
 pub use super::arch::x86_64::regs::setup_sregs;
 use super::kvm_bindings::*;
-use super::target::FirecrackerGDBServer;
 use super::{Elf64_Phdr, GuestAddress, GuestMemoryMmap, VcpuFd, PT_LOAD};
 
+// See Chapter 2.5 (Control Registers), Volume 3A in Intel Arch SW Developer's Manual.
+// Bit 0 of CR0 register on x86 architecture
 const CR0_PG: u64 = 0x80000000;
+// Bit 5 of CR4 register on x86 architecture
 const CR4_PAE: u64 = 0x00000020;
+// Bit 12 of CR4 register on x86 architecture
 const CR4_LA57: u64 = 0x00001000;
+
+// See Chapter 2.2.1 (Extended Feature Enable Register),
+// Volume 3A in Intel Arch SW Developer's Manual.
+// Bit 8 of IA32_EFER register on x86 architecture
 const EFER_LME: u64 = 0x00000100;
+
+// See Tables 4.16 - 4.18, Volume 3A in Intel Arch SW Developer's Manual.
+// Bit 7 of a PDPT entry
 const PDPTE_PS: u64 = 0x00000080;
+// Bit 7 of a PD entry
 const PDE_PS: u64 = 0x00000080;
 
+// See Chapter 4.7, Volume 3A in Intel Arch SW Developer's Manual.
+// Bit 0 in any level's page table entry. Marks whether a valid translation
+// is available
 const BIT_P: u64 = 0x1;
 
 // [PML4E, PDPTE_PS0, PDPTE_PS1, PDE_PS0, PDE_PS1, PTE]
 const TABLE_ENTRY_RSVD_BITS: [u64; 6] = [0x80, 0x0, 0x3fffe000, 0x0, 0x1fe000, 0x0];
 
+// Bits 51:12 of register CR3 and mostly any page table entry that follows.
+// These bits become part of the next level's entry address
 const TABLE_ENTRY_MASK: u64 = 0x000ffffffffff000u64;
+// Bits 51:30 of a PDPT entry when PS flag is 1.
+// These bits become part of a 1GB memory region start address
+const PDPTE_PS_ENTRY_MASK: u64 = 0x000fffffc0000000u64;
+// Bits 51:21 of PD entry when PS flag is 1.
+// These bits become part of a 2MB page table start address
+const PDE_PS_ENTRY_MASK: u64 = 0x000fffffffe00000u64;
 
+// In 4-Level paging mode we only need first 52 bits
+const LINEAR_ADDR_FULL_MASK: u64 = 0x0000ffffffffffffu64;
+// Mask of bits in the linear address that are to be part of PML4 entry address
+const LINEAR_ADDR_PML4_MASK: u64 = 0x0000ff8000000000u64;
+// Mask of bits in the linear address that are to be part of the final physical
+// address together with bits from a PDPT entry when PS flag is 1
+const LINEAR_ADDR_PDPTE_PS_MASK: u64 = 0x3fffffffu64;
+// Mask of bits in the linear address that are to be part of the final physical
+// address together with bits from a PD entry when PS flag is 1
+const LINEAR_ADDR_PDE_PS_MASK: u64 = 0x1fffff;
+// Mask of bits in the linear address that are to be part of the final physical
+// address together with bits from a PT entry
+const LINEAR_ADDR_PTE_MASK: u64 = 0xfff;
+
+// Possible paging modes on x86 architecture
 #[derive(PartialEq, Eq, Debug)]
 enum PagingType {
     NONE,
@@ -31,15 +68,15 @@ enum PagingType {
 }
 
 pub enum DebugEvent {
-    START,
-    NOTIFY(FullVcpuState),
-    GET_REGS,
-    PEEK_REGS(FullVcpuState),
-    CONTINUE(bool),
-    STEP_INTO(bool),
+    Notify(FullVcpuState),
+    SetRegs(FullVcpuState),
+    GetRegs,
+    PeekRegs(FullVcpuState),
+    Continue(bool),
+    StepInto(bool),
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct FullVcpuState {
     pub regular_regs: kvm_regs,
     pub special_regs: kvm_sregs,
@@ -82,9 +119,17 @@ impl Display for DebuggerError {
 pub struct Debugger;
 
 impl Debugger {
+    /// Enables KVM support for debugging. We make use of the capability
+    /// of KVM to generate a KVM_EXIT either when encountering a breakpoint
+    /// or after executing an instruction in single-step mode
+    ///
+    /// # Arguments
+    ///
+    /// * `vcpu` - reference of a vCPU object
+    /// * `step` - tells whether we want to generate a KVM_EXIT when encountering
+    ///             a breakpoint or after executing the next instruction (single-step)
     pub fn enable_kvm_debug(vcpu: &VcpuFd, step: bool) -> Result<(), DebuggerError> {
-        let mut control: __u32 = 0;
-        control |= KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP;
+        let mut control: __u32 = KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP;
         if step {
             control |= KVM_GUESTDBG_SINGLESTEP;
         }
@@ -103,57 +148,53 @@ impl Debugger {
         Ok(())
     }
 
-    /// Function that performs guest page-walking, on top of the 4-Level paging mechanism,
-    /// obtaining the physical address corresponding to the one received from a GDB client
+    /// Performs guest page-walking, on top of the 4-Level paging mechanism,
+    /// obtaining the physical address corresponding to the one received from a GDB client.
+    /// In case no valid entry is discovered in the page tables, the physical address
+    /// will be obtained by directly subtracting an offset - computed by using information
+    /// from the ELF executable only.
+    ///
+    /// See Chapter 4.5, Volume 3A in  Intel® 64 and IA-32 Architectures Software Developer’s Manual
+    /// for a detailed description of how this paging strategy works.
+    /// # Arguments
+    ///
+    /// * `addr`            - linear guest address to be translated.
+    /// * `guest_memory`    - guest memory mapping, from which we read page table entries
+    /// * `guest_state`     - current state of all guest registers, used in determining the paging
+    ///                     strategy and the start address of the paging hierarchy
+    /// * `e_phdrs`         - program headers of the kernel image, used in determining the physical
+    ///                     address when paging is not available
     pub fn virt_to_phys(
         addr: u64,
-        gm: &GuestMemoryMmap,
+        guest_memory: &GuestMemoryMmap,
         guest_state: &FullVcpuState,
         e_phdrs: &Vec<Elf64_Phdr>,
     ) -> Result<u64, DebuggerError> {
         let mut linear_addr = addr;
-        let context: kvm_sregs;
-        let mut pt_level = PagingType::NONE;
+        let pt_level = Debugger::get_paging_strategy(&guest_state.special_regs);
 
-        context = guest_state.special_regs;
-        // Paging enabled
-        if context.cr0 & CR0_PG != 0 {
-            // Determine the type of paging
-            // See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual
-            pt_level = if context.cr4 & CR4_LA57 != 0 {
-                PagingType::_5LVL
-            } else {
-                if context.efer & EFER_LME != 0 {
-                    PagingType::_4LVL
-                } else {
-                    if context.cr4 & CR4_PAE != 0 {
-                        PagingType::PAE
-                    } else {
-                        PagingType::_32BIT
-                    }
-                }
-            }
-        }
-
-        let mut paddr: u64 = 0;
-        let mut mask: u64 = 0;
-        let mut movem = 0;
+        let mut paddr: u64;
+        let mut mask: u64;
+        let mut movem;
         if pt_level == PagingType::_4LVL {
             // Translation from 48 bits linear address
             // to 52 bits physical address
-            linear_addr &= 0x0000ffffffffffffu64;
-            mask = 0x0000ff8000000000u64;
+            linear_addr &= LINEAR_ADDR_FULL_MASK;
+            mask = LINEAR_ADDR_PML4_MASK;
 
-            paddr = context.cr3 & 0x000ffffffffff000u64;
+            paddr = guest_state.special_regs.cr3 & TABLE_ENTRY_MASK;
+            // Shift value for the linear address bits in the PML4 entry address
             movem = 36;
         } else {
             return Err(DebuggerError::UnsupportedPagingStrategy);
         }
 
+        // Computing address of PML4 entry address
         paddr += (linear_addr & mask) >> movem;
 
         let mut table_entry;
-        if let Ok(e) = gm.read_obj(GuestAddress(paddr)) {
+        // Retrieving PML4 entry
+        if let Ok(e) = guest_memory.read_obj(GuestAddress(paddr)) {
             table_entry = e;
         } else {
             return Err(DebuggerError::MemoryError);
@@ -163,21 +204,25 @@ impl Debugger {
             return Debugger::fixup_pointer(addr, e_phdrs);
         }
 
-        // There is one loop iteration for each level (PDPT, PDT, PT);
+        // There is one loop iteration for each page-table level (PDPT, PDT, PT);
         // However, the way we check for the validity of the entry
         // changes for the first two, depending on the PS flag. Therefore,
         // we have to either keep track of the index in the TABLE_ENTRY_RSVD_BITS
         // array or create individual const symbols for each possible value or
-        // const symbols for each index
+        // const symbols for each index. We chose the first.
         let mut rsvd_idx = 0;
         for i in 0..3 {
             rsvd_idx = 2 * i + 1;
 
+            // Number of bits (9) and the shift value (9) for the part of the linear address
+            // that is used in the computation of next level's entry address are both
+            // constant with the exception of PDPT and PD entries when PS flag is 1.
+            // In that case, instead of ((addr & mask) >> movem) we simply use (addr & mask)
             mask >>= 9;
             movem -= 9;
             paddr = table_entry & TABLE_ENTRY_MASK;
             paddr += (linear_addr & mask) >> movem;
-            if let Ok(e) = gm.read_obj(GuestAddress(paddr)) {
+            if let Ok(e) = guest_memory.read_obj(GuestAddress(paddr)) {
                 table_entry = e;
             } else {
                 return Err(DebuggerError::MemoryError);
@@ -188,8 +233,8 @@ impl Debugger {
                 0 => {
                     if (table_entry & PDPTE_PS) != 0 {
                         // Final address
-                        paddr = table_entry & 0x000fffffc0000000u64;
-                        paddr += linear_addr & 0x3fffffffu64;
+                        paddr = table_entry & PDPTE_PS_ENTRY_MASK;
+                        paddr += linear_addr & LINEAR_ADDR_PDPTE_PS_MASK;
                         rsvd_idx = 2 * i + 2;
                         break;
                     }
@@ -197,16 +242,16 @@ impl Debugger {
                 1 => {
                     if (table_entry & PDE_PS) != 0 {
                         // Final address
-                        paddr = table_entry & 0x000fffffffe00000u64;
-                        paddr += linear_addr & 0x1fffff;
+                        paddr = table_entry & PDE_PS_ENTRY_MASK;
+                        paddr += linear_addr & LINEAR_ADDR_PDE_PS_MASK;
                         rsvd_idx = 2 * i + 2;
                         break;
                     }
                 }
                 2 => {
                     // Final address
-                    paddr = table_entry & 0x000ffffffffff000u64;
-                    paddr += linear_addr & 0xfff;
+                    paddr = table_entry & TABLE_ENTRY_MASK;
+                    paddr += linear_addr & LINEAR_ADDR_PTE_MASK;
                     break;
                 }
                 _ => {
@@ -224,8 +269,45 @@ impl Debugger {
         Ok(paddr)
     }
 
+    /// Determines the type of paging that is currently used by the guest.
+    /// Bits from registers CR0, CR4 and IA32_EFER are used for determining
+    /// the exact paging mode.
+    ///
+    /// See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual.
+    /// # Arguments
+    ///
+    /// * `context` - special registers corresponding to the current state of the vCPU   
+    fn get_paging_strategy(context: &kvm_sregs) -> PagingType {
+        let mut pt_level: PagingType = PagingType::NONE;
+        // Paging enabled
+        if context.cr0 & CR0_PG != 0 {
+            pt_level = if context.cr4 & CR4_LA57 != 0 {
+                PagingType::_5LVL
+            } else {
+                if context.efer & EFER_LME != 0 {
+                    PagingType::_4LVL
+                } else {
+                    if context.cr4 & CR4_PAE != 0 {
+                        PagingType::PAE
+                    } else {
+                        PagingType::_32BIT
+                    }
+                }
+            };
+        }
+        pt_level
+    }
+
     /// Checks whether the current table entry is valid (there is a valid translation
     /// for the linear address)
+    ///
+    /// See Chapter 4.7, Volume 3A in Intel Arch SW Developer's Manual.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry`           - contents of a page table entry
+    /// * `reserved_bits`   - depending on the actual page table the entry belongs to,
+    ///                     values of bits that that should not be set.
     fn check_entry(entry: u64, reserved_bits: u64) -> Result<(), DebuggerError> {
         if entry & BIT_P == 0 {
             return Err(DebuggerError::InvalidLinearAddress);
@@ -240,6 +322,12 @@ impl Debugger {
     /// Following the kernel strategy, during the early boot phase, before the notion
     /// of virtual addresses has been put in place, we obtain the corresponding
     /// physical address by subtracting the section offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr`    - linear address for which a valid translation through the page table
+    ///             mechanism was not found
+    /// * `e_phdrs` - ELF program headers   
     fn fixup_pointer(addr: u64, e_phdrs: &Vec<Elf64_Phdr>) -> Result<u64, DebuggerError> {
         for phdr in e_phdrs {
             if (phdr.p_type & PT_LOAD) == 0 {

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -30,7 +30,7 @@ enum PagingType {
 
 pub enum DebugEvent {
     START,
-    NOTIFY,
+    NOTIFY(FullVcpuState),
     GET_REGS,
     PEEK_REGS(FullVcpuState),
     CONTINUE(bool),
@@ -90,12 +90,12 @@ impl Debugger {
 
     /// Function that performs guest page-walking, on top of the 4-Level paging mechanism,
     /// obtaining the physical address corresponding to the one received from a GDB client
-    pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer, regs: &FullVcpuState) -> Result<u64, DebuggerError> {
+    pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer) -> Result<u64, DebuggerError> {
         let mut linear_addr = addr;
         let context : kvm_sregs;
         let mut pt_level = PagingType::NONE;
 
-        context = regs.special_regs;
+        context = srv.guest_state.special_regs;
         // Paging enabled
         if context.cr0 & CR0_PG != 0 {
         // Determine the type of paging

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::{Display, Formatter};
 use vm_memory::Bytes;
 use vmm_sys_util::errno::Error;

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -2,7 +2,9 @@ use std::fmt::{Display, Formatter};
 use vm_memory::Bytes;
 use vmm_sys_util::errno::Error;
 
+#[cfg(target_arch = "x86_64")]
 pub use arch::x86_64::regs::setup_sregs;
+#[cfg(target_arch = "x86_64")]
 pub use kernel::loader::elf::{Elf64_Phdr, PT_LOAD};
 
 use super::kvm_bindings::*;
@@ -120,6 +122,7 @@ impl Display for DebuggerError {
 
 pub struct Debugger;
 
+#[cfg(target_arch = "x86_64")]
 impl Debugger {
     /// Enables KVM support for debugging. We make use of the capability
     /// of KVM to generate a KVM_EXIT either when encountering a breakpoint
@@ -344,6 +347,7 @@ impl Debugger {
 }
 
 #[cfg(test)]
+#[cfg(target_arch = "x86_64")]
 mod tests {
     use super::setup_sregs;
     use kvm_ioctls::Kvm;

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -258,6 +258,9 @@ impl Debugger {
                     return Err(DebuggerError::InvalidState);
                 }
             }
+            // After each page table iteration we check whether the current entry is valid.
+            // If that is not the case, we try saving the translation process by skipping
+            // the page tables altogether and using direct translation through offset subtraction.
             if Debugger::check_entry(table_entry, TABLE_ENTRY_RSVD_BITS[rsvd_idx]).is_err() {
                 return Debugger::fixup_pointer(addr, e_phdrs);
             }

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -1,0 +1,206 @@
+use super::target::FirecrackerGDBServer;
+
+use super::kvm_bindings::*;
+use super::{Bytes, GuestAddress, VcpuFd};
+
+const CR0_PG : u64 = 0x80000000;
+const CR4_PAE : u64 = 0x00000020;
+const CR4_LA57 : u64 = 0x00001000;
+const CR4_PSE : u64 = 0x00000010;
+const EFER_LME : u64 = 0x00000100;
+const EFER_LMA : u64 = 0x00000400;
+const PDPTE_PS : u64 = 0x00000080;
+const PDE_PS : u64 = 0x00000080;
+#[derive(PartialEq, Eq, Debug)]
+enum PagingType {
+    NONE,
+    _32BIT,
+    PAE,
+    _4LVL,
+    _5LVL,
+}
+
+pub enum DebugEvent {
+    START,
+    PRINT_PTs(u64),
+    GET_REGS,
+    PEEK_REGS(FullVcpuState),
+    CONTINUE(bool),
+    STEP_INTO(bool),
+    BREAKPOINT,
+}
+
+pub struct FullVcpuState {
+    pub regular_regs : kvm_regs,
+    pub special_regs : kvm_sregs,
+}
+pub struct Debugger;
+
+impl Debugger {
+    pub fn enable_kvm_debug(vcpu: &VcpuFd, step: bool) {
+        let mut control : __u32 = 0;
+        control |= KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP;
+        if (step) {
+            control |= KVM_GUESTDBG_SINGLESTEP;
+        }
+        let debug_struct = kvm_guest_debug {
+            control : control,
+            pad : 0,
+            arch : kvm_guest_debug_arch { debugreg : [0,0,0,0,0,0,0,0]},
+        };
+ 
+        match vcpu.set_guest_debug(&debug_struct) {
+            Ok(_) => println!("Done setting the kvm guest debug flags"),
+            Err(_) => println!("Setting of KVM_SET_GUEST_DEBUG failed"),
+        }
+    }
+
+    pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer, regs: FullVcpuState) -> Result<u64, &'static str> {
+        /*
+        match self.vcpu.translate(new_addr) {
+            Ok(t) => println!("...Linear address {:x?} -> Physical address {:x?}", new_addr, t.physical_address),
+            Err(_) => println!("Translation failed"),
+        }
+        */
+        let mut linear_addr = addr;
+        let context : kvm_sregs;
+        let mut pt_level = PagingType::NONE;
+        
+        context = regs.special_regs;
+        // Paging enabled
+        if context.cr0 & CR0_PG == 0 {
+
+        // Determine the type of paging
+        } else {
+            // See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual
+            pt_level = 
+            if context.cr4 & CR4_LA57 != 0 {
+                PagingType::_5LVL
+            } else {
+                if context.efer & EFER_LME != 0 {
+                    PagingType::_4LVL
+                } else {
+                    if context.cr4 & CR4_PAE != 0 {
+                        PagingType::PAE
+                    } else {
+                        PagingType::_32BIT
+                    }
+                }
+            }
+        }
+        println!("cr4 = {:x?}; cr3 = {:x?} efer={:x?}", context.cr4, context.cr3, context.efer);
+        println!("Paging type: {:?}", pt_level);
+
+        let mut paddr: u64 = 0;
+        let mut mask : u64 = 0;
+        let mut movem = 0;
+        if pt_level == PagingType::PAE {
+            linear_addr &= 0x00000000ffffffffu64;
+            mask =  0x0000007fc0000000u64;
+
+            paddr = context.cr3 & 0x00000000ffffffe0u64;
+        } else {
+            if pt_level == PagingType::_4LVL {
+                // Translation from 48 bits linear address
+                // to 52 bits physical address
+                linear_addr &= 0x0000ffffffffffffu64;
+                mask =  0x0000ff8000000000u64;
+
+                paddr = context.cr3 & 0x000ffffffffff000u64;
+                movem = 36;
+            } else {
+                // Performs a translation from 32 bits linear address
+                // to a 40 bits physical address
+                if pt_level == PagingType::_32BIT {
+                    // The PDE physical address contains
+                    // on 31:12 -> bits 31:12 from cr3
+                    // on 11:2 -> bits 31:22 from the linear address
+                    // on 1:0 -> 0
+                    linear_addr &= 0x00000000ffffffffu64;
+                    mask =  0x00000000ffc00000u64;
+
+                    paddr = context.cr3 & 0x00000000fffff000u64;
+                    movem = 20;
+                }
+            }
+        }
+        // PML4 address after the kernel booting should be:
+        // 1c0a000, to this u add, as below, the offset from the 
+
+        println!("Linear address: {:x?}", linear_addr);
+        paddr += (linear_addr & mask) >> movem;
+        let mut table_entry: u64 = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("PML4={:x?} and PML4E content={:x?}", paddr, table_entry);
+
+        mask >>= 9;
+        movem -= 9;
+        paddr = table_entry & 0x000ffffffffff000u64;
+        paddr += (linear_addr & mask) >> movem;
+        table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("PDPT={:x?} and PDPTE content={:x?}", paddr, table_entry);
+
+        if table_entry & PDPTE_PS != 0 {
+            // translation to 1GB page
+            println!("Translation to 1GB page");
+            paddr = table_entry & 0x000fffffc0000000u64;
+            // Final address
+            paddr += linear_addr & 0x3fffffffu64;
+        } else {
+            // translation to 2MB page
+            println!("Translation to 2MB page");
+            mask >>= 9;
+            movem -= 9;
+            paddr = table_entry & 0x000ffffffffff000u64;
+            paddr += (linear_addr & mask) >> movem;
+
+            table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+            println!("Page directory addr: {:x?} and PDE: {:x?}", paddr, table_entry);
+            if table_entry & PDE_PS != 0 {
+                // Final address
+                paddr = table_entry & 0x000ffffffff00000u64;
+                paddr += linear_addr & 0xfffff;
+            } else {
+                mask >>= 9;
+                movem -= 9;
+                paddr = table_entry & 0x000ffffffffff000u64;
+                paddr += (linear_addr & mask) >> movem;
+
+                table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+                println!("2MB page addr: {:x?} and the entry: {:x?}", paddr, table_entry);
+                // Final address
+                paddr = table_entry & 0x000ffffffffff000u64;
+                paddr += linear_addr & 0xfff;
+            }
+        }
+        let data: u64 = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+        println!("Final address: {:x?} and data: {:x?}", paddr, data);
+
+        //if context.cr4 & CR4_PSE == 0 {
+            
+            // The PTE physical address contains
+            // on 31:12 -> 31:12 from pde
+            // on 11:2 -> 21:12 from the linear address
+            // on 1:0 -> 0
+        
+        /*    mask >>= 10;
+            paddr = pde & (!0xfffu64);
+            paddr += (linear_addr & mask) >> 10;
+            let raw_pte: u32 = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
+            let pte: u64 = raw_pte.into();
+            println!("PTE address: {:x?} and content: {}", paddr, pte);
+        */    
+            // The final physical address contains
+            // on 31:12 -> 31:12 from pte
+            // on 11:0 -> 11:0 from the linear address
+        /*    mask = 0xfff;
+            paddr = pte & (!0xfffu64);
+            paddr += linear_addr & mask;
+            let data: u32 = self.guest_memory.read_obj(GuestAddress(0x1000000 + paddr)).unwrap();
+            println!("At address {:x?} it's {}", paddr, data);
+        */
+        //}
+
+        // Regs state after boot: cr0:80050033 cr3:1c0a005 cr4:7606b0 efer:d01
+        Ok(paddr)
+    }
+}

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -1,21 +1,21 @@
 use std::fmt::{Display, Formatter};
-use vmm_sys_util::errno::{Error};
+use vmm_sys_util::errno::Error;
 
-use super::target::FirecrackerGDBServer;
 use super::kvm_bindings::*;
+use super::target::FirecrackerGDBServer;
 use super::{Bytes, GuestAddress, VcpuFd, PT_LOAD};
 
-const CR0_PG:   u64 = 0x80000000;
-const CR4_PAE:  u64 = 0x00000020;
+const CR0_PG: u64 = 0x80000000;
+const CR4_PAE: u64 = 0x00000020;
 const CR4_LA57: u64 = 0x00001000;
 const EFER_LME: u64 = 0x00000100;
 const PDPTE_PS: u64 = 0x00000080;
-const PDE_PS:   u64 = 0x00000080;
+const PDE_PS: u64 = 0x00000080;
 
-const BIT_P:        u64 = 0x1;
+const BIT_P: u64 = 0x1;
 
 // [PML4E, PDPTE_PS0, PDPTE_PS1, PDE_PS0, PDE_PS1, PTE]
-const TABLE_ENTRY_RSVD_BITS: [u64;6] = [0x80, 0x0, 0x3fffe000, 0x0, 0x1fe000, 0x0];
+const TABLE_ENTRY_RSVD_BITS: [u64; 6] = [0x80, 0x0, 0x3fffe000, 0x0, 0x1fe000, 0x0];
 
 const TABLE_ENTRY_MASK: u64 = 0x000ffffffffff000u64;
 
@@ -39,8 +39,8 @@ pub enum DebugEvent {
 
 #[derive(Default)]
 pub struct FullVcpuState {
-    pub regular_regs : kvm_regs,
-    pub special_regs : kvm_sregs,
+    pub regular_regs: kvm_regs,
+    pub special_regs: kvm_sregs,
 }
 
 #[derive(Debug)]
@@ -57,11 +57,22 @@ impl Display for DebuggerError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             DebuggerError::InvalidState => write!(f, "[GDB Server] An invalid state was reached"),
-            DebuggerError::ChannelError => write!(f, "[GDB Server] An error interrupted the GDB server - main thread communication"),
+            DebuggerError::ChannelError => write!(
+                f,
+                "[GDB Server] An error interrupted the GDB server - main thread communication"
+            ),
             DebuggerError::MemoryError => write!(f, "[GDB Server] Failed access to guest memory"),
-            DebuggerError::IoctlError(errno) => write!(f, "[GDB Server] Failed ioctl call: {}", errno),
-            DebuggerError::InvalidLinearAddress => write!(f, "[GDB Server] An invalid linear address was passed from client"),
-            DebuggerError::UnsupportedPagingStrategy => write!(f, "A paging strategy that is not currently supported has been detected"),
+            DebuggerError::IoctlError(errno) => {
+                write!(f, "[GDB Server] Failed ioctl call: {}", errno)
+            }
+            DebuggerError::InvalidLinearAddress => write!(
+                f,
+                "[GDB Server] An invalid linear address was passed from client"
+            ),
+            DebuggerError::UnsupportedPagingStrategy => write!(
+                f,
+                "A paging strategy that is not currently supported has been detected"
+            ),
         }
     }
 }
@@ -70,17 +81,19 @@ pub struct Debugger;
 
 impl Debugger {
     pub fn enable_kvm_debug(vcpu: &VcpuFd, step: bool) -> Result<(), DebuggerError> {
-        let mut control : __u32 = 0;
+        let mut control: __u32 = 0;
         control |= KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP;
         if step {
             control |= KVM_GUESTDBG_SINGLESTEP;
         }
         let debug_struct = kvm_guest_debug {
-            control : control,
-            pad : 0,
-            arch : kvm_guest_debug_arch { debugreg : [0,0,0,0,0,0,0,0]},
+            control: control,
+            pad: 0,
+            arch: kvm_guest_debug_arch {
+                debugreg: [0, 0, 0, 0, 0, 0, 0, 0],
+            },
         };
- 
+
         if let Err(errno) = vcpu.set_guest_debug(&debug_struct) {
             return Err(DebuggerError::IoctlError(errno));
         }
@@ -92,38 +105,37 @@ impl Debugger {
     /// obtaining the physical address corresponding to the one received from a GDB client
     pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer) -> Result<u64, DebuggerError> {
         let mut linear_addr = addr;
-        let context : kvm_sregs;
+        let context: kvm_sregs;
         let mut pt_level = PagingType::NONE;
 
         context = srv.guest_state.special_regs;
         // Paging enabled
         if context.cr0 & CR0_PG != 0 {
-        // Determine the type of paging
+            // Determine the type of paging
             // See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual
-            pt_level = 
-                if context.cr4 & CR4_LA57 != 0 {
-                    PagingType::_5LVL
+            pt_level = if context.cr4 & CR4_LA57 != 0 {
+                PagingType::_5LVL
+            } else {
+                if context.efer & EFER_LME != 0 {
+                    PagingType::_4LVL
                 } else {
-                    if context.efer & EFER_LME != 0 {
-                        PagingType::_4LVL
+                    if context.cr4 & CR4_PAE != 0 {
+                        PagingType::PAE
                     } else {
-                        if context.cr4 & CR4_PAE != 0 {
-                            PagingType::PAE
-                        } else {
-                            PagingType::_32BIT
-                        }
+                        PagingType::_32BIT
                     }
                 }
+            }
         }
 
         let mut paddr: u64 = 0;
-        let mut mask : u64 = 0;
+        let mut mask: u64 = 0;
         let mut movem = 0;
         if pt_level == PagingType::_4LVL {
             // Translation from 48 bits linear address
             // to 52 bits physical address
             linear_addr &= 0x0000ffffffffffffu64;
-            mask =  0x0000ff8000000000u64;
+            mask = 0x0000ff8000000000u64;
 
             paddr = context.cr3 & 0x000ffffffffff000u64;
             movem = 36;

--- a/src/gdb_server/src/util.rs
+++ b/src/gdb_server/src/util.rs
@@ -1,16 +1,24 @@
+use std::fmt::{Display, Formatter};
+use vmm_sys_util::errno::{Error};
+
 use super::target::FirecrackerGDBServer;
-
 use super::kvm_bindings::*;
-use super::{Bytes, GuestAddress, VcpuFd};
+use super::{Bytes, GuestAddress, VcpuFd, PT_LOAD};
 
-const CR0_PG : u64 = 0x80000000;
-const CR4_PAE : u64 = 0x00000020;
-const CR4_LA57 : u64 = 0x00001000;
-const CR4_PSE : u64 = 0x00000010;
-const EFER_LME : u64 = 0x00000100;
-const EFER_LMA : u64 = 0x00000400;
-const PDPTE_PS : u64 = 0x00000080;
-const PDE_PS : u64 = 0x00000080;
+const CR0_PG:   u64 = 0x80000000;
+const CR4_PAE:  u64 = 0x00000020;
+const CR4_LA57: u64 = 0x00001000;
+const EFER_LME: u64 = 0x00000100;
+const PDPTE_PS: u64 = 0x00000080;
+const PDE_PS:   u64 = 0x00000080;
+
+const BIT_P:        u64 = 0x1;
+
+// [PML4E, PDPTE, PDE, PTE]
+const TABLE_ENTRY_RSVD_BITS: [u64;4] = [0x80, 0x0, 0x1fe000, 0x0];
+
+const TABLE_ENTRY_MASK: u64 = 0x000ffffffffff000u64;
+
 #[derive(PartialEq, Eq, Debug)]
 enum PagingType {
     NONE,
@@ -22,25 +30,49 @@ enum PagingType {
 
 pub enum DebugEvent {
     START,
-    PRINT_PTs(u64),
+    NOTIFY,
     GET_REGS,
     PEEK_REGS(FullVcpuState),
     CONTINUE(bool),
     STEP_INTO(bool),
-    BREAKPOINT,
 }
 
+#[derive(Default)]
 pub struct FullVcpuState {
     pub regular_regs : kvm_regs,
     pub special_regs : kvm_sregs,
 }
+
+#[derive(Debug)]
+pub enum DebuggerError {
+    InvalidState,
+    ChannelError,
+    MemoryError,
+    IoctlError(Error),
+    InvalidLinearAddress,
+    UnsupportedPagingStrategy,
+}
+
+impl Display for DebuggerError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            DebuggerError::InvalidState => write!(f, "[GDB Server] An invalid state was reached"),
+            DebuggerError::ChannelError => write!(f, "[GDB Server] An error interrupted the GDB server - main thread communication"),
+            DebuggerError::MemoryError => write!(f, "[GDB Server] Failed access to guest memory"),
+            DebuggerError::IoctlError(errno) => write!(f, "[GDB Server] Failed ioctl call: {}", errno),
+            DebuggerError::InvalidLinearAddress => write!(f, "[GDB Server] An invalid linear address was passed from client"),
+            DebuggerError::UnsupportedPagingStrategy => write!(f, "A paging strategy that is not currently supported has been detected"),
+        }
+    }
+}
+
 pub struct Debugger;
 
 impl Debugger {
-    pub fn enable_kvm_debug(vcpu: &VcpuFd, step: bool) {
+    pub fn enable_kvm_debug(vcpu: &VcpuFd, step: bool) -> Result<(), DebuggerError> {
         let mut control : __u32 = 0;
         control |= KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP;
-        if (step) {
+        if step {
             control |= KVM_GUESTDBG_SINGLESTEP;
         }
         let debug_struct = kvm_guest_debug {
@@ -49,158 +81,143 @@ impl Debugger {
             arch : kvm_guest_debug_arch { debugreg : [0,0,0,0,0,0,0,0]},
         };
  
-        match vcpu.set_guest_debug(&debug_struct) {
-            Ok(_) => println!("Done setting the kvm guest debug flags"),
-            Err(_) => println!("Setting of KVM_SET_GUEST_DEBUG failed"),
+        if let Err(errno) = vcpu.set_guest_debug(&debug_struct) {
+            return Err(DebuggerError::IoctlError(errno));
         }
+
+        Ok(())
     }
 
-    pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer, regs: FullVcpuState) -> Result<u64, &'static str> {
-        /*
-        match self.vcpu.translate(new_addr) {
-            Ok(t) => println!("...Linear address {:x?} -> Physical address {:x?}", new_addr, t.physical_address),
-            Err(_) => println!("Translation failed"),
-        }
-        */
+    /// Function that performs guest page-walking, on top of the 4-Level paging mechanism,
+    /// obtaining the physical address corresponding to the one received from a GDB client
+    pub fn virt_to_phys(addr: u64, srv: &FirecrackerGDBServer, regs: &FullVcpuState) -> Result<u64, DebuggerError> {
         let mut linear_addr = addr;
         let context : kvm_sregs;
         let mut pt_level = PagingType::NONE;
-        
+
         context = regs.special_regs;
         // Paging enabled
-        if context.cr0 & CR0_PG == 0 {
-
+        if context.cr0 & CR0_PG != 0 {
         // Determine the type of paging
-        } else {
             // See Table 4.1, Volume 3A in Intel Arch SW Developer's Manual
             pt_level = 
-            if context.cr4 & CR4_LA57 != 0 {
-                PagingType::_5LVL
-            } else {
-                if context.efer & EFER_LME != 0 {
-                    PagingType::_4LVL
+                if context.cr4 & CR4_LA57 != 0 {
+                    PagingType::_5LVL
                 } else {
-                    if context.cr4 & CR4_PAE != 0 {
-                        PagingType::PAE
+                    if context.efer & EFER_LME != 0 {
+                        PagingType::_4LVL
                     } else {
-                        PagingType::_32BIT
+                        if context.cr4 & CR4_PAE != 0 {
+                            PagingType::PAE
+                        } else {
+                            PagingType::_32BIT
+                        }
                     }
                 }
-            }
         }
-        println!("cr4 = {:x?}; cr3 = {:x?} efer={:x?}", context.cr4, context.cr3, context.efer);
-        println!("Paging type: {:?}", pt_level);
 
         let mut paddr: u64 = 0;
         let mut mask : u64 = 0;
         let mut movem = 0;
-        if pt_level == PagingType::PAE {
-            linear_addr &= 0x00000000ffffffffu64;
-            mask =  0x0000007fc0000000u64;
+        if pt_level == PagingType::_4LVL {
+            // Translation from 48 bits linear address
+            // to 52 bits physical address
+            linear_addr &= 0x0000ffffffffffffu64;
+            mask =  0x0000ff8000000000u64;
 
-            paddr = context.cr3 & 0x00000000ffffffe0u64;
+            paddr = context.cr3 & 0x000ffffffffff000u64;
+            movem = 36;
         } else {
-            if pt_level == PagingType::_4LVL {
-                // Translation from 48 bits linear address
-                // to 52 bits physical address
-                linear_addr &= 0x0000ffffffffffffu64;
-                mask =  0x0000ff8000000000u64;
+            return Err(DebuggerError::UnsupportedPagingStrategy);
+        }
 
-                paddr = context.cr3 & 0x000ffffffffff000u64;
-                movem = 36;
+        paddr += (linear_addr & mask) >> movem;
+
+        let mut table_entry;
+        if let Ok(e) = srv.guest_memory.read_obj(GuestAddress(paddr)) {
+            table_entry = e;
+        } else {
+            return Err(DebuggerError::MemoryError);
+        }
+
+        if Debugger::check_entry(table_entry, TABLE_ENTRY_RSVD_BITS[0]).is_err() {
+            return Debugger::fixup_pointer(addr, srv);
+        }
+
+        for i in 0..3 {
+            mask >>= 9;
+            movem -= 9;
+            paddr = table_entry & TABLE_ENTRY_MASK;
+            paddr += (linear_addr & mask) >> movem;
+            if let Ok(e) = srv.guest_memory.read_obj(GuestAddress(paddr)) {
+                table_entry = e;
             } else {
-                // Performs a translation from 32 bits linear address
-                // to a 40 bits physical address
-                if pt_level == PagingType::_32BIT {
-                    // The PDE physical address contains
-                    // on 31:12 -> bits 31:12 from cr3
-                    // on 11:2 -> bits 31:22 from the linear address
-                    // on 1:0 -> 0
-                    linear_addr &= 0x00000000ffffffffu64;
-                    mask =  0x00000000ffc00000u64;
+                return Err(DebuggerError::MemoryError);
+            }
 
-                    paddr = context.cr3 & 0x00000000fffff000u64;
-                    movem = 20;
+            if Debugger::check_entry(table_entry, TABLE_ENTRY_RSVD_BITS[i + 1]).is_err() {
+                return Debugger::fixup_pointer(addr, srv);
+            }
+
+            match i {
+                // translation to 1GB page
+                0 => {
+                    if (table_entry & PDPTE_PS) != 0 {
+                        // Final address
+                        paddr = table_entry & 0x000fffffc0000000u64;
+                        paddr += linear_addr & 0x3fffffffu64;
+                        break;
+                    }
+                }
+                1 => {
+                    if (table_entry & PDE_PS) != 0 {
+                        // Final address
+                        paddr = table_entry & 0x000fffffffe00000u64;
+                        paddr += linear_addr & 0x1fffff;
+                        break;
+                    }
+                }
+                2 => {
+                    // Final address
+                    paddr = table_entry & 0x000ffffffffff000u64;
+                    paddr += linear_addr & 0xfff;
+                    break;
+                }
+                _ => {
+                    return Err(DebuggerError::InvalidState);
                 }
             }
         }
-        // PML4 address after the kernel booting should be:
-        // 1c0a000, to this u add, as below, the offset from the 
 
-        println!("Linear address: {:x?}", linear_addr);
-        paddr += (linear_addr & mask) >> movem;
-        let mut table_entry: u64 = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-        println!("PML4={:x?} and PML4E content={:x?}", paddr, table_entry);
+        Ok(paddr)
+    }
 
-        mask >>= 9;
-        movem -= 9;
-        paddr = table_entry & 0x000ffffffffff000u64;
-        paddr += (linear_addr & mask) >> movem;
-        table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-        println!("PDPT={:x?} and PDPTE content={:x?}", paddr, table_entry);
+    /// Checks whether the current table entry is valid (there is a valid translation
+    /// for the linear address)
+    fn check_entry(entry: u64, reserved_bits: u64) -> Result<(), DebuggerError> {
+        if entry & BIT_P == 0 {
+            return Err(DebuggerError::InvalidLinearAddress);
+        }
+        if entry & reserved_bits != 0 {
+            return Err(DebuggerError::InvalidLinearAddress);
+        }
 
-        if table_entry & PDPTE_PS != 0 {
-            // translation to 1GB page
-            println!("Translation to 1GB page");
-            paddr = table_entry & 0x000fffffc0000000u64;
-            // Final address
-            paddr += linear_addr & 0x3fffffffu64;
-        } else {
-            // translation to 2MB page
-            println!("Translation to 2MB page");
-            mask >>= 9;
-            movem -= 9;
-            paddr = table_entry & 0x000ffffffffff000u64;
-            paddr += (linear_addr & mask) >> movem;
+        Ok(())
+    }
 
-            table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-            println!("Page directory addr: {:x?} and PDE: {:x?}", paddr, table_entry);
-            if table_entry & PDE_PS != 0 {
-                // Final address
-                paddr = table_entry & 0x000ffffffff00000u64;
-                paddr += linear_addr & 0xfffff;
-            } else {
-                mask >>= 9;
-                movem -= 9;
-                paddr = table_entry & 0x000ffffffffff000u64;
-                paddr += (linear_addr & mask) >> movem;
-
-                table_entry = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-                println!("2MB page addr: {:x?} and the entry: {:x?}", paddr, table_entry);
-                // Final address
-                paddr = table_entry & 0x000ffffffffff000u64;
-                paddr += linear_addr & 0xfff;
+    /// Following the kernel strategy, during the early boot phase, before the notion
+    /// of virtual addresses has been put in place, we obtain the corresponding
+    /// physical address by subtracting the section offset.
+    fn fixup_pointer(addr: u64, srv: &FirecrackerGDBServer) -> Result<u64, DebuggerError> {
+        for phdr in &srv.e_phdrs {
+            if (phdr.p_type & PT_LOAD) == 0 {
+                continue;
+            }
+            if (phdr.p_vaddr <= addr) && (phdr.p_vaddr + phdr.p_memsz > addr) {
+                return Ok(addr - phdr.p_vaddr + phdr.p_paddr);
             }
         }
-        let data: u64 = srv.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-        println!("Final address: {:x?} and data: {:x?}", paddr, data);
 
-        //if context.cr4 & CR4_PSE == 0 {
-            
-            // The PTE physical address contains
-            // on 31:12 -> 31:12 from pde
-            // on 11:2 -> 21:12 from the linear address
-            // on 1:0 -> 0
-        
-        /*    mask >>= 10;
-            paddr = pde & (!0xfffu64);
-            paddr += (linear_addr & mask) >> 10;
-            let raw_pte: u32 = self.guest_memory.read_obj(GuestAddress(paddr)).unwrap();
-            let pte: u64 = raw_pte.into();
-            println!("PTE address: {:x?} and content: {}", paddr, pte);
-        */    
-            // The final physical address contains
-            // on 31:12 -> 31:12 from pte
-            // on 11:0 -> 11:0 from the linear address
-        /*    mask = 0xfff;
-            paddr = pte & (!0xfffu64);
-            paddr += linear_addr & mask;
-            let data: u32 = self.guest_memory.read_obj(GuestAddress(0x1000000 + paddr)).unwrap();
-            println!("At address {:x?} it's {}", paddr, data);
-        */
-        //}
-
-        // Regs state after boot: cr0:80050033 cr3:1c0a005 cr4:7606b0 efer:d01
-        Ok(paddr)
+        Err(DebuggerError::InvalidLinearAddress)
     }
 }

--- a/src/gdb_server/src/walker.rs
+++ b/src/gdb_server/src/walker.rs
@@ -1,0 +1,152 @@
+#[cfg(target_arch = "x86_64")]
+pub use arch::x86_64::regs::setup_sregs;
+
+use crate::vm_memory::Bytes;
+
+use super::{GuestAddress, GuestMemoryMmap};
+use super::kvm_bindings::*;
+
+// If 1, enable paging and use the § CR3 register, else disable paging.
+const CR0_PG_MASK: u64 = 1 << 31;
+
+// 4 level paging - Enabling PAE (by setting bit 5, PAE, of the system register CR4)
+// If set, changes page table layout to translate 32-bit virtual addresses into extended 36-bit
+// physical addresses.
+const CR4_PAE_MASK: u64 = 1 << 5;
+
+// 5 level paging - Likewise, the new extension is enabled by setting bit 12 of the CR4 register
+// (known as LA57). If the bit is not set, the processor operates with four paging levels.
+const CR4_LA57_MASK: u64 = 1 << 12;
+
+// Long mode Active
+// when BIT 10 of Extended Feature Enable Register (EFER) register is set,
+// it indicates long mode is active
+const MSR_EFER_LMA: u64 = 1 << 10;
+
+// bits 12 through 51 are the address in a PTE.
+// fffff & !0x0fff
+// Bit mask for Page Number
+const PTE_ADDR_MASK: u64 = ((1 << 52) - 1) & !0x0fff;
+
+// If more than 12 bits remain in the linear address, bit 7 (PS — page size) of the current
+// paging-structure entry is consulted. If the bit is 0, the entry references
+// another paging structure;
+const PAGE_PSE_MASK: u64 = 0x1 << 7;
+
+// See Chapter 4.7, Volume 3A in Intel Arch SW Developer's Manual.
+// Bit 0 in any level's page table entry. Marks whether a valid translation
+// is available
+const PAGE_PRESENT: u64 = 0x1;
+
+//Paging types
+const PAGE_SIZE_4K: u64 = 4 * 1024;
+const PAGE_SIZE_2M: u64 = 2 * 1024 * 1024;
+const PAGE_SIZE_1G: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum Error {
+    UnsupportedPagingStrategy,
+    VirtAddrTranslationError,
+}
+
+#[derive(Default, Clone)]
+pub struct FullVcpuState {
+    pub regular_regs: kvm_regs,
+    pub special_regs: kvm_sregs,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+//https://github.com/crash-utility/crash/blob/master/qemu.c#L72
+fn virt_to_phys(
+    vaddr: u64,
+    guest_memory: &GuestMemoryMmap,
+    guest_state: &FullVcpuState,
+) -> Result<(u64, u64)> {
+    // Moves from one page table entry to next page table entry.
+    fn walk(
+        guest_memory: &GuestMemoryMmap,
+        table_entry: u64,
+        vaddr: u64,
+        page_level: usize,
+    ) -> Result<u64> {
+        let page_number = table_entry & PTE_ADDR_MASK;
+        let paddr = page_number + page_table_offset(vaddr, page_level);
+        let next_entry: u64 = guest_memory.read_obj(GuestAddress(paddr))
+            .map_err(|_| Error::VirtAddrTranslationError)?;
+
+        Ok(next_entry)
+    }
+
+    fn page_offset(vaddr: u64, page_size: u64) -> u64 {
+        // Offset = (address reference % page size)
+        // vaddr % page_size
+        vaddr & (page_size - 1)
+    }
+
+    fn page_table_offset(addr: u64, level: usize) -> u64 {
+        // 12 bits offset with 9 bits of for each level.
+        let offset = (level - 1) * 9 + 12;
+        // Shifting right to 12 bits in binary is equivalent to shifting
+        // a hexadecimal number 3 places to the right
+        // eg - (((addr >> 39) & 0x1ff) << 3))
+        ((addr >> offset) & 0x1ff) << 3
+    }
+
+    if guest_state.special_regs.cr0 & CR0_PG_MASK == 0 {
+        return Ok((vaddr, PAGE_SIZE_4K));
+    }
+
+    if guest_state.special_regs.cr4 & CR4_PAE_MASK == 0 {
+        return Err(Error::VirtAddrTranslationError);
+    }
+
+    if guest_state.special_regs.efer & MSR_EFER_LMA != 0 {
+        let mut pg_lvl_5_ent: Option<u64> = None;
+        let pg_lvl_4_ent;
+
+        if guest_state.special_regs.cr4 & CR4_LA57_MASK != 0 {
+            // 5 level paging enabled
+            // The first paging structure used for any translation is located at the physical address in CR3
+            pg_lvl_5_ent = Some(walk(guest_memory, guest_state.special_regs.cr3, vaddr, 5)?);
+        }
+
+        if let Some(ent) = pg_lvl_5_ent {
+            pg_lvl_4_ent = walk(guest_memory, ent, vaddr, 4)?;
+        } else {
+            pg_lvl_4_ent = walk(guest_memory, guest_state.special_regs.cr3, vaddr, 4)?;
+        }
+
+        //Level 3
+        let pg_lvl_3_ent = walk(guest_memory, pg_lvl_4_ent, vaddr, 3)?;
+        // Till now, we have traversed 18 bits or 27 bits (for 5 level paging) and if we see
+        // PAGE_PSE_MASK set, we clearly have space for a 1G page .
+        if pg_lvl_3_ent & PAGE_PSE_MASK != 0 {
+            // Find the page address through the page table entry
+            let page_addr = pg_lvl_3_ent & PTE_ADDR_MASK;
+            //Find the offset within the page through the linear address
+            let offset = page_offset(vaddr, PAGE_SIZE_1G);
+            //Physical address = page address + page offset
+            let paddr = page_addr | offset;
+            return Ok((paddr, PAGE_SIZE_1G));
+        }
+
+        //Level 2
+        let pg_lvl_2_ent = walk(guest_memory, pg_lvl_3_ent, vaddr, 2)?;
+        if pg_lvl_2_ent & PAGE_PSE_MASK != 0 {
+            let page_addr = pg_lvl_2_ent & PTE_ADDR_MASK;
+            let offset = page_offset(vaddr, PAGE_SIZE_2M);
+            let paddr = page_addr | offset;
+            return Ok((paddr, PAGE_SIZE_2M));
+        }
+
+        //Level 1
+        let pg_lvl_1_ent = walk(guest_memory, pg_lvl_2_ent, vaddr, 1)?;
+        let page_addr = pg_lvl_1_ent & PTE_ADDR_MASK;
+        let offset = page_offset(vaddr, PAGE_SIZE_2M);
+        let paddr = page_addr | offset;
+        return Ok((paddr, PAGE_SIZE_4K));
+    }
+
+    Err(Error::VirtAddrTranslationError)
+}

--- a/src/kernel/src/loader/elf.rs
+++ b/src/kernel/src/loader/elf.rs
@@ -10,6 +10,8 @@
  * From upstream linux include/uapi/linux/elf.h at commit:
  * 806276b7f07a39a1cc3f38bb1ef5c573d4594a38
  */
+#[allow(non_camel_case_types)]
+
 pub const EI_MAG0: ::std::os::raw::c_uint = 0;
 pub const EI_MAG1: ::std::os::raw::c_uint = 1;
 pub const EI_MAG2: ::std::os::raw::c_uint = 2;
@@ -25,23 +27,37 @@ pub const ELFMAG1: u8 = b'E';
 pub const ELFMAG2: u8 = b'L';
 pub const ELFMAG3: u8 = b'F';
 
+#[allow(non_camel_case_types)]
 type Elf64_Addr = __u64;
+#[allow(non_camel_case_types)]
 type Elf64_Half = __u16;
+#[allow(non_camel_case_types)]
 type Elf64_Off = __u64;
+#[allow(non_camel_case_types)]
 type Elf64_Word = __u32;
+#[allow(non_camel_case_types)]
 type Elf64_Xword = __u64;
 
+#[allow(non_camel_case_types)]
 type __s8 = ::std::os::raw::c_schar;
+#[allow(non_camel_case_types)]
 type __u8 = ::std::os::raw::c_uchar;
+#[allow(non_camel_case_types)]
 type __s16 = ::std::os::raw::c_short;
+#[allow(non_camel_case_types)]
 type __u16 = ::std::os::raw::c_ushort;
+#[allow(non_camel_case_types)]
 type __s32 = ::std::os::raw::c_int;
+#[allow(non_camel_case_types)]
 type __u32 = ::std::os::raw::c_uint;
+#[allow(non_camel_case_types)]
 type __s64 = ::std::os::raw::c_longlong;
+#[allow(non_camel_case_types)]
 type __u64 = ::std::os::raw::c_ulonglong;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
+#[allow(non_camel_case_types)]
 pub struct elf64_hdr {
     pub e_ident: [::std::os::raw::c_uchar; 16usize],
     pub e_type: Elf64_Half,
@@ -63,10 +79,10 @@ impl Clone for elf64_hdr {
         *self
     }
 }
-pub type Elf64_Ehdr = elf64_hdr;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy)]
+#[allow(non_camel_case_types)]
 pub struct elf64_phdr {
     pub p_type: Elf64_Word,
     pub p_flags: Elf64_Word,
@@ -83,6 +99,11 @@ impl Clone for elf64_phdr {
         *self
     }
 }
+
+#[allow(non_camel_case_types)]
+pub type Elf64_Ehdr = elf64_hdr;
+
+#[allow(non_camel_case_types)]
 pub type Elf64_Phdr = elf64_phdr;
 
 #[cfg(test)]

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -20,6 +20,8 @@ use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemo
 // Add here any other architecture that uses as kernel image an ELF file.
 mod elf;
 
+pub use elf::{Elf64_Phdr, PT_LOAD};
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe impl ByteValued for elf::Elf64_Ehdr {}
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -424,4 +426,30 @@ mod tests {
         let val: u8 = gm.read_obj(cmdline_address).unwrap();
         assert_eq!(val, b'\0');
     }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn extract_phdrs<F>(kernel_image: &mut F) -> Result<Vec<elf::Elf64_Phdr>>
+    where F: Read + Seek,
+{
+    let mut ehdr: elf::Elf64_Ehdr = Default::default();
+    kernel_image
+        .seek(SeekFrom::Start(0))
+        .map_err(|_| Error::SeekKernelImage)?;
+    unsafe {
+        // read_struct is safe when reading a POD struct.  It can be used and dropped without issue.
+        read_struct(kernel_image, &mut ehdr)
+            .map_err(|_| Error::ReadKernelDataStruct("Failed to read ELF header"))?;
+    }
+
+    kernel_image
+        .seek(SeekFrom::Start(ehdr.e_phoff))
+        .map_err(|_| Error::SeekProgramHeader)?;
+    let phdrs: Vec<elf::Elf64_Phdr> = unsafe {
+        // Reading the structs is safe for a slice of POD structs.
+        utils::structs::read_struct_slice(kernel_image, ehdr.e_phnum as usize)
+            .map_err(|_| Error::ReadKernelDataStruct("Failed to read ELF program header"))?
+    };
+
+    Ok(phdrs)
 }

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -430,7 +430,8 @@ mod tests {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn extract_phdrs<F>(kernel_image: &mut F) -> Result<Vec<elf::Elf64_Phdr>>
-    where F: Read + Seek,
+where
+    F: Read + Seek,
 {
     let mut ehdr: elf::Elf64_Ehdr = Default::default();
     kernel_image

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -15,7 +15,7 @@ use std::mem;
 use super::cmdline::Error as CmdlineError;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
-#[allow(non_camel_case_types)]
+// #[allow(non_camel_case_types)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 // Add here any other architecture that uses as kernel image an ELF file.
 pub mod elf;

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -18,9 +18,7 @@ use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemo
 #[allow(non_camel_case_types)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 // Add here any other architecture that uses as kernel image an ELF file.
-mod elf;
-
-pub use elf::{Elf64_Phdr, PT_LOAD};
+pub mod elf;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe impl ByteValued for elf::Elf64_Ehdr {}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -24,6 +24,7 @@ rate_limiter = { path = "../rate_limiter" }
 seccomp = { path = "../seccomp" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
+gdb_server = { path = "../gdb_server" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -10,7 +10,6 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{mpsc::Receiver, mpsc::Sender, Arc, Mutex};
 use std::thread;
 
-
 #[cfg(target_arch = "aarch64")]
 use crate::construct_kvm_mpidrs;
 #[cfg(target_arch = "x86_64")]
@@ -306,7 +305,6 @@ pub fn build_microvm_for_boot(
         track_dirty_pages,
     )?;
     let vcpu_config = vm_resources.vcpu_config();
-    let entry_addr = load_kernel(boot_config, &guest_memory)?;
     let track_dirty_pages = vm_resources.track_dirty_pages();
     let (entry_addr, e_phdrs) = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;
@@ -490,7 +488,7 @@ pub fn create_guest_memory(
 fn load_kernel(
     boot_config: &BootConfig,
     guest_memory: &GuestMemoryMmap,
-) -> std::result::Result<(GuestAddress, Vec<kernel::loader::Elf64_Phdr>), StartMicrovmError> {
+) -> std::result::Result<(GuestAddress, Vec<kernel::loader::elf::Elf64_Phdr>), StartMicrovmError> {
     let mut kernel_file = boot_config
         .kernel_file
         .try_clone()
@@ -862,7 +860,7 @@ fn vmm_run_gdb_server(
     vmm_mem: GuestMemoryMmap,
     receiver: Receiver<gdb_server::DebugEvent>,
     sender: Sender<gdb_server::DebugEvent>,
-    e_phdrs: Vec<kernel::loader::Elf64_Phdr>,
+    e_phdrs: Vec<kernel::loader::elf::Elf64_Phdr>,
     entry_point: GuestAddress,
     vcpus: &[Vcpu],
 ) -> Result<(), StartMicrovmError> {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -500,6 +500,8 @@ fn load_kernel(
         kernel::loader::load_kernel(guest_memory, &mut kernel_file, arch::get_kernel_start())
             .map_err(StartMicrovmError::KernelLoader)?;
 
+    // The program headers of the kernel image are necessary in the address translation
+    // mechanism in the GDB Server thread
     let phdrs = kernel::loader::extract_phdrs(&mut kernel_file).unwrap();
 
     Ok((entry_addr, phdrs))

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -7,10 +7,9 @@ use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 use std::io::{self, Read, Seek, SeekFrom};
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc::Receiver, mpsc::Sender};
+use std::thread;
 
-use vm_memory::guest_memory::GuestMemory;
-use vm_memory::guest_memory::GuestMemoryRegion;
 
 #[cfg(target_arch = "aarch64")]
 use crate::construct_kvm_mpidrs;
@@ -22,7 +21,7 @@ use crate::persist::{MicrovmState, MicrovmStateError};
 use crate::vmm_config::boot_source::BootConfig;
 use crate::vstate::{
     system::KvmContext,
-    vcpu::{Vcpu, VcpuConfig},
+    vcpu::{Vcpu, VcpuConfig, VcpuEvent},
     vm::Vm,
 };
 use crate::{device_manager, Error, Vmm, VmmEventsObserver};
@@ -302,7 +301,6 @@ pub fn build_microvm_for_boot(
             .ok_or(MissingMemSizeConfig)?,
         track_dirty_pages,
     )?;
-    guest_memory.with_regions(|idx, region|{ println!("MRMEESEEKS"); unsafe {println!("{} {}", (*region).as_slice().unwrap()[0], (*region).start_addr().0); } Err("")});
     let vcpu_config = vm_resources.vcpu_config();
     let entry_addr = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;
@@ -359,11 +357,9 @@ pub fn build_microvm_for_boot(
         boot_cmdline,
     )?;
 
-    vmm_run_gdb_server(&vmm, &vcpus);
-    println!("Going further with execution...");
-    let new_addr : u64 = 0x10001d0;
-    let int3 : u8 = 0xCC;
-    //vmm.guest_memory().write_obj(int3, GuestAddress(new_addr));
+    let dbg_event_receiver = vcpus[0].dbg_event_receiver.take().unwrap();
+    let dbg_event_sender = vcpus[0].dbg_response_sender.take().unwrap();
+    vmm_run_gdb_server(vmm.guest_memory().clone(), dbg_event_receiver, dbg_event_sender, &vcpus);
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(vcpus, seccomp_filter).map_err(Internal)?;
@@ -842,9 +838,17 @@ fn attach_balloon_device(
     attach_virtio_device(event_manager, vmm, id, balloon.clone(), cmdline)
 }
 
-fn vmm_run_gdb_server<'a>(vmm: &'a Vmm, vcpus : &'a Vec<Vcpu>) {
+fn vmm_run_gdb_server<'a>(vmm_mem: GuestMemoryMmap, receiver: Receiver<gdb_server::DebugEvent>,
+                          sender: Sender<gdb_server::DebugEvent>, vcpus: &Vec<Vcpu>) {
     // For now we assume there's one vcpu only
-    gdb_server::run_gdb_server(vmm.guest_memory(), &vcpus[0].kvm_vcpu.fd);
+    gdb_server::Debugger::enable_kvm_debug(&vcpus[0].kvm_vcpu.fd, false);
+    let join_handle = thread::Builder::new()
+        .spawn(move || {
+            gdb_server::run_gdb_server(vmm_mem,
+                                       receiver, sender).unwrap();
+        });
+    // Block until the GDB server is ready to handle vcpus execution
+    vcpus[0].dbg_response_receiver.recv().expect("Error receiving notification from GDB server");
 }
 
 // Adds `O_NONBLOCK` to the stdout flags.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -21,7 +21,7 @@ use crate::persist::{MicrovmState, MicrovmStateError};
 use crate::vmm_config::boot_source::BootConfig;
 use crate::vstate::{
     system::KvmContext,
-    vcpu::{Vcpu, VcpuConfig, VcpuEvent},
+    vcpu::{Vcpu, VcpuConfig},
     vm::Vm,
 };
 use crate::{device_manager, Error, Vmm, VmmEventsObserver};
@@ -856,13 +856,13 @@ fn attach_balloon_device(
     attach_virtio_device(event_manager, vmm, id, balloon.clone(), cmdline)
 }
 
-fn vmm_run_gdb_server<'a>(
+fn vmm_run_gdb_server(
     vmm_mem: GuestMemoryMmap,
     receiver: Receiver<gdb_server::DebugEvent>,
     sender: Sender<gdb_server::DebugEvent>,
     e_phdrs: Vec<kernel::loader::Elf64_Phdr>,
     entry_point: GuestAddress,
-    vcpus: &Vec<Vcpu>,
+    vcpus: &[Vcpu],
 ) -> Result<(), StartMicrovmError> {
     // For now we assume there's one vcpu only
     if gdb_server::Debugger::enable_kvm_debug(&vcpus[0].kvm_vcpu.fd, false).is_err() {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -355,6 +355,8 @@ pub fn build_microvm_for_boot(
         boot_cmdline,
     )?;
 
+    gdb_server::run_gdb_server();
+
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(vcpus, seccomp_filter).map_err(Internal)?;
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -78,6 +78,8 @@ pub enum StartMicrovmError {
     RegisterMmioDevice(device_manager::mmio::Error),
     /// Cannot restore microvm state.
     RestoreMicrovmState(MicrovmStateError),
+    /// The GDB server thread terminated abruptly
+    GDBServer,
 }
 
 /// It's convenient to automatically convert `kernel::cmdline::Error`s
@@ -155,6 +157,7 @@ impl Display for StartMicrovmError {
                 )
             }
             RestoreMicrovmState(err) => write!(f, "Cannot restore microvm state. Error: {}", err),
+            GDBServer => write!(f, "GDB session ended due to an error"),
         }
     }
 }
@@ -303,6 +306,8 @@ pub fn build_microvm_for_boot(
     )?;
     let vcpu_config = vm_resources.vcpu_config();
     let entry_addr = load_kernel(boot_config, &guest_memory)?;
+    let track_dirty_pages = vm_resources.track_dirty_pages();
+    let (entry_addr, e_phdrs) = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
@@ -359,7 +364,10 @@ pub fn build_microvm_for_boot(
 
     let dbg_event_receiver = vcpus[0].dbg_event_receiver.take().unwrap();
     let dbg_event_sender = vcpus[0].dbg_response_sender.take().unwrap();
-    vmm_run_gdb_server(vmm.guest_memory().clone(), dbg_event_receiver, dbg_event_sender, &vcpus);
+    if let Err(err) = vmm_run_gdb_server(vmm.guest_memory().clone(), dbg_event_receiver, dbg_event_sender,
+         e_phdrs, entry_addr, &vcpus) {
+            return Err(err);
+        }
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(vcpus, seccomp_filter).map_err(Internal)?;
@@ -474,7 +482,7 @@ pub fn create_guest_memory(
 fn load_kernel(
     boot_config: &BootConfig,
     guest_memory: &GuestMemoryMmap,
-) -> std::result::Result<GuestAddress, StartMicrovmError> {
+) -> std::result::Result<(GuestAddress, Vec<kernel::loader::Elf64_Phdr>), StartMicrovmError> {
     let mut kernel_file = boot_config
         .kernel_file
         .try_clone()
@@ -484,7 +492,9 @@ fn load_kernel(
         kernel::loader::load_kernel(guest_memory, &mut kernel_file, arch::get_kernel_start())
             .map_err(StartMicrovmError::KernelLoader)?;
 
-    Ok(entry_addr)
+    let phdrs = kernel::loader::extract_phdrs(&mut kernel_file).unwrap();
+
+    Ok((entry_addr, phdrs))
 }
 
 fn load_initrd_from_config(
@@ -839,16 +849,29 @@ fn attach_balloon_device(
 }
 
 fn vmm_run_gdb_server<'a>(vmm_mem: GuestMemoryMmap, receiver: Receiver<gdb_server::DebugEvent>,
-                          sender: Sender<gdb_server::DebugEvent>, vcpus: &Vec<Vcpu>) {
+                          sender: Sender<gdb_server::DebugEvent>, e_phdrs: Vec<kernel::loader::Elf64_Phdr>,
+                          entry_point: GuestAddress, vcpus: &Vec<Vcpu>) -> Result<(), StartMicrovmError>{
     // For now we assume there's one vcpu only
-    gdb_server::Debugger::enable_kvm_debug(&vcpus[0].kvm_vcpu.fd, false);
+    if gdb_server::Debugger::enable_kvm_debug(&vcpus[0].kvm_vcpu.fd, false).is_err() {
+        return Err(StartMicrovmError::GDBServer);
+    }
     let join_handle = thread::Builder::new()
-        .spawn(move || {
-            gdb_server::run_gdb_server(vmm_mem,
-                                       receiver, sender).unwrap();
+        .spawn(move || -> Result<(), StartMicrovmError>{
+            if gdb_server::run_gdb_server(vmm_mem, entry_point, e_phdrs,
+                                          receiver, sender).is_err() {
+                return Err(StartMicrovmError::GDBServer);
+            }
+            Ok(())
         });
+    if join_handle.is_err() {
+        return Err(StartMicrovmError::GDBServer);
+    }
     // Block until the GDB server is ready to handle vcpus execution
-    vcpus[0].dbg_response_receiver.recv().expect("Error receiving notification from GDB server");
+    if vcpus[0].dbg_response_receiver.recv().is_err() {
+        return Err(StartMicrovmError::GDBServer);
+    }
+
+    Ok(())
 }
 
 // Adds `O_NONBLOCK` to the stdout flags.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -292,6 +292,7 @@ pub fn build_microvm_for_boot(
     vm_resources: &super::resources::VmResources,
     event_manager: &mut EventManager,
     seccomp_filter: BpfProgramRef,
+    debugger_enabled: bool,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     use self::StartMicrovmError::*;
     let boot_config = vm_resources.boot_source().ok_or(MissingKernelConfig)?;
@@ -361,13 +362,14 @@ pub fn build_microvm_for_boot(
         &initrd,
         boot_cmdline,
     )?;
-
-    let dbg_event_receiver = vcpus[0].dbg_event_receiver.take().unwrap();
-    let dbg_event_sender = vcpus[0].dbg_response_sender.take().unwrap();
-    if let Err(err) = vmm_run_gdb_server(vmm.guest_memory().clone(), dbg_event_receiver, dbg_event_sender,
-         e_phdrs, entry_addr, &vcpus) {
+    if debugger_enabled {
+        let dbg_event_receiver = vcpus[0].dbg_event_receiver.take().unwrap();
+        let dbg_event_sender = vcpus[0].dbg_response_sender.take().unwrap();
+        if let Err(err) = vmm_run_gdb_server(vmm.guest_memory().clone(),
+            dbg_event_receiver, dbg_event_sender, e_phdrs, entry_addr, &vcpus) {
             return Err(err);
         }
+    }
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(vcpus, seccomp_filter).map_err(Internal)?;

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -47,6 +47,13 @@ const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
 const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
 const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
 const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
+const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
+const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
+const KVM_GET_XSAVE: u64 = 0x9000_aea4;
+const KVM_SET_XSAVE: u64 = 0x5000_aea5;
+const KVM_GET_XCRS: u64 = 0x8188_aea6;
+const KVM_SET_XCRS: u64 = 0x4188_aea7;
+const KVM_SET_GUEST_DEBUG: u64 = 0x4048_ae9b;
 
 // Use this mod to define ioctl params that are architecture specific.
 // To add other architectures, add another module declaration with the right cfg attribute.
@@ -140,6 +147,8 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_GUEST_DEBUG)?],
+
     ];
 
     rule.append(&mut create_arch_specific_ioctl_conditions()?);

--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -47,12 +47,6 @@ const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
 const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
 const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
 const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
-const KVM_GET_DEBUGREGS: u64 = 0x8080_aea1;
-const KVM_SET_DEBUGREGS: u64 = 0x4080_aea2;
-const KVM_GET_XSAVE: u64 = 0x9000_aea4;
-const KVM_SET_XSAVE: u64 = 0x5000_aea5;
-const KVM_GET_XCRS: u64 = 0x8188_aea6;
-const KVM_SET_XCRS: u64 = 0x4188_aea7;
 const KVM_SET_GUEST_DEBUG: u64 = 0x4048_ae9b;
 
 // Use this mod to define ioctl params that are architecture specific.
@@ -148,7 +142,6 @@ fn create_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_GUEST_DEBUG)?],
-
     ];
 
     rule.append(&mut create_arch_specific_ioctl_conditions()?);

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -66,7 +66,7 @@ use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;
 use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap};
 
-use gdb_server;
+pub use gdb_server;
 
 /// Success exit code.
 pub const FC_EXIT_CODE_OK: u8 = 0;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -66,6 +66,8 @@ use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;
 use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap};
 
+use gdb_server;
+
 /// Success exit code.
 pub const FC_EXIT_CODE_OK: u8 = 0;
 /// Generic error exit code.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -93,6 +93,8 @@ pub struct VmResources {
     pub mmds_config: Option<MmdsConfig>,
     /// Whether or not to load boot timer device.
     pub boot_timer: bool,
+    /// Whether or not to lauch the vm under GDB
+    pub debugger: bool,
 }
 
 impl VmResources {

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -433,6 +433,7 @@ mod tests {
             net_builder: default_net_builder(),
             mmds_config: None,
             boot_timer: false,
+            debugger: false,
         }
     }
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -848,6 +848,7 @@ mod tests {
             net_builder: default_net_builder(),
             mmds_config: None,
             boot_timer: false,
+            debugger: false,
         };
         let mut new_balloon_cfg = BalloonDeviceConfig {
             amount_mb: 100,
@@ -879,6 +880,7 @@ mod tests {
             net_builder: default_net_builder(),
             mmds_config: None,
             boot_timer: false,
+            debugger: false,
         };
         new_balloon_cfg.amount_mb = 256;
         assert!(vm_resources.set_balloon_device(new_balloon_cfg).is_err());

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -390,6 +390,7 @@ impl<'a> PrebootApiController<'a> {
             &self.vm_resources,
             &mut self.event_manager,
             &self.seccomp_filter,
+            self.vm_resources.debugger,
         )
         .map(|vmm| {
             self.built_vmm = Some(vmm);
@@ -706,6 +707,7 @@ mod tests {
         pub boot_timer: bool,
         // when `true`, all self methods are forced to fail
         pub force_errors: bool,
+        pub debugger: bool,
     }
 
     impl MockVmRes {
@@ -806,6 +808,7 @@ mod tests {
         pub update_net_rate_limiters_called: bool,
         // when `true`, all self methods are forced to fail
         pub force_errors: bool,
+        pub debugger: bool,
     }
 
     impl MockVmm {
@@ -911,6 +914,7 @@ mod tests {
         _: &VmResources,
         _: &mut EventManager,
         _: BpfProgramRef,
+        _: bool,
     ) -> Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
         Ok(Arc::new(Mutex::new(MockVmm::default())))
     }
@@ -1284,6 +1288,7 @@ mod tests {
             },
             commands,
             expected_resp,
+            false,
             false,
         );
     }

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -248,6 +248,7 @@ impl<'a> PrebootApiController<'a> {
         recv_req: F,
         respond: G,
         boot_timer_enabled: bool,
+        debugger_enabled: bool,
     ) -> (VmResources, Arc<Mutex<Vmm>>)
     where
         F: Fn() -> VmmAction,
@@ -255,6 +256,7 @@ impl<'a> PrebootApiController<'a> {
     {
         let mut vm_resources = VmResources::default();
         vm_resources.boot_timer = boot_timer_enabled;
+        vm_resources.debugger = debugger_enabled;
         let mut preboot_controller = PrebootApiController::new(
             seccomp_filter,
             instance_info,

--- a/src/vmm/src/utilities/test_utils/mod.rs
+++ b/src/vmm/src/utilities/test_utils/mod.rs
@@ -40,7 +40,8 @@ pub fn create_vmm(_kernel_image: Option<&str>, is_diff: bool) -> (Arc<Mutex<Vmm>
     };
 
     (
-        build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filter).unwrap(),
+        build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filter, false)
+            .unwrap(),
         event_manager,
     )
 }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -33,6 +33,7 @@ use utils::{
     signal::{register_signal_handler, sigrtmin, Killable},
     sm::StateMachine,
 };
+use crate::gdb_server::{DebugEvent, FullVcpuState};
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) mod aarch64;
@@ -114,6 +115,15 @@ pub struct Vcpu {
     response_receiver: Option<Receiver<VcpuResponse>>,
     // The transmitting end of the responses channel owned by the vcpu side.
     response_sender: Sender<VcpuResponse>,
+    // The receiving end of the response channel which will be given to the handler
+    // and used by gdb server instances
+    pub dbg_event_receiver: Option<Receiver<DebugEvent>>,
+    // The transmitting end of the responses channel owned by the vcpu side and
+    // used to communicate to the gdb server instances
+    dbg_event_sender: Sender<DebugEvent>,
+
+    pub dbg_response_receiver: Receiver<DebugEvent>,
+    pub dbg_response_sender: Option<Sender<DebugEvent>>,
 
     // Exit reason used to test run_emulation function.
     #[cfg(test)]
@@ -214,6 +224,8 @@ impl Vcpu {
     pub fn new(index: u8, vm: &Vm, exit_evt: EventFd) -> Result<Self> {
         let (event_sender, event_receiver) = channel();
         let (response_sender, response_receiver) = channel();
+        let (dbg_event_sender, dbg_event_receiver) = channel();
+        let (dbg_response_sender, dbg_response_receiver) = channel();
         let kvm_vcpu = KvmVcpu::new(index, vm).unwrap();
 
         Ok(Vcpu {
@@ -222,6 +234,10 @@ impl Vcpu {
             event_sender: Some(event_sender),
             response_receiver: Some(response_receiver),
             response_sender,
+            dbg_event_receiver: Some(dbg_event_receiver),
+            dbg_event_sender,
+            dbg_response_receiver,
+            dbg_response_sender: Some(dbg_response_sender),
             kvm_vcpu,
             #[cfg(test)]
             vcpu_exit_reason: Mutex::new(None),
@@ -511,6 +527,43 @@ impl Vcpu {
                         )))
                     }
                 },
+                // Either a breakpoint was reached or we are single-stepping
+                VcpuExit::Debug => {
+                    let regular_regs = self.kvm_vcpu.fd.get_regs().unwrap();
+                    let special_regs = self.kvm_vcpu.fd.get_sregs().unwrap();
+                    // For now we don't differentiate between a kvm exit caused
+                    // by a breakpoint and one caused by single-stepping
+                    self.dbg_event_sender.send(DebugEvent::PRINT_PTs(special_regs.cr3))
+                        .expect("Failed notifying GDB server");
+                    loop {
+                        match self.dbg_response_receiver.recv() {
+                            Ok(DebugEvent::GET_REGS) => {
+                                self.dbg_event_sender.send(DebugEvent::PEEK_REGS(
+                                    FullVcpuState { regular_regs, special_regs, })).unwrap();
+                                continue;
+                            }
+                            Ok(DebugEvent::BREAKPOINT) => {
+                                continue;
+                            }
+                            Ok(DebugEvent::CONTINUE(single_step_en)) => {
+                                if single_step_en {
+                                    gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, false);
+                                }
+                                break;
+                            }
+                            Ok(DebugEvent::STEP_INTO(single_step_en)) => {
+                                if !single_step_en {
+                                    gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, true);
+                                }
+                                break;
+                            }
+                            Ok(_) => println!("No handle available for this type of packet"),
+                            Err(_) => println!("Error while waiting for sth/someone to come"),
+                        }
+                    }
+
+                    Ok(VcpuEmulation::Handled)
+                }
                 arch_specific_reason => {
                     // run specific architecture emulation.
                     self.kvm_vcpu.run_arch_emulation(arch_specific_reason)

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -602,7 +602,9 @@ impl Vcpu {
                             }
                             Ok(_) => return Err(Error::GDBServer("Invalid state".to_string())),
                             Err(_) => {
-                                return Err(Error::GDBServer("Communication terminated".to_string()))
+                                return Err(Error::GDBServer(
+                                    "Communication terminated".to_string(),
+                                ))
                             }
                         }
                     }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -538,22 +538,22 @@ impl Vcpu {
                     // by a breakpoint and one caused by single-stepping
                     if self
                         .dbg_event_sender
-                        .send(DebugEvent::Notify(FullVcpuState {
+                        .send(DebugEvent::Notify(Box::new(FullVcpuState {
                             regular_regs,
                             special_regs,
-                        }))
+                        })))
                         .is_err()
                     {
-                        return Err(Error::GDBServer(format!("Invalid state")));
+                        return Err(Error::GDBServer("Invalid state".to_string()));
                     }
                     loop {
                         match self.dbg_response_receiver.recv() {
                             Ok(DebugEvent::GetRegs) => {
                                 self.dbg_event_sender
-                                    .send(DebugEvent::PeekRegs(FullVcpuState {
+                                    .send(DebugEvent::PeekRegs(Box::new(FullVcpuState {
                                         regular_regs,
                                         special_regs,
-                                    }))
+                                    })))
                                     .unwrap();
                                 continue;
                             }
@@ -600,9 +600,9 @@ impl Vcpu {
                                 }
                                 break;
                             }
-                            Ok(_) => return Err(Error::GDBServer(format!("Invalid state"))),
+                            Ok(_) => return Err(Error::GDBServer("Invalid state".to_string())),
                             Err(_) => {
-                                return Err(Error::GDBServer(format!("Communication terminated")))
+                                return Err(Error::GDBServer("Communication terminated".to_string()))
                             }
                         }
                     }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -536,7 +536,7 @@ impl Vcpu {
                     let special_regs = self.kvm_vcpu.fd.get_sregs().unwrap();
                     // For now we don't differentiate between a kvm exit caused
                     // by a breakpoint and one caused by single-stepping
-                    if self.dbg_event_sender.send(DebugEvent::NOTIFY).is_err() {
+                    if self.dbg_event_sender.send(DebugEvent::NOTIFY(FullVcpuState{regular_regs, special_regs})).is_err() {
                         return Err(Error::GDBServer(format!("Invalid state")));
                     }
                     loop {

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -66,6 +66,8 @@ pub enum Error {
     VcpuTlsInit,
     /// Vcpu not present in TLS.
     VcpuTlsNotPresent,
+    /// An error occurred on the GDB server side
+    GDBServer(String),
 }
 
 impl Display for Error {
@@ -80,6 +82,7 @@ impl Display for Error {
             VcpuSpawn(e) => write!(f, "Cannot spawn a new vCPU thread: {}", e),
             VcpuTlsInit => write!(f, "Cannot clean init vcpu TLS"),
             VcpuTlsNotPresent => write!(f, "Vcpu not present in TLS"),
+            GDBServer(ref e) => write!(f, "GDB server session terminated due to error: {}", e),
         }
     }
 }
@@ -533,8 +536,9 @@ impl Vcpu {
                     let special_regs = self.kvm_vcpu.fd.get_sregs().unwrap();
                     // For now we don't differentiate between a kvm exit caused
                     // by a breakpoint and one caused by single-stepping
-                    self.dbg_event_sender.send(DebugEvent::PRINT_PTs(special_regs.cr3))
-                        .expect("Failed notifying GDB server");
+                    if self.dbg_event_sender.send(DebugEvent::NOTIFY).is_err() {
+                        return Err(Error::GDBServer(format!("Invalid state")));
+                    }
                     loop {
                         match self.dbg_response_receiver.recv() {
                             Ok(DebugEvent::GET_REGS) => {
@@ -542,23 +546,24 @@ impl Vcpu {
                                     FullVcpuState { regular_regs, special_regs, })).unwrap();
                                 continue;
                             }
-                            Ok(DebugEvent::BREAKPOINT) => {
-                                continue;
-                            }
                             Ok(DebugEvent::CONTINUE(single_step_en)) => {
                                 if single_step_en {
-                                    gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, false);
+                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, false) {
+                                        return Err(Error::GDBServer(format!("Ioctl call failed: {}", err)));
+                                    }
                                 }
                                 break;
                             }
                             Ok(DebugEvent::STEP_INTO(single_step_en)) => {
                                 if !single_step_en {
-                                    gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, true);
+                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, true) {
+                                        return Err(Error::GDBServer(format!("Ioctl call failed: {}", err)));
+                                    }
                                 }
                                 break;
                             }
-                            Ok(_) => println!("No handle available for this type of packet"),
-                            Err(_) => println!("Error while waiting for sth/someone to come"),
+                            Ok(_) => return Err(Error::GDBServer(format!("Invalid state"))),
+                            Err(_) => return Err(Error::GDBServer(format!("Communication terminated"))),
                         }
                     }
 

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -19,6 +19,7 @@ use std::{
     thread,
 };
 
+use crate::gdb_server::{DebugEvent, FullVcpuState};
 use crate::{
     vmm_config::machine_config::CpuFeaturesTemplate, vstate::vm::Vm, FC_EXIT_CODE_GENERIC_ERROR,
     FC_EXIT_CODE_OK,
@@ -33,7 +34,6 @@ use utils::{
     signal::{register_signal_handler, sigrtmin, Killable},
     sm::StateMachine,
 };
-use crate::gdb_server::{DebugEvent, FullVcpuState};
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) mod aarch64;
@@ -536,34 +536,59 @@ impl Vcpu {
                     let special_regs = self.kvm_vcpu.fd.get_sregs().unwrap();
                     // For now we don't differentiate between a kvm exit caused
                     // by a breakpoint and one caused by single-stepping
-                    if self.dbg_event_sender.send(DebugEvent::NOTIFY(FullVcpuState{regular_regs, special_regs})).is_err() {
+                    if self
+                        .dbg_event_sender
+                        .send(DebugEvent::NOTIFY(FullVcpuState {
+                            regular_regs,
+                            special_regs,
+                        }))
+                        .is_err()
+                    {
                         return Err(Error::GDBServer(format!("Invalid state")));
                     }
                     loop {
                         match self.dbg_response_receiver.recv() {
                             Ok(DebugEvent::GET_REGS) => {
-                                self.dbg_event_sender.send(DebugEvent::PEEK_REGS(
-                                    FullVcpuState { regular_regs, special_regs, })).unwrap();
+                                self.dbg_event_sender
+                                    .send(DebugEvent::PEEK_REGS(FullVcpuState {
+                                        regular_regs,
+                                        special_regs,
+                                    }))
+                                    .unwrap();
                                 continue;
                             }
                             Ok(DebugEvent::CONTINUE(single_step_en)) => {
                                 if single_step_en {
-                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, false) {
-                                        return Err(Error::GDBServer(format!("Ioctl call failed: {}", err)));
+                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(
+                                        &self.kvm_vcpu.fd,
+                                        false,
+                                    ) {
+                                        return Err(Error::GDBServer(format!(
+                                            "Ioctl call failed: {}",
+                                            err
+                                        )));
                                     }
                                 }
                                 break;
                             }
                             Ok(DebugEvent::STEP_INTO(single_step_en)) => {
                                 if !single_step_en {
-                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(&self.kvm_vcpu.fd, true) {
-                                        return Err(Error::GDBServer(format!("Ioctl call failed: {}", err)));
+                                    if let Err(err) = gdb_server::Debugger::enable_kvm_debug(
+                                        &self.kvm_vcpu.fd,
+                                        true,
+                                    ) {
+                                        return Err(Error::GDBServer(format!(
+                                            "Ioctl call failed: {}",
+                                            err
+                                        )));
                                     }
                                 }
                                 break;
                             }
                             Ok(_) => return Err(Error::GDBServer(format!("Invalid state"))),
-                            Err(_) => return Err(Error::GDBServer(format!("Communication terminated"))),
+                            Err(_) => {
+                                return Err(Error::GDBServer(format!("Communication terminated")))
+                            }
                         }
                     }
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -51,7 +51,8 @@ fn test_build_microvm() {
         let mut event_manager = EventManager::new().unwrap();
         let empty_seccomp_filter = get_seccomp_filter(SeccompLevel::None).unwrap();
 
-        let vmm_ret = build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filter);
+        let vmm_ret =
+            build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filter, false);
         assert_eq!(format!("{:?}", vmm_ret.err()), "Some(MissingKernelConfig)");
     }
 
@@ -100,7 +101,8 @@ fn test_vmm_seccomp() {
 
             // The customer "forgot" to whitelist the KVM_RUN ioctl.
             let filter: BpfProgram = MockSeccomp::new().without_kvm_run().into();
-            let vmm = build_microvm_for_boot(&resources, &mut event_manager, &filter).unwrap();
+            let vmm =
+                build_microvm_for_boot(&resources, &mut event_manager, &filter, false).unwrap();
             // Give the vCPUs a chance to attempt KVM_RUN.
             thread::sleep(Duration::from_millis(200));
             // Should never get here.

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2067944,
+        "FC_BINARY_SIZE_TARGET": 2270993,
         "JAILER_BINARY_SIZE_TARGET": 1439512,
-        "FC_BINARY_SIZE_LIMIT": 2171516,
+        "FC_BINARY_SIZE_LIMIT": 2270994,
         "JAILER_BINARY_SIZE_LIMIT": 1511488,
     },
     "aarch64": {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.38, "AMD": 84.65, "ARM": 83.46}
+COVERAGE_DICT = {"Intel": 83.25, "AMD": 82.58, "ARM": 83.30}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -9,7 +9,7 @@ import time
 
 import host_tools.logging as log_tools
 
-MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2600}
+MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2698}
 """ The maximum acceptable startup time in CPU us. """
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 


### PR DESCRIPTION
## Reason for This PR

Initial implementation of a GDB server for guest debugging (https://github.com/firecracker-microvm/firecracker/pull/2168)


## Description of Changes

- Created a new package implementing the gdbstub interface for client-server communication
- Implemented the following functionalities: breakpoint, single-step, reading of registers and memory
- Implemented virtual-to-physical address translation, used by any guest memory access performed as part of the above-mentioned functionalities
- Created a new thread for handling client requests and two channels for vCPU - GDB server thread communication
- Added a "--debugger" command-line option for the firecracker executable

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
