### PR TITLE
balloon: fix possible loop in inflation process

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -262,15 +262,18 @@ impl Balloon {
         // The pfn buffer index used during descriptor processing.
         let mut pfn_buffer_idx = 0;
         let mut needs_interrupt = false;
+        let mut valid_descs_found = true;
 
-        // Loop until we consume the entire queue.
-        while !queue.is_empty(&mem) {
+        // Loop until there are no more valid DescriptorChains.
+        while valid_descs_found {
+            valid_descs_found = false;
             // Internal loop processes descriptors and acummulates the pfns in `pfn_buffer`.
             // Breaks out when there is not enough space in `pfn_buffer` to completely process
             // the next descriptor.
             while let Some(head) = queue.pop(&mem) {
                 let len = head.len as usize;
                 let max_len = MAX_PAGES_IN_DESC * SIZE_OF_U32;
+                valid_descs_found = true;
 
                 if !head.is_write_only() && len % SIZE_OF_U32 == 0 {
                     // Check descriptor pfn count.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.12, "AMD": 84.35, "ARM": 83.13}
+COVERAGE_DICT = {"Intel": 85.12, "AMD": 84.35, "ARM": 83.18}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
## Reason for This PR

Fix an infinite loop when guest virtio balloon driver provides invalid
descriptor chains to the balloon device.

## Description of Changes

Instead of looping while queue is not empty, only loop as long as there
are valid descriptor chains available.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
