### PR TITLE
Release v0.24.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,4 @@ Alin Dima <alindima@amazon.com>
 Andrei Sandu <sandreim@amazon.com> <54316454+sandreim@users.noreply.github.com>
 Diana Popa <dpopa@amazon.com> <dpopa@38f9d3563971.ant.amazon.com>
 Alexandru Cihodaru <cihodar@amazon.com>
+Liviu Berciu <lberciu@amazon.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.24.1]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed off-by-one error in virtio-block descriptor address validation.
+
 ## [0.24.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "api_server 0.1.0",
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -346,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.24.0
+  version: 0.24.1
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -301,9 +301,10 @@ impl Block {
                             e.status()
                         }
                     };
-                    // We use unwrap because the request parsing process already checked that the
-                    // status_addr was valid.
-                    mem.write_obj(status, request.status_addr).unwrap();
+
+                    if let Err(e) = mem.write_obj(status, request.status_addr) {
+                        error!("Failed to write virtio block status: {:?}", e)
+                    }
                 }
                 Err(e) => {
                     error!("Failed to parse available descriptor chain: {:?}", e);
@@ -604,6 +605,39 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_addr_out_of_bounds() {
+        let mut block = default_block();
+        // Default mem size is 0x10000
+        let mem = default_mem();
+        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        set_queue(&mut block, 0, vq.create_queue());
+        block.activate(mem.clone()).unwrap();
+        initialize_virtqueue(&vq);
+        vq.dtable[1].set(0xff00, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
+
+        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
+
+        // Mark the next available descriptor.
+        vq.avail.idx.set(1);
+        // Read.
+        {
+            vq.used.idx.set(0);
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            check_metric_after_block!(
+                &METRICS.block.invalid_reqs_count,
+                1,
+                invoke_handler_for_queue_event(&mut block)
+            );
+        }
+    }
+
+    #[test]
     fn test_request_execute_failures() {
         let mut block = default_block();
         let mem = default_mem();
@@ -689,6 +723,39 @@ pub(crate) mod tests {
             mem.read_obj::<u32>(status_addr).unwrap(),
             VIRTIO_BLK_S_UNSUPP
         );
+    }
+    #[test]
+    fn test_end_of_region() {
+        let mut block = default_block();
+        let mem = default_mem();
+        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        set_queue(&mut block, 0, vq.create_queue());
+        block.activate(mem.clone()).unwrap();
+        initialize_virtqueue(&vq);
+        vq.dtable[1].set(0xf000, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
+
+        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
+        let status_addr = GuestAddress(vq.dtable[2].addr.get());
+
+        vq.used.idx.set(0);
+
+        mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+            .unwrap();
+        vq.dtable[1]
+            .flags
+            .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+        check_metric_after_block!(
+            &METRICS.block.read_count,
+            1,
+            invoke_handler_for_queue_event(&mut block)
+        );
+
+        assert_eq!(vq.used.idx.get(), 1);
+        assert_eq!(vq.used.ring[0].get().id, 0);
+        // Added status byte length.
+        assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get() + 1);
+        assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
     }
 
     #[test]

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -33,16 +33,10 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
             ),
             // Called for expanding the heap
             allow_syscall(libc::SYS_brk),
-            // Used for metrics, via the helpers in utils/src/time.rs
-            allow_syscall_if(
-                libc::SYS_clock_gettime,
-                or![and![Cond::new(
-                    0,
-                    ArgLen::DWORD,
-                    Eq,
-                    libc::CLOCK_PROCESS_CPUTIME_ID as u64
-                )?],],
-            ),
+            // Used for metrics and logging, via the helpers in utils/src/time.rs
+            // It's not called on some platforms, because of vdso optimisations. In those cases,
+            // musl falls back to the regular syscall.
+            allow_syscall(libc::SYS_clock_gettime),
             allow_syscall(libc::SYS_close),
             // Needed for vsock
             allow_syscall(libc::SYS_connect),

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.2, "AMD": 84.43, "ARM": 83.18}
+COVERAGE_DICT = {"Intel": 85.1, "AMD": 84.37, "ARM": 83.06}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Releasing the v0.24.1 patch release.

## Description of Changes

Apply patch from upstream and release v0.24.1
Apply fix for `clock_gettime` on platforms without VDSO.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
