### PR TITLE
devtool: allow fetching private git repos

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,3 +10,6 @@ rustflags = [
 	"-C", "link-arg=-lgcc",
 	"-C", "link-arg=-lfdt",
 ]
+
+[net]
+git-fetch-with-cli = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added devtool build `--ssh-keys` flag to support fetching from private
+  git repositories.
+
 ### Changed
 
 - Changed Docker images repository from DockerHub to Amazon ECR.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -287,6 +287,20 @@ This will build and place the two Firecracker binaries at:
 - `build/cargo_target/${toolchain}/debug/firecracker` and
 - `build/cargo_target/${toolchain}/debug/jailer`.
 
+If you would like to test a new feature and work with
+dependencies on libraries located in private git repos, you
+can use the `--ssh-keys` flag to specify the paths to your
+public and private SSH keys on the host. Both of them are
+required for git authentication when fetching the repositories.
+
+```bash
+tools/devtool build --ssh-keys ~/.ssh/id_rsa.pub ~/.ssh/id_rsa
+```
+
+Please note that only a single set of credentials is supported.
+`devtool` cannot fetch multiple private repos which rely on
+different credentials.
+
 The default build profile is `debug`. If you want to build
 the release binaries (optimized and stripped of debug info),
 use the `--release` option:

--- a/tools/devtool
+++ b/tools/devtool
@@ -13,7 +13,7 @@
 #   building: `./devtool build`
 #     Then find the binaries under build/debug/
 #   testing: `./devtool test`
-#     Will run the entire test battery; will take serveral minutes to complete.
+#     Will run the entire test battery; will take several minutes to complete.
 #   deep-dive: `./devtool shell`
 #     Open a shell prompt inside the container. Then build or test (or do
 #     anything, really) manually.
@@ -113,6 +113,12 @@ CTR_CARGO_TARGET_DIR="$CTR_FC_BUILD_DIR/cargo_target"
 
 # Full path to the microVM images cache dir
 CTR_MICROVM_IMAGES_DIR="$CTR_FC_BUILD_DIR/img"
+
+# Full path to the public key mapping on the guest
+PUB_KEY_PATH=/root/.ssh/id_rsa.pub
+
+# Full path to the private key mapping on the guest
+PRIV_KEY_PATH=/root/.ssh/id_rsa
 
 # Global options received by $0
 # These options are not command-specific, so we store them as global vars
@@ -279,13 +285,13 @@ ensure_release_binaries_exist() {
     firecracker_bin_path="$CARGO_TARGET_DIR/$target/$profile/firecracker"
     jailer_bin_path="$CARGO_TARGET_DIR/$target/$profile/jailer"
 
-    # Both binaries must exist for the stripping to be succesgitsful.
+    # Both binaries must exist for the stripping to be successful.
     [ -f $firecracker_bin_path ] && [ -f $jailer_bin_path ] || \
     die "Missing release binaries. Needed files:\n* $firecracker_bin_path\n* $jailer_bin_path."
 }
 
 # Fix build/ dir permissions after a privileged container run.
-# Since the privileged cotainer runs as root, any files it creates will be
+# Since the privileged container runs as root, any files it creates will be
 # owned by root. This fixes that by recursively changing the ownership of build/
 # to the current user.
 #
@@ -412,6 +418,14 @@ run_devctr() {
         "$DEVCTR_IMAGE" "${ctr_args[@]}"
 }
 
+# Helper function to test that the argument provided is a valid path to a SSH key.
+#
+test_key() {
+    ssh-keygen -lf "$1" &>/dev/null
+    ret=$?
+    [ $ret -ne 0 ] && die "$1 is not a valid key file."
+}
+
 # `$0 help`
 # Show the detailed devtool usage information.
 #
@@ -434,6 +448,9 @@ cmd_help() {
     echo "        --release             Build the release binaries."
     echo "        -l, --libc musl|gnu   Choose the libc flavor against which Firecracker will"
     echo "                              be linked. Default is musl."
+    echo "        --ssh-keys            Provide the paths to the public and private SSH keys on the host"
+    echo "                              (in this particular order) required for the git authentication."
+    echo "                              It is mandatory that both keys are specified."
     echo ""
     echo "    strip [--target-libc musl|gnu]"
     echo "        Strip debug symbols from the Firecracker release binaries."
@@ -501,6 +518,20 @@ cmd_build() {
             "-h"|"--help")  { cmd_help; exit 1;     } ;;
             "--debug")      { profile="debug";      } ;;
             "--release")    { profile="release";    } ;;
+            "--ssh-keys")
+                shift
+                [[ -z "$1" ]] && \
+                    die "Please provide the path to the public SSH key."
+                [[ ! -f "$1" ]]  && die "The public key file does not exist: $1."
+                test_key "$1"
+                host_pub_key_path="$1"
+                shift
+                [[ -z "$1" ]] && \
+                    die "Please provide the path to the private SSH key."
+                [[ ! -f "$1" ]]  && die "The private key file does not exist: $1."
+                test_key "$1"
+                host_priv_key_path="$1"
+                ;;
             "-l"|"--libc")
                 shift
                 [[ "$1" =~ ^(musl|gnu)$ ]] || \
@@ -543,7 +574,12 @@ cmd_build() {
 
     [ $profile = "release" ] && cargo_args+=("--release")
 
-    # artificially trigger a re-run of the build script,
+    # Map the public and private keys to the guest if they are specified.
+    [ ! -z "$host_pub_key_path" ] && [ ! -z "$host_priv_key_path" ] &&
+        extra_args="--volume $host_pub_key_path:$PUB_KEY_PATH:z \
+                    --volume $host_priv_key_path:$PRIV_KEY_PATH:z"
+
+    # Artificially trigger a re-run of the build script,
     # to make sure that `firecracker --version` reports the latest changes.
     touch "$FC_ROOT_DIR/build.rs"
 
@@ -553,6 +589,7 @@ cmd_build() {
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
+        ${extra_args} \
         -- \
         cargo build \
             --target-dir "$CTR_CARGO_TARGET_DIR" \
@@ -566,6 +603,7 @@ cmd_build() {
         run_devctr \
             --user "$(id -u):$(id -g)" \
             --workdir "$CTR_FC_ROOT_DIR" \
+            ${extra_args} \
             -- \
             cargo build -p jailer \
                 --target-dir "$CTR_CARGO_TARGET_DIR" \


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/2104

TL;DR: `devtool` runs the `cargo build` command from inside the container. When working with dependencies on libraries which reside inside private git repositories, we need a way to perform git authentication for fetching those dependencies.

## Description of Changes

Added `devtool` build `--ssh-keys` flag to provide a way to specify the paths to the public and private SSH keys on the host. These will be mapped to the guest and used for authentication when fetching from private repositories.

This is how the added functionality was tested:
- Mirrored one of Firecracker's dependencies (say `dep-name`) into a private git repository on my account (with the title `new-dep-name`)
- Replaced `dep-name`'s Cargo.toml entry with the SSH URL of the duplicate repository, using this format:
`dep-name = { git = "ssh://git@github.com/username/new-dep-name.git" }`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
