### PR TITLE
[performance] block device test

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -5,17 +5,18 @@
 import os
 import platform
 import tempfile
-from enum import Enum
-from pathlib import Path
-from stat import S_IREAD, S_IWRITE
 from shutil import copyfile
+from enum import Enum
+from stat import S_IREAD, S_IWRITE
+from pathlib import Path
 import boto3
 import botocore.client
-from host_tools.snapshot_helper import merge_memory_bitmaps
+from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.utils import compare_versions
+from host_tools.snapshot_helper import merge_memory_bitmaps
 
 
-ARTIFACTS_LOCAL_ROOT = "/tmp/ci-artifacts"
+ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts"
 
 
 class ArtifactType(Enum):
@@ -36,7 +37,7 @@ class ArtifactType(Enum):
 class Artifact:
     """A generic read-only artifact manipulation class."""
 
-    LOCAL_ARTIFACT_DIR = "/tmp/local-artifacts"
+    LOCAL_ARTIFACT_DIR = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/local-artifacts"
 
     def __init__(self,
                  bucket,

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 from pathlib import Path
 from conftest import init_microvm
+from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.artifacts import (
     Artifact, DiskArtifact, Snapshot, SnapshotType, NetIfaceConfig
 )
@@ -43,7 +44,9 @@ class MicrovmBuilder:
 
     def init_root_path(self):
         """Initialize microvm root path."""
-        self._root_path = tempfile.mkdtemp(MicrovmBuilder.ROOT_PREFIX)
+        self._root_path = tempfile.mkdtemp(
+            MicrovmBuilder.ROOT_PREFIX,
+            dir=f"{DEFAULT_TEST_SESSION_ROOT_PATH}")
 
     def build(self,
               kernel: Artifact,

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -4,19 +4,27 @@
 
 from pathlib import Path
 
+# URL prefix used for the API calls through a UNIX domain socket
 API_USOCKET_URL_PREFIX = 'http+unix://'
-"""URL prefix used for the API calls through a UNIX domain socket."""
+# Firecracker's binary name
 FC_BINARY_NAME = 'firecracker'
-"""Firecracker's binary name."""
+# Jailer's binary name
 JAILER_BINARY_NAME = 'jailer'
-"""Jailer's binary name."""
+# The Firecracker sources workspace dir
 FC_WORKSPACE_DIR = Path(__file__).parent.parent.parent.resolve()
-"""The Firecracker sources workspace dir."""
+# Cargo target dir for the Firecracker workspace. Set via .cargo/config
 FC_WORKSPACE_TARGET_DIR = Path(FC_WORKSPACE_DIR).joinpath("build/cargo_target")
-"""Cargo target dir for the Firecracker workspace. Set via .cargo/config."""
+# Maximum accepted duration of an API call, in milliseconds
 MAX_API_CALL_DURATION_MS = 300
-"""Maximum accepted duration of an API call, in milliseconds."""
+# Relative path to the location of the kernel file
 MICROVM_KERNEL_RELPATH = 'kernel/'
-"""Relative path to the location of the kernel file."""
+# Relative path to the location of the filesystems
 MICROVM_FSFILES_RELPATH = 'fsfiles/'
-"""Relative path to the location of the filesystems."""
+"""The s3 bucket that holds global Firecracker specifications"""
+SPEC_S3_BUCKET = 'spec.ccfc.min'
+"""The default s3 bucket that holds Firecracker microvm test images"""
+DEFAULT_TEST_IMAGES_S3_BUCKET = 'spec.ccfc.min'
+"""Global directory for any of the pytest tests temporary files"""
+ENV_TEST_IMAGES_S3_BUCKET = 'TEST_MICROVM_IMAGES_S3_BUCKET'
+"""Default test session root directory path"""
+DEFAULT_TEST_SESSION_ROOT_PATH = "/srv"

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -8,12 +8,13 @@ import stat
 from pathlib import Path
 from retry.api import retry_call
 import framework.utils as utils
+import framework.defs as defs
 from framework.defs import FC_BINARY_NAME
 
 # Default name for the socket used for API calls.
 DEFAULT_USOCKET_NAME = 'run/firecracker.socket'
 # The default location for the chroot.
-DEFAULT_CHROOT_PATH = '/srv/jailer'
+DEFAULT_CHROOT_PATH = f'{defs.DEFAULT_TEST_SESSION_ROOT_PATH}/jailer'
 
 
 class JailerContext:

--- a/tests/framework/statistics/__init__.py
+++ b/tests/framework/statistics/__init__.py
@@ -9,3 +9,4 @@ from . import producer
 from . import types
 from . import criteria
 from . import function
+from . import baselines_util

--- a/tests/framework/statistics/baselines_util.py
+++ b/tests/framework/statistics/baselines_util.py
@@ -1,0 +1,76 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Module to define utility abstractions to be used when working with...
+
+...baselines in performance tests.
+"""
+
+from abc import abstractmethod, ABC
+from typing import Any
+
+
+# pylint: disable=R0903
+class DictQuery:
+    """Utility class to query python dicts key paths.
+
+    The keys from the path must be `str`s.
+    Example:
+    > d = {
+            "a": {
+                "b": {
+                    "c": 0
+                }
+            },
+            "d": 1
+      }
+    > dq = DictQuery(d)
+    > print(dq.get("a/b/c"))
+    0
+    > print(dq.get("d"))
+    1
+    """
+
+    def __init__(self, d: dict):
+        """Initialize the dict query."""
+        self._inner = d
+
+    def get(self, keys_path: str, default=None):
+        """Retrieve value corresponding to the key path."""
+        keys = keys_path.strip().split("/")
+        if len(keys) < 1:
+            return default
+
+        result = self._inner.get(keys[0])
+        for key in keys[1:]:
+            if not result:
+                return default
+
+            result = result.get(key)
+
+        return result
+
+    def __str__(self):
+        """Representation as a string."""
+        return str(self._inner)
+
+
+class BaselineProvider(ABC):
+    """Abstraction class for ease of retrieving baselines."""
+
+    def __init__(self, baselines: DictQuery):
+        """Initialize the provider with the baselines data."""
+        self._baselines = baselines
+
+    @abstractmethod
+    def target(self, key: str) -> Any:
+        """Return the target corresponding to the baseline represented by...
+
+        ...key. The key must be valid with respect to JSON pointer syntax.
+        """
+
+    @abstractmethod
+    def delta(self, key: str) -> Any:
+        """Return the delta corresponding to the baseline represented by...
+
+        ...key. The key must be valid with respect to JSON pointer syntax.
+        """

--- a/tests/framework/statistics/core.py
+++ b/tests/framework/statistics/core.py
@@ -31,13 +31,14 @@ class Core:
     """Base class for statistics core driver."""
 
     # pylint: disable=W0102
-    def __init__(self, name, iterations, custom={}):
+    def __init__(self, name, iterations, custom={}, check=True):
         """Core constructor."""
         self._pipes = defaultdict(Pipe)
         self._statistics = Statistics(name=name,
                                       iterations=iterations,
                                       results={},
                                       custom=custom)
+        self._check = check
 
     def add_pipe(self, producer: Producer, consumer: Consumer, tag=None):
         """Add a new producer-consumer pipe."""
@@ -58,7 +59,7 @@ class Core:
                 else:
                     pipe.consumer.ingest(iteration, raw_data)
             try:
-                stats, custom = pipe.consumer.process()
+                stats, custom = pipe.consumer.process(self._check)
             except Failed as err:
                 assert False, f"Failed on '{tag}': {err.msg}"
 
@@ -67,6 +68,9 @@ class Core:
             # Custom information extracted from all the iterations.
             if len(custom) > 0:
                 self._statistics['custom'][tag] = custom
+
+        if not self._check:
+            print(self._statistics)
 
         return self._statistics
 

--- a/tests/framework/statistics/function.py
+++ b/tests/framework/statistics/function.py
@@ -23,18 +23,25 @@ class StatisticFunction(ABC):
     def __call__(self) -> Any:
         """Builtin function needs to be implemented."""
 
+    @classmethod
+    @abstractmethod
+    def name(cls) -> str:
+        """Return the name identifier for the class."""
+
 
 # pylint: disable=R0903
-class Identity(StatisticFunction):
-    """A function which extracts the last observation from a list of...
-
-    ...observations.
-    """
+class GetFirstObservation(StatisticFunction):
+    """A function which return the first observation."""
 
     def __call__(self) -> Any:
-        """Get the last result only."""
-        assert len(self.results) == 1
+        """Get the first result only."""
+        assert len(self.results) > 0
         return self.results[0]
+
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `GetFirstObservation`."""
+        return "get_first_observation"
 
 
 # pylint: disable=R0903
@@ -48,6 +55,11 @@ class Min(StatisticFunction):
         """Get the minimum observation."""
         return min(self.results)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Min`."""
+        return "min"
+
 
 # pylint: disable=R0903
 class Max(StatisticFunction):
@@ -60,6 +72,11 @@ class Max(StatisticFunction):
         """Get the maximum observation."""
         return max(self.results)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Max`."""
+        return "max"
+
 
 # pylint: disable=R0903
 class Avg(StatisticFunction):
@@ -69,6 +86,11 @@ class Avg(StatisticFunction):
         """Get the average."""
         return mean(self.results)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Avg`."""
+        return "avg"
+
 
 # pylint: disable=R0903
 class Sum(StatisticFunction):
@@ -77,6 +99,11 @@ class Sum(StatisticFunction):
     def __call__(self) -> Any:
         """Get the sum."""
         return sum(self.results)
+
+    @classmethod
+    def name(cls) -> str:
+        """Return identifier for `Sum`."""
+        return "sum"
 
 
 # pylint: disable=R0903
@@ -94,9 +121,14 @@ class Stddev(StatisticFunction):
             return self.results[0]
         return stdev(self.results)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Stddev`."""
+        return "stddev"
+
 
 # pylint: disable=R0903
-class Percentile(StatisticFunction):
+class Percentile(StatisticFunction, ABC):
     """A function which computes the kth percentile of a list of...
 
     ...observations.
@@ -132,6 +164,11 @@ class Percentile50(Percentile):
         """Initialize the function."""
         super().__init__(results, 50)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Percentile50`."""
+        return "p50"
+
 
 class Percentile90(Percentile):
     """A function which computes the 90th percentile of a list of...
@@ -143,6 +180,11 @@ class Percentile90(Percentile):
         """Initialize the function."""
         super().__init__(results, 90)
 
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Percentile90`."""
+        return "p90"
+
 
 class Percentile99(Percentile):
     """A function which computes the 99th percentile of a list of...
@@ -153,3 +195,8 @@ class Percentile99(Percentile):
     def __init__(self, results: List):
         """Initialize the function."""
         super().__init__(results, 99)
+
+    @classmethod
+    def name(cls) -> str:
+        """Return an identifier for `Percentile99`."""
+        return "p99"

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -59,6 +59,23 @@ class SSHConnection:
         else:
             utils.run_cmd(cmd)
 
+    def scp_get_file(self, remote_path, local_path):
+        """Copy files from the VM using scp."""
+        cmd = ('scp -o StrictHostKeyChecking=no'
+               ' -o UserKnownHostsFile=/dev/null'
+               ' -i {} {}@{}:{} {}').format(
+            self.ssh_config['ssh_key_path'],
+            self.ssh_config['username'],
+            self.ssh_config['hostname'],
+            remote_path,
+            local_path
+        )
+        if self.netns_file_path:
+            with Namespace(self.netns_file_path, 'net'):
+                utils.run_cmd(cmd)
+        else:
+            utils.run_cmd(cmd)
+
     @retry(ConnectionError, delay=0.1, tries=20)
     def _init_connection(self):
         """Create an initial SSH client connection (retry until it works).

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -42,7 +42,7 @@ KCOV_TOTAL_LINES_REGEX = r'"total_lines" : "(\d+)"'
 
 
 @pytest.mark.timeout(400)
-def test_coverage(test_session_root_path, test_session_tmp_path):
+def test_coverage(test_fc_session_root_path, test_session_tmp_path):
     """Test line coverage with kcov.
 
     The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
@@ -75,7 +75,7 @@ def test_coverage(test_session_root_path, test_session_tmp_path):
         '--exclude-region={} --verify'
     ).format(
         host.get_rustflags(),
-        os.path.join(test_session_root_path, CARGO_KCOV_REL_PATH),
+        os.path.join(test_fc_session_root_path, CARGO_KCOV_REL_PATH),
         target,
         test_session_tmp_path,
         exclude_pattern,

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -17,7 +17,7 @@ TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
     "target",
     TARGETS
 )
-def test_unittests(test_session_root_path, target):
+def test_unittests(test_fc_session_root_path, target):
     """Run unit and doc tests for all supported targets."""
     extra_args = "--release --target {} ".format(target)
 
@@ -27,6 +27,6 @@ def test_unittests(test_session_root_path, target):
                     " code-coverage.")
 
     host.cargo_test(
-        test_session_root_path,
+        test_fc_session_root_path,
         extra_args=extra_args
     )

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -97,11 +97,11 @@ def _test_seq_snapshots(context):
     assert exit_code == 0
 
     if snapshot_type == SnapshotType.FULL:
-        test_session_root_path = context.custom['test_session_root_path']
+        test_fc_session_root_path = context.custom['test_fc_session_root_path']
         vsock_helper = context.custom['bin_vsock_path']
         vm_blob_path = "/tmp/vsock/test.blob"
         # Generate a random data file for vsock.
-        blob_path, blob_hash = make_blob(test_session_root_path)
+        blob_path, blob_hash = make_blob(test_fc_session_root_path)
         # Copy the data file and a vsock helper to the guest.
         _copy_vsock_data_to_guest(ssh_connection,
                                   blob_path,
@@ -269,7 +269,7 @@ def test_patch_drive_snapshot(bin_cloner_path):
 def test_5_full_snapshots(network_config,
                           bin_cloner_path,
                           bin_vsock_path,
-                          test_session_root_path):
+                          test_fc_session_root_path):
     """Test scenario: 5 full sequential snapshots."""
     logger = logging.getLogger("snapshot_sequence")
 
@@ -292,7 +292,7 @@ def test_5_full_snapshots(network_config,
         'snapshot_type': SnapshotType.FULL,
         'seq_len': 5,
         'bin_vsock_path': bin_vsock_path,
-        'test_session_root_path': test_session_root_path
+        'test_fc_session_root_path': test_fc_session_root_path
     }
 
     # Create the test matrix.

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -29,7 +29,7 @@ def test_vsock(
         test_microvm_with_ssh,
         network_config,
         bin_vsock_path,
-        test_session_root_path
+        test_fc_session_root_path
 ):
     """Vsock tests. See the module docstring for a high-level description."""
     vm = test_microvm_with_ssh
@@ -46,7 +46,7 @@ def test_vsock(
     vm.start()
 
     # Generate the random data blob file.
-    blob_path, blob_hash = make_blob(test_session_root_path)
+    blob_path, blob_hash = make_blob(test_fc_session_root_path)
     vm_blob_path = "/tmp/vsock/test.blob"
 
     # Set up a tmpfs drive on the guest, so we can copy the blob there.

--- a/tests/integration_tests/performance/configs/block_performance_test_config_raw.json
+++ b/tests/integration_tests/performance/configs/block_performance_test_config_raw.json
@@ -1,0 +1,789 @@
+{
+  "block_device_size": 2048,
+  "time": 300,
+  "omit": 10,
+  "load_factor": 1,
+  "fio_blk_sizes": [
+    4096
+  ],
+  "fio_modes": [
+    "randrw",
+    "randread",
+    "read",
+    "readwrite"
+  ],
+  "hosts": {
+    "instances": {
+      "m5d.metal": {
+        "cpus": [
+          {
+            "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+            "baseline_cpu_utilization_vmm": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 36,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 35,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 35,
+                    "delta_percentage": 7
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 35,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 65,
+                    "delta_percentage": 7
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 64,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 63,
+                    "delta_percentage": 7
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 63,
+                    "delta_percentage": 7
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 35,
+                    "delta_percentage": 10
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 34,
+                    "delta_percentage": 11
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 33,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 34,
+                    "delta_percentage": 9
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 64,
+                    "delta_percentage": 7
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 64,
+                    "delta_percentage": 7
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 63,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 63,
+                    "delta_percentage": 7
+                  }
+                }
+              }
+            },
+            "baseline_cpu_utilization_vcpus_total": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  }
+                }
+              }
+            },
+            "baseline_iops_read": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 46845,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 94966,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 95720,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 47130,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 98332,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 200547,
+                    "delta_percentage": 9
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 200126,
+                    "delta_percentage": 9
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 97011,
+                    "delta_percentage": 8
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 47178,
+                    "delta_percentage": 9
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 94379,
+                    "delta_percentage": 10
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 94100,
+                    "delta_percentage": 10
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 46483,
+                    "delta_percentage": 9
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 98473,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 200619,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 200967,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 97069,
+                    "delta_percentage": 9
+                  }
+                }
+              }
+            },
+            "baseline_bw_read": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 187380,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 379862,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 382878,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 188520,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 393329,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 802187,
+                    "delta_percentage": 9
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 800506,
+                    "delta_percentage": 9
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 388044,
+                    "delta_percentage": 8
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 188713,
+                    "delta_percentage": 9
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 377517,
+                    "delta_percentage": 10
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 376399,
+                    "delta_percentage": 10
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 185930,
+                    "delta_percentage": 9
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 393893,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 802475,
+                    "delta_percentage": 8
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 803870,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 388277,
+                    "delta_percentage": 9
+                  }
+                }
+              }
+            },
+            "baseline_iops_write": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 46852,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 47132,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 98336,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 97014,
+                    "delta_percentage": 8
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 47176,
+                    "delta_percentage": 9
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 46478,
+                    "delta_percentage": 9
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 98478,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 97063,
+                    "delta_percentage": 9
+                  }
+                }
+              }
+            },
+            "baseline_bw_write": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 187406,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 188525,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 393344,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 388058,
+                    "delta_percentage": 8
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 188704,
+                    "delta_percentage": 9
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 185913,
+                    "delta_percentage": 9
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 393914,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 388255,
+                    "delta_percentage": 9
+                  }
+                }
+              }
+            }
+          },
+          {
+            "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+            "baseline_cpu_utilization_vmm": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 37,
+                    "delta_percentage": 6
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 36,
+                    "delta_percentage": 7
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 36,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 37,
+                    "delta_percentage": 8
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 70,
+                    "delta_percentage": 6
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 70,
+                    "delta_percentage": 6
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 70,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 69,
+                    "delta_percentage": 6
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 42,
+                    "delta_percentage": 7
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 41,
+                    "delta_percentage": 7
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 40,
+                    "delta_percentage": 7
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 40,
+                    "delta_percentage": 7
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 71,
+                    "delta_percentage": 6
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 71,
+                    "delta_percentage": 6
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 70,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 71,
+                    "delta_percentage": 6
+                  }
+                }
+              }
+            },
+            "baseline_cpu_utilization_vcpus_total": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 172,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 172,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 86,
+                    "delta_percentage": 5
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 171,
+                    "delta_percentage": 5
+                  }
+                }
+              }
+            },
+            "baseline_iops_read": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 38454,
+                    "delta_percentage": 6
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 77842,
+                    "delta_percentage": 6
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 78046,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 38592,
+                    "delta_percentage": 6
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 77385,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 157316,
+                    "delta_percentage": 9
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 159630,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 77705,
+                    "delta_percentage": 9
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 50049,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 100510,
+                    "delta_percentage": 12
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 101105,
+                    "delta_percentage": 10
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 49333,
+                    "delta_percentage": 11
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 109656,
+                    "delta_percentage": 16
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 184727,
+                    "delta_percentage": 17
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 179659,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 90853,
+                    "delta_percentage": 14
+                  }
+                }
+              }
+            },
+            "baseline_bw_read": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 153814,
+                    "delta_percentage": 6
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 311365,
+                    "delta_percentage": 6
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 312182,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 154367,
+                    "delta_percentage": 6
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 309535,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 629264,
+                    "delta_percentage": 9
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 638517,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 310816,
+                    "delta_percentage": 9
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 200194,
+                    "delta_percentage": 8
+                  },
+                  "randread-bs4096-1vcpu": {
+                    "target": 402041,
+                    "delta_percentage": 12
+                  },
+                  "read-bs4096-1vcpu": {
+                    "target": 404418,
+                    "delta_percentage": 10
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 197330,
+                    "delta_percentage": 11
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 438623,
+                    "delta_percentage": 16
+                  },
+                  "randread-bs4096-2vcpu": {
+                    "target": 738904,
+                    "delta_percentage": 17
+                  },
+                  "read-bs4096-2vcpu": {
+                    "target": 718630,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 363409,
+                    "delta_percentage": 14
+                  }
+                }
+              }
+            },
+            "baseline_iops_write": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 38458,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 38587,
+                    "delta_percentage": 6
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 77386,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 77696,
+                    "delta_percentage": 9
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 50049,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 49336,
+                    "delta_percentage": 11
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 109658,
+                    "delta_percentage": 26
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 90852,
+                    "delta_percentage": 14
+                  }
+                }
+              }
+            },
+            "baseline_bw_write": {
+              "vmlinux-4.14.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 153831,
+                    "delta_percentage": 6
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 154348,
+                    "delta_percentage": 6
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 309544,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 310784,
+                    "delta_percentage": 9
+                  }
+                }
+              },
+              "vmlinux-4.9.bin": {
+                "ubuntu-18.04.ext4": {
+                  "randrw-bs4096-1vcpu": {
+                    "target": 200194,
+                    "delta_percentage": 8
+                  },
+                  "readwrite-bs4096-1vcpu": {
+                    "target": 197343,
+                    "delta_percentage": 11
+                  },
+                  "randrw-bs4096-2vcpu": {
+                    "target": 438632,
+                    "delta_percentage": 16
+                  },
+                  "readwrite-bs4096-2vcpu": {
+                    "target": 363410,
+                    "delta_percentage": 14
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.py
+++ b/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.py
@@ -3,6 +3,8 @@
 """Configuration file for the network TCP throughput test."""
 
 # pylint: disable=C0302
+from framework.statistics.types import DefaultMeasurement
+
 DEBUG = False
 
 IPERF3 = "iperf3"
@@ -12,11 +14,11 @@ DURATION = "duration"
 DURATION_TOTAL = "total"
 RETRANSMITS = "retransmits"
 RETRANSMITS_TOTAL = "total"
-CPU_UTILIZATION_HOST = "cpu_utilization_host"
-CPU_UTILIZATION_GUEST = "cpu_utilization_guest"
 BASE_PORT = 5000
-CPU_UTILIZATION_VMM_TAG = "vmm"
-CPU_UTILIZATION_VCPUS_TOTAL_TAG = "vcpus_total"
+CPU_UTILIZATION_VMM = \
+    f"{DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()}"
+CPU_UTILIZATION_VCPUS_TOTAL = \
+    f"{DefaultMeasurement.CPU_UTILIZATION_VCPUS_TOTAL.name.lower()}"
 IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG = "cpu_utilization_percent"
 IPERF3_END_RESULTS_TAG = "end"
 DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG = "cpu_utilization_vmm_samples"

--- a/tests/integration_tests/performance/configs/vsock_throughput_test_config.py
+++ b/tests/integration_tests/performance/configs/vsock_throughput_test_config.py
@@ -2,16 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Configuration file for the VSOCK throughput test."""
 
+from framework.statistics.types import DefaultMeasurement
+
 IPERF3 = "iperf3-vsock"
 THROUGHPUT = "throughput"
 THROUGHPUT_TOTAL = "total"
 DURATION = "duration"
 DURATION_TOTAL = "total"
-CPU_UTILIZATION_HOST = "cpu_utilization_host"
-CPU_UTILIZATION_GUEST = "cpu_utilization_guest"
 BASE_PORT = 5201
-CPU_UTILIZATION_VMM_TAG = "vmm"
-CPU_UTILIZATION_VCPUS_TOTAL_TAG = "vcpus_total"
+CPU_UTILIZATION_VMM = \
+                    f"{DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()}"
+CPU_UTILIZATION_VCPUS_TOTAL = \
+    f"{DefaultMeasurement.CPU_UTILIZATION_VCPUS_TOTAL.name.lower()}"
 IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG = "cpu_utilization_percent"
 IPERF3_END_RESULTS_TAG = "end"
 TARGET_TAG = "target"

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -1,0 +1,469 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Performance benchmark for block device emulation."""
+import concurrent
+import json
+import logging
+import os
+from enum import Enum
+import shutil
+from numbers import Number
+
+import pytest
+
+
+from conftest import _test_images_s3_bucket
+from framework import utils
+from framework.artifacts import ArtifactCollection, ArtifactSet
+from framework.builder import MicrovmBuilder
+from framework.matrix import TestContext, TestMatrix
+from framework.statistics import core, criteria
+from framework.statistics.baselines_util import BaselineProvider, DictQuery
+from framework.statistics.types import DefaultMeasurement
+from framework.utils import get_cpu_percent, CmdBuilder, eager_map
+from framework.utils_cpuid import get_cpu_model_name
+import host_tools.drive as drive_tools
+import host_tools.network as net_tools  # pylint: disable=import-error
+import framework.statistics as st
+
+
+DEBUG = False
+TEST_ID = "block_device_performance"
+FIO = "fio"
+
+# Measurements tags.
+IOPS = "iops_{}"
+BW = "bw_{}"
+LAT = "lat_{}"
+CLAT = "clat_{}"
+SLAT = "slat_{}"
+READ_OP = "read"
+WRITE_OP = "write"
+CPU_UTILIZATION_VMM = DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()
+CPU_UTILIZATION_VMM_SAMPLES_TAG = f"{CPU_UTILIZATION_VMM}_samples"
+CPU_UTILIZATION_VCPUS_TOTAL = \
+    f"{DefaultMeasurement.CPU_UTILIZATION_VCPUS_TOTAL.name.lower()}"
+
+# Measurements units.
+KIBPERSEC_UNIT = "KiB/s"
+IOPERSEC_UNIT = "io/s"
+
+CONFIG_RAW_FILE = os.path.join(
+    os.path.dirname(__file__),
+    'configs/block_performance_test_config_raw.json')
+
+
+with open(CONFIG_RAW_FILE) as config_raw:
+    CONFIG = json.load(config_raw)
+
+
+class BlockBaselineProvider(BaselineProvider):
+    """Implementation of a baseline provider for the block performance test."""
+
+    def __init__(self, cpu_model_name):
+        """Block baseline provider initialization."""
+        baselines = list(filter(
+            lambda cpu_baseline: cpu_baseline["model"] == cpu_model_name,
+            CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]))
+
+        super().__init__(DictQuery(dict()))
+        if len(baselines) > 0:
+            super().__init__(DictQuery(baselines[0]))
+
+    def target(self, key: str) -> Number:
+        """Return the target value corresponding to the key."""
+        return self._baselines.get(key)["target"]
+
+    def delta(self, key: str) -> Number:
+        """Return the delta value corresponding to the key."""
+        return self.target(key) * self._baselines.get(key)[
+            "delta_percentage"] / 100
+
+
+def cpu_utilization_measurements():
+    """CPU utilization measurements."""
+    return [st.consumer.MeasurementDef.cpu_utilization_vmm(),
+            st.consumer.MeasurementDef.cpu_utilization_vcpus_total()]
+
+
+def ops_measurements(operation: str):
+    """Return measurements based on the operation (read/write)."""
+    return [st.consumer.MeasurementDef(IOPS.format(operation), IOPERSEC_UNIT),
+            st.consumer.MeasurementDef(BW.format(operation), KIBPERSEC_UNIT)]
+
+
+def measurements(mode):
+    """Define metrics based on the mode."""
+    ms = cpu_utilization_measurements()
+    ms.extend(ops_measurements(READ_OP))
+    if mode.endswith(WRITE_OP) or mode.endswith("rw"):
+        ms.extend(ops_measurements(WRITE_OP))
+    return ms
+
+
+def no_criteria_cpu_utilization_stats():
+    """Return the set of CPU utilization statistics without criteria."""
+    return [
+        st.consumer.StatisticDef.get_first_observation(CPU_UTILIZATION_VMM,
+                                                       st_name="value"),
+        st.consumer.StatisticDef.get_first_observation(
+            CPU_UTILIZATION_VCPUS_TOTAL, st_name="value"
+        )
+    ]
+
+
+def criteria_cpu_utilization_stats(env_id, fio_id):
+    """Return the set of CPU utilization statistics with criteria."""
+    cpu_util_vmm_key = f"baseline_cpu_utilization_vmm/{env_id}/{fio_id}"
+    cpu_util_vcpus_total_key = "baseline_cpu_utilization_vcpus_total/" \
+                               f"{env_id}/{fio_id}"
+    blk_baseline_provider = BlockBaselineProvider(get_cpu_model_name())
+    return [
+        st.consumer.StatisticDef.get_first_observation(
+            st_name="value",
+            ms_name=CPU_UTILIZATION_VMM,
+            criteria=criteria.EqualWith(
+                blk_baseline_provider.target(cpu_util_vmm_key),
+                blk_baseline_provider.delta(cpu_util_vmm_key))
+        ),
+        st.consumer.StatisticDef.get_first_observation(
+            st_name="value",
+            ms_name=CPU_UTILIZATION_VCPUS_TOTAL,
+            criteria=criteria.EqualWith(
+                blk_baseline_provider.target(cpu_util_vcpus_total_key),
+                blk_baseline_provider.delta(cpu_util_vcpus_total_key))
+        )
+    ]
+
+
+def no_criteria_ops_stats(operation: str):
+    """Return statistics without criteria."""
+    return [
+        st.consumer.StatisticDef.avg(IOPS.format(operation)),
+        st.consumer.StatisticDef.stddev(IOPS.format(operation)),
+        st.consumer.StatisticDef.avg(BW.format(operation)),
+        st.consumer.StatisticDef.stddev(BW.format(operation))]
+
+
+def criteria_ops_stats(env_id: str, fio_id: str, operation: str):
+    """Return statistics with pass criteria given by the baselines."""
+    bw_key = f"baseline_{BW.format(operation)}/{env_id}/{fio_id}"
+    iops_key = f"baseline_{IOPS.format(operation)}/{env_id}/{fio_id}"
+    blk_baseline_provider = BlockBaselineProvider(get_cpu_model_name())
+    return [
+        st.consumer.StatisticDef.avg(
+            IOPS.format(operation),
+            criteria=criteria.EqualWith(
+                blk_baseline_provider.target(iops_key),
+                blk_baseline_provider.delta(iops_key))),
+        st.consumer.StatisticDef.stddev(IOPS.format(operation)),
+        st.consumer.StatisticDef.avg(
+            BW.format(operation),
+            criteria=criteria.EqualWith(
+                blk_baseline_provider.target(bw_key),
+                blk_baseline_provider.delta(bw_key))),
+        st.consumer.StatisticDef.stddev(BW.format(operation))]
+
+
+def statistics(mode, env_id, fio_id):
+    """Define statistics based on the mode."""
+    host_cpu_model = get_cpu_model_name()
+    cpu_baselines = CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]
+    host_cpu_baselines = None
+    for baselines in cpu_baselines:
+        if baselines["model"] == host_cpu_model:
+            host_cpu_baselines = baselines
+            break
+
+    # Because of current fio modes (randread, randrw, readwrite, read) we can
+    # always assume that we measure read operations.
+    stats = no_criteria_cpu_utilization_stats()
+    stats.extend(no_criteria_ops_stats("read"))
+
+    if host_cpu_baselines:
+        stats = criteria_cpu_utilization_stats(env_id, fio_id)
+        stats.extend(criteria_ops_stats(env_id, fio_id, "read"))
+
+    if mode.endswith("write") or mode.endswith("rw"):
+        if host_cpu_baselines:
+            stats.extend(criteria_ops_stats(env_id, fio_id, "write"))
+        else:
+            stats.extend(no_criteria_ops_stats("write"))
+
+    return stats
+
+
+def run_fio(env_id, basevm, ssh_conn, mode, bs):
+    """Run a fio test in the specified mode with block size bs."""
+    # Compute the fio command. Pin it to the first guest CPU.
+    cmd = CmdBuilder(FIO) \
+        .with_arg(f"--name={mode}-{bs}")\
+        .with_arg(f"--rw={mode}")\
+        .with_arg(f"--bs={bs}")\
+        .with_arg("--filename=/dev/vdb") \
+        .with_arg("--time_base=1") \
+        .with_arg(f"--size={CONFIG['block_device_size']}M")\
+        .with_arg("--direct=1") \
+        .with_arg("--ioengine=libaio") \
+        .with_arg("--iodepth=32") \
+        .with_arg(f"--ramp_time={CONFIG['omit']}") \
+        .with_arg(f"--numjobs={CONFIG['load_factor'] * basevm.vcpus_count}") \
+        .with_arg("--randrepeat=0") \
+        .with_arg(f"--runtime={CONFIG['time']}")\
+        .with_arg(f"--write_iops_log={mode}{bs}") \
+        .with_arg(f"--write_bw_log={mode}{bs}") \
+        .with_arg("--log_avg_msec=1000") \
+        .with_arg("--output-format=json+") \
+        .build()
+
+    rc, _, stderr = ssh_conn.execute_command(
+        "echo 'none' > /sys/block/vdb/queue/scheduler")
+    assert rc == 0, stderr.read()
+    assert stderr.read() == ""
+
+    utils.run_cmd("echo 3 > /proc/sys/vm/drop_caches")
+
+    rc, _, stderr = ssh_conn.execute_command(
+        "echo 3 > /proc/sys/vm/drop_caches")
+    assert rc == 0, stderr.read()
+    assert stderr.read() == ""
+
+    # Start the CPU load monitor.
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        cpu_load_future = executor.submit(get_cpu_percent,
+                                          basevm.jailer_clone_pid,
+                                          CONFIG["time"],
+                                          omit=CONFIG["omit"])
+
+        # Print the fio command in the log and run it
+        rc, _, stderr = ssh_conn.execute_command(cmd)
+        assert rc == 0, stderr.read()
+        assert stderr.read() == ""
+
+        if os.path.isdir(f"results/{env_id}/{mode}{bs}"):
+            shutil.rmtree(f"results/{env_id}/{mode}{bs}")
+
+        os.makedirs(f"results/{env_id}/{mode}{bs}")
+
+        ssh_conn.scp_get_file("*.log", f"results/{env_id}/{mode}{bs}/")
+        rc, _, stderr = ssh_conn.execute_command("rm *.log")
+        assert rc == 0, stderr.read()
+
+        result = dict()
+        cpu_load = cpu_load_future.result()
+        tag = "firecracker"
+        assert tag in cpu_load and len(cpu_load[tag]) == 1
+
+        data = list(cpu_load[tag].values())[0]
+        data_len = len(data)
+        assert data_len == CONFIG["time"]
+
+        result[CPU_UTILIZATION_VMM] = sum(data)/data_len
+        if DEBUG:
+            result[CPU_UTILIZATION_VMM_SAMPLES_TAG] = data
+
+        vcpus_util = 0
+        for vcpu in range(basevm.vcpus_count):
+            # We expect a single fc_vcpu thread tagged with
+            # f`fc_vcpu {vcpu}`.
+            tag = f"fc_vcpu {vcpu}"
+            cpu_utilization_prefix = \
+                DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()
+            assert tag in cpu_load and len(cpu_load[tag]) == 1
+            data = list(cpu_load[tag].values())[0]
+            data_len = len(data)
+
+            assert data_len == CONFIG["time"]
+            if DEBUG:
+                result[f"{cpu_utilization_prefix}_samples_fc_vcpu_{vcpu}"] = \
+                    data
+            vcpus_util += sum(data)/data_len
+
+        result[CPU_UTILIZATION_VCPUS_TOTAL] = vcpus_util
+        return result
+
+
+class DataDirection(Enum):
+    """Operation type."""
+
+    READ = 0
+    WRITE = 1
+    TRIM = 2
+
+    def __str__(self):
+        """Representation as string."""
+        # pylint: disable=W0143
+        if self.value == 0:
+            return "read"
+        # pylint: disable=W0143
+        if self.value == 1:
+            return "write"
+        # pylint: disable=W0143
+        if self.value == 2:
+            return "trim"
+        return ""
+
+
+def read_values(cons, numjobs, env_id, mode, bs, measurement):
+    """Read the values for each measurement.
+
+    The values are logged once every second. The time resolution is in msec.
+    The log file format documentation can be found here:
+    https://fio.readthedocs.io/en/latest/fio_doc.html#log-file-formats
+    """
+    values = dict()
+
+    for job_id in range(numjobs):
+        file_path = f"results/{env_id}/{mode}{bs}/{mode}{bs}_{measurement}" \
+                  f".{job_id + 1}.log"
+        file = open(file_path)
+        lines = file.readlines()
+
+        direction_count = 1
+        if mode.endswith("readwrite") or mode.endswith("rw"):
+            direction_count = 2
+
+        for idx in range(0, len(lines), direction_count):
+            value_idx = idx//direction_count
+            for direction in range(direction_count):
+                data = lines[idx + direction].split(sep=",")
+                data_dir = DataDirection(int(data[2].strip()))
+
+                measurement_id = f"{measurement}_{str(data_dir)}"
+                if measurement_id not in values:
+                    values[measurement_id] = dict()
+
+                if value_idx not in values[measurement_id]:
+                    values[measurement_id][value_idx] = list()
+                values[measurement_id][value_idx].append(int(data[1].strip()))
+
+        for measurement_id in values:
+            for idx in values[measurement_id]:
+                # Discard data points which were not measured by all jobs.
+                if len(values[measurement_id][idx]) != numjobs:
+                    continue
+
+                value = sum(values[measurement_id][idx])
+                if DEBUG:
+                    cons.consume_custom(measurement_id, value)
+                cons.consume_measurement(measurement_id, value)
+
+
+def consume_fio_output(cons, result, numjobs, mode, bs, env_id):
+    """Consumer function."""
+    cpu_utilization_vmm = result[CPU_UTILIZATION_VMM]
+    cpu_utilization_vcpus = result[CPU_UTILIZATION_VCPUS_TOTAL]
+
+    cons.consume_measurement(CPU_UTILIZATION_VMM, cpu_utilization_vmm)
+    cons.consume_measurement(CPU_UTILIZATION_VCPUS_TOTAL,
+                             cpu_utilization_vcpus)
+
+    read_values(cons, numjobs, env_id, mode, bs, "iops")
+    read_values(cons, numjobs, env_id, mode, bs, "bw")
+
+
+@pytest.mark.nonci
+@pytest.mark.timeout(CONFIG["time"] * 1000)
+def test_block_performance(bin_cloner_path):
+    """Test network throughput driver for multiple artifacts."""
+    logger = logging.getLogger(TEST_ID)
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_1024mb"))
+    microvm_artifacts.insert(artifacts.microvms(keyword="1vcpu_1024mb"))
+    kernel_artifacts = ArtifactSet(artifacts.kernels())
+    disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
+
+    # Create a test context and add builder, logger, network.
+    test_context = TestContext()
+    test_context.custom = {
+        'builder': MicrovmBuilder(bin_cloner_path),
+        'logger': logger,
+        'name': TEST_ID
+    }
+
+    print(f"CPU model: {get_cpu_model_name()}.")
+
+    test_matrix = TestMatrix(context=test_context,
+                             artifact_sets=[
+                                 microvm_artifacts,
+                                 kernel_artifacts,
+                                 disk_artifacts
+                             ])
+    test_matrix.run_test(fio_workload)
+
+
+def fio_workload(context):
+    """Execute block device emulation benchmarking scenarios."""
+    vm_builder = context.custom['builder']
+    logger = context.custom["logger"]
+
+    # Create a rw copy artifact.
+    rw_disk = context.disk.copy()
+    # Get ssh key from read-only artifact.
+    ssh_key = context.disk.ssh_key()
+    # Create a fresh microvm from artifacts.
+    basevm = vm_builder.build(kernel=context.kernel,
+                              disks=[rw_disk],
+                              ssh_key=ssh_key,
+                              config=context.microvm)
+
+    # Add a secondary block device for benchmark tests.
+    fs = drive_tools.FilesystemFile(
+        os.path.join(basevm.fsfiles, 'scratch'),
+        CONFIG["block_device_size"]
+    )
+    basevm.add_drive('scratch', fs.path)
+    basevm.start()
+
+    # Get names of threads in Firecracker.
+    current_cpu_id = 0
+    basevm.pin_vmm(current_cpu_id)
+    current_cpu_id += 1
+    basevm.pin_api(current_cpu_id)
+    for vcpu_id in range(basevm.vcpus_count):
+        current_cpu_id += 1
+        basevm.pin_vcpu(vcpu_id, current_cpu_id)
+
+    st_core = core.Core(name=TEST_ID,
+                        iterations=1,
+                        custom={"microvm": context.microvm.name(),
+                                "kernel": context.kernel.name(),
+                                "disk": context.disk.name()})
+
+    logger.info("Testing with microvm: \"{}\", kernel {}, disk {}"
+                .format(context.microvm.name(),
+                        context.kernel.name(),
+                        context.disk.name()))
+
+    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+    env_id = f"{context.kernel.name()}/{context.disk.name()}"
+    for mode in CONFIG["fio_modes"]:
+        ms_defs = measurements(mode)
+        for bs in CONFIG["fio_blk_sizes"]:
+            fio_id = f"{mode}-bs{bs}-{basevm.vcpus_count}vcpu"
+            st_defs = statistics(mode, env_id, fio_id)
+            st_prod = st.producer.LambdaProducer(
+                func=run_fio,
+                func_kwargs={
+                    "env_id": env_id,
+                    "basevm": basevm,
+                    "ssh_conn": ssh_connection,
+                    "mode": mode,
+                    "bs": bs
+                }
+            )
+
+            numjobs = CONFIG['load_factor'] * basevm.vcpus_count
+            st_cons = st.consumer.LambdaConsumer(
+                consume_stats=False,
+                func=consume_fio_output,
+                func_kwargs={"numjobs": numjobs,
+                             "mode": mode,
+                             "bs": bs,
+                             "env_id": env_id})
+            eager_map(st_cons.set_measurement_def, ms_defs)
+            eager_map(st_cons.set_stat_def, st_defs)
+            st_core.add_pipe(st_prod, st_cons, tag=f"{env_id}/{fio_id}")
+
+    st_core.run_exercise()
+    basevm.kill()

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -13,80 +13,82 @@ from framework.artifacts import ArtifactCollection, ArtifactSet, \
     DEFAULT_HOST_IP
 from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder
-from framework.statistics import core, consumer, producer, criteria,  types, \
-    function
+from framework.statistics import core, consumer, producer, criteria, types
 from framework.utils import CpuMap, CmdBuilder, run_cmd, eager_map, \
     get_cpu_percent
 from framework.utils_cpuid import get_cpu_model_name
 import host_tools.network as net_tools
-from integration_tests.performance.network_tcp_throughput_test_config import \
-    THROUGHPUT, DURATION, RETRANSMITS, CPU_UTILIZATION_HOST, \
-    CPU_UTILIZATION_GUEST, CONFIG, CPU_UTILIZATION_VMM_TAG, \
-    CPU_UTILIZATION_VCPUS_TOTAL_TAG, THROUGHPUT_TOTAL, RETRANSMITS_TOTAL, \
-    DURATION_TOTAL, IPERF3, BASE_PORT, DEBUG, \
-    IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG, IPERF3_END_RESULTS_TAG, \
-    DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG, DELTA_PERCENTAGE_TAG, TARGET_TAG
+import integration_tests.performance.configs\
+    .network_tcp_throughput_test_config as test_cfg
 
 
-def measurements_tcp():
+def measurements():
     """Define the produced measurements for TCP workloads."""
-    return [types.MeasurementDef(THROUGHPUT, "Mbps"),
-            types.MeasurementDef(DURATION, "seconds"),
-            types.MeasurementDef(RETRANSMITS, "#"),
-            types.MeasurementDef(CPU_UTILIZATION_HOST, "percentage"),
-            types.MeasurementDef(CPU_UTILIZATION_GUEST, "percentage")]
+    return [types.MeasurementDef.cpu_utilization_vcpus_total(),
+            types.MeasurementDef.cpu_utilization_vmm(),
+            types.MeasurementDef(test_cfg.THROUGHPUT, "Mbps"),
+            types.MeasurementDef(test_cfg.DURATION, "seconds"),
+            types.MeasurementDef(test_cfg.RETRANSMITS, "#")]
 
 
-def stats_tcp(host_cpu_model: str, iperf3_id: str, env_id: str):
-    """Define statistics for TCP measurements."""
-    cpus = CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]
-    for cpu in cpus:
-        if cpu["model"] == host_cpu_model:
-            baseline_bw = cpu["baseline_bw"][env_id][iperf3_id]
-            delta_throughput =\
-                baseline_bw[DELTA_PERCENTAGE_TAG] * \
-                baseline_bw[TARGET_TAG] / 100
-            baseline_cpu_util = cpu["baseline_cpu_utilization"][env_id]
-            baseline_cpu_host = baseline_cpu_util[CPU_UTILIZATION_VMM_TAG][
-                iperf3_id]
-            baseline_host_target = baseline_cpu_host[TARGET_TAG]
-            baseline_host_delta = \
-                baseline_cpu_host[DELTA_PERCENTAGE_TAG] * \
-                baseline_host_target / 100
-            baseline_cpu_guest = \
-                baseline_cpu_util[CPU_UTILIZATION_VCPUS_TOTAL_TAG][iperf3_id]
-            baseline_guest_target = baseline_cpu_guest[TARGET_TAG]
-            baseline_guest_delta = \
-                baseline_cpu_guest[DELTA_PERCENTAGE_TAG] * \
-                baseline_guest_target / 100
+def criteria_stats(cpu_baseline: dict, iperf3_id: str, env_id: str):
+    """Return statistics definitions based with pass criteria."""
+    baseline_bw = cpu_baseline["baseline_bw"][env_id][iperf3_id]
+    delta_throughput = \
+        baseline_bw[test_cfg.DELTA_PERCENTAGE_TAG] * \
+        baseline_bw[test_cfg.TARGET_TAG] / 100
+    baseline_cpu_util = cpu_baseline["baseline_cpu_utilization"][env_id]
+    baseline_cpu_host = baseline_cpu_util["vmm"][
+        iperf3_id]
+    baseline_vmm_target = baseline_cpu_host[test_cfg.TARGET_TAG]
+    baseline_vmm_delta = \
+        baseline_cpu_host[test_cfg.DELTA_PERCENTAGE_TAG] * \
+        baseline_vmm_target / 100
+    baseline_cpu_vcpus_total = \
+        baseline_cpu_util["vcpus_total"][iperf3_id]
+    baseline_vcpus_total_target = baseline_cpu_vcpus_total[test_cfg.TARGET_TAG]
+    baseline_vcpus_total_delta = \
+        baseline_cpu_vcpus_total[test_cfg.DELTA_PERCENTAGE_TAG] * \
+        baseline_vcpus_total_target / 100
 
-            return [
-                types.StatisticDef(THROUGHPUT_TOTAL, THROUGHPUT, function.Sum,
-                                   criteria.EqualWith(baseline_bw[TARGET_TAG],
-                                                      delta_throughput)),
-                types.StatisticDef(RETRANSMITS_TOTAL, RETRANSMITS,
-                                   function.Sum),
-                types.StatisticDef(DURATION_TOTAL, DURATION, function.Avg),
-                types.StatisticDef(CPU_UTILIZATION_VMM_TAG,
-                                   CPU_UTILIZATION_HOST,
-                                   function.Identity,
-                                   criteria.EqualWith(baseline_host_target,
-                                                      baseline_host_delta)),
-                types.StatisticDef(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                                   CPU_UTILIZATION_GUEST,
-                                   function.Identity,
-                                   criteria.EqualWith(baseline_guest_target,
-                                                      baseline_guest_delta))
-            ]
     return [
-        types.StatisticDef(THROUGHPUT_TOTAL, THROUGHPUT, function.Sum),
-        types.StatisticDef(RETRANSMITS_TOTAL, RETRANSMITS, function.Sum),
-        types.StatisticDef(DURATION_TOTAL, DURATION, function.Avg),
-        types.StatisticDef(CPU_UTILIZATION_VMM_TAG, CPU_UTILIZATION_HOST,
-                           function.Identity),
-        types.StatisticDef(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                           CPU_UTILIZATION_GUEST,
-                           function.Identity)
+        types.StatisticDef.sum(
+            st_name=test_cfg.THROUGHPUT_TOTAL,
+            ms_name=test_cfg.THROUGHPUT,
+            criteria=criteria.EqualWith(baseline_bw[test_cfg.TARGET_TAG],
+                                        delta_throughput)),
+        types.StatisticDef.sum(ms_name=test_cfg.RETRANSMITS,
+                               st_name=test_cfg.RETRANSMITS_TOTAL),
+        types.StatisticDef.avg(test_cfg.DURATION),
+        types.StatisticDef.get_first_observation(
+            ms_name=test_cfg.CPU_UTILIZATION_VMM,
+            st_name="value",
+            criteria=criteria.EqualWith(baseline_vmm_target,
+                                        baseline_vmm_delta)),
+        types.StatisticDef.get_first_observation(
+            ms_name=test_cfg.CPU_UTILIZATION_VCPUS_TOTAL,
+            st_name="value",
+            criteria=criteria.EqualWith(baseline_vcpus_total_target,
+                                        baseline_vcpus_total_delta))]
+
+
+def no_criteria_stats():
+    """Return stats without pass criteria.
+
+    These statistics are useful for baseline gathering.
+    """
+    return [
+        types.StatisticDef.sum(st_name=test_cfg.THROUGHPUT_TOTAL,
+                               ms_name=test_cfg.THROUGHPUT),
+        types.StatisticDef.sum(st_name=test_cfg.RETRANSMITS_TOTAL,
+                               ms_name=test_cfg.RETRANSMITS),
+        types.StatisticDef.avg(ms_name=test_cfg.DURATION),
+        types.StatisticDef.get_first_observation(
+            st_name="value",
+            ms_name=test_cfg.CPU_UTILIZATION_VMM),
+        types.StatisticDef.get_first_observation(
+            st_name="value",
+            ms_name=test_cfg.CPU_UTILIZATION_VCPUS_TOTAL)
     ]
 
 
@@ -109,9 +111,9 @@ def produce_iperf_output(basevm,
         iperf_server = \
             CmdBuilder(f"taskset --cpu-list {assigned_cpu}") \
             .with_arg(basevm.jailer.netns_cmd_prefix()) \
-            .with_arg(IPERF3) \
+            .with_arg(test_cfg.IPERF3) \
             .with_arg("-sD") \
-            .with_arg("-p", f"{BASE_PORT + server_idx}") \
+            .with_arg("-p", f"{test_cfg.BASE_PORT + server_idx}") \
             .with_arg("-1") \
             .build()
         run_cmd(iperf_server)
@@ -125,7 +127,7 @@ def produce_iperf_output(basevm,
     def spawn_iperf_client(conn, client_idx, mode):
         # Add the port where the iperf3 client is going to send/receive.
         cmd = guest_cmd_builder                                 \
-            .with_arg("-p", f"{BASE_PORT + client_idx}")       \
+            .with_arg("-p", f"{test_cfg.BASE_PORT + client_idx}")       \
             .with_arg(mode)                                     \
             .build()
         pinned_cmd = f"taskset --cpu-list {client_idx % basevm.vcpus_count}" \
@@ -133,7 +135,7 @@ def produce_iperf_output(basevm,
         _, stdout, _ = conn.execute_command(pinned_cmd)
         return stdout.read()
 
-    # Subtract 2 to remove the readings from the workloads end.
+    # Remove inaccurate readings from the workloads end.
     cpu_load_runtime = runtime - 2
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = list()
@@ -154,8 +156,8 @@ def produce_iperf_output(basevm,
         cpu_load = cpu_load_future.result()
         for future in futures[:-1]:
             res = json.loads(future.result())
-            res[IPERF3_END_RESULTS_TAG][
-                IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = None
+            res[test_cfg.IPERF3_END_RESULTS_TAG][
+                test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = None
             yield res
 
         # Attach the real CPU utilization vmm/vcpus to
@@ -170,12 +172,12 @@ def produce_iperf_output(basevm,
             data_len = len(data)
             assert data_len == cpu_load_runtime
             vmm_util = sum(data)/data_len
-            cpu_util_perc = res[IPERF3_END_RESULTS_TAG][
-                IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = dict()
-            cpu_util_perc[CPU_UTILIZATION_VMM_TAG] = vmm_util
-            if DEBUG:
-                res[IPERF3_END_RESULTS_TAG][
-                    DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG] \
+            cpu_util_perc = res[test_cfg.IPERF3_END_RESULTS_TAG][
+                test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = dict()
+            cpu_util_perc[test_cfg.CPU_UTILIZATION_VMM] = vmm_util
+            if test_cfg.DEBUG:
+                res[test_cfg.IPERF3_END_RESULTS_TAG][
+                    test_cfg.DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG] \
                     = data
 
         vcpus_util = 0
@@ -188,13 +190,13 @@ def produce_iperf_output(basevm,
                 data = cpu_load[tag][thread_id]
                 data_len = len(data)
                 assert data_len == cpu_load_runtime
-                if DEBUG:
-                    res[IPERF3_END_RESULTS_TAG][f"cpu_utilization_fc_vcpu"
-                                                f"_{vcpu}_samples"] = \
-                        data
+                if test_cfg.DEBUG:
+                    res[test_cfg.IPERF3_END_RESULTS_TAG][
+                        f"cpu_utilization_fc_vcpu_{vcpu}_samples"] = data
+
                 vcpus_util += sum(data)/data_len
 
-        cpu_util_perc[CPU_UTILIZATION_VCPUS_TOTAL_TAG] = vcpus_util
+        cpu_util_perc[test_cfg.CPU_UTILIZATION_VCPUS_TOTAL] = vcpus_util
 
         yield res
 
@@ -203,44 +205,41 @@ def consume_iperf_tcp_output(cons,
                              result,
                              vcpus_count):
     """Consume iperf3 output result for TCP workload."""
-    total_received = result[IPERF3_END_RESULTS_TAG]['sum_received']
+    total_received = result[test_cfg.IPERF3_END_RESULTS_TAG]['sum_received']
     duration = float(total_received['seconds'])
-    cons.consume_stat(DURATION_TOTAL, DURATION, duration)
+    cons.consume_measurement(test_cfg.DURATION, duration)
 
-    total_sent = result[IPERF3_END_RESULTS_TAG]['sum_sent']
+    total_sent = result[test_cfg.IPERF3_END_RESULTS_TAG]['sum_sent']
     retransmits = int(total_sent['retransmits'])
-    cons.consume_stat(RETRANSMITS_TOTAL, RETRANSMITS, retransmits)
+    cons.consume_measurement(test_cfg.RETRANSMITS, retransmits)
 
     # Computed at the receiving end.
     total_recv_bytes = int(total_received['bytes'])
     tput = round((total_recv_bytes*8) / (1024*1024*duration), 2)
-    cons.consume_stat(THROUGHPUT_TOTAL, THROUGHPUT, tput)
+    cons.consume_measurement(test_cfg.THROUGHPUT, tput)
 
-    cpu_util = result[IPERF3_END_RESULTS_TAG][
-        IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG]
+    cpu_util = result[test_cfg.IPERF3_END_RESULTS_TAG][
+        test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG]
     if cpu_util:
-        cpu_util_host = cpu_util[CPU_UTILIZATION_VMM_TAG]
-        cpu_util_guest = cpu_util[CPU_UTILIZATION_VCPUS_TOTAL_TAG]
+        cpu_util_host = cpu_util[test_cfg.CPU_UTILIZATION_VMM]
+        cpu_util_guest = cpu_util[test_cfg.CPU_UTILIZATION_VCPUS_TOTAL]
 
-        cons.consume_stat(CPU_UTILIZATION_VMM_TAG,
-                          CPU_UTILIZATION_HOST,
-                          cpu_util_host)
-        cons.consume_stat(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                          CPU_UTILIZATION_GUEST,
-                          cpu_util_guest)
+        cons.consume_measurement(test_cfg.CPU_UTILIZATION_VMM, cpu_util_host)
+        cons.consume_measurement(test_cfg.CPU_UTILIZATION_VCPUS_TOTAL,
+                                 cpu_util_guest)
 
-    if DEBUG:
-        if DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG in result['end']:
-            cpu_util_vmm_samples = result[IPERF3_END_RESULTS_TAG][
-                DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG]
-            cons.consume_custom(DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG,
+    if test_cfg.DEBUG:
+        if test_cfg.DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG in result['end']:
+            cpu_util_vmm_samples = result[test_cfg.IPERF3_END_RESULTS_TAG][
+                test_cfg.DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG]
+            cons.consume_custom(test_cfg.DEBUG_CPU_UTILIZATION_VMM_SAMPLES_TAG,
                                 cpu_util_vmm_samples)
 
         for vcpu in range(vcpus_count):
             fcvcpu_samples_tag = f"cpu_utilization_fc_vcpu_{vcpu}_samples"
-            if fcvcpu_samples_tag in result[IPERF3_END_RESULTS_TAG]:
-                cpu_util_fc_vcpu_samples = result[IPERF3_END_RESULTS_TAG][
-                    fcvcpu_samples_tag]
+            if fcvcpu_samples_tag in result[test_cfg.IPERF3_END_RESULTS_TAG]:
+                cpu_util_fc_vcpu_samples = \
+                    result[test_cfg.IPERF3_END_RESULTS_TAG][fcvcpu_samples_tag]
                 cons.consume_custom(fcvcpu_samples_tag,
                                     cpu_util_fc_vcpu_samples)
 
@@ -253,12 +252,18 @@ def create_pipes_generator(basevm,
                            env_id):
     """Create producer/consumer pipes."""
     host_cpu_model_name = get_cpu_model_name()
+    cpus_baselines = test_cfg.CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]
+    stats = no_criteria_stats()
+    baselines = list(filter(
+        lambda baseline: baseline["model"] == host_cpu_model_name,
+        cpus_baselines))
+
     for payload_length in protocol["payload_length"]:
         for ws in protocol["window_size"]:
-            iperf_guest_cmd_builder = CmdBuilder(IPERF3) \
+            iperf_guest_cmd_builder = CmdBuilder(test_cfg.IPERF3) \
                 .with_arg("--verbose") \
                 .with_arg("--client", host_ip) \
-                .with_arg("--time", CONFIG["time"]) \
+                .with_arg("--time", test_cfg.CONFIG["time"]) \
                 .with_arg("--json") \
                 .with_arg("--omit", protocol["omit"])
 
@@ -280,25 +285,27 @@ def create_pipes_generator(basevm,
                         f"-ws{iperf3_id_ws}-{basevm.vcpus_count}vcpu-{mode}"
 
             cons = consumer.LambdaConsumer(
-                consume_stats=True,
+                consume_stats=False,
                 func=consume_iperf_tcp_output,
                 func_kwargs={
                     "vcpus_count": basevm.vcpus_count
                 }
             )
 
-            eager_map(cons.set_measurement_def, measurements_tcp())
-            eager_map(cons.set_stat_def, stats_tcp(host_cpu_model_name,
-                                                   iperf3_id, env_id))
+            if len(baselines) > 0:
+                stats = criteria_stats(baselines[0], iperf3_id, env_id)
+
+            eager_map(cons.set_measurement_def, measurements())
+            eager_map(cons.set_stat_def, stats)
 
             prod_kwargs = {
                 "guest_cmd_builder": iperf_guest_cmd_builder,
                 "basevm": basevm,
                 "current_avail_cpu": current_avail_cpu,
-                "runtime": CONFIG["time"],
+                "runtime": test_cfg.CONFIG["time"],
                 "omit": protocol["omit"],
-                "load_factor": CONFIG["load_factor"],
-                "modes": CONFIG["modes"][mode]
+                "load_factor": test_cfg.CONFIG["load_factor"],
+                "modes": test_cfg.CONFIG["modes"][mode]
             }
             prod = producer.LambdaProducer(produce_iperf_output,
                                            prod_kwargs)
@@ -307,14 +314,14 @@ def create_pipes_generator(basevm,
 
 def pipes(basevm, host_ip, current_avail_cpu, env_id):
     """Pipes generator."""
-    for mode in CONFIG["modes"]:
+    for mode in test_cfg.CONFIG["modes"]:
         # We run bi-directional tests only on uVM with more than 2 vCPus
         # because we need to pin one iperf3/direction per vCPU, and since we
         # have two directions, we need at least two vCPUs.
         if mode == "bd" and basevm.vcpus_count < 2:
             continue
 
-        for protocol in CONFIG["protocols"]:
+        for protocol in test_cfg.CONFIG["protocols"]:
             # Distribute modes evenly between producers and consumers.
             pipes_generator = create_pipes_generator(basevm,
                                                      mode,
@@ -376,6 +383,7 @@ def iperf_workload(context):
               "disk": context.disk.name()}
     st_core = core.Core(name="network_tcp_throughput",
                         iterations=1,
+                        check=True,
                         custom=custom)
 
     # Check if the needed CPU cores are available. We have the API thread, VMM

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -6,8 +6,9 @@ import json
 import logging
 import os
 import platform
-from conftest import _test_images_s3_bucket, DEFAULT_TEST_IMAGES_S3_BUCKET
+from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
+from framework.defs import DEFAULT_TEST_IMAGES_S3_BUCKET
 from framework.matrix import TestMatrix, TestContext
 from framework.microvms import VMMicro
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -13,83 +13,80 @@ from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder
-from framework.statistics import core, consumer, producer, criteria,  types, \
-    function
+from framework.statistics import core, consumer, producer, criteria, types
 from framework.utils import CpuMap, CmdBuilder, run_cmd, eager_map, \
     get_cpu_percent
 from framework.utils_cpuid import get_cpu_model_name
 import host_tools.network as net_tools
-from integration_tests.performance.vsock_throughput_test_config import \
-    THROUGHPUT, DURATION, CPU_UTILIZATION_HOST, \
-    CPU_UTILIZATION_GUEST, CONFIG, CPU_UTILIZATION_VMM_TAG, \
-    CPU_UTILIZATION_VCPUS_TOTAL_TAG, THROUGHPUT_TOTAL, \
-    DURATION_TOTAL, IPERF3, BASE_PORT, \
-    IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG, IPERF3_END_RESULTS_TAG, \
-    TARGET_TAG, DELTA_PERCENTAGE_TAG, THROUGHPUT_UNIT, DURATION_UNIT, \
-    CPU_UTILIZATION_UNIT
+import integration_tests.performance.configs.vsock_throughput_test_config as\
+    test_cfg
 
-SERVER_STARTUP_TIME = CONFIG["server_startup_time"]
 
+SERVER_STARTUP_TIME = test_cfg.CONFIG["server_startup_time"]
 VSOCK_UDS_PATH = "v.sock"
 
 
-def measurements_vsock():
+def measurements():
     """Define the produced measurements for VSOCK workloads."""
-    return [types.MeasurementDef(THROUGHPUT, THROUGHPUT_UNIT),
-            types.MeasurementDef(DURATION, DURATION_UNIT),
-            types.MeasurementDef(CPU_UTILIZATION_HOST, CPU_UTILIZATION_UNIT),
-            types.MeasurementDef(CPU_UTILIZATION_GUEST, CPU_UTILIZATION_UNIT)]
+    return [types.MeasurementDef(test_cfg.THROUGHPUT,
+                                 test_cfg.THROUGHPUT_UNIT),
+            types.MeasurementDef(test_cfg.DURATION, test_cfg.DURATION_UNIT),
+            types.MeasurementDef.cpu_utilization_vmm(),
+            types.MeasurementDef.cpu_utilization_vcpus_total()]
 
 
-def stats_vsock(host_cpu_model: str, iperf3_id: str, env_id: str):
-    """Define statistics and pass criteria for VSOCK measurements."""
-    cpus = CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]
-    for cpu in cpus:
-        if cpu["model"] == host_cpu_model:
-            baseline_bw = cpu["baseline_bw"][env_id][iperf3_id]
-            delta_throughput = baseline_bw[DELTA_PERCENTAGE_TAG] * \
-                baseline_bw[TARGET_TAG] / 100
-            baseline_cpu_util = cpu["baseline_cpu_utilization"][env_id]
-            baseline_cpu_host = \
-                baseline_cpu_util[CPU_UTILIZATION_VMM_TAG][iperf3_id]
-            baseline_host_target = baseline_cpu_host[TARGET_TAG]
-            baseline_host_delta = \
-                baseline_cpu_host[DELTA_PERCENTAGE_TAG] * \
-                baseline_host_target / 100
-            baseline_cpu_guest = \
-                baseline_cpu_util[CPU_UTILIZATION_VCPUS_TOTAL_TAG][iperf3_id]
-            baseline_guest_target = baseline_cpu_guest[TARGET_TAG]
-            baseline_guest_delta = \
-                baseline_guest_target * baseline_guest_target / 100
+def no_criteria_stats():
+    """Return statistics without pass criteria.
 
-            return \
-                [types.StatisticDef(THROUGHPUT_TOTAL, THROUGHPUT, function.Sum,
-                                    criteria.EqualWith(baseline_bw[TARGET_TAG],
-                                                       delta_throughput)),
-                 types.StatisticDef(DURATION_TOTAL, DURATION, function.Avg),
-                 types.StatisticDef(CPU_UTILIZATION_VMM_TAG,
-                                    CPU_UTILIZATION_HOST,
-                                    function.Identity,
-                                    criteria.EqualWith(baseline_host_target,
-                                                       baseline_host_delta)),
-                 types.StatisticDef(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                                    CPU_UTILIZATION_GUEST,
-                                    function.Identity,
-                                    criteria.EqualWith(baseline_guest_target,
-                                                       baseline_guest_delta))
-                 ]
+    Useful for baselines gathering.
+    """
+    return [types.StatisticDef.sum(st_name=test_cfg.THROUGHPUT_TOTAL,
+                                   ms_name=test_cfg.THROUGHPUT),
+            types.StatisticDef.avg(test_cfg.DURATION),
+            types.StatisticDef.get_first_observation(
+                st_name="value",
+                ms_name=test_cfg.CPU_UTILIZATION_VMM),
+            types.StatisticDef.get_first_observation(
+                st_name="value",
+                ms_name=test_cfg.CPU_UTILIZATION_VCPUS_TOTAL)]
 
-    # If there are no baselines for the host CPU model, do not define any
-    # criteria. Useful for gathering baselines on new CPUs.
-    return [types.StatisticDef(THROUGHPUT_TOTAL, THROUGHPUT, function.Sum),
-            types.StatisticDef(DURATION_TOTAL, DURATION, function.Avg),
-            types.StatisticDef(CPU_UTILIZATION_VMM_TAG,
-                               CPU_UTILIZATION_HOST,
-                               function.Identity),
-            types.StatisticDef(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                               CPU_UTILIZATION_GUEST,
-                               function.Identity)
-            ]
+
+def criteria_stats(cpu_baselines: str, iperf3_id: str, env_id: str):
+    """Return statistics tailored to the platform cpu model."""
+    baseline_bw = cpu_baselines["baseline_bw"][env_id][iperf3_id]
+    delta_throughput = \
+        baseline_bw[test_cfg.DELTA_PERCENTAGE_TAG] * baseline_bw[
+            test_cfg.TARGET_TAG] / 100
+    baseline_cpu_util = cpu_baselines["baseline_cpu_utilization"][env_id]
+    baseline_cpu_host = \
+        baseline_cpu_util["vmm"][iperf3_id]
+    baseline_host_target = baseline_cpu_host[test_cfg.TARGET_TAG]
+    baseline_host_delta = \
+        baseline_cpu_host[test_cfg.DELTA_PERCENTAGE_TAG] * \
+        baseline_host_target / 100
+    baseline_cpu_guest = \
+        baseline_cpu_util["vcpus_total"][iperf3_id]
+    baseline_guest_target = baseline_cpu_guest[test_cfg.TARGET_TAG]
+    baseline_guest_delta = \
+        baseline_guest_target * baseline_guest_target / 100
+
+    return [types.StatisticDef.sum(
+                st_name=test_cfg.THROUGHPUT_TOTAL,
+                ms_name=test_cfg.THROUGHPUT,
+                criteria=criteria.EqualWith(baseline_bw[test_cfg.TARGET_TAG],
+                                            delta_throughput)),
+            types.StatisticDef.avg(test_cfg.DURATION),
+            types.StatisticDef.get_first_observation(
+                st_name="value",
+                ms_name=test_cfg.CPU_UTILIZATION_VMM,
+                criteria=criteria.EqualWith(baseline_host_target,
+                                            baseline_host_delta)),
+            types.StatisticDef.get_first_observation(
+                st_name="value",
+                ms_name=test_cfg.CPU_UTILIZATION_VCPUS_TOTAL,
+                criteria=criteria.EqualWith(baseline_guest_target,
+                                            baseline_guest_delta)
+            )]
 
 
 def produce_iperf_output(basevm,
@@ -115,11 +112,11 @@ def produce_iperf_output(basevm,
         assigned_cpu = CpuMap(current_avail_cpu)
         iperf_server = \
             CmdBuilder(f"taskset --cpu-list {assigned_cpu}") \
-            .with_arg(IPERF3) \
+            .with_arg(test_cfg.IPERF3) \
             .with_arg("-sD") \
             .with_arg("--vsock") \
             .with_arg("-B", host_uds_path) \
-            .with_arg("-p", f"{BASE_PORT + server_idx}") \
+            .with_arg("-p", f"{test_cfg.BASE_PORT + server_idx}") \
             .with_arg("-1") \
             .build()
 
@@ -134,13 +131,13 @@ def produce_iperf_output(basevm,
     def spawn_iperf_client(conn, client_idx, mode):
         # Add the port where the iperf3 client is going to send/receive.
         cmd = guest_cmd_builder.with_arg(
-            "-p", BASE_PORT + client_idx).with_arg(mode).build()
+            "-p", test_cfg.BASE_PORT + client_idx).with_arg(mode).build()
 
         # Bind the UDS in the jailer's root.
         basevm.create_jailed_resource(os.path.join(
             basevm.path,
-            _make_host_port_path(VSOCK_UDS_PATH, BASE_PORT + client_idx)
-        ))
+            _make_host_port_path(VSOCK_UDS_PATH,
+                                 test_cfg.BASE_PORT + client_idx)))
 
         pinned_cmd = f"taskset --cpu-list {client_idx % basevm.vcpus_count}" \
             f" {cmd}"
@@ -169,8 +166,8 @@ def produce_iperf_output(basevm,
         cpu_load = cpu_load_future.result()
         for future in futures[:-1]:
             res = json.loads(future.result())
-            res[IPERF3_END_RESULTS_TAG][
-                IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = None
+            res[test_cfg.IPERF3_END_RESULTS_TAG][
+                test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = None
             yield res
 
         # Attach the real CPU utilization vmm/vcpus to
@@ -183,9 +180,9 @@ def produce_iperf_output(basevm,
         thread_id = list(cpu_load[tag])[0]
         data = cpu_load[tag][thread_id]
         vmm_util = sum(data)/len(data)
-        cpu_util_perc = res[IPERF3_END_RESULTS_TAG][
-            IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = dict()
-        cpu_util_perc[CPU_UTILIZATION_VMM_TAG] = vmm_util
+        cpu_util_perc = res[test_cfg.IPERF3_END_RESULTS_TAG][
+            test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG] = dict()
+        cpu_util_perc[test_cfg.CPU_UTILIZATION_VMM] = vmm_util
 
         vcpus_util = 0
         for vcpu in range(basevm.vcpus_count):
@@ -197,55 +194,59 @@ def produce_iperf_output(basevm,
             data = cpu_load[tag][thread_id]
             vcpus_util += (sum(data)/len(data))
 
-        cpu_util_perc[CPU_UTILIZATION_VCPUS_TOTAL_TAG] = vcpus_util
+        cpu_util_perc[test_cfg.CPU_UTILIZATION_VCPUS_TOTAL] = vcpus_util
 
         yield res
 
 
 def consume_iperf_output(cons, result):
     """Consume iperf3 output result for TCP workload."""
-    total_received = result[IPERF3_END_RESULTS_TAG]['sum_received']
+    total_received = result[test_cfg.IPERF3_END_RESULTS_TAG]['sum_received']
     duration = float(total_received['seconds'])
-    cons.consume_stat(DURATION_TOTAL, DURATION, duration)
+    cons.consume_measurement(test_cfg.DURATION, duration)
 
     # Computed at the receiving end.
     total_recv_bytes = int(total_received['bytes'])
     tput = round((total_recv_bytes*8) / (1024*1024*duration), 2)
-    cons.consume_stat(THROUGHPUT_TOTAL, THROUGHPUT, tput)
+    cons.consume_measurement(test_cfg.THROUGHPUT, tput)
 
-    cpu_util = result[IPERF3_END_RESULTS_TAG][
-        IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG]
+    cpu_util = result[test_cfg.IPERF3_END_RESULTS_TAG][
+        test_cfg.IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG]
     if cpu_util:
-        cpu_util_host = cpu_util[CPU_UTILIZATION_VMM_TAG]
-        cpu_util_guest = cpu_util[CPU_UTILIZATION_VCPUS_TOTAL_TAG]
+        cpu_util_host = cpu_util[test_cfg.CPU_UTILIZATION_VMM]
+        cpu_util_guest = cpu_util[test_cfg.CPU_UTILIZATION_VCPUS_TOTAL]
 
-        cons.consume_stat(CPU_UTILIZATION_VMM_TAG,
-                          CPU_UTILIZATION_HOST,
-                          cpu_util_host)
-        cons.consume_stat(CPU_UTILIZATION_VCPUS_TOTAL_TAG,
-                          CPU_UTILIZATION_GUEST,
-                          cpu_util_guest)
+        cons.consume_measurement(test_cfg.CPU_UTILIZATION_VMM, cpu_util_host)
+        cons.consume_measurement(test_cfg.CPU_UTILIZATION_VCPUS_TOTAL,
+                                 cpu_util_guest)
 
 
 def pipes(basevm, current_avail_cpu, env_id):
     """Producer/Consumer pipes generator."""
-    for mode in CONFIG["modes"]:
+    host_cpu_model_name = get_cpu_model_name()
+    cpus_baselines = test_cfg.CONFIG["hosts"]["instances"]["m5d.metal"]["cpus"]
+    stats = no_criteria_stats()
+    baselines = list(filter(
+        lambda baseline: baseline["model"] == host_cpu_model_name,
+        cpus_baselines))
+
+    for mode in test_cfg.CONFIG["modes"]:
         # We run bi-directional tests only on uVM with more than 2 vCPus
         # because we need to pin one iperf3/direction per vCPU, and since we
         # have two directions, we need at least two vCPUs.
         if mode == "bd" and basevm.vcpus_count < 2:
             continue
 
-        for protocol in CONFIG["protocols"]:
+        for protocol in test_cfg.CONFIG["protocols"]:
             host_cpu_model_name = get_cpu_model_name()
 
             for payload_length in protocol["payload_length"]:
-                iperf_guest_cmd_builder = CmdBuilder(IPERF3) \
+                iperf_guest_cmd_builder = CmdBuilder(test_cfg.IPERF3) \
                     .with_arg("--vsock") \
                     .with_arg("-c", 2)       \
                     .with_arg("--json") \
                     .with_arg("--omit", protocol["omit"]) \
-                    .with_arg("--time", CONFIG["time"]) \
+                    .with_arg("--time", test_cfg.CONFIG["time"])
 
                 if payload_length:
                     iperf_guest_cmd_builder = iperf_guest_cmd_builder \
@@ -258,30 +259,32 @@ def pipes(basevm, current_avail_cpu, env_id):
                     f"-{basevm.vcpus_count}vcpu-{mode}"
 
                 cons = consumer.LambdaConsumer(
-                    consume_stats=True,
+                    consume_stats=False,
                     func=consume_iperf_output
                 )
 
-                eager_map(cons.set_measurement_def, measurements_vsock())
-                eager_map(cons.set_stat_def, stats_vsock(host_cpu_model_name,
-                                                         iperf3_id, env_id))
+                if len(baselines) > 0:
+                    stats = criteria_stats(baselines[0], iperf3_id, env_id)
+
+                eager_map(cons.set_measurement_def, measurements())
+                eager_map(cons.set_stat_def, stats)
 
                 prod_kwargs = {
                     "guest_cmd_builder": iperf_guest_cmd_builder,
                     "basevm": basevm,
                     "current_avail_cpu": current_avail_cpu,
-                    "runtime": CONFIG["time"],
+                    "runtime": test_cfg.CONFIG["time"],
                     "omit": protocol["omit"],
-                    "load_factor": CONFIG["load_factor"],
-                    "modes": CONFIG["modes"][mode],
+                    "load_factor": test_cfg.CONFIG["load_factor"],
+                    "modes": test_cfg.CONFIG["modes"][mode],
                 }
                 prod = producer.LambdaProducer(produce_iperf_output,
                                                prod_kwargs)
                 yield cons, prod, f"{env_id}/{iperf3_id}"
 
 
-@ pytest.mark.nonci
-@ pytest.mark.timeout(600)
+@pytest.mark.nonci
+@pytest.mark.timeout(600)
 def test_vsock_throughput(bin_cloner_path):
     """Test vsock throughput driver for multiple artifacts."""
     logger = logging.getLogger("vsock_throughput")
@@ -367,7 +370,7 @@ def iperf_workload(context):
 
     # Start running the commands on guest, gather results and verify pass
     # criteria.
-    print(st_core.run_exercise())
+    st_core.run_exercise()
 
     basevm.kill()
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -118,6 +118,9 @@ CTR_MICROVM_IMAGES_DIR="$CTR_FC_BUILD_DIR/img"
 # These options are not command-specific, so we store them as global vars
 OPT_UNATTENDED=false
 
+DEFAULT_TEST_SESSION_ROOT_PATH=/srv
+DEFAULT_RAMDISK_PATH=/mnt/devtool-ramdisk
+
 
 # Send a decorated message to stdout, followed by a new line
 #
@@ -436,6 +439,11 @@ cmd_help() {
     echo "        will be passed through to pytest."
     echo "        -c, --cpuset-cpus cpulist    Set a dedicated cpulist to be used by the tests."
     echo "        -m, --cpuset-mems memlist    Set a dedicated memlist to be used by the tests."
+    echo "        -r, --ramdisk size[k|m|g]    Use a ramdisk of `size` MB for
+                                               the entire test session (e.g
+                                               stored artifacts, Firecracker
+                                               binaries, logs/metrics FIFOs
+                                               and test created device files)."
     echo ""
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
@@ -593,6 +601,21 @@ cmd_strip() {
     return $ret
 }
 
+mount_ramdisk() {
+    say "Using ramdisk ..."
+    local ramdisk_size="$1"
+    umount_ramdisk
+    mkdir -p ${DEFAULT_RAMDISK_PATH} && \
+    mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
+    mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
+    mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
+}
+
+umount_ramdisk() {
+    umount ${DEFAULT_RAMDISK_PATH} &>/dev/null
+    rmdir ${DEFAULT_RAMDISK_PATH} &>/dev/null
+}
+
 # `$0 test` - run integration tests
 # Please see `$0 help` for more information.
 #
@@ -609,6 +632,11 @@ cmd_test() {
             "-m"|"--cpuset-mems")
                 shift
                 local cpuset_mems="$1"
+                ;;
+            "-r"|"--ramdisk")
+                shift
+                local ramdisk_size="$1"
+                local ramdisk=true
                 ;;
             "--")               { shift; break;     } ;;
             *)
@@ -627,6 +655,11 @@ cmd_test() {
     say "$(date -u +'%F %H:%M:%S %Z')"
     say "Starting test run ..."
 
+    if [[ $ramdisk = true ]]; then
+        mount_ramdisk ${ramdisk_size}
+        ramdisk_args="--volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
+    fi
+
     # Testing (running Firecracker via the jailer) needs root access,
     # in order to set-up the Firecracker jail (manipulating cgroups, net
     # namespaces, etc).
@@ -639,10 +672,16 @@ cmd_test() {
         --workdir "$CTR_FC_ROOT_DIR/tests" \
         --cpuset-cpus="$cpuset_cpus" \
         --cpuset-mems="$cpuset_mems" \
+        ${ramdisk_args} \
         -- \
         pytest "$@"
 
     ret=$?
+
+
+    if [[ $ramdisk = true ]]; then
+        umount_ramdisk
+    fi
 
     # Running as root would have created some root-owned files under the build
     # dir. Let's fix that.
@@ -664,6 +703,12 @@ cmd_shell() {
         case "$1" in
             "-h"|"--help")          { cmd_help; exit 1; } ;;
             "-p"|"--privileged")    { privileged=true;  } ;;
+            "-r"|"--ramdisk")
+                  shift
+                  local ramdisk_size="$1"
+                  local ramdisk=true
+                  ;;
+              "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
             ;;
@@ -674,6 +719,11 @@ cmd_shell() {
     # Make sure we have what we need to continue.
     ensure_devctr
     ensure_build_dir
+
+    if [[ $ramdisk = true ]]; then
+        mount_ramdisk ${ramdisk_size}
+        ramdisk_args="--volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
+    fi
 
     if [[ $privileged = true ]]; then
         # If requested, spin up a privileged container.
@@ -687,6 +737,7 @@ cmd_shell() {
             --ulimit nofile=4096:4096 \
             --security-opt seccomp=unconfined \
             --workdir "$CTR_FC_ROOT_DIR" \
+            ${ramdisk_args} \
             -- \
             bash
         ret=$?
@@ -715,6 +766,10 @@ cmd_shell() {
             -- \
             bash --norc
         ret=$?
+    fi
+
+    if [[ $ramdisk = true ]]; then
+        umount_ramdisk
     fi
 
     return $ret


### PR DESCRIPTION
## Reason for This PR

Lack of a block device performance test.

## Description of Changes

Added a test for Firecracker block device performance regression detection:
* Used `fio` to compute: iops, bandwidth, latency.
* Used `top` to compute cpu utilization host/guest.
* `fio` workloads cover the following modes: randread, randrw, read, readwrite.
* Block sizes for disk requests vary between: 512, 1024, 4096, 65536 bytes.

**NOTE**: I am still working through validating the computed baselines.

~~- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).~~

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [ ] All added/changed functionality is tested.~~
