### PR TITLE
Fix serial device bug for a full, non-blocking buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Increased the maximum number of virtio devices from 11 to 19.
 - Added a new check that prevents creating v0.23 snapshots when more than 11
   devices are attached.
+- If the stdout buffer is full and non-blocking, the serial writes no longer block.
+  Any new bytes will be lost, until the buffer is freed. The device also logs these
+  errors and increments the `uart.error_count` metric for each lost byte.
 
 ### Fixed
 

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -59,6 +59,10 @@ device in production. To disable it in the guest kernel, use the
 aware that the device can be reactivated from within the guest even if it was
 disabled at boot.
 
+If Firecracker's `stdout` buffer is non-blocking and full (assuming it has a
+bounded size), any subsequent writes will fail, resulting in data loss, until
+the buffer is freed.
+
 ### Log files
 
 Firecracker outputs logging data into a named pipe, socket, or file using the

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.37, "ARM": 83.03}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.37, "ARM": 83.2}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Reason for This PR

If the stdout buffer is full and non-blocking, the serial writes block.

## Description of Changes

If the stdout buffer is full and non-blocking, the serial writes no longer block.
Any new bytes will be lost, until the buffer is freed. The device also logs these
errors and increments the `uart.error_count` metric for each lost byte.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
