### PR TITLE
[aarch64][snap] Split the GicState per vCPUs

### DIFF
--- a/src/arch/src/aarch64/gic/mod.rs
+++ b/src/arch/src/aarch64/gic/mod.rs
@@ -21,6 +21,8 @@ pub enum Error {
     CreateGIC(kvm_ioctls::Error),
     /// Error while setting or getting device attributes for the GIC.
     DeviceAttribute(kvm_ioctls::Error, bool, u32),
+    /// The number of vCPUs in the GicState doesn't match the number of vCPUs on the system
+    InconsistentVcpuCount,
 }
 type Result<T> = result::Result<T, Error>;
 

--- a/src/arch/src/aarch64/gic/regs/dist_regs.rs
+++ b/src/arch/src/aarch64/gic/regs/dist_regs.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::aarch64::gic::regs::{MmioReg, SimpleReg, VgicRegEngine};
+use crate::aarch64::gic::regs::{GicRegState, MmioReg, SimpleReg, VgicRegEngine};
 use crate::aarch64::gic::Result;
 use crate::{IRQ_BASE, IRQ_MAX};
 use kvm_bindings::KVM_DEV_ARM_VGIC_GRP_DIST_REGS;
@@ -112,7 +112,7 @@ impl VgicRegEngine for DistRegEngine {
     }
 }
 
-pub(crate) fn get_dist_regs(fd: &DeviceFd) -> Result<Vec<Vec<u32>>> {
+pub(crate) fn get_dist_regs(fd: &DeviceFd) -> Result<Vec<GicRegState<u32>>> {
     Ok(DistRegEngine::get_regs_data(
         fd,
         Box::new(VGIC_DIST_REGS.iter()),
@@ -120,7 +120,7 @@ pub(crate) fn get_dist_regs(fd: &DeviceFd) -> Result<Vec<Vec<u32>>> {
     )?)
 }
 
-pub(crate) fn set_dist_regs(fd: &DeviceFd, state: &[Vec<u32>]) -> Result<()> {
+pub(crate) fn set_dist_regs(fd: &DeviceFd, state: &[GicRegState<u32>]) -> Result<()> {
     DistRegEngine::set_regs_data(fd, Box::new(VGIC_DIST_REGS.iter()), state, 0)
 }
 
@@ -143,7 +143,7 @@ mod tests {
         let state = res.unwrap();
         assert_eq!(state.len(), 12);
         // Check GICD_CTLR size.
-        assert_eq!(state[0].len(), 1);
+        assert_eq!(state[0].chunks.len(), 1);
 
         let res = set_dist_regs(&gic_fd.device_fd(), &state);
         assert!(res.is_ok());

--- a/src/arch/src/aarch64/gic/regs/icc_regs.rs
+++ b/src/arch/src/aarch64/gic/regs/icc_regs.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::aarch64::gic::regs::{SimpleReg, VgicRegEngine};
+use crate::aarch64::gic::regs::{GicRegState, SimpleReg, VgicRegEngine};
 use crate::aarch64::gic::Result;
 use kvm_bindings::*;
 use kvm_ioctls::DeviceFd;
@@ -79,8 +79,8 @@ impl SimpleReg {
 /// Structure for serializing the state of the Vgic ICC regs
 #[derive(Debug, Default, Versionize)]
 pub struct VgicSysRegsState {
-    main_icc_regs: Vec<Vec<u64>>,
-    conditional_icc_regs: Vec<Vec<u64>>,
+    main_icc_regs: Vec<GicRegState<u64>>,
+    conditional_icc_regs: Vec<GicRegState<u64>>,
 }
 
 struct VgicSysRegEngine {}
@@ -99,7 +99,7 @@ impl VgicRegEngine for VgicSysRegEngine {
 }
 
 fn num_priority_bits(fd: &DeviceFd, mpidr: u64) -> Result<u64> {
-    let reg_val = &VgicSysRegEngine::get_reg_data(fd, &SYS_ICC_CTLR_EL1, mpidr)?[0];
+    let reg_val = &VgicSysRegEngine::get_reg_data(fd, &SYS_ICC_CTLR_EL1, mpidr)?.chunks[0];
 
     Ok(((reg_val & ICC_CTLR_EL1_PRIBITS_MASK) >> ICC_CTLR_EL1_PRIBITS_SHIFT) + 1)
 }

--- a/src/arch/src/aarch64/gic/regs/icc_regs.rs
+++ b/src/arch/src/aarch64/gic/regs/icc_regs.rs
@@ -129,47 +129,35 @@ fn conditional_icc_regs(num_priority_bits: u64) -> Box<dyn Iterator<Item = &'sta
     }))
 }
 
-pub(crate) fn get_icc_regs(fd: &DeviceFd, mpidrs: &[u64]) -> Result<Vec<VgicSysRegsState>> {
-    let mut state: Vec<VgicSysRegsState> = Vec::with_capacity(mpidrs.len());
+pub(crate) fn get_icc_regs(fd: &DeviceFd, mpidr: u64) -> Result<VgicSysRegsState> {
+    let main_icc_regs =
+        VgicSysRegEngine::get_regs_data(fd, Box::new(MAIN_VGIC_ICC_REGS.iter()), mpidr)?;
+    let num_priority_bits = num_priority_bits(fd, mpidr)?;
 
-    for mpidr in mpidrs {
-        let main_icc_regs =
-            VgicSysRegEngine::get_regs_data(fd, Box::new(MAIN_VGIC_ICC_REGS.iter()), *mpidr)?;
-        let num_priority_bits = num_priority_bits(fd, *mpidr)?;
+    let conditional_icc_regs =
+        VgicSysRegEngine::get_regs_data(fd, conditional_icc_regs(num_priority_bits), mpidr)?;
 
-        let conditional_icc_regs =
-            VgicSysRegEngine::get_regs_data(fd, conditional_icc_regs(num_priority_bits), *mpidr)?;
-
-        state.push(VgicSysRegsState {
-            main_icc_regs,
-            conditional_icc_regs,
-        });
-    }
-
-    Ok(state)
+    Ok(VgicSysRegsState {
+        main_icc_regs,
+        conditional_icc_regs,
+    })
 }
 
-pub(crate) fn set_icc_regs(
-    fd: &DeviceFd,
-    mpidrs: &[u64],
-    state: &[VgicSysRegsState],
-) -> Result<()> {
-    for (mpidr, regs) in mpidrs.iter().zip(state) {
-        VgicSysRegEngine::set_regs_data(
-            fd,
-            Box::new(MAIN_VGIC_ICC_REGS.iter()),
-            &regs.main_icc_regs,
-            *mpidr,
-        )?;
-        let num_priority_bits = num_priority_bits(fd, *mpidr)?;
+pub(crate) fn set_icc_regs(fd: &DeviceFd, mpidr: u64, state: &VgicSysRegsState) -> Result<()> {
+    VgicSysRegEngine::set_regs_data(
+        fd,
+        Box::new(MAIN_VGIC_ICC_REGS.iter()),
+        &state.main_icc_regs,
+        mpidr,
+    )?;
+    let num_priority_bits = num_priority_bits(fd, mpidr)?;
 
-        VgicSysRegEngine::set_regs_data(
-            fd,
-            conditional_icc_regs(num_priority_bits),
-            &regs.conditional_icc_regs,
-            *mpidr,
-        )?;
-    }
+    VgicSysRegEngine::set_regs_data(
+        fd,
+        conditional_icc_regs(num_priority_bits),
+        &state.conditional_icc_regs,
+        mpidr,
+    )?;
 
     Ok(())
 }
@@ -188,26 +176,24 @@ mod tests {
         let _ = vm.create_vcpu(0).unwrap();
         let gic_fd = create_gic(&vm, 1).expect("Cannot create gic");
 
-        let mut gicr_typer = Vec::new();
-        gicr_typer.push(123);
-        let res = get_icc_regs(&gic_fd.device_fd(), &gicr_typer);
+        let gicr_typer = 123;
+        let res = get_icc_regs(&gic_fd.device_fd(), gicr_typer);
         assert!(res.is_ok());
         let state = res.unwrap();
-        println!("{}", state.len());
-        assert_eq!(state.len(), 1);
+        assert_eq!(state.main_icc_regs.len(), 7);
 
-        assert!(set_icc_regs(&gic_fd.device_fd(), &gicr_typer, &state).is_ok());
+        assert!(set_icc_regs(&gic_fd.device_fd(), gicr_typer, &state).is_ok());
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
-        let res = set_icc_regs(&gic_fd.device_fd(), &gicr_typer, &state);
+        let res = set_icc_regs(&gic_fd.device_fd(), gicr_typer, &state);
         assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 6)"
         );
 
-        let res = get_icc_regs(&gic_fd.device_fd(), &gicr_typer);
+        let res = get_icc_regs(&gic_fd.device_fd(), gicr_typer);
         assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),

--- a/src/arch/src/aarch64/gic/regs/redist_regs.rs
+++ b/src/arch/src/aarch64/gic/regs/redist_regs.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::aarch64::gic::regs::{SimpleReg, VgicRegEngine};
+use crate::aarch64::gic::regs::{GicRegState, SimpleReg, VgicRegEngine};
 use crate::aarch64::gic::Result;
 use kvm_bindings::*;
 use kvm_ioctls::DeviceFd;
@@ -66,7 +66,7 @@ fn redist_regs() -> Box<dyn Iterator<Item = &'static SimpleReg>> {
     Box::new(VGIC_RDIST_REGS.iter().chain(VGIC_SGI_REGS))
 }
 
-pub(crate) fn get_redist_regs(fd: &DeviceFd, mpidrs: &[u64]) -> Result<Vec<Vec<Vec<u32>>>> {
+pub(crate) fn get_redist_regs(fd: &DeviceFd, mpidrs: &[u64]) -> Result<Vec<Vec<GicRegState<u32>>>> {
     let mut data = Vec::with_capacity(mpidrs.len());
     for mpidr in mpidrs {
         data.push(RedistRegEngine::get_regs_data(fd, redist_regs(), *mpidr)?);
@@ -78,7 +78,7 @@ pub(crate) fn get_redist_regs(fd: &DeviceFd, mpidrs: &[u64]) -> Result<Vec<Vec<V
 pub(crate) fn set_redist_regs(
     fd: &DeviceFd,
     mpidrs: &[u64],
-    state: &[Vec<Vec<u32>>],
+    state: &[Vec<GicRegState<u32>>],
 ) -> Result<()> {
     for (mpidr, data) in mpidrs.iter().zip(state) {
         RedistRegEngine::set_regs_data(fd, redist_regs(), data, *mpidr)?;

--- a/src/arch/src/aarch64/gic/regs/redist_regs.rs
+++ b/src/arch/src/aarch64/gic/regs/redist_regs.rs
@@ -66,25 +66,12 @@ fn redist_regs() -> Box<dyn Iterator<Item = &'static SimpleReg>> {
     Box::new(VGIC_RDIST_REGS.iter().chain(VGIC_SGI_REGS))
 }
 
-pub(crate) fn get_redist_regs(fd: &DeviceFd, mpidrs: &[u64]) -> Result<Vec<Vec<GicRegState<u32>>>> {
-    let mut data = Vec::with_capacity(mpidrs.len());
-    for mpidr in mpidrs {
-        data.push(RedistRegEngine::get_regs_data(fd, redist_regs(), *mpidr)?);
-    }
-
-    Ok(data)
+pub(crate) fn get_redist_regs(fd: &DeviceFd, mpidr: u64) -> Result<Vec<GicRegState<u32>>> {
+    RedistRegEngine::get_regs_data(fd, redist_regs(), mpidr)
 }
 
-pub(crate) fn set_redist_regs(
-    fd: &DeviceFd,
-    mpidrs: &[u64],
-    state: &[Vec<GicRegState<u32>>],
-) -> Result<()> {
-    for (mpidr, data) in mpidrs.iter().zip(state) {
-        RedistRegEngine::set_regs_data(fd, redist_regs(), data, *mpidr)?;
-    }
-
-    Ok(())
+pub(crate) fn set_redist_regs(fd: &DeviceFd, mpidr: u64, data: &[GicRegState<u32>]) -> Result<()> {
+    RedistRegEngine::set_regs_data(fd, redist_regs(), data, mpidr)
 }
 
 #[cfg(test)]
@@ -101,25 +88,24 @@ mod tests {
         let _ = vm.create_vcpu(0).unwrap();
         let gic_fd = create_gic(&vm, 1).expect("Cannot create gic");
 
-        let mut gicr_typer = Vec::new();
-        gicr_typer.push(123);
-        let res = get_redist_regs(&gic_fd.device_fd(), &gicr_typer);
+        let gicr_typer = 123;
+        let res = get_redist_regs(&gic_fd.device_fd(), gicr_typer);
         assert!(res.is_ok());
         let state = res.unwrap();
-        assert_eq!(state.iter().flatten().count(), 14);
+        assert_eq!(state.iter().count(), 14);
 
-        assert!(set_redist_regs(&gic_fd.device_fd(), &gicr_typer, &state).is_ok());
+        assert!(set_redist_regs(&gic_fd.device_fd(), gicr_typer, &state).is_ok());
 
         unsafe { libc::close(gic_fd.device_fd().as_raw_fd()) };
 
-        let res = set_redist_regs(&gic_fd.device_fd(), &gicr_typer, &state);
+        let res = set_redist_regs(&gic_fd.device_fd(), gicr_typer, &state);
         assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),
             "DeviceAttribute(Error(9), true, 5)"
         );
 
-        let res = get_redist_regs(&gic_fd.device_fd(), &gicr_typer);
+        let res = get_redist_regs(&gic_fd.device_fd(), gicr_typer);
         assert!(res.is_err());
         assert_eq!(
             format!("{:?}", res.unwrap_err()),


### PR DESCRIPTION
## Reason for This PR

Improves on top of the fix for #2234

## Description of Changes

Split the GicState per vCPUs

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
