### PR TITLE
Support and tools for easier baseline gathering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 __pycache__
 *.pyc
 .vscode
+test_results/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,11 +144,11 @@ def init_microvm(root_path, bin_cloner_path,
     assert jailer_binary
 
     vm = Microvm(
-         resource_path=root_path,
-         fc_binary_path=fc_binary,
-         jailer_binary_path=jailer_binary,
-         microvm_id=microvm_id,
-         bin_cloner_path=bin_cloner_path)
+        resource_path=root_path,
+        fc_binary_path=fc_binary,
+        jailer_binary_path=jailer_binary,
+        microvm_id=microvm_id,
+        bin_cloner_path=bin_cloner_path)
     vm.setup()
     return vm
 
@@ -166,11 +166,12 @@ def pytest_configure(config):
 
 
 def pytest_addoption(parser):
-    """Pytest hook. Add concurrency command line option.
-
-    For some reason, pytest doesn't properly pick up this hook in our plugin
-    class, so we need to call it from here.
-    """
+    """Pytest hook. Add command line options."""
+    parser.addoption(
+        "--dump-results-to-file",
+        action="store_true",
+        help="Flag to dump test results to the test_results folder.",
+    )
     return PytestScheduler.instance().do_pytest_addoption(parser)
 
 
@@ -208,6 +209,15 @@ def test_session_tmp_path(test_fc_session_root_path):
     tmp_path = tempfile.mkdtemp(prefix=test_fc_session_root_path)
     yield tmp_path
     shutil.rmtree(tmp_path)
+
+
+@pytest.fixture
+def results_file_dumper(request):
+    """Yield the custom --dump-results-to-file test flag."""
+    if request.config.getoption("--dump-results-to-file"):
+        return utils.ResultsFileDumper(request.node.originalname)
+
+    return None
 
 
 def _gcc_compile(src_file, output_file, extra_flags="-static -O3"):

--- a/tests/framework/defs.py
+++ b/tests/framework/defs.py
@@ -28,3 +28,5 @@ DEFAULT_TEST_IMAGES_S3_BUCKET = 'spec.ccfc.min'
 ENV_TEST_IMAGES_S3_BUCKET = 'TEST_MICROVM_IMAGES_S3_BUCKET'
 """Default test session root directory path"""
 DEFAULT_TEST_SESSION_ROOT_PATH = "/srv"
+"""Absolute path to the test results folder"""
+TEST_RESULTS_DIR = Path(FC_WORKSPACE_DIR) / "test_results"

--- a/tests/framework/statistics/core.py
+++ b/tests/framework/statistics/core.py
@@ -31,14 +31,14 @@ class Core:
     """Base class for statistics core driver."""
 
     # pylint: disable=W0102
-    def __init__(self, name, iterations, custom={}, check=True):
+    def __init__(self, name, iterations, custom={}, check_criteria=True):
         """Core constructor."""
         self._pipes = defaultdict(Pipe)
         self._statistics = Statistics(name=name,
                                       iterations=iterations,
                                       results={},
                                       custom=custom)
-        self._check = check
+        self._check_criteria = check_criteria
 
     def add_pipe(self, producer: Producer, consumer: Consumer, tag=None):
         """Add a new producer-consumer pipe."""
@@ -59,7 +59,7 @@ class Core:
                 else:
                     pipe.consumer.ingest(iteration, raw_data)
             try:
-                stats, custom = pipe.consumer.process(self._check)
+                stats, custom = pipe.consumer.process(self._check_criteria)
             except Failed as err:
                 assert False, f"Failed on '{tag}': {err.msg}"
 
@@ -68,9 +68,6 @@ class Core:
             # Custom information extracted from all the iterations.
             if len(custom) > 0:
                 self._statistics['custom'][tag] = custom
-
-        if not self._check:
-            print(self._statistics)
 
         return self._statistics
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -14,6 +14,7 @@ import time
 from collections import namedtuple, defaultdict
 import psutil
 from retry import retry
+from framework import defs
 
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
 CMDLOG = logging.getLogger("commands")
@@ -515,3 +516,26 @@ def compare_versions(first, second):
         return first[1] - second[1]
 
     return first[0] - second[0]
+
+
+class ResultsFileDumper:
+    """Class responsible with outputting test results to files."""
+
+    def __init__(self, test_name: str, append=True):
+        """Initialize the instance."""
+        if not append:
+            flags = "w"
+        else:
+            flags = "a"
+
+        self._root_path = defs.TEST_RESULTS_DIR
+
+        # Create the root directory, if it doesn't exist.
+        self._root_path.mkdir(exist_ok=True)
+
+        self._file = open(self._root_path / test_name, flags)
+
+    def writeln(self, data: str):
+        """Write the `data` string to the output file, appending a newline."""
+        self._file.write(data)
+        self._file.write("\n")

--- a/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.py
+++ b/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.py
@@ -48,1074 +48,1510 @@ CONFIG = {
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ "
                                  "2.50GHz",
-                        'baseline_bw': {
-                            'vmlinux-4.14.bin/ubuntu-18.04.ext4': {
-                                'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 3359, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 25813,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 28051,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 3363, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 25835,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 28806,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4144, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 23533,
-                                    DELTA_PERCENTAGE_TAG: 9},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 30387,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4147, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 25834,
-                                    DELTA_PERCENTAGE_TAG: 15},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 33251,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 4164, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 26737,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 30161,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 4164,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 27379,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 31033,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2976, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 20375,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 27174,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2973, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 20379,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 28513,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2619, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 14510,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 31480,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2620, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 16999,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 33932,
-                                    DELTA_PERCENTAGE_TAG: 5}},
-                            'vmlinux-4.9.bin/ubuntu-18.04.ext4': {
-                                'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 3114, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 25659,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 27725,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 3114, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 25661,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 28344,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4202, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 23208,
-                                    DELTA_PERCENTAGE_TAG: 9},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 26071,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4201, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 25986,
-                                    DELTA_PERCENTAGE_TAG: 14},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 32578,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3955, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 26075,
-                                    DELTA_PERCENTAGE_TAG: 8},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 29308,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3945,
-                                    DELTA_PERCENTAGE_TAG: 13},
-                                'tcp-p1024K-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 26777,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 30801,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2857, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 20169,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 27132,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2858, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 20180,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 27699,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2563, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 14245,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 24591,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2564, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 16910,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 33405,
-                                    DELTA_PERCENTAGE_TAG: 5}}},
-                        'baseline_cpu_utilization': {
-                            'vmlinux-4.14.bin/ubuntu-18.04.ext4': {
-                                'vmm': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 83,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 83,
-                                        DELTA_PERCENTAGE_TAG: 13},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 58,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 91,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 58,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 91,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 49,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 75,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 49,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 75,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 92,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 39,
-                                        DELTA_PERCENTAGE_TAG: 11},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 56,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 87,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 39,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 54,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 88,
-                                        DELTA_PERCENTAGE_TAG: 6}},
-                                'vcpus_total': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 114,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 114,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 190,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 186,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 176,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 164,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5}}},
-                            'vmlinux-4.9.bin/ubuntu-18.04.ext4': {
-                                'vmm': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 88,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 51,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 82,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 84,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 84,
-                                        DELTA_PERCENTAGE_TAG: 11},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 88,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 55,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 55,
-                                        DELTA_PERCENTAGE_TAG: 14},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 92,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 47,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 74,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 47,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 74,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 38,
-                                        DELTA_PERCENTAGE_TAG: 11},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 55,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 78,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 38,
-                                        DELTA_PERCENTAGE_TAG: 11},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 54,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 87,
-                                        DELTA_PERCENTAGE_TAG: 7}},
-                                'vcpus_total': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 114,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 118,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 181,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 184,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 175,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 164,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5}}}}
+                        "throughput": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 3359,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 25813,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 28051,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 3363,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 25835,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 28806,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 4144,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 23533,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 30387,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 4147,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 25834,
+                                        "delta_percentage": 15
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 33251,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 4164,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 26737,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 30161,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 4164,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 27379,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 31033,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 2976,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 20375,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 27174,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 2973,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 20379,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 28513,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 2619,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 14510,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 31480,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 2620,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 16999,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 33932,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 3114,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 25659,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 27725,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 3114,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 25661,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 28344,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 4202,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 23208,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 26071,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 4201,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 25986,
+                                        "delta_percentage": 14
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 32578,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 3955,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 26075,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 29308,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 3945,
+                                        "delta_percentage": 13
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 26777,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 30801,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 2857,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 20169,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 27132,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 2858,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 20180,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 27699,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 2563,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 14245,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 24591,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 2564,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 16910,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 33405,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            }
+                        },
+                        "cpu_utilization_vmm": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 57,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 94,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 57,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 89,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 94,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 83,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 83,
+                                        "delta_percentage": 13
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 58,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 91,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 94,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 58,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 91,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 93,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 49,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 75,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 49,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 75,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 92,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 39,
+                                        "delta_percentage": 11
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 56,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 87,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 39,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 54,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 88,
+                                        "delta_percentage": 6
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 88,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 93,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 93,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 51,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 82,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 84,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 84,
+                                        "delta_percentage": 11
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 88,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 55,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 94,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 55,
+                                        "delta_percentage": 14
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 92,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 47,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 74,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 47,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 74,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 38,
+                                        "delta_percentage": 11
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 55,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 78,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 38,
+                                        "delta_percentage": 11
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 54,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 87,
+                                        "delta_percentage": 7
+                                    }
+                                }
+                            }
+                        },
+                        "cpu_utilization_vcpus_total": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 114,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 114,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 190,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 186,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 176,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 164,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 114,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 118,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 181,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 184,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 175,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 164,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            }
+                        }
                     },
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ "
                                  "2.50GHz",
-                        'baseline_bw': {
-                            'vmlinux-4.14.bin/ubuntu-18.04.ext4': {
-                                'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 2749, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 24153,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 26827,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 2756, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 24139,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 27491,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 3434, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 20573,
-                                    DELTA_PERCENTAGE_TAG: 8},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 27994,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 3439, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 24089,
-                                    DELTA_PERCENTAGE_TAG: 15},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 31885,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3236, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 23782,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 29144,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3246,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 24308,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 29493,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2521, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 18606,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 25446,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2519, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 18638,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 26616,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2207, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 13812,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 29579,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2209, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 14839,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 31913,
-                                    DELTA_PERCENTAGE_TAG: 7}},
-                            'vmlinux-4.9.bin/ubuntu-18.04.ext4': {
-                                'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 2946, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 26944,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 27140,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                    TARGET_TAG: 2948, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                    TARGET_TAG: 26949,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                    TARGET_TAG: 27722,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4040, DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 21646,
-                                    DELTA_PERCENTAGE_TAG: 8},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 26125,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                    TARGET_TAG: 4046, DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                    TARGET_TAG: 23994,
-                                    DELTA_PERCENTAGE_TAG: 11},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                    TARGET_TAG: 33624,
-                                    DELTA_PERCENTAGE_TAG: 8},
-                                'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3723, DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 25134,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 28180,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws16K-2vcpu-bd': {
-                                    TARGET_TAG: 3720,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-ws256K-2vcpu-bd': {
-                                    TARGET_TAG: 25933,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                    TARGET_TAG: 29736,
-                                    DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2582, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 19537,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 26151,
-                                    DELTA_PERCENTAGE_TAG: 27},
-                                'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                    TARGET_TAG: 2580, DELTA_PERCENTAGE_TAG: 5},
-                                'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                    TARGET_TAG: 19529,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                    TARGET_TAG: 27303,
-                                    DELTA_PERCENTAGE_TAG: 6},
-                                'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2439, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 14706,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 24763,
-                                    DELTA_PERCENTAGE_TAG: 7},
-                                'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                    TARGET_TAG: 2439, DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                    TARGET_TAG: 15958,
-                                    DELTA_PERCENTAGE_TAG: 4},
-                                'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                    TARGET_TAG: 34569,
-                                    DELTA_PERCENTAGE_TAG: 6}}},
-                        'baseline_cpu_utilization': {
-                            'vmlinux-4.14.bin/ubuntu-18.04.ext4': {
-                                'vmm': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 56,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 56,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 94,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 80,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 87,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 84,
-                                        DELTA_PERCENTAGE_TAG: 13},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 95,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 89,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 51,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 74,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 51,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 74,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 91,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 40,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 59,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 86,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 40,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 52,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 86,
-                                        DELTA_PERCENTAGE_TAG: 7}},
-                                'vcpus_total': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 121,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 119,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 185,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 184,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 181,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 165,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5}}},
-                            'vmlinux-4.9.bin/ubuntu-18.04.ext4': {
-                                'vmm': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 97,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 95,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 57,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 97,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 95,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 60,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 84,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 88,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 61,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 84,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 92,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 62,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 92,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 95,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 62,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 92,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 51,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 78,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 91,
-                                        DELTA_PERCENTAGE_TAG: 26},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 51,
-                                        DELTA_PERCENTAGE_TAG: 9},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 78,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 93,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 44,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 60,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 82,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 44,
-                                        DELTA_PERCENTAGE_TAG: 10},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 56,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 90,
-                                        DELTA_PERCENTAGE_TAG: 7}},
-                                'vcpus_total': {
-                                    'tcp-pDEFAULT-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 117,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-p1024K-ws16K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-g2h': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-g2h': {
-                                        TARGET_TAG: 112,
-                                        DELTA_PERCENTAGE_TAG: 8},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 182,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-h2g': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-h2g': {
-                                        TARGET_TAG: 187,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-pDEFAULT-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 174,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-p1024K-ws16K-2vcpu-bd': {
-                                        TARGET_TAG: 198,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-2vcpu-bd': {
-                                        TARGET_TAG: 197,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-2vcpu-bd': {
-                                        TARGET_TAG: 163,
-                                        DELTA_PERCENTAGE_TAG: 6},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 7},
-                                    'tcp-p1024K-ws16K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-g2h': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws16K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-ws256K-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5},
-                                    'tcp-p1024K-wsDEFAULT-1vcpu-h2g': {
-                                        TARGET_TAG: 99,
-                                        DELTA_PERCENTAGE_TAG: 5}}}}
+                        "throughput": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 2749,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 24153,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 26827,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 2756,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 24139,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 27491,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 3434,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 20573,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 27994,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 3439,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 24089,
+                                        "delta_percentage": 15
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 31885,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 3236,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 23782,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 29144,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 3246,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 24308,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 29493,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 2521,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 18606,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 25446,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 2519,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 18638,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 26616,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 2207,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 13812,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 29579,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 2209,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 14839,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 31913,
+                                        "delta_percentage": 7
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 2946,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 26944,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 27140,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 2948,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 26949,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 27722,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 4040,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 21646,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 26125,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 4046,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 23994,
+                                        "delta_percentage": 11
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 33624,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 3723,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 25134,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 28180,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 3720,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 25933,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 29736,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 2582,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 19537,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 26151,
+                                        "delta_percentage": 27
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 2580,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 19529,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 27303,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 2439,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 14706,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 24763,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 2439,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 15958,
+                                        "delta_percentage": 4
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 34569,
+                                        "delta_percentage": 6
+                                    }
+                                }
+                            }
+                        },
+                        "cpu_utilization_vmm": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 56,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 94,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 56,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 94,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 80,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 87,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 84,
+                                        "delta_percentage": 13
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 57,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 95,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 57,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 89,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 93,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 51,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 74,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 51,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 74,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 91,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 40,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 59,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 86,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 40,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 52,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 86,
+                                        "delta_percentage": 7
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 57,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 97,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 95,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 57,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 97,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 95,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 60,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 84,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 88,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 61,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 84,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 92,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 62,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 92,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 95,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 62,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 92,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 93,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 51,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 78,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 91,
+                                        "delta_percentage": 26
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 51,
+                                        "delta_percentage": 9
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 78,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 93,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 44,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 60,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 82,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 44,
+                                        "delta_percentage": 10
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 56,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 90,
+                                        "delta_percentage": 7
+                                    }
+                                }
+                            }
+                        },
+                        "cpu_utilization_vcpus_total": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 121,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 119,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 185,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 184,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 181,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 165,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            },
+                            "vmlinux-4.9.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 117,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-g2h": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
+                                        "target": 112,
+                                        "delta_percentage": 8
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 182,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-h2g": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
+                                        "target": 187,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-pDEFAULT-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
+                                        "target": 174,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-p1024K-ws16K-2vcpu-bd": {
+                                        "target": 198,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-2vcpu-bd": {
+                                        "target": 197,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
+                                        "target": 163,
+                                        "delta_percentage": 6
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 7
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws16K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-ws256K-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    },
+                                    "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
+                                        "target": 99,
+                                        "delta_percentage": 5
+                                    }
+                                }
+                            }
+                        }
                     }
                 ]
             }

--- a/tests/integration_tests/performance/configs/vsock_throughput_test_config.py
+++ b/tests/integration_tests/performance/configs/vsock_throughput_test_config.py
@@ -11,7 +11,7 @@ DURATION = "duration"
 DURATION_TOTAL = "total"
 BASE_PORT = 5201
 CPU_UTILIZATION_VMM = \
-                    f"{DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()}"
+    f"{DefaultMeasurement.CPU_UTILIZATION_VMM.name.lower()}"
 CPU_UTILIZATION_VCPUS_TOTAL = \
     f"{DefaultMeasurement.CPU_UTILIZATION_VCPUS_TOTAL.name.lower()}"
 IPERF3_CPU_UTILIZATION_PERCENT_OUT_TAG = "cpu_utilization_percent"
@@ -47,73 +47,75 @@ CONFIG = {
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ "
                         "2.50GHz",
-                        "baseline_bw": {
-                            "vmlinux-4.14.bin/ubuntu-18.04.ext4": {
-                                "vsock-p1024K-1vcpu-g2h": {
-                                    "target": 7001,
-                                    "delta_percentage": 4
-                                },
-                                "vsock-pDEFAULT-1vcpu-g2h": {
-                                    "target": 7036,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-1vcpu-g2h": {
-                                    "target": 2358,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024K-1vcpu-h2g": {
-                                    "target": 5126,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-pDEFAULT-1vcpu-h2g": {
-                                    "target": 5008,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-1vcpu-h2g": {
-                                    "target": 1854,
-                                    "delta_percentage": 4
-                                },
-                                "vsock-p1024K-2vcpu-g2h": {
-                                    "target": 7299,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-pDEFAULT-2vcpu-g2h": {
-                                    "target": 7278,
-                                    "delta_percentage": 7
-                                },
-                                "vsock-p1024-2vcpu-g2h": {
-                                    "target": 3086,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-p1024K-2vcpu-h2g": {
-                                    "target": 5933,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-pDEFAULT-2vcpu-h2g": {
-                                    "target": 5845,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-2vcpu-h2g": {
-                                    "target": 2547,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024K-2vcpu-bd": {
-                                    "target": 5761,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-pDEFAULT-2vcpu-bd": {
-                                    "target": 5695,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-2vcpu-bd": {
-                                    "target": 2274,
-                                    "delta_percentage": 5
+                        "throughput": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "vsock-p1024K-1vcpu-g2h": {
+                                        "target": 7001,
+                                        "delta_percentage": 4
+                                    },
+                                    "vsock-pDEFAULT-1vcpu-g2h": {
+                                        "target": 7036,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-1vcpu-g2h": {
+                                        "target": 2358,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024K-1vcpu-h2g": {
+                                        "target": 5126,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-pDEFAULT-1vcpu-h2g": {
+                                        "target": 5008,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-1vcpu-h2g": {
+                                        "target": 1854,
+                                        "delta_percentage": 4
+                                    },
+                                    "vsock-p1024K-2vcpu-g2h": {
+                                        "target": 7299,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-g2h": {
+                                        "target": 7278,
+                                        "delta_percentage": 7
+                                    },
+                                    "vsock-p1024-2vcpu-g2h": {
+                                        "target": 3086,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-p1024K-2vcpu-h2g": {
+                                        "target": 5933,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-h2g": {
+                                        "target": 5845,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-2vcpu-h2g": {
+                                        "target": 2547,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024K-2vcpu-bd": {
+                                        "target": 5761,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-bd": {
+                                        "target": 5695,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-2vcpu-bd": {
+                                        "target": 2274,
+                                        "delta_percentage": 5
+                                    }
                                 }
                             }
                         },
-                        "baseline_cpu_utilization": {
-                            "vmlinux-4.14.bin/ubuntu-18.04.ext4": {
-                                "vmm": {
+                        "cpu_utilization_vmm": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
                                     "vsock-p1024K-1vcpu-g2h": {
                                         "target": 51,
                                         "delta_percentage": 9
@@ -174,8 +176,12 @@ CONFIG = {
                                         "target": 67,
                                         "delta_percentage": 8
                                     }
-                                },
-                                "vcpus_total": {
+                                }
+                            }
+                        },
+                        "cpu_utilization_vcpus_total": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
                                     "vsock-p1024K-1vcpu-g2h": {
                                         "target": 99,
                                         "delta_percentage": 6
@@ -243,73 +249,75 @@ CONFIG = {
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ "
                         "2.50GHz",
-                        "baseline_bw": {
-                            "vmlinux-4.14.bin/ubuntu-18.04.ext4": {
-                                "vsock-p1024K-1vcpu-g2h": {
-                                    "target": 5973,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-pDEFAULT-1vcpu-g2h": {
-                                    "target": 5993,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-p1024-1vcpu-g2h": {
-                                    "target": 948,
-                                    "delta_percentage": 10
-                                },
-                                "vsock-p1024K-1vcpu-h2g": {
-                                    "target": 4041,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-pDEFAULT-1vcpu-h2g": {
-                                    "target": 3934,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-1vcpu-h2g": {
-                                    "target": 307,
-                                    "delta_percentage": 8
-                                },
-                                "vsock-p1024K-2vcpu-g2h": {
-                                    "target": 6775,
-                                    "delta_percentage": 7
-                                },
-                                "vsock-pDEFAULT-2vcpu-g2h": {
-                                    "target": 6699,
-                                    "delta_percentage": 8
-                                },
-                                "vsock-p1024-2vcpu-g2h": {
-                                    "target": 2595,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-p1024K-2vcpu-h2g": {
-                                    "target": 4883,
-                                    "delta_percentage": 6
-                                },
-                                "vsock-pDEFAULT-2vcpu-h2g": {
-                                    "target": 4801,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-2vcpu-h2g": {
-                                    "target": 1669,
-                                    "delta_percentage": 18
-                                },
-                                "vsock-p1024K-2vcpu-bd": {
-                                    "target": 4544,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-pDEFAULT-2vcpu-bd": {
-                                    "target": 4517,
-                                    "delta_percentage": 5
-                                },
-                                "vsock-p1024-2vcpu-bd": {
-                                    "target": 1408,
-                                    "delta_percentage": 23
+                        "throughput": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
+                                    "vsock-p1024K-1vcpu-g2h": {
+                                        "target": 5973,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-pDEFAULT-1vcpu-g2h": {
+                                        "target": 5993,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-p1024-1vcpu-g2h": {
+                                        "target": 948,
+                                        "delta_percentage": 10
+                                    },
+                                    "vsock-p1024K-1vcpu-h2g": {
+                                        "target": 4041,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-pDEFAULT-1vcpu-h2g": {
+                                        "target": 3934,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-1vcpu-h2g": {
+                                        "target": 307,
+                                        "delta_percentage": 8
+                                    },
+                                    "vsock-p1024K-2vcpu-g2h": {
+                                        "target": 6775,
+                                        "delta_percentage": 7
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-g2h": {
+                                        "target": 6699,
+                                        "delta_percentage": 8
+                                    },
+                                    "vsock-p1024-2vcpu-g2h": {
+                                        "target": 2595,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-p1024K-2vcpu-h2g": {
+                                        "target": 4883,
+                                        "delta_percentage": 6
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-h2g": {
+                                        "target": 4801,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-2vcpu-h2g": {
+                                        "target": 1669,
+                                        "delta_percentage": 18
+                                    },
+                                    "vsock-p1024K-2vcpu-bd": {
+                                        "target": 4544,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-pDEFAULT-2vcpu-bd": {
+                                        "target": 4517,
+                                        "delta_percentage": 5
+                                    },
+                                    "vsock-p1024-2vcpu-bd": {
+                                        "target": 1408,
+                                        "delta_percentage": 23
+                                    }
                                 }
                             }
                         },
-                        "baseline_cpu_utilization": {
-                            "vmlinux-4.14.bin/ubuntu-18.04.ext4": {
-                                "vmm": {
+                        "cpu_utilization_vmm": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
                                     "vsock-p1024K-1vcpu-g2h": {
                                         "target": 51,
                                         "delta_percentage": 9
@@ -370,8 +378,12 @@ CONFIG = {
                                         "target": 65,
                                         "delta_percentage": 8
                                     }
-                                },
-                                "vcpus_total": {
+                                }
+                            }
+                        },
+                        "cpu_utilization_vcpus_total": {
+                            "vmlinux-4.14.bin": {
+                                "ubuntu-18.04.ext4": {
                                     "vsock-p1024K-1vcpu-g2h": {
                                         "target": 99,
                                         "delta_percentage": 5

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests checking against the existence of licenses in each file."""
 
+import datetime
 import framework.utils as utils
 
-AMAZON_COPYRIGHT_YEARS = (2018, 2019, 2020)
+AMAZON_COPYRIGHT_YEARS = range(2018, datetime.datetime.now().year + 1)
 AMAZON_COPYRIGHT = (
     "Copyright {} Amazon.com, Inc. or its affiliates. All Rights Reserved."
 )
@@ -62,29 +63,29 @@ def _validate_license(filename):
         copyright_info = file.readline()
 
         has_amazon_copyright = (
-                _has_amazon_copyright(copyright_info) and
-                _look_for_license(file, AMAZON_LICENSE)
+            _has_amazon_copyright(copyright_info) and
+            _look_for_license(file, AMAZON_LICENSE)
         )
 
         has_chromium_copyright = (
-                CHROMIUM_COPYRIGHT in copyright_info and
-                _look_for_license(file, CHROMIUM_LICENSE)
+            CHROMIUM_COPYRIGHT in copyright_info and
+            _look_for_license(file, CHROMIUM_LICENSE)
         )
 
         has_tuntap_copyright = (
-                TUNTAP_COPYRIGHT in copyright_info and
-                _look_for_license(file, CHROMIUM_LICENSE)
+            TUNTAP_COPYRIGHT in copyright_info and
+            _look_for_license(file, CHROMIUM_LICENSE)
         )
 
         has_alibaba_copyright = (
-                ALIBABA_COPYRIGHT in copyright_info and
-                _look_for_license(file, ALIBABA_LICENSE)
+            ALIBABA_COPYRIGHT in copyright_info and
+            _look_for_license(file, ALIBABA_LICENSE)
         )
         return (
-                has_amazon_copyright or
-                has_chromium_copyright or
-                has_tuntap_copyright or
-                has_alibaba_copyright
+            has_amazon_copyright or
+            has_chromium_copyright or
+            has_tuntap_copyright or
+            has_alibaba_copyright
         )
     return True
 

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -1,0 +1,83 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Script used to calculate baselines from raw performance test output."""
+
+import argparse
+import os
+import tempfile
+import json
+from typing import List
+
+from providers.types import FileDataProvider
+from providers.iperf3 import Iperf3DataParser
+
+OUTPUT_FILENAMES = {
+    'vsock_throughput': 'test_vsock_throughput',
+    'network_tcp_throughput': 'test_network_tcp_throughput'
+}
+
+DATA_PARSERS = {
+    'vsock_throughput': Iperf3DataParser,
+    'network_tcp_throughput': Iperf3DataParser
+}
+
+
+def get_data_files(args) -> List[str]:
+    """Return a list of files that contain results for this test."""
+    assert os.path.isdir(args.data_folder)
+
+    file_list = []
+
+    # Get all files in the dir tree that have the right name.
+    for root, _, files in os.walk(args.data_folder):
+        for file in files:
+            if file == OUTPUT_FILENAMES[args.test]:
+                file_list.append(os.path.join(root, file))
+
+    # We need at least one file.
+    assert len(file_list) > 0
+
+    return file_list
+
+
+def concatenate_data_files(data_files: List[str]):
+    """Create temp file to hold all concatenated results for this test."""
+    outfile = tempfile.NamedTemporaryFile()
+
+    for filename in data_files:
+        with open(filename) as infile:
+            outfile.write(str.encode(infile.read()))
+
+    return outfile
+
+
+def main():
+    """Run the main logic."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--data-folder",
+                        help="Path to folder containing raw test data.",
+                        action="store",
+                        required=True)
+    parser.add_argument("-t", "--test",
+                        help="Performance test for which baselines \
+                            are calculated.",
+                        action="store",
+                        choices=['vsock_throughput', 'network_tcp_throughput'],
+                        required=True)
+    args = parser.parse_args()
+
+    # Create the concatenated data file.
+    data_file = concatenate_data_files(get_data_files(args))
+
+    # Instantiate a file data provider.
+    data_provider = FileDataProvider(data_file.name)
+
+    # Instantiate the right data parser.
+    parser = DATA_PARSERS[args.test](data_provider)
+
+    # Finally, parse and print the baselines.
+    print(json.dumps(parser.parse(), indent=4))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/parse_baselines/providers/iperf3.py
+++ b/tools/parse_baselines/providers/iperf3.py
@@ -1,0 +1,114 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Implement the DataParser for iperf3 throughput tests."""
+
+import json
+import statistics
+import math
+from collections import defaultdict, Iterator
+from typing import List
+
+from providers.types import DataParser
+
+# We add a small extra percentage margin, to account for small variations
+# that were not caught while gathering baselines. This provides
+# slightly better reliability, while not affecting regression
+# detection.
+DELTA_EXTRA_MARGIN = 3
+
+
+def nesteddict():
+    """Create an infinitely nested dictionary."""
+    return defaultdict(nesteddict)
+
+
+# pylint: disable=R0903
+class Iperf3DataParser(DataParser):
+    """Parse the data provided by the iperf3 throughput tests."""
+
+    # pylint: disable=W0102
+    def __init__(self, data_provider: Iterator):
+        """Initialize the data parser."""
+        self._data_provider = iter(data_provider)
+        self._baselines_defs = [
+            "throughput/total",
+            "cpu_utilization_vcpus_total/value",
+            "cpu_utilization_vmm/value",
+        ]
+        # This object will hold the parsed data.
+        self._data = nesteddict()
+
+    # pylint: disable=R0201
+    def _calculate_baseline(self, data: List[float]) -> dict:
+        """Return the target and delta values, given a list of data points."""
+        avg = statistics.mean(data)
+        stddev = statistics.stdev(data)
+        return {
+            'target': math.ceil(round(avg, 2)),
+            'delta_percentage':
+                math.ceil(round(3 * stddev/avg * 100, 2)) + DELTA_EXTRA_MARGIN
+        }
+
+    def _format_baselines(self) -> List[dict]:
+        """Return the computed baselines into the right serializable format."""
+        baselines = dict()
+
+        for cpu_model in self._data:
+            baselines[cpu_model] = {
+                'model': cpu_model, **self._data[cpu_model]}
+
+        temp_baselines = baselines
+        baselines = []
+
+        for cpu_model in self._data:
+            baselines.append(temp_baselines[cpu_model])
+
+        return baselines
+
+    def _populate_baselines(self, key, parent):
+        """Traverse the data dict and compute the baselines."""
+        # Initial case.
+        if key is None:
+            for k in parent:
+                self._populate_baselines(k, parent)
+            return
+
+        # Base case, reached a data list.
+        if isinstance(parent[key], list):
+            parent[key] = self._calculate_baseline(parent[key])
+            return
+
+        # Recurse for all children.
+        for k in parent[key]:
+            self._populate_baselines(k, parent[key])
+
+    def parse(self) -> dict:
+        """Parse the rows and return baselines."""
+        line = next(self._data_provider)
+        while line:
+            json_line = json.loads(line)
+            measurements = json_line['results']
+            cpu_model = json_line['custom']['cpu_model']
+
+            # Consume the data and aggregate into lists.
+            for tag in measurements.keys():
+                for key in self._baselines_defs:
+                    [ms_name, st_name] = key.split("/")
+                    ms_data = measurements[tag].get(ms_name)
+
+                    st_data = ms_data.get(st_name)
+
+                    [kernel_version, rootfs_type,
+                        iperf_config] = tag.split("/")
+
+                    data = self._data[cpu_model][ms_name]
+                    data = data[kernel_version][rootfs_type]
+                    if isinstance(data[iperf_config], list):
+                        data[iperf_config].append(st_data)
+                    else:
+                        data[iperf_config] = [st_data]
+            line = next(self._data_provider)
+
+        self._populate_baselines(None, self._data)
+
+        return self._format_baselines()

--- a/tools/parse_baselines/providers/types.py
+++ b/tools/parse_baselines/providers/types.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Define data types and abstractions for parsers."""
+
+from abc import abstractmethod, ABC
+from collections.abc import Iterator
+from typing import AnyStr
+
+# pylint: disable=R0903
+
+
+class FileDataProvider(Iterator):
+    """File based data provider."""
+
+    def __init__(self, file_path: str):
+        """Construct the file based data provider."""
+        self._file = open(file_path, "r")
+
+    def __iter__(self) -> 'FileDataProvider':
+        """Return the iterator object (self)."""
+        return self
+
+    def __next__(self) -> AnyStr:
+        """Get a line of data from the file."""
+        return self._file.readline()
+
+
+class DataParser(ABC):
+    """Abstract class to be used for baselines extraction."""
+
+    @abstractmethod
+    def parse(self) -> dict:
+        """Parse the raw data and return baselines."""


### PR DESCRIPTION
# Reason for This PR

There is currently no standard way of gathering baselines when it comes to long-running performance tests.
In order to gather baselines:

- One has to modify the test code in order to output the raw results.
- After a number of test iterations are run, the resulting data has to be parsed with manual written scripts into the right baselines.

## Description of Changes

- Add support for pytest `--dump-results-to-file`, which will transform into a `results_file_dumper` fixture used for writing raw test data in the `test_results` folder
- Added a `parse_baselines` script that allows for custom logic for parsing the raw data into baselines.
- Added implementations for `parse_baselines` for vsock and network tcp tests.
- Refactored the `vsock_throughput` and `network_tcp_throughput` performance tests to use the `results_file_dumper` fixture and slight refactor of the baselines format.
- Fixed the `test_licenses` test which failed for Amazon 2021 copyright year.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
