### PR TITLE
[ARM] Forbid snapshot creation for target version: 0.23.0

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -316,13 +316,13 @@ impl MMIODeviceManager {
         &self.id_to_dev_info
     }
 
+    #[cfg(target_arch = "x86_64")]
     /// Gets the number of interrupts used by the devices registered.
     pub fn used_irqs_count(&self) -> usize {
         let mut irq_number = 0;
-        let _: Result<()> = self.for_each_device(|_, _, device_info, _| {
-            irq_number += device_info.irqs.len();
-            Ok(())
-        });
+        self.get_device_info()
+            .iter()
+            .for_each(|(_, device_info)| irq_number += device_info.irqs.len());
         irq_number
     }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.12, "AMD": 84.35, "ARM": 83.18}
+COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.0}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

ARM snapshot functionality does not support target version "0.23.0".
Also the version map needed updates for ARM.

## Description of Changes

- Moved snapshot version sanity checks and translation to a dedicated function.
- Added sanity check to prevent snapshot creation on ARM with "0.23.0" target version.
- Added the ARM specific VM/VCPU states to the specific root struct version.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
