### PR TITLE
Fix README path in snapshot-support.md

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -38,7 +38,7 @@ guest workload at that particular point in time.
 ### Supported platforms
 
 The Firecracker snapshot feature is in [developer preview](../RELEASE_POLICY.md)
-on all CPU micro-architectures listed in [README](../README.md#supported-platforms).
+on all CPU micro-architectures listed in [README](../../README.md#supported-platforms).
 
 ### Overview
 


### PR DESCRIPTION
# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

Path to README.md file in snapshot-support.md is broken and this fixes it to correctly point to the README at the root of the repo.

## Description of Changes

`[Author TODO: add description of changes.]`

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
