### PR TITLE
Add prefix properly to MicrovmBuilder rootpath

### DIFF
--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -45,7 +45,7 @@ class MicrovmBuilder:
     def init_root_path(self):
         """Initialize microvm root path."""
         self._root_path = tempfile.mkdtemp(
-            MicrovmBuilder.ROOT_PREFIX,
+            prefix=MicrovmBuilder.ROOT_PREFIX,
             dir=f"{DEFAULT_TEST_SESSION_ROOT_PATH}")
 
     def build(self,


### PR DESCRIPTION
Signed-off-by: berciuliviu <lberciu@amazon.com>

# Reason for This PR

The prefix wasn't added properly to the beginning of the folder name when creating MicrovmBuilder rootpath.

## Description of Changes

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
