### PR TITLE
Mention lack of cross-architecture emulation support in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -59,13 +59,14 @@ Firecracker is an
 that is purpose-built for running serverless functions and containers safely and
 efficiently, and nothing more. Firecracker is written in Rust, provides a
 minimal required device model to the guest operating system while excluding
-non-essential functionality (only 5 emulated devices are available: virtio-net,
-virtio-block, virtio-vsock, serial console, and a minimal keyboard controller
-used only to stop the microVM). This, along with a streamlined kernel loading
-process enables a < 125 ms startup time and a < 5 MiB memory footprint. The
-Firecracker process also provides a RESTful control API, handles resource rate
-limiting for microVMs, and provides a microVM metadata service to enable the
-sharing of configuration data between the host and guest.
+non-essential functionality (only 6 emulated devices are available: virtio-net,
+virtio-balloon, virtio-block, virtio-vsock, serial console, and a minimal
+keyboard controller used only to stop the microVM). This, along with a
+streamlined kernel loading process enables a < 125 ms startup time and a < 5
+MiB memory footprint. The Firecracker process also provides a RESTful control
+API, handles resource rate limiting for microVMs, and provides a microVM
+metadata service to enable the sharing of configuration data between the host
+and guest.
 
 ### What operating systems are supported by Firecracker?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -102,6 +102,14 @@ to create new Firecracker releases.
 
 ## Technical FAQ & Troubleshooting
 
+### Can I emulate a different architecture in the guest than the one on the host?
+
+Guest operating systems must be built for the same CPU architecture as the
+host on which it will run. Firecracker does not support running microVMs on
+any architecture other than the one the host is running on. In other words,
+running an OS built for a `x86_64` on an `aarch64` system will not work, and
+vice versa.
+
 ### I tried using an initrd for boot but it doesn't seem to be used. Is initrd supported?
 
 Initrds are only recently supported in Firecracker. If your release predates


### PR DESCRIPTION
## Reason for This PR

No mention of lack of cross-architecture emulation support in FAQ.

## Description of Changes

Mentioned lack of cross-architecture emulation support in FAQ.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
