### PR TITLE
aarch64/rtc: update reset value for RTCPeriphID2

### DIFF
--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -33,7 +33,7 @@ const RTCICR: u64 = 0x1c; // Interrupt Clear Register.
                           // AMBA standard devices have CIDs (Cell IDs) and PIDs (Peripheral IDs). The linux kernel will look for these in order to assert the identity
                           // of these devices (i.e look at the `amba_device_try_add` function).
                           // We are putting the expected values (look at 'Reset value' column from above mentioned document) in an array.
-const PL031_ID: [u8; 8] = [0x31, 0x10, 0x14, 0x00, 0x0d, 0xf0, 0x05, 0xb1];
+const PL031_ID: [u8; 8] = [0x31, 0x10, 0x04, 0x00, 0x0d, 0xf0, 0x05, 0xb1];
 // We are only interested in the margins.
 const AMBA_ID_LOW: u64 = 0xFE0;
 const AMBA_ID_HIGH: u64 = 0x1000;


### PR DESCRIPTION
## Reason for This PR

The reset value for RTCPeriphID2 on aarch64 was incorrect.

## Description of Changes

According to https://developer.arm.com/documentation/ddi0224/c/Programmers-model/Summary-of-RTC-registers,
the reset value should be 0x04, not 0x14.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
