### PR TITLE
Added number of virtq available descriptors check on snapshot restore

### DIFF
--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -267,6 +267,13 @@ impl Queue {
         } else if used_ring.raw_value() & 0x3 != 0 {
             error!("virtio queue used ring breaks alignment constraints");
             false
+        } else if self.len(mem) > self.max_size {
+            error!(
+                "virtio queue number of available descriptors {} is greater than queue max size {}",
+                self.len(mem),
+                self.max_size
+            );
+            false
         } else {
             true
         }

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -476,6 +476,24 @@ pub(crate) mod tests {
         assert!(!q.is_valid(m));
         q.size = q.max_size;
 
+        // or when avail_idx - next_avail > max_size
+        q.next_avail = Wrapping(5);
+        assert!(!q.is_valid(m));
+        // avail_ring + 2 is the address of avail_idx in guest mem
+        m.write_obj::<u16>(64 as u16, q.avail_ring.unchecked_add(2))
+            .unwrap();
+        assert!(!q.is_valid(m));
+        m.write_obj::<u16>(5 as u16, q.avail_ring.unchecked_add(2))
+            .unwrap();
+        q.max_size = 2;
+        assert!(!q.is_valid(m));
+
+        // reset dirtied values
+        q.max_size = 16;
+        q.next_avail = Wrapping(0);
+        m.write_obj::<u16>(0, q.avail_ring.unchecked_add(2))
+            .unwrap();
+
         // or if the various addresses are off
 
         q.desc_table = GuestAddress(0xffff_ffff);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.05}
+COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.18}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Reason for This PR

We have no check for an invalid number of descriptors in the available ring of the virito queues.

## Description of Changes
Added a check for an invalid number of descriptors in the available ring of the virito queues.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
