### PR TITLE
[aarch64][snap][GIC regs state] simplify construct_gicr_typer()

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -10,7 +10,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
 
 #[cfg(target_arch = "aarch64")]
-use crate::construct_gicr_typer;
+use crate::construct_kvm_mpidrs;
 #[cfg(target_arch = "x86_64")]
 use crate::device_manager::legacy::PortIODeviceManager;
 use crate::device_manager::mmio::MMIODeviceManager;
@@ -400,7 +400,7 @@ pub fn build_microvm_from_snapshot(
 
     #[cfg(target_arch = "aarch64")]
     {
-        let mpidrs = construct_gicr_typer(&microvm_state.vcpu_states);
+        let mpidrs = construct_kvm_mpidrs(&microvm_state.vcpu_states);
         // Restore kvm vm state.
         vmm.vm
             .restore_state(&mpidrs, &microvm_state.vm_state)


### PR DESCRIPTION
## Reason for This PR

- useful for #2236 
- code simplification
- possible bug fix: `construct_gicr_typer()` was touching bits below 32, possibly altering the offset or the instr encoded in the `attr` field 

## Description of Changes

We only use construct_gicr_typer() for calling:
- KVM_DEV_ARM_VGIC_GRP_REDIST_REGS
- KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS

But for this ioctls we don't need to construct the GICR_TYPER register.
We only need a squashed MPIDR, as specified in the linux kernel
documentation: https://github.com/torvalds/linux/blob/master/Documentation/virt/kvm/devices/arm-vgic-v3.rst

Quoting:

```
  KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS
  Attributes:
    The attr field of kvm_device_attr encodes two values:
    bits:     | 63      ....       32 | 31  ....  16 | 15  ....  0 |
    values:   |         mpidr         |      RES     |    instr    |

    The mpidr field encodes the CPU ID based on the affinity information in the
    architecture defined MPIDR, and the field is encoded as follows:
      | 63 .... 56 | 55 .... 48 | 47 .... 40 | 39 .... 32 |
      |    Aff3    |    Aff2    |    Aff1    |    Aff0    |
```

Similar for `KVM_DEV_ARM_VGIC_GRP_REDIST_REGS`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
