### PR TITLE
devtool: fix retry_cmd returning error code

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -213,9 +213,6 @@ retry_cmd() {
     {
         $command
     } || {
-        # Save error code
-        err_code=$?
-
         # Command failed, substract one from retry_cnt
         retry_cnt=$((retry_cnt - 1))
 
@@ -225,9 +222,6 @@ retry_cmd() {
             sleep "$sleep_int"
             retry_cmd "$command" "$retry_cnt" "$sleep_int"
         fi
-
-        # Set what error code docker returned
-        $(exit "$err_code")
     }
 }
 
@@ -456,13 +450,13 @@ test_key() {
     [ $ret -ne 0 ] && die "$1 is not a valid key file."
 }
 
-# Tries to update any outdated python packages on the container, 
+# Tries to update any outdated python packages on the container,
 # locks the new versions and copies back the ```poetry.lock```
-# file to the host. 
+# file to the host.
 #
 update_python_package_version() {
     say "Updating python packages..."
-    
+
     # defined in Dockerfile
     poetry_dir_on_container="/tmp/poetry"
     lock_file_location_on_host="$FC_DEVCTR_DIR/poetry.lock"
@@ -472,7 +466,7 @@ update_python_package_version() {
         "$dummy_container_name" \
         "$image_id" \
         bash)
-    
+
     docker start "$dummy_container_id"
     cmd="cd "$poetry_dir_on_container"; poetry update"
     docker exec -ti "$dummy_container_id" /bin/bash -c "${cmd}"


### PR DESCRIPTION
The initial implementation for retry_cmd was returning the
first error code of the failed command. If that command later
succeeded, the first error code would still be returned.

Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
