### PR TITLE
Add JSON lint integration test

### DIFF
--- a/tests/integration_tests/style/test_json.py
+++ b/tests/integration_tests/style/test_json.py
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for JSON linter checks."""
 
-import framework.utils as utils
 import json
+import framework.utils as utils
 
 
 def test_json_style():
-    """Fail if the repository contains malformed JSON in .json files"""
-
+    """Fail if the repository contains malformed JSON in .json files."""
     # Get all *.json files from the project
     json_files = utils.get_files_from(
         find_path="..",
@@ -19,13 +18,13 @@ def test_json_style():
 
     # for each .json file we find, check that
     # it can be parsed as JSON
-    for file_name in json_files:
-        assert is_json_file_valid(file_name)
+    invalid_files = [f for f in json_files if not is_json_file_valid(f)]
+    if len(invalid_files) > 0:
+        assert False, "Invalid JSON files: {}".format(", ".join(invalid_files))
 
 
 def is_json_file_valid(file_path):
     """returns whether or not the file at the specified path contains valid JSON"""
-
     with open(file_path, 'r') as file_stream:
         try:
             json.load(file_stream)

--- a/tests/integration_tests/style/test_json.py
+++ b/tests/integration_tests/style/test_json.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for JSON linter checks."""
+
+import framework.utils as utils
+import json
+
+
+def test_json_style():
+    """Fail if the repository contains malformed JSON in .json files"""
+
+    # Get all *.json files from the project
+    json_files = utils.get_files_from(
+        find_path="..",
+        pattern="*.json",
+        exclude_names=["build"])
+
+    assert len(json_files) != 0
+
+    # for each .json file we find, check that
+    # it can be parsed as JSON
+    for file_name in json_files:
+        assert is_json_file_valid(file_name)
+
+
+def is_json_file_valid(file_path):
+    """returns whether or not the file at the specified path contains valid JSON"""
+
+    with open(file_path, 'r') as file_stream:
+        try:
+            json.load(file_stream)
+
+            # no exception was thrown
+            # therefore file's contents are valid JSON
+            return True
+        except json.JSONDecodeError:
+            # json failed to decode
+            return False


### PR DESCRIPTION
Validates that all files ending in `.json` within the repostiory contain valid JSON contents

# Reason for This PR

To implement the feature specified in #2422 

## Description of Changes

Adds a python file called `test_json` in `tests/integration_tests/style` which will fail if any files with names ending in `.json` contain contents which are not valid JSON.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
