### PR TITLE
Guard Pages Mechanism

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -456,15 +456,10 @@ pub fn create_guest_memory(
     let mem_size = mem_size_mib << 20;
     let arch_mem_regions = arch::arch_memory_regions(mem_size);
 
-    if !track_dirty_pages {
-        Ok(GuestMemoryMmap::from_ranges(&arch_mem_regions)
-            .map_err(StartMicrovmError::GuestMemoryMmap)?)
-    } else {
-        Ok(
-            GuestMemoryMmap::from_ranges_with_tracking(&arch_mem_regions)
-                .map_err(StartMicrovmError::GuestMemoryMmap)?,
-        )
-    }
+    Ok(
+        GuestMemoryMmap::from_ranges_guarded(&arch_mem_regions, track_dirty_pages)
+            .map_err(StartMicrovmError::GuestMemoryMmap)?,
+    )
 }
 
 fn load_kernel(

--- a/src/vmm/src/memory_snapshot.rs
+++ b/src/vmm/src/memory_snapshot.rs
@@ -11,7 +11,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{
     Bytes, FileOffset, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
-    GuestMemoryRegion, GuestRegionMmap, MemoryRegionAddress, MmapRegion,
+    GuestMemoryRegion, GuestRegionMmap, MemoryRegionAddress,
 };
 
 use crate::DirtyBitmap;
@@ -174,7 +174,7 @@ impl SnapshotMemory for GuestMemoryMmap {
     ) -> std::result::Result<Self, Error> {
         let mut mmap_regions = Vec::new();
         for region in state.regions.iter() {
-            let mmap_region = MmapRegion::build(
+            let mmap_region = GuestRegionMmap::build_guarded(
                 Some(FileOffset::new(
                     file.try_clone().map_err(Error::FileHandle)?,
                     region.offset,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.19, "AMD": 84.43, "ARM": 83.28}
+COVERAGE_DICT = {"Intel": 85.18, "AMD": 84.47, "ARM": 83.25}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Reason for This PR

This PR fixes the following [issue](https://github.com/firecracker-microvm/firecracker/issues/1533).

## Description of Changes

A guard page mechanism is implemented for guest memory creation and restore from Snapshot. Every memory region in the before mentioned cases will be surrounded by a left/right border, with the dimension of a system's PAGE_SIZE.
Rust unittests are also implemented.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
