### PR TITLE
Call sync_all on DiskProperties drop

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -123,6 +123,14 @@ impl DiskProperties {
     }
 }
 
+impl Drop for DiskProperties {
+    fn drop(&mut self) {
+        if let Err(e) = self.file.sync_all() {
+            error!("File sync_all error: {:?}", e);
+        }
+    }
+}
+
 /// Virtio device for exposing block level read/write operations on a host file.
 pub struct Block {
     // Host file and properties.


### PR DESCRIPTION
Signed-off-by: berciuliviu <lberciu@amazon.com>

# Reason for This PR

Fixes [2188](https://github.com/firecracker-microvm/firecracker/issues/2188)

## Description of Changes

Call **sync_all** function when dropping DiskProperties to catch File.close() errors.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
