### PR TITLE
block perf test: parse_baselines script

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -584,3 +584,4 @@ class ResultsFileDumper:
         """Write the `data` string to the output file, appending a newline."""
         self._file.write(data)
         self._file.write("\n")
+        self._file.flush()

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -186,7 +186,7 @@ def read_values(cons, numjobs, env_id, mode, bs, measurement):
 
     for job_id in range(numjobs):
         file_path = f"results/{env_id}/{mode}{bs}/{mode}{bs}_{measurement}" \
-                  f".{job_id + 1}.log"
+            f".{job_id + 1}.log"
         file = open(file_path)
         lines = file.readlines()
 

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -10,15 +10,18 @@ from typing import List
 
 from providers.types import FileDataProvider
 from providers.iperf3 import Iperf3DataParser
+from providers.block import BlockDataParser
 
 OUTPUT_FILENAMES = {
     'vsock_throughput': 'test_vsock_throughput',
-    'network_tcp_throughput': 'test_network_tcp_throughput'
+    'network_tcp_throughput': 'test_network_tcp_throughput',
+    'block_performance': 'test_block_performance'
 }
 
 DATA_PARSERS = {
     'vsock_throughput': Iperf3DataParser,
-    'network_tcp_throughput': Iperf3DataParser
+    'network_tcp_throughput': Iperf3DataParser,
+    'block_performance': BlockDataParser
 }
 
 
@@ -62,7 +65,9 @@ def main():
                         help="Performance test for which baselines \
                             are calculated.",
                         action="store",
-                        choices=['vsock_throughput', 'network_tcp_throughput'],
+                        choices=['vsock_throughput',
+                                 'network_tcp_throughput',
+                                 'block_performance'],
                         required=True)
     args = parser.parse_args()
 

--- a/tools/parse_baselines/providers/block.py
+++ b/tools/parse_baselines/providers/block.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Implement the DataParser for iperf3 throughput tests."""
+"""Implement the DataParser for block device performance tests."""
 
 import statistics
 import math
@@ -12,18 +12,21 @@ from providers.types import DataParser
 # that were not caught while gathering baselines. This provides
 # slightly better reliability, while not affecting regression
 # detection.
-DELTA_EXTRA_MARGIN = 3
+DELTA_EXTRA_MARGIN = 4
 
 
 # pylint: disable=R0903
-class Iperf3DataParser(DataParser):
-    """Parse the data provided by the iperf3 throughput tests."""
+class BlockDataParser(DataParser):
+    """Parse the data provided by the block performance tests."""
 
     # pylint: disable=W0102
     def __init__(self, data_provider: Iterator):
         """Initialize the data parser."""
         super().__init__(data_provider, [
-            "throughput/total",
+            "iops_read/Avg",
+            "iops_write/Avg",
+            "bw_read/Avg",
+            "bw_write/Avg",
             "cpu_utilization_vcpus_total/value",
             "cpu_utilization_vmm/value",
         ])
@@ -36,5 +39,5 @@ class Iperf3DataParser(DataParser):
         return {
             'target': math.ceil(round(avg, 2)),
             'delta_percentage':
-                math.ceil(round(3 * stddev/avg * 100, 2)) + DELTA_EXTRA_MARGIN
+                math.ceil(3 * stddev/avg * 100) + DELTA_EXTRA_MARGIN
         }

--- a/tools/parse_baselines/providers/types.py
+++ b/tools/parse_baselines/providers/types.py
@@ -2,11 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Define data types and abstractions for parsers."""
 
+import json
 from abc import abstractmethod, ABC
 from collections.abc import Iterator
+from collections import defaultdict
 from typing import AnyStr
+from typing import List
+
 
 # pylint: disable=R0903
+
+def nested_dict():
+    """Create an infinitely nested dictionary."""
+    return defaultdict(nested_dict)
 
 
 class FileDataProvider(Iterator):
@@ -28,6 +36,81 @@ class FileDataProvider(Iterator):
 class DataParser(ABC):
     """Abstract class to be used for baselines extraction."""
 
+    def __init__(self, data_provider: Iterator, baselines_defs):
+        """Initialize the data parser."""
+        self._data_provider = iter(data_provider)
+        self._baselines_defs = baselines_defs
+        # This object will hold the parsed data.
+        self._data = nested_dict()
+
     @abstractmethod
+    def calculate_baseline(self, data: List[float]) -> dict:
+        """Return the target and delta values, given a list of data points."""
+
+    def _format_baselines(self) -> List[dict]:
+        """Return the computed baselines into the right serializable format."""
+        baselines = dict()
+
+        for cpu_model in self._data:
+            baselines[cpu_model] = {
+                'model': cpu_model, **self._data[cpu_model]}
+
+        temp_baselines = baselines
+        baselines = []
+
+        for cpu_model in self._data:
+            baselines.append(temp_baselines[cpu_model])
+
+        return baselines
+
+    def _populate_baselines(self, key, parent):
+        """Traverse the data dict and compute the baselines."""
+        # Initial case.
+        if key is None:
+            for k in parent:
+                self._populate_baselines(k, parent)
+            return
+
+        # Base case, reached a data list.
+        if isinstance(parent[key], list):
+            parent[key] = self.calculate_baseline(parent[key])
+            return
+
+        # Recurse for all children.
+        for k in parent[key]:
+            self._populate_baselines(k, parent[key])
+
     def parse(self) -> dict:
-        """Parse the raw data and return baselines."""
+        """Parse the rows and return baselines."""
+        line = next(self._data_provider)
+        while line:
+            json_line = json.loads(line)
+            measurements = json_line['results']
+            cpu_model = json_line['custom']['cpu_model_name']
+
+            # Consume the data and aggregate into lists.
+            for tag in measurements.keys():
+                for key in self._baselines_defs:
+                    [ms_name, st_name] = key.split("/")
+                    ms_data = measurements[tag].get(ms_name)
+
+                    if ms_data is None:
+                        continue
+
+                    st_data = ms_data.get(st_name)
+
+                    [kernel_version,
+                     rootfs_type,
+                     test_config] = tag.split("/")
+
+                    data = self._data[cpu_model][ms_name]
+                    data = data[kernel_version][rootfs_type][st_name]
+                    if isinstance(data[test_config], list):
+                        data[test_config].append(st_data)
+                    else:
+                        data[test_config] = [st_data]
+            line = next(self._data_provider)
+
+        self._populate_baselines(None, self._data)
+
+        return self._format_baselines()


### PR DESCRIPTION
# Reason for This PR

Add baseline parser for block performance test.

## Description of Changes

- Refactor `DataParser` interface.
- Add baseline parser for block performance test.
- Add flush on `ResultsFileDumper.writeln()`.
- Refactor block performance test to use the default VM temp folder instead of `src/tests/results`, for storing fio logs

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
