### PR TITLE
jailer: some minor corrections

### DIFF
--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -263,9 +263,8 @@ impl Env {
     }
 
     fn join_netns(path: &str) -> Result<()> {
-        // This will take ownership of the raw fd.
-        // TODO: for some reason, if we use as_raw_fd here instead, the resulting fd cannot
-        // be used with setns, because we get an EBADFD error. I wonder why?
+        // Not used `as_raw_fd` as it will create a dangling fd (object will be freed immediately) instead
+        // used `into_raw_fd` which provides underlying fd ownership to caller.
         let netns_fd = File::open(path)
             .map_err(|e| Error::FileOpen(PathBuf::from(path), e))?
             .into_raw_fd();

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -134,11 +134,8 @@ impl Env {
                 .parse::<u32>()
                 .map_err(|_| Error::NumaNode(numa_node_str.to_owned()))?;
 
-            if let Ok(mut numa_cgroups) =
-                cgroup::cgroups_from_numa_node(numa_node, id, &exec_file_name)
-            {
-                cgroups.append(&mut numa_cgroups);
-            }
+            let mut numa_cgroups = cgroup::cgroups_from_numa_node(numa_node, id, &exec_file_name)?;
+            cgroups.append(&mut numa_cgroups);
         }
 
         // cgroup format: <cgroup_controller>.<cgroup_property>=<value>,...
@@ -463,7 +460,7 @@ mod tests {
     impl ArgVals<'_> {
         pub fn new() -> ArgVals<'static> {
             ArgVals {
-                node: "1",
+                node: "0",
                 id: "bd65600d-8669-4903-8a14-af88203add38",
                 exec_file: "/proc/cpuinfo",
                 uid: "1001",
@@ -762,7 +759,7 @@ mod tests {
         let some_dir_path = some_dir.as_path().to_str().unwrap();
 
         let some_arg_vals = ArgVals {
-            node: "1",
+            node: "0",
             id: "bd65600d-8669-4903-8a14-af88203add38",
             exec_file: some_file_path,
             uid: "1001",

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -267,7 +267,7 @@ pub fn build_arg_parser() -> ArgParser<'static> {
         ))
         .arg(Argument::new("cgroup").allow_multiple(true).help(
             "Cgroup and value to be set by the jailer. It must follow this format: \
-             <cgroup_file>=<value> (e.g cpu.shares=10). This argument can be used
+             <cgroup_file>=<value> (e.g cpu.shares=10). This argument can be used \
              multiple times to add multiple cgroups.",
         ))
         .arg(

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -432,7 +432,7 @@ impl<'a> Arguments<'a> {
                     .clone();
 
                 if argument.allow_multiple {
-                    match argument.user_value.clone() {
+                    match argument.user_value.take() {
                         Some(Value::Multiple(mut v)) => {
                             v.push(val);
                             Value::Multiple(v)

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.18}
+COVERAGE_DICT = {"Intel": 85.19, "AMD": 84.43, "ARM": 83.28}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Description of Changes

`[Author TODO: add description of changes.]`

- Alignment fixed in jailer's cgroup help text.
- In arg_parser replaced `clone` with `take`. Instead of cloning the user value each time, taking the value is a better alternative because clone overhead will be eliminated.
- In jailer commented for using `into_raw_fd` in netns. author written a TODO to check why EBADFD is faced while using`as_raw_fd` but not in `into_raw_fd`. added a comment to clarify that.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
