### PR TITLE
vsock: little changes for accessibility purposes

### DIFF
--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -75,11 +75,7 @@ impl<B> Vsock<B>
 where
     B: VsockBackend,
 {
-    pub(crate) fn with_queues(
-        cid: u64,
-        backend: B,
-        queues: Vec<VirtQueue>,
-    ) -> super::Result<Vsock<B>> {
+    pub fn with_queues(cid: u64, backend: B, queues: Vec<VirtQueue>) -> super::Result<Vsock<B>> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
             queue_events.push(EventFd::new(libc::EFD_NONBLOCK).map_err(VsockError::EventFd)?);


### PR DESCRIPTION
# Reason for This PR

* be able to access vsock constructor from outside the `devices` crate
* expand auxiliary function to return the fd's for the complete interest list of the vsock device

## Description of Changes

* pub crate -> pub
* return all the 5 fd's in vsock's interest list

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
