### PR TITLE
Fix memory corruption during Aarch64 GICv3 serialization

### DIFF
--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -347,7 +347,7 @@ pub struct VmState {
 pub struct VmState {
     dist: Vec<u32>,
     rdist: Vec<u32>,
-    icc: Vec<u32>,
+    icc: Vec<u64>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of Changes

The `KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS` group of GICv3 registers are serialized in 64bit chunks, instead of 32bit chunks.

Added a regression unit-test that fails without this fix and passes with it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
