### PR TITLE
Apply block off-by-one patch and release v0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.22.3]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed off-by-one error in virtio-block descriptor address validation.
+
 ## [0.22.2]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "firecracker"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.22.2
+  version: 0.22.3
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -160,7 +160,7 @@ impl Request {
 
             // Check that the address of the data descriptor is valid in guest memory.
             let _ = mem
-                .checked_offset(data_desc.addr, data_desc.len as usize)
+                .checked_offset(data_desc.addr, (data_desc.len - 1) as usize)
                 .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
                     data_desc.addr,
                 )))?;
@@ -181,7 +181,7 @@ impl Request {
         // Check that the address of the status descriptor is valid in guest memory.
         // We will write an u32 status here after executing the request.
         let _ = mem
-            .checked_offset(status_desc.addr, mem::size_of::<u32>())
+            .checked_offset(status_desc.addr, (mem::size_of::<u32>() - 1) as usize)
             .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
                 status_desc.addr,
             )))?;

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.22.2"
+version = "0.22.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.22.2"
+version = "0.22.3"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -148,7 +148,13 @@ def run_cmd_list_async(cmd_list):
     :param cmd_list: list of commands to execute
     :return: None
     """
-    loop = asyncio.get_event_loop()
+    loop = None
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # Create event loop when one is not available
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     cmds = []
     # Create a list of partial functions to run
@@ -172,7 +178,13 @@ def run_cmd(cmd, ignore_return_code=False, no_shell=False):
     :param noshell: don't run the command in a sub-shell
     :returns: tuple of (return code, stdout, stderr)
     """
-    loop = asyncio.get_event_loop()
+    loop = None
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # Create event loop when one is not available
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     return loop.run_until_complete(
         run_cmd_async(cmd=cmd,

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -22,34 +22,36 @@ INITRD_BOOT_TIME_US = 160000 if platform.machine() == "x86_64" else 500000
 TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
 
-def test_boottime_no_network(test_microvm_with_boottime):
+def test_boottime_no_network(test_microvm_with_old_boottime):
     """Check guest boottime of microvm without network."""
-    _ = _configure_vm(test_microvm_with_boottime)
+    _ = _configure_vm(test_microvm_with_old_boottime)
     time.sleep(0.4)
-    boottime_us = _test_microvm_boottime(test_microvm_with_boottime.log_data)
+    boottime_us = _test_microvm_boottime(
+        test_microvm_with_old_boottime.log_data)
     print("Boot time with no network is: " + str(boottime_us) + " us")
 
 
 def test_boottime_with_network(
-        test_microvm_with_boottime,
+        test_microvm_with_old_boottime,
         network_config
 ):
     """Check guest boottime of microvm with network."""
-    _tap = _configure_vm(test_microvm_with_boottime, {
+    _tap = _configure_vm(test_microvm_with_old_boottime, {
         "config": network_config, "iface_id": "1"
     })
     time.sleep(0.4)
-    boottime_us = _test_microvm_boottime(test_microvm_with_boottime.log_data)
+    boottime_us = _test_microvm_boottime(
+        test_microvm_with_old_boottime.log_data)
     print("Boot time with network configured is: " + str(boottime_us) + " us")
 
 
 def test_initrd_boottime(
-        test_microvm_with_initrd):
+        test_microvm_with_old_initrd):
     """Check guest boottime of microvm with initrd."""
-    _tap = _configure_vm(test_microvm_with_initrd, initrd=True)
+    _tap = _configure_vm(test_microvm_with_old_initrd, initrd=True)
     time.sleep(0.8)
     boottime_us = _test_microvm_boottime(
-        test_microvm_with_initrd.log_data, max_time_us=INITRD_BOOT_TIME_US)
+        test_microvm_with_old_initrd.log_data, max_time_us=INITRD_BOOT_TIME_US)
     print("Boot time with initrd is: " + str(boottime_us) + " us")
 
 


### PR DESCRIPTION
# Reason for This PR

Applying off-by-one block device patch to v0.22.

## Description of Changes

Adapt patch from upstream and release v0.22.3

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
