### PR TITLE
Seccomp: allow clock_gettime with any parameters.

### DIFF
--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -89,11 +89,12 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mremap),
             // Used for freeing memory
             allow_syscall(libc::SYS_munmap),
-            // Used for reading the timezone in LocalTime::now()
             allow_syscall_if(
                 libc::SYS_mmap,
                 or![
+                    // Used for reading the timezone in LocalTime::now()
                     and![Cond::new(3, ArgLen::DWORD, Eq, libc::MAP_SHARED as u64)?],
+                    // Used by the balloon device
                     and![Cond::new(
                         3,
                         ArgLen::DWORD,

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -9,11 +9,6 @@ use seccomp::{
 };
 use utils::signal::sigrtmin;
 
-#[cfg(target_arch = "aarch64")]
-pub const SYS_FTRUNCATE: libc::c_long = 46;
-#[cfg(target_arch = "x86_64")]
-pub const SYS_FTRUNCATE: libc::c_long = 77;
-
 /// The default filter containing the white listed syscall rules required by `Firecracker` to
 /// function.
 /// Any non-trivial modification to this allow list needs a proper comment to specify its source
@@ -63,7 +58,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             // Used for drive patching & rescanning, for reading the local timezone
             allow_syscall(libc::SYS_fstat),
             // Used for snapshotting
-            allow_syscall(SYS_FTRUNCATE),
+            allow_syscall(libc::SYS_ftruncate),
             // Used for synchronization
             allow_syscall_if(
                 libc::SYS_futex,

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -28,16 +28,10 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             ),
             // Called for expanding the heap
             allow_syscall(libc::SYS_brk),
-            // Used for metrics, via the helpers in utils/src/time.rs
-            allow_syscall_if(
-                libc::SYS_clock_gettime,
-                or![and![Cond::new(
-                    0,
-                    ArgLen::DWORD,
-                    Eq,
-                    libc::CLOCK_PROCESS_CPUTIME_ID as u64
-                )?],],
-            ),
+            // Used for metrics and logging, via the helpers in utils/src/time.rs
+            // It's not called on some platforms, because of vdso optimisations. In those cases,
+            // musl falls back to the regular syscall.
+            allow_syscall(libc::SYS_clock_gettime),
             allow_syscall(libc::SYS_close),
             // Needed for vsock
             allow_syscall(libc::SYS_connect),


### PR DESCRIPTION
# Reason for This PR

Fixes #2393. 
More details in this comment: https://github.com/firecracker-microvm/firecracker/issues/2393#issuecomment-757936727

## Description of Changes

Removed seccomp param checks for `clock_gettime`
Minor comment updates
Replace hardcoded `SYS_ftruncate` value with rust/libc constant

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
