### PR TITLE
tests: fix snapshot tests for older versions

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -477,3 +477,41 @@ def wait_process_termination(p_pid):
     except ChildProcessError:
         return
     raise Exception("{} process is still alive: ".format(stdout.strip()))
+
+
+def get_firecracker_version_from_toml():
+    """
+    Return the version of the firecracker crate, from Cargo.toml.
+
+    Usually different from the output of `./firecracker --version`, if
+    the code has not been released.
+    """
+    cmd = "cd ../src/firecracker && cargo pkgid | cut -d# -f2 | cut -d: -f2"
+
+    rc, stdout, _ = run_cmd(cmd)
+    assert rc == 0
+
+    return stdout
+
+
+def compare_versions(first, second):
+    """
+    Compare two versions with format `X.Y.Z`.
+
+    :param first: first version string
+    :param second: second version string
+    :returns: 0 if equal, <0 if first < second, >0 if second < first
+    """
+    first = list(map(int, first.split('.')))
+    second = list(map(int, second.split('.')))
+
+    if first[0] == second[0]:
+        if first[1] == second[1]:
+            if first[2] == second[2]:
+                return 0
+
+            return first[2] - second[2]
+
+        return first[1] - second[1]
+
+    return first[0] - second[0]

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -11,6 +11,7 @@ from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, NetIfaceConfig
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.microvms import VMNano
+from framework.utils import get_firecracker_version_from_toml
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.drive as drive_tools
 
@@ -46,7 +47,8 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
     # Fetch all firecracker binaries.
     # With each binary create a snapshot and try to restore in current
     # version.
-    firecracker_artifacts = artifacts.firecrackers()
+    firecracker_artifacts = artifacts.firecrackers(
+        older_than=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()
         jailer = firecracker.jailer()
@@ -96,7 +98,8 @@ def test_restore_old_version_all_devices(bin_cloner_path):
     # Fetch all firecracker binaries.
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
-    firecracker_artifacts = artifacts.firecrackers()
+    firecracker_artifacts = artifacts.firecrackers(
+        older_than=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()
         jailer = firecracker.jailer()


### PR DESCRIPTION
# Reason for This PR

Previously, the snapshot tests that were supposed to retrieve
the older Firecracker binaries from S3 were not filtering the artifacts
by version number.

This results in test failures for patch releases, where the test
will use both older and newer binaries.

## Description of Changes

Added support in the testing framework for this and fixed the
respective tests.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
