### PR TITLE
Mask XSAVE PKRU bit in C2/T3 templates

### DIFF
--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -240,6 +240,7 @@ pub mod leaf_0xd {
 
             pub const MPX_STATE_BITRANGE: BitRange = bit_range!(4, 3);
             pub const AVX512_STATE_BITRANGE: BitRange = bit_range!(7, 5);
+            pub const PKRU_BITINDEX: u32 = 9;
         }
     }
 

--- a/src/cpuid/src/template/intel/c3.rs
+++ b/src/cpuid/src/template/intel/c3.rs
@@ -123,6 +123,10 @@ fn update_xsave_features_entry(
         entry
             .eax
             .write_bits_in_range(&index0::eax::AVX512_STATE_BITRANGE, 0);
+
+        // OSPKE is masked in leaf_0x7 index 0 - RDPKRU/WRPKRU not exposed.
+        // Here we mask the XSAVE PKRU capabilities.
+        entry.eax.write_bit(index0::eax::PKRU_BITINDEX, false);
     }
 
     if entry.index == 1 {

--- a/src/cpuid/src/template/intel/t2.rs
+++ b/src/cpuid/src/template/intel/t2.rs
@@ -117,6 +117,10 @@ fn update_xsave_features_entry(
         entry
             .eax
             .write_bits_in_range(&index0::eax::AVX512_STATE_BITRANGE, 0);
+
+        // OSPKE is masked in leaf_0x7 index 0 - RDPKRU/WRPKRU not exposed.
+        // Here we mask the XSAVE PKRU capabilities.
+        entry.eax.write_bit(index0::eax::PKRU_BITINDEX, false);
     }
 
     if entry.index == 1 {

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -329,3 +329,11 @@ def test_cpu_template(test_microvm_with_ssh, network_config, cpu_template):
     # Check that all features in `common_masked_features` are properly masked.
     for feature in common_masked_features:
         assert feature not in cpu_flags_output
+
+    # Check if XSAVE PKRU is masked for T3/C2.
+    expected_cpu_features = {
+        "XCR0 supported: PKRU state": "false"
+    }
+
+    _check_guest_cmd_output(test_microvm, "cpuid -1", None, '=',
+                            expected_cpu_features)


### PR DESCRIPTION
## Reason for This PR

Fixes an inconsistency in the templates - the OSPKE feature bit is masked, but the XSAVE PKRU bit is not. Snapshots created on a CPU with OSPKE from a T2/C3 uVM would fail to load on a CPU without OSPKE (Broadwell): https://elixir.bootlin.com/linux/latest/source/arch/x86/kvm/x86.c#L4299.

## Description of Changes

Provided in commit message.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
