### PR TITLE
Add thread name to logger prefix.

### DIFF
--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -44,16 +44,17 @@ def check_log_message_format(log_str, instance_id, level, show_level,
     Parse the string representing the logs and look for the parts
     that should be there.
     The log line should look lie this:
-         YYYY-MM-DDTHH:MM:SS.NNNNNNNNN [ID:LEVEL:FILE:LINE] MESSAGE
+         YYYY-MM-DDTHH:MM:SS.NNNNNNNNN [ID:THREAD:LEVEL:FILE:LINE] MESSAGE
     where LEVEL and FILE:LINE are both optional.
-    e.g.:
-    `2018-09-09T12:52:00.123456789 [MYID:WARN:/path/to/file.rs:52] warning`
+    e.g. with THREAD NAME as TN
+    `2018-09-09T12:52:00.123456789 [MYID:TN:WARN:/path/to/file.rs:52] warning`
     """
     (timestamp, tag, _) = log_str.split(' ')[:3]
     timestamp = timestamp[:-10]
     strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
 
     pattern = "\\[(" + instance_id + ")"
+    pattern += ":(.*)"
     if show_level:
         pattern += ":(" + "|".join(LOG_LEVELS) + ")"
     if show_origin:
@@ -64,7 +65,7 @@ def check_log_message_format(log_str, instance_id, level, show_level,
     assert mo is not None
 
     if show_level:
-        tag_level = mo.group(2)
+        tag_level = mo.group(3)
         tag_level_no = LOG_LEVELS.index(tag_level)
         configured_level_no = LOG_LEVELS.index(to_formal_log_level(level))
         assert tag_level_no <= configured_level_no


### PR DESCRIPTION
As per issue #2117, add capability to logger to log current
thread name in the prefix. Add unit test that spawns named
thread and checks the logged prefix for that name.

Signed-off-by: sundar.preston.789@gmail.com <sundar.preston.789@gmail.com>

Co-authored-by: Kevin Guo <kev.guo123@gmail.com>

## Reason for This PR

Addresses issue #2117 
Submitted earlier PR #2314, but accidentally messed up git rebase. :cry:.

## Description of Changes

`[Author TODO: add description of changes.]`


* Modified `src/logger/src/logger.rs` to always append the thread name to the log prefix. Also added unit test that creates a thread with custom name and checks the log's prefix for that name.
* Updated `tests/integration_tests/functional/test_logging.py` to reflect newly added thread names in log prefix.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
