### PR TITLE
Updated FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -199,9 +199,10 @@ Firecracker process remains unaware of the guest shutdown so it lives on.
 Running the `reboot` command in a Linux guest will gracefully bring down the guest
 system and also bring a graceful end to the Firecracker process.
 
-Issuing a `SendCtrlAltDel` action command through the Firecracker API will generate a
-`Ctrl + Alt + Del` keyboard event in the guest resulting in a clean reboot on most
-guest Linux systems.
+On `x86_64` systems, issuing a `SendCtrlAltDel` action command through the
+Firecracker API will generate a `Ctrl + Alt + Del` keyboard event in the guest
+which triggers a behavior identical to running the `reboot` command. This is,
+however, not supported on `aarch64` systems.
 
 ### How can I create my own rootfs or kernel images?
 


### PR DESCRIPTION
## Reason for This PR

No mention of `SendCtrlAltDel` being unsupported on `aarch64` in FAQ.

## Description of Changes

Addition in FAQ.md to mention `SendCtrlAltDel` is not supported in the context of cleanly rebooting a VM on ARM.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
