### PR TITLE
re-enable test_older_snapshot_resume_latency for aarch64

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import platform
-import pytest
 from conftest import _test_images_s3_bucket, DEFAULT_TEST_IMAGES_S3_BUCKET
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.matrix import TestMatrix, TestContext
@@ -329,10 +328,6 @@ def test_snapshot_resume_latency(network_config,
     test_matrix.run_test(_test_snapshot_resume_latency)
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="Snapshot format not final. No translations implemented."
-)
 def test_older_snapshot_resume_latency(bin_cloner_path):
     """Test scenario: Older snapshot load performance measurement."""
     logger = logging.getLogger("old_snapshot_load")


### PR DESCRIPTION
## Reason for This PR

re-enable test_older_snapshot_resume_latency for aarch64

## Description of Changes

re-enable test_older_snapshot_resume_latency for aarch64

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
