### PR TITLE
Fix block used bytes reporting

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -19,7 +19,7 @@ use logger::{error, warn, IncMetric, METRICS};
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::*;
-use vm_memory::{Bytes, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestMemoryError, GuestMemoryMmap};
 
 use super::{
     super::{ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BLOCK, VIRTIO_MMIO_INT_VRING},
@@ -258,15 +258,46 @@ impl Block {
                             break;
                         }
                     }
+
                     let status = match request.execute(&mut self.disk, mem) {
                         Ok(l) => {
-                            len = l;
-                            VIRTIO_BLK_S_OK
+                            // Account for the status byte as well.
+                            // With a non-faulty driver, we shouldn't get to the point where we
+                            // overflow here (since data len must be a multiple of 512 bytes, so
+                            // it can't be u32::MAX). In the future, this should be fixed at the
+                            // request parsing level, so no data will actually be transferred in
+                            // scenarios like this one.
+                            if let Some(l) = l.checked_add(1) {
+                                len = l;
+                                VIRTIO_BLK_S_OK
+                            } else {
+                                len = l;
+                                VIRTIO_BLK_S_IOERR
+                            }
                         }
                         Err(e) => {
-                            error!("Failed to execute request: {:?}", e);
                             METRICS.block.invalid_reqs_count.inc();
-                            len = 1; // We need at least 1 byte for the status.
+                            match e {
+                                ExecuteError::Read(GuestMemoryError::PartialBuffer {
+                                    completed,
+                                    expected,
+                                }) => {
+                                    error!(
+                                        "Failed to execute virtio block read request: can only \
+                                        write {} of {} bytes.",
+                                        completed, expected
+                                    );
+                                    METRICS.block.read_bytes.add(completed);
+                                    // This can not overflow since `completed` < data len which is
+                                    // an u32.
+                                    len = completed as u32 + 1;
+                                }
+                                _ => {
+                                    error!("Failed to execute virtio block request: {:?}", e);
+                                    // Status byte only.
+                                    len = 1;
+                                }
+                            };
                             e.status()
                         }
                     };
@@ -690,7 +721,7 @@ pub(crate) mod tests {
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
 
@@ -713,9 +744,99 @@ pub(crate) mod tests {
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get());
+            // Added status byte length.
+            assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get() + 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
+        }
+
+        // Read with error.
+        {
+            vq.used.idx.set(0);
+            set_queue(&mut block, 0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            let size = block.disk.file.seek(SeekFrom::End(0)).unwrap();
+            block.disk.file.set_len(size / 2).unwrap();
+            mem.write_obj(10, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // Only status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
             assert_eq!(mem.read_obj::<u64>(data_addr).unwrap(), 123_456_789);
+        }
+
+        // Partial buffer error on read.
+        {
+            vq.used.idx.set(0);
+            set_queue(&mut block, 0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            let size = block.disk.file.seek(SeekFrom::End(0)).unwrap();
+            block.disk.file.set_len(size / 2).unwrap();
+            // Update sector number: stored at `request_type_addr.0 + 8`
+            mem.write_obj(5, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            // This will attempt to read past end of file.
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // No data since can't read past end of file, only status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
+            assert_eq!(mem.read_obj::<u64>(data_addr).unwrap(), 123_456_789);
+        }
+
+        {
+            vq.used.idx.set(0);
+            set_queue(&mut block, 0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+            vq.dtable[1].len.set(1024);
+
+            mem.write_obj(1, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // File has 2 sectors and we try to read from the second sector, which means we will
+            // read 512 bytes (instead of 1024).
+            assert_eq!(vq.used.ring[0].get().len, 513);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
         }
     }
 
@@ -741,7 +862,7 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
 
@@ -757,7 +878,8 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            // status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }
@@ -786,7 +908,7 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 21);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
 
             assert!(blk_metadata.is_ok());
@@ -897,7 +1019,7 @@ pub(crate) mod tests {
             // Make sure the data queue advanced.
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }
@@ -988,7 +1110,7 @@ pub(crate) mod tests {
             // Make sure the data queue advanced.
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -175,7 +175,7 @@ pub mod tests {
 
         assert_eq!(vq.used.idx.get(), 1);
         assert_eq!(vq.used.ring[0].get().id, 0);
-        assert_eq!(vq.used.ring[0].get().len, 0);
+        assert_eq!(vq.used.ring[0].get().len, 1);
         assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
     }
 }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -352,7 +352,7 @@ fn main() {
                 println!("{}\n", arg_parser.formatted_help());
                 println!(
                     "Any arguments after the -- separator will be supplied to the jailed \
-                    binary.\n"
+                     binary.\n"
                 );
                 process::exit(0);
             }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.37, "ARM": 83.03}
+COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.19}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -12,6 +12,7 @@ import host_tools.drive as drive_tools
 import host_tools.network as net_tools  # pylint: disable=import-error
 
 PARTUUID = {"x86_64": "0eaa91a0-01", "aarch64": "7bf14469-01"}
+MB = 1024 * 1024
 
 
 def test_rescan_file(test_microvm_with_ssh, network_config):
@@ -26,9 +27,11 @@ def test_rescan_file(test_microvm_with_ssh, network_config):
 
     _tap, _, _ = test_microvm_with_ssh.ssh_network_config(network_config, '1')
 
+    block_size = 2
     # Add a scratch block device.
     fs = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, 'scratch')
+        os.path.join(test_microvm.fsfiles, 'scratch'),
+        size=block_size
     )
     test_microvm.add_drive(
         'scratch',
@@ -38,11 +41,18 @@ def test_rescan_file(test_microvm_with_ssh, network_config):
     test_microvm.start()
 
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-
     _check_block_size(ssh_connection, '/dev/vdb', fs.size())
 
-    # Resize the filesystem from 256 MiB (default) to 512 MiB.
-    fs.resize(512)
+    # Check if reading from the entire disk results in a file of the same size
+    # or errors out, after a truncate on the host.
+    truncated_size = block_size//2
+    utils.run_cmd(f"truncate --size {truncated_size}M {fs.path}")
+    block_copy_name = "dev_vdb_copy"
+    _, _, stderr = ssh_connection.execute_command(
+        f"dd if=/dev/vdb of={block_copy_name} bs=1M count={block_size}")
+    assert "dd: error reading '/dev/vdb': Input/output error" in stderr.read()
+    _check_file_size(ssh_connection, f'{block_copy_name}',
+                     truncated_size * MB)
 
     response = test_microvm.drive.patch(
         drive_id='scratch',
@@ -377,7 +387,7 @@ def test_patch_drive_limiter(test_microvm_with_ssh, network_config):
         is_read_only=False,
         rate_limiter={
             'bandwidth': {
-                'size': 1024*1024*10,
+                'size': 10 * MB,
                 'refill_time': 100
             },
             'ops': {
@@ -401,7 +411,7 @@ def test_patch_drive_limiter(test_microvm_with_ssh, network_config):
         drive_id='scratch',
         rate_limiter={
             'bandwidth': {
-                'size': 1024*1024*100,
+                'size': 100 * MB,
                 'refill_time': 100
             },
             'ops': {
@@ -434,6 +444,15 @@ def test_patch_drive_limiter(test_microvm_with_ssh, network_config):
 def _check_block_size(ssh_connection, dev_path, size):
     _, stdout, stderr = ssh_connection.execute_command(
         'blockdev --getsize64 {}'.format(dev_path)
+    )
+
+    assert stderr.read() == ''
+    assert stdout.readline().strip() == str(size)
+
+
+def _check_file_size(ssh_connection, dev_path, size):
+    _, stdout, stderr = ssh_connection.execute_command(
+        'stat --format=%s {}'.format(dev_path)
     )
 
     assert stderr.read() == ''


### PR DESCRIPTION
## Reason for This PR

Fix the reported used bytes for any virtio block request.

## Description of Changes

Report the correct/actual bytes written/read from the virtio block buffers, which are accounted as used, and reported back to driver.

~~- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).~~

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
