### PR TITLE
Made performance tests fail fast mechanism optional by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,30 @@ ARTIFACTS_COLLECTION = ArtifactCollection(_test_images_s3_bucket())
 MICROVM_S3_FETCHER = MicrovmImageS3Fetcher(_test_images_s3_bucket())
 
 
+class ResultsFileDumper:  # pylint: disable=too-few-public-methods
+    """Class responsible with outputting test results to files."""
+
+    def __init__(self, test_name: str, append=True):
+        """Initialize the instance."""
+        if not append:
+            flags = "w"
+        else:
+            flags = "a"
+
+        self._root_path = defs.TEST_RESULTS_DIR
+
+        # Create the root directory, if it doesn't exist.
+        self._root_path.mkdir(exist_ok=True)
+
+        self._file = open(self._root_path / test_name, flags)
+
+    def writeln(self, data: str):
+        """Write the `data` string to the output file, appending a newline."""
+        self._file.write(data)
+        self._file.write("\n")
+        self._file.flush()
+
+
 def init_microvm(root_path, bin_cloner_path,
                  fc_binary=None, jailer_binary=None):
     """Auxiliary function for instantiating a microvm and setting it up."""
@@ -215,7 +239,7 @@ def test_session_tmp_path(test_fc_session_root_path):
 def results_file_dumper(request):
     """Yield the custom --dump-results-to-file test flag."""
     if request.config.getoption("--dump-results-to-file"):
-        return utils.ResultsFileDumper(request.node.originalname)
+        return ResultsFileDumper(request.node.originalname)
 
     return None
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -768,6 +768,10 @@ class Microvm:
             daemon=True)
         self.logging_thread.start()
 
+    def __del__(self):
+        """Teardown the object."""
+        self.kill()
+
 
 class Serial:
     """Class for serial console communication with a Microvm."""

--- a/tests/framework/statistics/consumer.py
+++ b/tests/framework/statistics/consumer.py
@@ -7,9 +7,21 @@ from abc import ABC, abstractmethod
 from numbers import Number
 from typing import Any, Callable
 from collections import defaultdict
+from framework.utils import ExceptionAggregator
+
+from .criteria import CriteriaException
 from .metadata import Provider as MetadataProvider
-from .criteria import Failed
 from .types import MeasurementDef
+
+
+class ProcessingException(ExceptionAggregator):
+    """Exception to be raised when criteria fails."""
+
+    def __init__(self, stats=None, custom=None):
+        """Initialize the exception."""
+        super().__init__()
+        self.stats = stats
+        self.custom = custom
 
 
 class Consumer(ABC):
@@ -34,6 +46,8 @@ class Consumer(ABC):
 
         # Final statistics.
         self._statistics = dict()
+
+        self._failure_aggregator = ProcessingException()
 
     @abstractmethod
     def ingest(self, iteration: int, raw_data: Any):
@@ -75,44 +89,70 @@ class Consumer(ABC):
         """
         for ms_name in self._results:
             if ms_name not in self._measurements_defs:
-                raise Exception(f"'{ms_name}' measurement does not have a "
-                                "corresponding measurement definition.")
+                self._failure_aggregator.add_row(
+                    f"'{ms_name}' measurement does not have a "
+                    "corresponding measurement definition.")
+
+        if self._failure_aggregator.has_any():
+            raise self._failure_aggregator
 
     def _reset(self):
         """Reset the results of this consumer, used in a previous exercise."""
         self._results = defaultdict()
 
-    def process(self, check_criteria=True) -> (dict, dict):
+    def process(self, fail_fast=False) -> (dict, dict):
         """Generate statistics as a dictionary."""
         self._validate()
         for ms_name in self._results:
             self._statistics.setdefault(ms_name, {})[self.UNIT_KEY] \
                 = self._measurements_defs[ms_name].unit
-
+            has_data = Consumer.DATA_KEY in self._results[ms_name]
             st_defs = self._measurements_defs[ms_name].statistics
             for st_def in st_defs:
                 if st_def.name not in self._results[ms_name]:
-                    assert Consumer.DATA_KEY in self._results[ms_name], \
-                        "Results does not have extracted data points for" \
-                        f" {ms_name} measurement."
+                    if not has_data:
+                        self._failure_aggregator.add_row(
+                            f"Processing '{st_def.name}' statistic failed due "
+                            f"to lack of data points for '{ms_name}' "
+                            "measurement.")
+                        continue
                     self._statistics[ms_name][st_def.name] = \
-                        st_def.func(self._results[ms_name][self.DATA_KEY])
+                        self._statistics[ms_name][st_def.name] = {
+                            "value": st_def.func(self._results[ms_name][
+                                                 self.DATA_KEY])
+                        }
                 else:
-                    self._statistics[ms_name][st_def.name] = self._results[
-                        ms_name][st_def.name]
+                    self._statistics[ms_name][st_def.name] = {
+                        "value": self._results[ms_name][st_def.name]
+                    }
 
                 pass_criteria = st_def.pass_criteria
-                if pass_criteria and check_criteria:
-                    res = self._statistics[ms_name][st_def.name]
+                if pass_criteria:
+                    self._statistics[ms_name][st_def.name][
+                        "pass_criteria"] = {
+                            pass_criteria.name: pass_criteria.baseline
+                        }
+                    res = self._statistics[ms_name][st_def.name]["value"]
                     try:
                         pass_criteria.check(res)
-                    except Failed as err:
-                        self._reset()
+                        self._statistics[ms_name][st_def.name]["outcome"] = \
+                            "PASSED"
+                    except CriteriaException as err:
                         # pylint: disable=W0707
-                        raise Failed(msg=f"'{ms_name}/{st_def.name}':"
-                                         f" {err.msg}")
+                        self._statistics[ms_name][st_def.name]["outcome"] = \
+                            "FAILED"
+                        fail_msg = f"'{ms_name}/{st_def.name}': {err}"
+                        self._failure_aggregator.add_row(fail_msg)
+                        if fail_fast:
+                            raise self._failure_aggregator
 
         self._reset()
+
+        if self._failure_aggregator.has_any():
+            self._failure_aggregator.stats = self._statistics
+            self._failure_aggregator.custom = self._custom
+            raise self._failure_aggregator
+
         return self._statistics, self._custom
 
 

--- a/tests/framework/statistics/criteria.py
+++ b/tests/framework/statistics/criteria.py
@@ -7,23 +7,8 @@ from abc import ABC, abstractmethod
 from pydoc import locate
 
 
-class Failed(Exception):
-    """Exception to be raised when criteria fails."""
-
-    def __init__(self, msg=""):
-        """Initialize the exception."""
-        super().__init__()
-        self._msg = msg
-
-    @property
-    def msg(self):
-        """Return the exception message."""
-        return self._msg
-
-    @msg.setter
-    def msg(self, msg):
-        """Set the exception message."""
-        self._msg = msg
+class CriteriaException(Exception):
+    """Exception returned by failure of check criteria."""
 
 
 # pylint: disable=R0903
@@ -71,9 +56,14 @@ class ComparisonCriteria(ABC):
         """Return criteria target."""
         target = self._baseline.get("target")
         if not target:
-            raise Failed("Baseline target not defined.")
+            raise CriteriaException("Baseline target not defined.")
 
         return target
+
+    @property
+    def baseline(self) -> dict:
+        """Return the baseline."""
+        return self._baseline
 
     def fail_msg(self, actual):
         """Return the default fail message."""
@@ -92,7 +82,7 @@ class GreaterThan(ComparisonCriteria):
     def check(self, actual):
         """Compare the target and the actual."""
         if actual < self.target:
-            raise Failed(msg=self.fail_msg(actual))
+            raise CriteriaException(self.fail_msg(actual))
 
 
 # pylint: disable=R0903
@@ -106,7 +96,7 @@ class LowerThan(ComparisonCriteria):
     def check(self, actual):
         """Compare the target and the actual."""
         if actual > self.target:
-            raise Failed(msg=self.fail_msg(actual))
+            raise CriteriaException(self.fail_msg(actual))
 
 
 # pylint: disable=R0903
@@ -135,7 +125,7 @@ class EqualWith(ComparisonCriteria):
         """Return the `delta` field of the baseline."""
         delta = self._baseline.get("delta")
         if not delta:
-            raise Failed("Baseline delta not defined.")
+            raise CriteriaException("Baseline delta not defined.")
         return delta
 
     def fail_msg(self, actual):
@@ -146,4 +136,4 @@ class EqualWith(ComparisonCriteria):
     def check(self, actual):
         """Compare the target and the actual."""
         if abs(self.target - actual) > self.delta:
-            raise Failed(msg=self.fail_msg(actual))
+            raise CriteriaException(self.fail_msg(actual))

--- a/tests/framework/statistics/function.py
+++ b/tests/framework/statistics/function.py
@@ -49,7 +49,7 @@ class ValuePlaceholder(Function):
     retain only the result corresponding to the last iteration.
     """
 
-    def __init__(self, name="value"):
+    def __init__(self, name="result"):
         """Initialize the statistic function."""
         super().__init__(name)
 

--- a/tests/framework/statistics/metadata.py
+++ b/tests/framework/statistics/metadata.py
@@ -3,6 +3,8 @@
 """Module for common statistic tests metadata providers."""
 
 from abc import ABC, abstractmethod
+from typing import Dict
+
 from framework.statistics.criteria import CriteriaFactory
 from framework.statistics.function import FunctionFactory
 from framework.statistics.types import MeasurementDef, StatisticDef
@@ -16,14 +18,19 @@ class Provider(ABC):
     Metadata consists from measurements and statistics definitions.
     """
 
-    def __init__(self):
+    def __init__(self, baseline_provider: BaselineProvider):
         """Initialize the metadata provider."""
-        self._measurements = dict()
+        self._baseline_provider = baseline_provider
 
     @property
     @abstractmethod
-    def measurements(self):
+    def measurements(self) -> Dict[str, MeasurementDef]:
         """Return measurement dictionary."""
+
+    @property
+    def baseline_provider(self) -> BaselineProvider:
+        """Return the baseline provider."""
+        return self._baseline_provider
 
 
 # pylint: disable=R0903
@@ -104,7 +111,9 @@ class DictProvider(Provider):
         }
         ```
         """
-        super().__init__()
+        super().__init__(baseline_provider)
+
+        self._measurements = dict()
         for ms_name in measurements:
             assert DictProvider.UNIT_KEY in measurements[ms_name], \
                 f"'{DictProvider.UNIT_KEY}' field is required for '" \

--- a/tests/integration_tests/performance/configs/block_performance_test_config.json
+++ b/tests/integration_tests/performance/configs/block_performance_test_config.json
@@ -65,6 +65,7 @@
       "unit": "percentage",
       "statistics": [
         {
+          "name": "Avg",
           "function": "ValuePlaceholder",
           "criteria": "EqualWith"
         }
@@ -74,6 +75,7 @@
       "unit": "percentage",
       "statistics": [
         {
+          "name": "Avg",
           "function": "ValuePlaceholder",
           "criteria": "EqualWith"
         }
@@ -90,76 +92,88 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 36,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 35,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 35,
-                        "delta_percentage": 7
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 35,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 65,
-                        "delta_percentage": 7
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 64,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 63,
-                        "delta_percentage": 7
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 63,
-                        "delta_percentage": 7
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 36,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 35,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 35,
+                          "delta_percentage": 7
+                        },
+                        "readwrite-bs4096": {
+                          "target": 35,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 65,
+                          "delta_percentage": 7
+                        },
+                        "randread-bs4096": {
+                          "target": 64,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 63,
+                          "delta_percentage": 7
+                        },
+                        "readwrite-bs4096": {
+                          "target": 63,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 35,
-                        "delta_percentage": 10
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 34,
-                        "delta_percentage": 11
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 33,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 34,
-                        "delta_percentage": 9
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 64,
-                        "delta_percentage": 7
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 64,
-                        "delta_percentage": 7
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 63,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 63,
-                        "delta_percentage": 7
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 35,
+                          "delta_percentage": 10
+                        },
+                        "randread-bs4096": {
+                          "target": 34,
+                          "delta_percentage": 11
+                        },
+                        "read-bs4096": {
+                          "target": 33,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 34,
+                          "delta_percentage": 9
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 64,
+                          "delta_percentage": 7
+                        },
+                        "randread-bs4096": {
+                          "target": 64,
+                          "delta_percentage": 7
+                        },
+                        "read-bs4096": {
+                          "target": 63,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 63,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
@@ -168,76 +182,88 @@
               "cpu_utilization_vcpus_total": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
@@ -246,77 +272,88 @@
               "iops_read": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 46845,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 94966,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 95720,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 47130,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 98332,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 200547,
-                        "delta_percentage": 9
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 200126,
-                        "delta_percentage": 9
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 97011,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 46845,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 94966,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 95720,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 47130,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 98332,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 200547,
+                          "delta_percentage": 9
+                        },
+                        "read-bs4096": {
+                          "target": 200126,
+                          "delta_percentage": 9
+                        },
+                        "readwrite-bs4096": {
+                          "target": 97011,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "Criteria": "EqualWith",
-                      "randrw-bs4096-1vcpu": {
-                        "target": 47178,
-                        "delta_percentage": 9
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 94379,
-                        "delta_percentage": 10
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 94100,
-                        "delta_percentage": 10
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 46483,
-                        "delta_percentage": 9
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 98473,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 200619,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 200967,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 97069,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 47178,
+                          "delta_percentage": 9
+                        },
+                        "randread-bs4096": {
+                          "target": 94379,
+                          "delta_percentage": 10
+                        },
+                        "read-bs4096": {
+                          "target": 94100,
+                          "delta_percentage": 10
+                        },
+                        "readwrite-bs4096": {
+                          "target": 46483,
+                          "delta_percentage": 9
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 98473,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 200619,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 200967,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 97069,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
@@ -325,76 +362,88 @@
               "bw_read": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 187380,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 379862,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 382878,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 188520,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 393329,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 802187,
-                        "delta_percentage": 9
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 800506,
-                        "delta_percentage": 9
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 388044,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 187380,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 379862,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 382878,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 188520,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 393329,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 802187,
+                          "delta_percentage": 9
+                        },
+                        "read-bs4096": {
+                          "target": 800506,
+                          "delta_percentage": 9
+                        },
+                        "readwrite-bs4096": {
+                          "target": 388044,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 188713,
-                        "delta_percentage": 9
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 377517,
-                        "delta_percentage": 10
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 376399,
-                        "delta_percentage": 10
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 185930,
-                        "delta_percentage": 9
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 393893,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 802475,
-                        "delta_percentage": 8
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 803870,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 388277,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 188713,
+                          "delta_percentage": 9
+                        },
+                        "randread-bs4096": {
+                          "target": 377517,
+                          "delta_percentage": 10
+                        },
+                        "read-bs4096": {
+                          "target": 376399,
+                          "delta_percentage": 10
+                        },
+                        "readwrite-bs4096": {
+                          "target": 185930,
+                          "delta_percentage": 9
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 393893,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 802475,
+                          "delta_percentage": 8
+                        },
+                        "read-bs4096": {
+                          "target": 803870,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 388277,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
@@ -403,44 +452,56 @@
               "iops_write": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 46852,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 47132,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 98336,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 97014,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 46852,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 47132,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 98336,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 97014,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 47176,
-                        "delta_percentage": 9
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 46478,
-                        "delta_percentage": 9
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 98478,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 97063,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 47176,
+                          "delta_percentage": 9
+                        },
+                        "readwrite-bs4096": {
+                          "target": 46478,
+                          "delta_percentage": 9
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 98478,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 97063,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
@@ -449,44 +510,56 @@
               "bw_write": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 187406,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 188525,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 393344,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 388058,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 187406,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 188525,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 393344,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 388058,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 188704,
-                        "delta_percentage": 9
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 185913,
-                        "delta_percentage": 9
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 393914,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 388255,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 188704,
+                          "delta_percentage": 9
+                        },
+                        "readwrite-bs4096": {
+                          "target": 185913,
+                          "delta_percentage": 9
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 393914,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 388255,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
@@ -500,76 +573,88 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 37,
-                        "delta_percentage": 6
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 36,
-                        "delta_percentage": 7
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 36,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 37,
-                        "delta_percentage": 8
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 70,
-                        "delta_percentage": 6
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 70,
-                        "delta_percentage": 6
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 70,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 69,
-                        "delta_percentage": 6
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 37,
+                          "delta_percentage": 6
+                        },
+                        "randread-bs4096": {
+                          "target": 36,
+                          "delta_percentage": 7
+                        },
+                        "read-bs4096": {
+                          "target": 36,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 37,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 70,
+                          "delta_percentage": 6
+                        },
+                        "randread-bs4096": {
+                          "target": 70,
+                          "delta_percentage": 6
+                        },
+                        "read-bs4096": {
+                          "target": 70,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 69,
+                          "delta_percentage": 6
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 42,
-                        "delta_percentage": 7
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 41,
-                        "delta_percentage": 7
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 40,
-                        "delta_percentage": 7
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 40,
-                        "delta_percentage": 7
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 71,
-                        "delta_percentage": 6
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 71,
-                        "delta_percentage": 6
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 70,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 71,
-                        "delta_percentage": 6
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 42,
+                          "delta_percentage": 7
+                        },
+                        "randread-bs4096": {
+                          "target": 41,
+                          "delta_percentage": 7
+                        },
+                        "read-bs4096": {
+                          "target": 40,
+                          "delta_percentage": 7
+                        },
+                        "readwrite-bs4096": {
+                          "target": 40,
+                          "delta_percentage": 7
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 71,
+                          "delta_percentage": 6
+                        },
+                        "randread-bs4096": {
+                          "target": 71,
+                          "delta_percentage": 6
+                        },
+                        "read-bs4096": {
+                          "target": 70,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 71,
+                          "delta_percentage": 6
+                        }
                       }
                     }
                   }
@@ -578,38 +663,44 @@
               "cpu_utilization_vcpus_total": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 86,
-                        "delta_percentage": 5
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 172,
-                        "delta_percentage": 5
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 172,
-                        "delta_percentage": 5
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 171,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 86,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        },
+                        "randread-bs4096": {
+                          "target": 172,
+                          "delta_percentage": 5
+                        },
+                        "read-bs4096": {
+                          "target": 172,
+                          "delta_percentage": 5
+                        },
+                        "readwrite-bs4096": {
+                          "target": 171,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
@@ -618,76 +709,88 @@
               "iops_read": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 38454,
-                        "delta_percentage": 6
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 77842,
-                        "delta_percentage": 6
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 78046,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 38592,
-                        "delta_percentage": 6
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 77385,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 157316,
-                        "delta_percentage": 9
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 159630,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 77705,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 38454,
+                          "delta_percentage": 6
+                        },
+                        "randread-bs4096": {
+                          "target": 77842,
+                          "delta_percentage": 6
+                        },
+                        "read-bs4096": {
+                          "target": 78046,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 38592,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 77385,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 157316,
+                          "delta_percentage": 9
+                        },
+                        "read-bs4096": {
+                          "target": 159630,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 77705,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 50049,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 100510,
-                        "delta_percentage": 12
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 101105,
-                        "delta_percentage": 10
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 49333,
-                        "delta_percentage": 11
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 109656,
-                        "delta_percentage": 16
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 184727,
-                        "delta_percentage": 17
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 179659,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 90853,
-                        "delta_percentage": 14
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 50049,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 100510,
+                          "delta_percentage": 12
+                        },
+                        "read-bs4096": {
+                          "target": 101105,
+                          "delta_percentage": 10
+                        },
+                        "readwrite-bs4096": {
+                          "target": 49333,
+                          "delta_percentage": 11
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 109656,
+                          "delta_percentage": 16
+                        },
+                        "randread-bs4096": {
+                          "target": 184727,
+                          "delta_percentage": 17
+                        },
+                        "read-bs4096": {
+                          "target": 179659,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 90853,
+                          "delta_percentage": 14
+                        }
                       }
                     }
                   }
@@ -696,76 +799,88 @@
               "bw_read": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 153814,
-                        "delta_percentage": 6
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 311365,
-                        "delta_percentage": 6
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 312182,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 154367,
-                        "delta_percentage": 6
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 309535,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 629264,
-                        "delta_percentage": 9
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 638517,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 310816,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 153814,
+                          "delta_percentage": 6
+                        },
+                        "randread-bs4096": {
+                          "target": 311365,
+                          "delta_percentage": 6
+                        },
+                        "read-bs4096": {
+                          "target": 312182,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 154367,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 309535,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 629264,
+                          "delta_percentage": 9
+                        },
+                        "read-bs4096": {
+                          "target": 638517,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 310816,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 200194,
-                        "delta_percentage": 8
-                      },
-                      "randread-bs4096-1vcpu": {
-                        "target": 402041,
-                        "delta_percentage": 12
-                      },
-                      "read-bs4096-1vcpu": {
-                        "target": 404418,
-                        "delta_percentage": 10
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 197330,
-                        "delta_percentage": 11
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 438623,
-                        "delta_percentage": 16
-                      },
-                      "randread-bs4096-2vcpu": {
-                        "target": 738904,
-                        "delta_percentage": 17
-                      },
-                      "read-bs4096-2vcpu": {
-                        "target": 718630,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 363409,
-                        "delta_percentage": 14
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 200194,
+                          "delta_percentage": 8
+                        },
+                        "randread-bs4096": {
+                          "target": 402041,
+                          "delta_percentage": 12
+                        },
+                        "read-bs4096": {
+                          "target": 404418,
+                          "delta_percentage": 10
+                        },
+                        "readwrite-bs4096": {
+                          "target": 197330,
+                          "delta_percentage": 11
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 438623,
+                          "delta_percentage": 16
+                        },
+                        "randread-bs4096": {
+                          "target": 738904,
+                          "delta_percentage": 17
+                        },
+                        "read-bs4096": {
+                          "target": 718630,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 363409,
+                          "delta_percentage": 14
+                        }
                       }
                     }
                   }
@@ -774,44 +889,56 @@
               "iops_write": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 38458,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 38587,
-                        "delta_percentage": 6
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 77386,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 77696,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 38458,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 38587,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 77386,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 77696,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 50049,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 49336,
-                        "delta_percentage": 11
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 109658,
-                        "delta_percentage": 26
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 90852,
-                        "delta_percentage": 14
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 50049,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 49336,
+                          "delta_percentage": 11
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 109658,
+                          "delta_percentage": 26
+                        },
+                        "readwrite-bs4096": {
+                          "target": 90852,
+                          "delta_percentage": 14
+                        }
                       }
                     }
                   }
@@ -820,44 +947,56 @@
               "bw_write": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 153831,
-                        "delta_percentage": 6
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 154348,
-                        "delta_percentage": 6
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 309544,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 310784,
-                        "delta_percentage": 9
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 153831,
+                          "delta_percentage": 6
+                        },
+                        "readwrite-bs4096": {
+                          "target": 154348,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 309544,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 310784,
+                          "delta_percentage": 9
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "Avg": {
-                      "randrw-bs4096-1vcpu": {
-                        "target": 200194,
-                        "delta_percentage": 8
-                      },
-                      "readwrite-bs4096-1vcpu": {
-                        "target": 197343,
-                        "delta_percentage": 11
-                      },
-                      "randrw-bs4096-2vcpu": {
-                        "target": 438632,
-                        "delta_percentage": 16
-                      },
-                      "readwrite-bs4096-2vcpu": {
-                        "target": 363410,
-                        "delta_percentage": 14
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 200194,
+                          "delta_percentage": 8
+                        },
+                        "readwrite-bs4096": {
+                          "target": 197343,
+                          "delta_percentage": 11
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "randrw-bs4096": {
+                          "target": 438632,
+                          "delta_percentage": 16
+                        },
+                        "readwrite-bs4096": {
+                          "target": 363410,
+                          "delta_percentage": 14
+                        }
                       }
                     }
                   }

--- a/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.json
+++ b/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.json
@@ -53,6 +53,7 @@
     "cpu_utilization_vmm": {
       "unit": "percentage",
       "statistics": [{
+        "name": "Avg",
         "function": "ValuePlaceholder",
         "criteria": "EqualWith"
       }]
@@ -60,6 +61,7 @@
     "cpu_utilization_vcpus_total": {
       "unit": "percentage",
       "statistics": [{
+        "name": "Avg",
         "function": "ValuePlaceholder",
         "criteria": "EqualWith"
       }]
@@ -75,252 +77,264 @@
               "throughput": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 3359,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 25813,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 28051,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 3363,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 25835,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 28806,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 4144,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 23533,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 30387,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 4147,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 25834,
-                        "delta_percentage": 15
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 33251,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 4164,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 26737,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 30161,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 4164,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 27379,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 31033,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 2976,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 20375,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 27174,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 2973,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 20379,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 28513,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 2619,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 14510,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 31480,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 2620,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 16999,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 33932,
-                        "delta_percentage": 5
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 3359,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 25813,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 28051,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 3363,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 25835,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 28806,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 4144,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 23533,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 30387,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 4147,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 25834,
+                          "delta_percentage": 15
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 33251,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 4164,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 26737,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 30161,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 4164,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 27379,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 31033,
+                          "delta_percentage": 4
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2976,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 20375,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 27174,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2973,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 20379,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 28513,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 2619,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 14510,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 31480,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 2620,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 16999,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 33932,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 3114,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 25659,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 27725,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 3114,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 25661,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 28344,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 4202,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 23208,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 26071,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 4201,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 25986,
-                        "delta_percentage": 14
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 32578,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 3955,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 26075,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 29308,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 3945,
-                        "delta_percentage": 13
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 26777,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 30801,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 2857,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 20169,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 27132,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 2858,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 20180,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 27699,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 2563,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 14245,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 24591,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 2564,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 16910,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 33405,
-                        "delta_percentage": 5
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 3114,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 25659,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 27725,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 3114,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 3,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 28344,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 4202,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 23208,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 26071,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 4201,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 25986,
+                          "delta_percentage": 14
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 32578,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 3955,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 26075,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 29308,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 3945,
+                          "delta_percentage": 13
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 26777,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 30801,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2857,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 20169,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 27132,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2858,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 20180,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 27699,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 2563,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 14245,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 24591,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 2564,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 16910,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 33405,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
@@ -329,252 +343,264 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 57,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 94,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 57,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 89,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 94,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 83,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 83,
-                        "delta_percentage": 13
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 58,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 91,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 94,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 58,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 91,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 93,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 49,
-                        "delta_percentage": 10
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 75,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 90,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 49,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 75,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 92,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 39,
-                        "delta_percentage": 11
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 56,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 87,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 39,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 54,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 88,
-                        "delta_percentage": 6
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 57,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 94,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 57,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 89,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 94,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 83,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 83,
+                          "delta_percentage": 13
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 58,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 91,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 94,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 58,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 91,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 93,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 49,
+                          "delta_percentage": 10
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 75,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 49,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 75,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 92,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 39,
+                          "delta_percentage": 11
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 56,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 87,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 39,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 54,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 88,
+                          "delta_percentage": 6
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 88,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 93,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 93,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 82,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 84,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 84,
-                        "delta_percentage": 11
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 88,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 55,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 90,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 94,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 55,
-                        "delta_percentage": 14
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 92,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 47,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 74,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 90,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 47,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 74,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 90,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 38,
-                        "delta_percentage": 11
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 55,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 78,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 38,
-                        "delta_percentage": 11
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 54,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 87,
-                        "delta_percentage": 7
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 88,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 93,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 93,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 82,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 84,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 84,
+                          "delta_percentage": 11
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 88,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 55,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 94,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 55,
+                          "delta_percentage": 14
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 92,
+                          "delta_percentage": 7
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 47,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 74,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 47,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 74,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 38,
+                          "delta_percentage": 11
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 55,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 78,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 38,
+                          "delta_percentage": 11
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 54,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 87,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
@@ -582,252 +608,264 @@
                 "cpu_utilization_vcpus_total": {
                   "vmlinux-4.14.bin": {
                     "ubuntu-18.04.ext4": {
-                      "value": {
-                        "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                          "target": 114,
-                          "delta_percentage": 7
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                          "target": 114,
-                          "delta_percentage": 8
-                        },
-                        "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                          "target": 190,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                          "target": 186,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                          "target": 197,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                          "target": 176,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                          "target": 164,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws16K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws16K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws256K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
+                      "2vcpu_1024mb.json": {
+                        "Avg": {
+                          "tcp-pDEFAULT-ws16K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                            "target": 114,
+                            "delta_percentage": 7
+                          },
+                          "tcp-p1024K-ws16K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-g2h": {
+                            "target": 114,
+                            "delta_percentage": 8
+                          },
+                          "tcp-pDEFAULT-ws16K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                            "target": 190,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws16K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-h2g": {
+                            "target": 186,
+                            "delta_percentage": 6
+                          },
+                          "tcp-pDEFAULT-ws16K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-bd": {
+                            "target": 197,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-bd": {
+                            "target": 176,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws16K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-bd": {
+                            "target": 164,
+                            "delta_percentage": 6
+                          }
+                        }
+                      },
+                      "1vcpu_1024mb.json": {
+                        "Avg": {
+                          "tcp-pDEFAULT-ws16K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws16K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws16K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws16K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws256K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          }
                         }
                       }
                     }
                   },
                   "vmlinux-4.9.bin": {
                     "ubuntu-18.04.ext4": {
-                      "value": {
-                        "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                          "target": 114,
-                          "delta_percentage": 7
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-g2h": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                          "target": 118,
-                          "delta_percentage": 8
-                        },
-                        "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                          "target": 197,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                          "target": 181,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-h2g": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                          "target": 184,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                          "target": 175,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws16K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-2vcpu-bd": {
-                          "target": 198,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                          "target": 164,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws16K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-ws256K-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws16K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
-                        },
-                        "tcp-p1024K-ws256K-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 6
-                        },
-                        "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                          "target": 99,
-                          "delta_percentage": 5
+                      "2vcpu_1024mb.json": {
+                        "Avg": {
+                          "tcp-pDEFAULT-ws16K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                            "target": 114,
+                            "delta_percentage": 7
+                          },
+                          "tcp-p1024K-ws16K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-g2h": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-g2h": {
+                            "target": 118,
+                            "delta_percentage": 8
+                          },
+                          "tcp-pDEFAULT-ws16K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-h2g": {
+                            "target": 197,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                            "target": 181,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws16K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-h2g": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-h2g": {
+                            "target": 184,
+                            "delta_percentage": 6
+                          },
+                          "tcp-pDEFAULT-ws16K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-bd": {
+                            "target": 175,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws16K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-bd": {
+                            "target": 198,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-bd": {
+                            "target": 164,
+                            "delta_percentage": 6
+                          }
+                        }
+                      },
+                      "1vcpu_1024mb.json": {
+                        "Avg": {
+                          "tcp-pDEFAULT-ws16K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws256K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws16K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-ws256K-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-wsDEFAULT-g2h": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-ws16K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-pDEFAULT-ws256K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws16K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          },
+                          "tcp-p1024K-ws256K-h2g": {
+                            "target": 99,
+                            "delta_percentage": 6
+                          },
+                          "tcp-p1024K-wsDEFAULT-h2g": {
+                            "target": 99,
+                            "delta_percentage": 5
+                          }
                         }
                       }
                     }
@@ -842,252 +880,264 @@
               "throughput": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 2749,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 24153,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 26827,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 2756,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 24139,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 27491,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 3434,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 20573,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 27994,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 3439,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 24089,
-                        "delta_percentage": 15
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 31885,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 3236,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 23782,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 29144,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 3246,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 24308,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 29493,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 2521,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 18606,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 25446,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 2519,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 18638,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 26616,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 2207,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 13812,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 29579,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 2209,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 14839,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 31913,
-                        "delta_percentage": 7
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2749,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 24153,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 26827,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2756,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 24139,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 27491,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 3434,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 20573,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 27994,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 3439,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 24089,
+                          "delta_percentage": 15
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 31885,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 3236,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 23782,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 29144,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 3246,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 24308,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 29493,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2521,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 18606,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 25446,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2519,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 18638,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 26616,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 2207,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 13812,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 29579,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 2209,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 14839,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 31913,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 2946,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 26944,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 27140,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 2948,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 26949,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 27722,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 4040,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 21646,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 26125,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 4046,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 23994,
-                        "delta_percentage": 11
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 33624,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 3723,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 25134,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 28180,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 3720,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 25933,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 29736,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 2582,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 19537,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 26151,
-                        "delta_percentage": 27
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 2580,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 19529,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 27303,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 2439,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 14706,
-                        "delta_percentage": 4
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 24763,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 2439,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 15958,
-                        "delta_percentage": 4
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 34569,
-                        "delta_percentage": 6
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2946,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 26944,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 27140,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2948,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 26949,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 27722,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 4040,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 21646,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 26125,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 4046,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 23994,
+                          "delta_percentage": 11
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 33624,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 3723,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 25134,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 28180,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 3720,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 25933,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 29736,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 2582,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 19537,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 26151,
+                          "delta_percentage": 27
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 2580,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 19529,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 27303,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 2439,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 14706,
+                          "delta_percentage": 4
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 24763,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 2439,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 15958,
+                          "delta_percentage": 4
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 34569,
+                          "delta_percentage": 6
+                        }
                       }
                     }
                   }
@@ -1096,252 +1146,264 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 56,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 94,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 56,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 94,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 80,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 87,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 84,
-                        "delta_percentage": 13
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 57,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 95,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 57,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 89,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 93,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 74,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 90,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 74,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 91,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 40,
-                        "delta_percentage": 10
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 59,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 86,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 40,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 86,
-                        "delta_percentage": 7
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 56,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 94,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 56,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 94,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 80,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 87,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 84,
+                          "delta_percentage": 13
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 57,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 95,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 57,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 89,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 93,
+                          "delta_percentage": 7
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 74,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 74,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 91,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 40,
+                          "delta_percentage": 10
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 59,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 86,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 40,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 86,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 57,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 97,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 95,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 57,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 97,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 95,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 60,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 84,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 88,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 61,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 84,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 92,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 62,
-                        "delta_percentage": 9
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 92,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 95,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 62,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 92,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 93,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 10
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 78,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 91,
-                        "delta_percentage": 26
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 78,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 93,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 44,
-                        "delta_percentage": 10
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 60,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 82,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 44,
-                        "delta_percentage": 10
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 56,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 90,
-                        "delta_percentage": 7
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 57,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 97,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 95,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 57,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 97,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 95,
+                          "delta_percentage": 6
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 60,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 84,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 88,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 61,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 84,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 92,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 62,
+                          "delta_percentage": 9
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 92,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 95,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 62,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 92,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 93,
+                          "delta_percentage": 7
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 10
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 78,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 91,
+                          "delta_percentage": 26
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 78,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 93,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 44,
+                          "delta_percentage": 10
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 60,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 82,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 44,
+                          "delta_percentage": 10
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 56,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 90,
+                          "delta_percentage": 7
+                        }
                       }
                     }
                   }
@@ -1350,252 +1412,264 @@
               "cpu_utilization_vcpus_total": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 197,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 121,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 119,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 185,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 184,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 181,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 197,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 165,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 197,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 121,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 119,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 185,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 184,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 181,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 197,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 165,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
                 },
                 "vmlinux-4.9.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "tcp-pDEFAULT-ws16K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-g2h": {
-                        "target": 117,
-                        "delta_percentage": 8
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-g2h": {
-                        "target": 112,
-                        "delta_percentage": 8
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-h2g": {
-                        "target": 197,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-h2g": {
-                        "target": 182,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-h2g": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-h2g": {
-                        "target": 187,
-                        "delta_percentage": 7
-                      },
-                      "tcp-pDEFAULT-ws16K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-2vcpu-bd": {
-                        "target": 174,
-                        "delta_percentage": 6
-                      },
-                      "tcp-p1024K-ws16K-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-2vcpu-bd": {
-                        "target": 197,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-2vcpu-bd": {
-                        "target": 163,
-                        "delta_percentage": 6
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 7
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws16K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-ws256K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-pDEFAULT-wsDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws16K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-ws256K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "tcp-p1024K-wsDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 117,
+                          "delta_percentage": 8
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 112,
+                          "delta_percentage": 8
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 197,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 182,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 187,
+                          "delta_percentage": 7
+                        },
+                        "tcp-pDEFAULT-ws16K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-bd": {
+                          "target": 174,
+                          "delta_percentage": 6
+                        },
+                        "tcp-p1024K-ws16K-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-bd": {
+                          "target": 197,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-bd": {
+                          "target": 163,
+                          "delta_percentage": 6
+                        }
+                      }
+                    },
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "tcp-pDEFAULT-ws16K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 7
+                        },
+                        "tcp-p1024K-ws16K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws16K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-ws256K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws16K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-ws256K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "tcp-p1024K-wsDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }

--- a/tests/integration_tests/performance/configs/vsock_throughput_test_config.json
+++ b/tests/integration_tests/performance/configs/vsock_throughput_test_config.json
@@ -43,7 +43,7 @@
     "cpu_utilization_vmm": {
       "unit": "percentage",
       "statistics": [{
-        "name": "value",
+        "name": "Avg",
         "function": "ValuePlaceholder",
         "criteria": "EqualWith"
       }]
@@ -51,7 +51,7 @@
     "cpu_utilization_vcpus_total": {
       "unit": "percentage",
       "statistics": [{
-        "name": "value",
+        "name": "Avg",
         "function": "ValuePlaceholder",
         "criteria": "EqualWith"
       }]
@@ -67,66 +67,72 @@
               "throughput": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 7001,
-                        "delta_percentage": 4
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 7036,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 2358,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 5126,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 5008,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 1854,
-                        "delta_percentage": 4
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 7299,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 7278,
-                        "delta_percentage": 7
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 3086,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 5933,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 5845,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 2547,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 5761,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 5695,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 2274,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "vsock-p1024K-g2h": {
+                          "target": 7001,
+                          "delta_percentage": 4
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 7036,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 2358,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 5126,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 5008,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 1854,
+                          "delta_percentage": 4
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "vsock-p1024K-g2h": {
+                          "target": 7299,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 7278,
+                          "delta_percentage": 7
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 3086,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 5933,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 5845,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 2547,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 5761,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 5695,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 2274,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
@@ -135,66 +141,72 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 48,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 60,
-                        "delta_percentage": 8
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 60,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 43,
-                        "delta_percentage": 10
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 65,
-                        "delta_percentage": 7
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 65,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 70,
-                        "delta_percentage": 7
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 77,
-                        "delta_percentage": 7
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 77,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 64,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 63,
-                        "delta_percentage": 8
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 64,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 67,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 48,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 60,
+                          "delta_percentage": 8
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 60,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 43,
+                          "delta_percentage": 10
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 65,
+                          "delta_percentage": 7
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 65,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 70,
+                          "delta_percentage": 7
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 77,
+                          "delta_percentage": 7
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 77,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 64,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 63,
+                          "delta_percentage": 8
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 64,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 67,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
@@ -203,66 +215,72 @@
               "cpu_utilization_vcpus_total": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 102,
-                        "delta_percentage": 10
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 131,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 131,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 177,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 121,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 122,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 102,
+                          "delta_percentage": 10
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 131,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 131,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 7,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 121,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 122,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }
@@ -276,66 +294,72 @@
               "throughput": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "total": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 5973,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 5993,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 948,
-                        "delta_percentage": 10
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 4041,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 3934,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 307,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 6775,
-                        "delta_percentage": 7
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 6699,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 2595,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 4883,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 4801,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 1669,
-                        "delta_percentage": 18
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 4544,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 4517,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 1408,
-                        "delta_percentage": 23
+                    "1vcpu_1024mb.json": {
+                      "total": {
+                        "vsock-p1024K-g2h": {
+                          "target": 5973,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 5993,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 948,
+                          "delta_percentage": 10
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 4041,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 3934,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 307,
+                          "delta_percentage": 8
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "total": {
+                        "vsock-p1024K-g2h": {
+                          "target": 6775,
+                          "delta_percentage": 7
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 6699,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 2595,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 4883,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 4801,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 1669,
+                          "delta_percentage": 18
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 4544,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 4517,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 1408,
+                          "delta_percentage": 23
+                        }
                       }
                     }
                   }
@@ -344,66 +368,72 @@
               "cpu_utilization_vmm": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 51,
-                        "delta_percentage": 9
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 52,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 44,
-                        "delta_percentage": 11
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 66,
-                        "delta_percentage": 8
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 65,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 32,
-                        "delta_percentage": 14
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 63,
-                        "delta_percentage": 9
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 63,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 66,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 79,
-                        "delta_percentage": 9
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 79,
-                        "delta_percentage": 7
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 60,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 68,
-                        "delta_percentage": 8
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 68,
-                        "delta_percentage": 8
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 65,
-                        "delta_percentage": 8
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 51,
+                          "delta_percentage": 9
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 52,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 44,
+                          "delta_percentage": 11
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 66,
+                          "delta_percentage": 8
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 65,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 32,
+                          "delta_percentage": 14
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 63,
+                          "delta_percentage": 9
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 63,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 66,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 79,
+                          "delta_percentage": 9
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 79,
+                          "delta_percentage": 7
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 60,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 68,
+                          "delta_percentage": 8
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 68,
+                          "delta_percentage": 8
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 65,
+                          "delta_percentage": 8
+                        }
                       }
                     }
                   }
@@ -412,66 +442,72 @@
               "cpu_utilization_vcpus_total": {
                 "vmlinux-4.14.bin": {
                   "ubuntu-18.04.ext4": {
-                    "value": {
-                      "vsock-p1024K-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-g2h": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-1vcpu-h2g": {
-                        "target": 99,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024K-2vcpu-g2h": {
-                        "target": 197,
-                        "delta_percentage": 5
-                      },
-                      "vsock-pDEFAULT-2vcpu-g2h": {
-                        "target": 198,
-                        "delta_percentage": 5
-                      },
-                      "vsock-p1024-2vcpu-g2h": {
-                        "target": 120,
-                        "delta_percentage": 9
-                      },
-                      "vsock-p1024K-2vcpu-h2g": {
-                        "target": 125,
-                        "delta_percentage": 7
-                      },
-                      "vsock-pDEFAULT-2vcpu-h2g": {
-                        "target": 125,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024-2vcpu-h2g": {
-                        "target": 181,
-                        "delta_percentage": 6
-                      },
-                      "vsock-p1024K-2vcpu-bd": {
-                        "target": 117,
-                        "delta_percentage": 6
-                      },
-                      "vsock-pDEFAULT-2vcpu-bd": {
-                        "target": 118,
-                        "delta_percentage": 7
-                      },
-                      "vsock-p1024-2vcpu-bd": {
-                        "target": 198,
-                        "delta_percentage": 5
+                    "1vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 99,
+                          "delta_percentage": 5
+                        }
+                      }
+                    },
+                    "2vcpu_1024mb.json": {
+                      "Avg": {
+                        "vsock-p1024K-g2h": {
+                          "target": 197,
+                          "delta_percentage": 5
+                        },
+                        "vsock-pDEFAULT-g2h": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        },
+                        "vsock-p1024-g2h": {
+                          "target": 120,
+                          "delta_percentage": 9
+                        },
+                        "vsock-p1024K-h2g": {
+                          "target": 125,
+                          "delta_percentage": 7
+                        },
+                        "vsock-pDEFAULT-h2g": {
+                          "target": 125,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024-h2g": {
+                          "target": 181,
+                          "delta_percentage": 6
+                        },
+                        "vsock-p1024K-bd": {
+                          "target": 117,
+                          "delta_percentage": 6
+                        },
+                        "vsock-pDEFAULT-bd": {
+                          "target": 118,
+                          "delta_percentage": 7
+                        },
+                        "vsock-p1024-bd": {
+                          "target": 198,
+                          "delta_percentage": 5
+                        }
                       }
                     }
                   }

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests the network latency of a Firecracker guest."""
-import json
 import logging
 import platform
 import re
@@ -16,6 +15,8 @@ from framework.statistics import core, consumer, producer, types, criteria,\
 from framework.utils import eager_map, CpuMap
 from framework.artifacts import DEFAULT_HOST_IP
 from framework.utils_cpuid import get_cpu_model_name
+from integration_tests.performance.utils import handle_failure, \
+    dump_test_result
 
 PING = "ping -c {} -i {} {}"
 LATENCY_AVG_BASELINES = {
@@ -220,6 +221,9 @@ def _g2h_send_ping(context):
     st_core.add_pipe(producer=prod, consumer=cons, tag="ping")
 
     # Gather results and verify pass criteria.
-    result = st_core.run_exercise(file_dumper is None)
-    if file_dumper:
-        file_dumper.writeln(json.dumps(result))
+    try:
+        result = st_core.run_exercise()
+    except core.CoreException as err:
+        handle_failure(file_dumper, err)
+
+    dump_test_result(file_dumper, result)

--- a/tests/integration_tests/performance/utils.py
+++ b/tests/integration_tests/performance/utils.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utility abstractions for performance tests."""
+import json
+
+
+def handle_failure(file_dumper, fail_err):
+    """Handle `statistics.core.CoreException` raised during...
+
+    ...`statistics.core.Core`s `run_exercise`.
+
+    :param file_dumper - ResultsFileDumper
+    :param fail_err - statistics.CoreException
+    """
+    dump_test_result(file_dumper, fail_err.result)
+    if fail_err:
+        raise fail_err
+
+
+def dump_test_result(file_dumper, result):
+    """Dump tests results to file using the `file_dumper`.
+
+    :param file_dumper - ResultsFileDumper
+    :param result - dict
+    """
+    if isinstance(result, dict) and file_dumper:
+        file_dumper.writeln(json.dumps(result))

--- a/tools/parse_baselines/providers/block.py
+++ b/tools/parse_baselines/providers/block.py
@@ -27,8 +27,8 @@ class BlockDataParser(DataParser):
             "iops_write/Avg",
             "bw_read/Avg",
             "bw_write/Avg",
-            "cpu_utilization_vcpus_total/value",
-            "cpu_utilization_vmm/value",
+            "cpu_utilization_vcpus_total/Avg",
+            "cpu_utilization_vmm/Avg",
         ])
 
     # pylint: disable=R0201

--- a/tools/parse_baselines/providers/iperf3.py
+++ b/tools/parse_baselines/providers/iperf3.py
@@ -24,8 +24,8 @@ class Iperf3DataParser(DataParser):
         """Initialize the data parser."""
         super().__init__(data_provider, [
             "throughput/total",
-            "cpu_utilization_vcpus_total/value",
-            "cpu_utilization_vmm/value",
+            "cpu_utilization_vcpus_total/Avg",
+            "cpu_utilization_vmm/Avg",
         ])
 
     # pylint: disable=R0201

--- a/tools/parse_baselines/providers/types.py
+++ b/tools/parse_baselines/providers/types.py
@@ -84,7 +84,7 @@ class DataParser(ABC):
         """Parse the rows and return baselines."""
         line = next(self._data_provider)
         while line:
-            json_line = json.loads(line)
+            json_line = json.loads(line.strip())
             measurements = json_line['results']
             cpu_model = json_line['custom']['cpu_model_name']
 
@@ -97,14 +97,16 @@ class DataParser(ABC):
                     if ms_data is None:
                         continue
 
-                    st_data = ms_data.get(st_name)
+                    st_data = ms_data.get(st_name)['value']
 
                     [kernel_version,
                      rootfs_type,
+                     microvm_config,
                      test_config] = tag.split("/")
 
                     data = self._data[cpu_model][ms_name]
-                    data = data[kernel_version][rootfs_type][st_name]
+                    data = data[kernel_version][rootfs_type]
+                    data = data[microvm_config][st_name]
                     if isinstance(data[test_config], list):
                         data[test_config].append(st_data)
                     else:


### PR DESCRIPTION
# Reason for This PR

Performance tests fail fast. When the first case of misalignment between the baselines and the values gathered by the test cases is detected, the test stops.

## Description of Changes

* made the fail fast mechanism optional by default and introduced an exception aggregator abstraction. Exception message example:
```
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-p1024K-1vcpu-g2h': 
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '51 +- 4.59' vs Actual: '23.35'.
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-pDEFAULT-1vcpu-g2h': 
E   'throughput/total': EqualWith failed. Target: '7036 +- 351.8' vs Actual: '8144.99'.
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '51 +- 4.59' vs Actual: '26.65'.
E   'cpu_utilization_vcpus_total/value': EqualWith failed. Target: '99 +- 4.95' vs Actual: '63.300000000000004'.
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-p1024-1vcpu-g2h': 
E   'throughput/total': EqualWith failed. Target: '2358 +- 117.9' vs Actual: '854.6'.
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '48 +- 4.32' vs Actual: '20.0'.
E   'cpu_utilization_vcpus_total/value': EqualWith failed. Target: '99 +- 4.95' vs Actual: '60.0'.
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-p1024K-1vcpu-h2g': 
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '1 +- 0.08' vs Actual: '33.35'.
E   'cpu_utilization_vcpus_total/value': EqualWith failed. Target: '99 +- 4.95' vs Actual: '59.95'.
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-pDEFAULT-1vcpu-h2g': 
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '1 +- 0.08' vs Actual: '33.35'.
E   'cpu_utilization_vcpus_total/value': EqualWith failed. Target: '99 +- 4.95' vs Actual: '68.7'.
E   Failed on 'vmlinux-4.14.bin/ubuntu-18.04.ext4/vsock-p1024-1vcpu-h2g': 
E   'throughput/total': EqualWith failed. Target: '1854 +- 74.16' vs Actual: '322.41'.
E   'cpu_utilization_vmm/value': EqualWith failed. Target: '43 +- 4.3' vs Actual: '10.0'.
E   'cpu_utilization_vcpus_total/value': EqualWith failed. Target: '99 +- 4.95' vs Actual: '63.300000000000004'.
```
* changed the test behavior to always run until the end, even if failures are detected (fail fast is disabled by default).
* if `--dump-results-to-file` is passed to pytest and the `fail_fast` mechanism is disabled, then the  test result dump will be `None` - due to not being able to finish and gather the whole test exercise data.
* added pass criteria details and PASS|FAIL verdict to each test case.

~~- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).~~

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] Any newly added `unsafe` code is properly documented.~~
~~- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.~~
~~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [ ] All added/changed functionality is tested.~~
