### PR TITLE
cargo.lock: add missing criterion dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ version = "0.1.0"
 dependencies = [
  "arch 0.1.0",
  "cpuid 0.1.0",
+ "criterion 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "kernel 0.1.0",
  "kvm-bindings 0.3.0 (git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.3.0-3)",


### PR DESCRIPTION
## Reason for This PR

Fix `Cargo.lock` after commit `9b95abacdd17b0e6c3132e202585e5281c9c495f` introduced `criterion` dependency.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
