### PR TITLE
Made the previous off-by-one error fix more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the reported used bytes for any virtio-block request.
+- Fixed all virtio-block read/write operations to valid guest addresses
+  with buffer length of 0 to result in no-op.
+
 ## [0.22.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.22.4]
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "firecracker"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "api_server 0.1.0",
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.22.3
+  version: 0.22.4
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -19,7 +19,7 @@ use logger::{Metric, METRICS};
 use rate_limiter::{RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::*;
-use vm_memory::{Bytes, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestMemoryError, GuestMemoryMmap};
 
 use super::{
     super::{ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BLOCK, VIRTIO_MMIO_INT_VRING},
@@ -220,13 +220,43 @@ impl Block {
                         &self.disk_image_id,
                     ) {
                         Ok(l) => {
-                            len = l;
-                            VIRTIO_BLK_S_OK
+                            // Account for the status byte as well.
+                            // With a non-faulty driver, we shouldn't get to the point where we
+                            // overflow here (since data len must be a multiple of 512 bytes, so
+                            // it can't be u32::MAX). In the future, this should be fixed at the
+                            // request parsing level, so no data will actually be transferred in
+                            // scenarios like this one.
+                            if let Some(l) = l.checked_add(1) {
+                                len = l;
+                                VIRTIO_BLK_S_OK
+                            } else {
+                                len = l;
+                                VIRTIO_BLK_S_IOERR
+                            }
                         }
                         Err(e) => {
-                            error!("Failed to execute request: {:?}", e);
                             METRICS.block.invalid_reqs_count.inc();
-                            len = 1; // We need at least 1 byte for the status.
+                            match e {
+                                ExecuteError::Read(GuestMemoryError::PartialBuffer {
+                                    completed,
+                                    expected,
+                                }) => {
+                                    error!(
+                                        "Failed to execute virtio block read request: can only \
+                                         write {} of {} bytes.",
+                                        completed, expected
+                                    );
+                                    METRICS.block.read_bytes.add(completed);
+                                    // This can not overflow since `completed` < data len which is
+                                    // an u32.
+                                    len = completed as u32 + 1;
+                                }
+                                _ => {
+                                    error!("Failed to execute virtio block request: {:?}", e);
+                                    // Status byte only.
+                                    len = 1;
+                                }
+                            };
                             e.status()
                         }
                     };
@@ -702,7 +732,7 @@ pub(crate) mod tests {
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
 
@@ -725,9 +755,99 @@ pub(crate) mod tests {
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get());
+            // Added status byte length.
+            assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get() + 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
+        }
+
+        // Read with error.
+        {
+            vq.used.idx.set(0);
+            block.set_queue(0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            let size = block.disk_image.seek(SeekFrom::End(0)).unwrap();
+            block.disk_image.set_len(size / 2).unwrap();
+            mem.write_obj(10, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // Only status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
             assert_eq!(mem.read_obj::<u64>(data_addr).unwrap(), 123_456_789);
+        }
+
+        // Partial buffer error on read.
+        {
+            vq.used.idx.set(0);
+            block.set_queue(0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            let size = block.disk_image.seek(SeekFrom::End(0)).unwrap();
+            block.disk_image.set_len(size / 2).unwrap();
+            // Update sector number: stored at `request_type_addr.0 + 8`
+            mem.write_obj(5, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            // This will attempt to read past end of file.
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // No data since can't read past end of file, only status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
+            assert_eq!(mem.read_obj::<u64>(data_addr).unwrap(), 123_456_789);
+        }
+
+        {
+            vq.used.idx.set(0);
+            block.set_queue(0, vq.create_queue());
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+            vq.dtable[1].len.set(1024);
+
+            mem.write_obj(1, GuestAddress(request_type_addr.0 + 8))
+                .unwrap();
+
+            invoke_handler_for_queue_event(&mut block);
+
+            assert_eq!(vq.used.idx.get(), 1);
+            assert_eq!(vq.used.ring[0].get().id, 0);
+
+            // File has 2 sectors and we try to read from the second sector, which means we will
+            // read 512 bytes (instead of 1024).
+            assert_eq!(vq.used.ring[0].get().len, 513);
+            assert_eq!(
+                mem.read_obj::<u32>(status_addr).unwrap(),
+                VIRTIO_BLK_S_IOERR
+            );
         }
     }
 
@@ -753,7 +873,7 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
 
@@ -769,7 +889,8 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            // status byte length.
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }
@@ -798,7 +919,7 @@ pub(crate) mod tests {
             invoke_handler_for_queue_event(&mut block);
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 21);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
 
             assert!(blk_metadata.is_ok());
@@ -900,7 +1021,7 @@ pub(crate) mod tests {
             // Make sure the data queue advanced.
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }
@@ -979,7 +1100,7 @@ pub(crate) mod tests {
             // Make sure the data queue advanced.
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
-            assert_eq!(vq.used.ring[0].get().len, 0);
+            assert_eq!(vq.used.ring[0].get().len, 1);
             assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
         }
     }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -260,9 +260,10 @@ impl Block {
                             e.status()
                         }
                     };
-                    // We use unwrap because the request parsing process already checked that the
-                    // status_addr was valid.
-                    mem.write_obj(status, request.status_addr).unwrap();
+
+                    if let Err(e) = mem.write_obj(status, request.status_addr) {
+                        error!("Failed to write virtio block status: {:?}", e)
+                    }
                 }
                 Err(e) => {
                     error!("Failed to parse available descriptor chain: {:?}", e);
@@ -615,6 +616,39 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_addr_out_of_bounds() {
+        let mut block = default_block();
+        // Default mem size is 0x10000
+        let mem = default_mem();
+        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        block.set_queue(0, vq.create_queue());
+        block.activate(mem.clone()).unwrap();
+        initialize_virtqueue(&vq);
+        vq.dtable[1].set(0xff00, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
+
+        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
+
+        // Mark the next available descriptor.
+        vq.avail.idx.set(1);
+        // Read.
+        {
+            vq.used.idx.set(0);
+
+            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+                .unwrap();
+            vq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+            check_metric_after_block!(
+                &METRICS.block.invalid_reqs_count,
+                1,
+                invoke_handler_for_queue_event(&mut block)
+            );
+        }
+    }
+
+    #[test]
     fn test_request_execute_failures() {
         let mut block = default_block();
         let mem = default_mem();
@@ -700,6 +734,39 @@ pub(crate) mod tests {
             mem.read_obj::<u32>(status_addr).unwrap(),
             VIRTIO_BLK_S_UNSUPP
         );
+    }
+    #[test]
+    fn test_end_of_region() {
+        let mut block = default_block();
+        let mem = default_mem();
+        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
+        block.set_queue(0, vq.create_queue());
+        block.activate(mem.clone()).unwrap();
+        initialize_virtqueue(&vq);
+        vq.dtable[1].set(0xf000, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
+
+        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
+        let status_addr = GuestAddress(vq.dtable[2].addr.get());
+
+        vq.used.idx.set(0);
+
+        mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
+            .unwrap();
+        vq.dtable[1]
+            .flags
+            .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+
+        check_metric_after_block!(
+            &METRICS.block.read_count,
+            1,
+            invoke_handler_for_queue_event(&mut block)
+        );
+
+        assert_eq!(vq.used.idx.get(), 1);
+        assert_eq!(vq.used.ring[0].get().id, 0);
+        // Added status byte length.
+        assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get() + 1);
+        assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
     }
 
     #[test]

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -230,10 +230,9 @@ impl Block {
                             e.status()
                         }
                     };
-
-                    if let Err(e) = mem.write_obj(status, request.status_addr) {
-                        error!("Failed to write virtio block status: {:?}", e)
-                    }
+                    // We use unwrap because the request parsing process already checked that the
+                    // status_addr was valid.
+                    mem.write_obj(status, request.status_addr).unwrap();
                 }
                 Err(e) => {
                     error!("Failed to parse available descriptor chain: {:?}", e);
@@ -586,39 +585,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_addr_out_of_bounds() {
-        let mut block = default_block();
-        // Default mem size is 0x10000
-        let mem = default_mem();
-        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        block.set_queue(0, vq.create_queue());
-        block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
-        vq.dtable[1].set(0xff00, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
-
-        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
-
-        // Mark the next available descriptor.
-        vq.avail.idx.set(1);
-        // Read.
-        {
-            vq.used.idx.set(0);
-
-            mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
-                .unwrap();
-            vq.dtable[1]
-                .flags
-                .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
-
-            check_metric_after_block!(
-                &METRICS.block.execute_fails,
-                1,
-                invoke_handler_for_queue_event(&mut block)
-            );
-        }
-    }
-
-    #[test]
     fn test_request_execute_failures() {
         let mut block = default_block();
         let mem = default_mem();
@@ -704,38 +670,6 @@ pub(crate) mod tests {
             mem.read_obj::<u32>(status_addr).unwrap(),
             VIRTIO_BLK_S_UNSUPP
         );
-    }
-    #[test]
-    fn test_end_of_region() {
-        let mut block = default_block();
-        let mem = default_mem();
-        let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
-        block.set_queue(0, vq.create_queue());
-        block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
-        vq.dtable[1].set(0xf000, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
-
-        let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
-        let status_addr = GuestAddress(vq.dtable[2].addr.get());
-
-        vq.used.idx.set(0);
-
-        mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
-            .unwrap();
-        vq.dtable[1]
-            .flags
-            .set(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
-
-        check_metric_after_block!(
-            &METRICS.block.read_count,
-            1,
-            invoke_handler_for_queue_event(&mut block)
-        );
-
-        assert_eq!(vq.used.idx.get(), 1);
-        assert_eq!(vq.used.ring[0].get().id, 0);
-        assert_eq!(vq.used.ring[0].get().len, vq.dtable[1].len.get());
-        assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
     }
 
     #[test]

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -168,7 +168,7 @@ pub mod tests {
 
         assert_eq!(vq.used.idx.get(), 1);
         assert_eq!(vq.used.ring[0].get().id, 0);
-        assert_eq!(vq.used.ring[0].get().len, 0);
+        assert_eq!(vq.used.ring[0].get().len, 1);
         assert_eq!(mem.read_obj::<u32>(status_addr).unwrap(), VIRTIO_BLK_S_OK);
     }
 }

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -7,12 +7,11 @@
 
 use std::convert::From;
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::mem;
 use std::result;
 
 use logger::{Metric, METRICS};
 use virtio_gen::virtio_blk::*;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
 use super::super::DescriptorChain;
 use super::{Error, SECTOR_SHIFT, SECTOR_SIZE};
@@ -158,13 +157,6 @@ impl Request {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }
 
-            // Check that the address of the data descriptor is valid in guest memory.
-            let _ = mem
-                .checked_offset(data_desc.addr, data_desc.len as usize)
-                .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
-                    data_desc.addr,
-                )))?;
-
             req.data_addr = data_desc.addr;
             req.data_len = data_desc.len;
         }
@@ -177,14 +169,6 @@ impl Request {
         if status_desc.len < 1 {
             return Err(Error::DescriptorLengthTooSmall);
         }
-
-        // Check that the address of the status descriptor is valid in guest memory.
-        // We will write an u32 status here after executing the request.
-        let _ = mem
-            .checked_offset(status_desc.addr, mem::size_of::<u32>())
-            .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
-                status_desc.addr,
-            )))?;
 
         req.status_addr = status_desc.addr;
 
@@ -253,7 +237,7 @@ impl Request {
 mod tests {
     use super::*;
     use crate::virtio::queue::tests::*;
-    use vm_memory::{Address, GuestAddress};
+    use vm_memory::{Address, GuestAddress, GuestMemory};
 
     #[test]
     fn test_read_request_header() {
@@ -436,13 +420,12 @@ mod tests {
             // Fix status descriptor length.
             vq.dtable[status_descriptor].len.set(0x1000);
             // Invalid guest address for the status descriptor.
+            // Parsing will still succeed as the operation that
+            // will fail happens when executing the request.
             vq.dtable[status_descriptor]
                 .addr
                 .set(m.last_addr().raw_value());
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_))) => true,
-                _ => false,
-            });
+            assert!(Request::parse(&q.pop(m).unwrap(), m).is_ok());
         }
 
         {
@@ -450,13 +433,12 @@ mod tests {
             // Restore status descriptor.
             vq.dtable[status_descriptor].set(0x3000, 0x1000, VIRTQ_DESC_F_WRITE, 0);
             // Invalid guest address for the data descriptor.
+            // Parsing will still succeed as the operation that
+            // will fail happens when executing the request.
             vq.dtable[data_descriptor]
                 .addr
                 .set(m.last_addr().raw_value());
-            assert!(match Request::parse(&q.pop(m).unwrap(), m) {
-                Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(_))) => true,
-                _ => false,
-            });
+            assert!(Request::parse(&q.pop(m).unwrap(), m).is_ok());
         }
 
         {

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -160,7 +160,7 @@ impl Request {
 
             // Check that the address of the data descriptor is valid in guest memory.
             let _ = mem
-                .checked_offset(data_desc.addr, (data_desc.len - 1) as usize)
+                .checked_offset(data_desc.addr, data_desc.len as usize)
                 .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
                     data_desc.addr,
                 )))?;
@@ -181,7 +181,7 @@ impl Request {
         // Check that the address of the status descriptor is valid in guest memory.
         // We will write an u32 status here after executing the request.
         let _ = mem
-            .checked_offset(status_desc.addr, (mem::size_of::<u32>() - 1) as usize)
+            .checked_offset(status_desc.addr, mem::size_of::<u32>())
             .ok_or(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
                 status_desc.addr,
             )))?;

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -213,36 +213,39 @@ impl Request {
             .map_err(ExecuteError::Seek)?;
 
         match self.request_type {
-            RequestType::In => {
-                mem.read_from(self.data_addr, disk, self.data_len as usize)
-                    .map_err(ExecuteError::Read)?;
-                METRICS.block.read_bytes.add(self.data_len as usize);
-                METRICS.block.read_count.inc();
-                return Ok(self.data_len);
-            }
-            RequestType::Out => {
-                mem.write_to(self.data_addr, disk, self.data_len as usize)
-                    .map_err(ExecuteError::Write)?;
-                METRICS.block.write_bytes.add(self.data_len as usize);
-                METRICS.block.write_count.inc();
-            }
-            RequestType::Flush => match disk.flush() {
-                Ok(_) => {
+            RequestType::In => mem
+                .read_exact_from(self.data_addr, disk, self.data_len as usize)
+                .map(|_| {
+                    METRICS.block.read_bytes.add(self.data_len as usize);
+                    METRICS.block.read_count.inc();
+                    self.data_len
+                })
+                .map_err(ExecuteError::Read),
+            RequestType::Out => mem
+                .write_all_to(self.data_addr, disk, self.data_len as usize)
+                .map(|_| {
+                    METRICS.block.write_bytes.add(self.data_len as usize);
+                    METRICS.block.write_count.inc();
+                    0
+                })
+                .map_err(ExecuteError::Write),
+            RequestType::Flush => disk
+                .flush()
+                .map(|_| {
                     METRICS.block.flush_count.inc();
-                    return Ok(0);
-                }
-                Err(e) => return Err(ExecuteError::Flush(e)),
-            },
+                    0
+                })
+                .map_err(ExecuteError::Flush),
             RequestType::GetDeviceID => {
                 if (self.data_len as usize) < disk_id.len() {
                     return Err(ExecuteError::BadRequest(Error::InvalidOffset));
                 }
                 mem.write_slice(disk_id, self.data_addr)
-                    .map_err(ExecuteError::Write)?;
+                    .map(|_| VIRTIO_BLK_ID_BYTES)
+                    .map_err(ExecuteError::Write)
             }
-            RequestType::Unsupported(t) => return Err(ExecuteError::Unsupported(t)),
-        };
-        Ok(0)
+            RequestType::Unsupported(t) => Err(ExecuteError::Unsupported(t)),
+        }
     }
 }
 

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.22.3"
+version = "0.22.4"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.22.3"
+version = "0.22.4"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 
 [dependencies]

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -11,6 +11,8 @@ import framework.utils as utils
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools  # pylint: disable=import-error
 
+MB = 1024 * 1024
+
 
 def test_rescan_file(test_microvm_with_ssh, network_config):
     """Verify that rescan works with a file-backed virtio device."""
@@ -24,9 +26,11 @@ def test_rescan_file(test_microvm_with_ssh, network_config):
 
     _tap, _, _ = test_microvm_with_ssh.ssh_network_config(network_config, '1')
 
+    block_size = 2
     # Add a scratch block device.
     fs = drive_tools.FilesystemFile(
-        os.path.join(test_microvm.fsfiles, 'scratch')
+        os.path.join(test_microvm.fsfiles, 'scratch'),
+        size=block_size
     )
     response = test_microvm.drive.put(
         drive_id='scratch',
@@ -42,8 +46,16 @@ def test_rescan_file(test_microvm_with_ssh, network_config):
 
     _check_scratch_size(ssh_connection, fs.size())
 
-    # Resize the filesystem from 256 MiB (default) to 512 MiB.
-    fs.resize(512)
+    # Check if reading from the entire disk results in a file of the same size
+    # or errors out, after a truncate on the host.
+    truncated_size = block_size//2
+    utils.run_cmd(f"truncate --size {truncated_size}M {fs.path}")
+    block_copy_name = "dev_vdb_copy"
+    _, _, stderr = ssh_connection.execute_command(
+        f"dd if=/dev/vdb of={block_copy_name} bs=1M count={block_size}")
+    assert "dd: error reading '/dev/vdb': Input/output error" in stderr.read()
+    _check_file_size(ssh_connection, f'{block_copy_name}',
+                     truncated_size * MB)
 
     response = test_microvm.drive.patch(
         drive_id='scratch',
@@ -294,6 +306,15 @@ def _check_scratch_size(ssh_connection, size):
     # The scratch block device is /dev/vdb in the guest.
     _, stdout, stderr = ssh_connection.execute_command(
         'blockdev --getsize64 /dev/vdb'
+    )
+
+    assert stderr.read() == ''
+    assert stdout.readline().strip() == str(size)
+
+
+def _check_file_size(ssh_connection, dev_path, size):
+    _, stdout, stderr = ssh_connection.execute_command(
+        'stat --format=%s {}'.format(dev_path)
     )
 
     assert stderr.read() == ''


### PR DESCRIPTION
# Reason for This PR

Improved the previous off-by-one error fix by making it more generic in order to preserve consistency across versions.

## Description of Changes

- Reverted the previous off-by-one error fix
- Added the used bytes reporting fix
- Added the off-by-one error fix which is consistent across all patches

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
