### PR TITLE
[Block] Add option to configure block device flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added devtool build `--ssh-keys` flag to support fetching from private
   git repositories.
+- Added option to configure block device flush.
 
 ### Changed
 

--- a/docs/api_requests/block-caching.md
+++ b/docs/api_requests/block-caching.md
@@ -1,0 +1,70 @@
+# Block device caching strategies
+
+Firecracker offers the possiblity of choosing the block device caching
+strategy. Caching strategy affects the path data written from inside the
+microVM takes to the host persistent storage.
+
+## How it works
+
+When installing a block device through a PUT /drives API call, users can choose
+the caching strategy by inserting a `cache_type` field in the JSON body of the
+request. The available cache types are:
+
+- `Unsafe`
+- `Writeback`
+
+### Unsafe mode (default)
+
+When configuring the block caching strategy to `Unsafe`, the device will
+advertise the VirtIO `flush` feature to the guest driver. If negotiated when
+activating the device, the guest driver will be able to send flush requests
+to the device, but the device will just acknowledge the request without
+actually performing any flushing on the host side. The data which was not
+yet committed to disk will continue to reside in the host page cache.
+
+### Writeback mode
+
+When configuring the block caching strategy to `Writeback`, the device will
+advertise the VirtIO `flush` feature to the guest driver. If negotiated when
+activating the device, the guest driver will be able to send flush requests
+to the device. When the device executes a flush request, it will perform an
+`fsync` syscall on the backing block file, committing all data in the host
+page cache to disk.
+
+## Supported use cases
+
+The caching strategy should be used in order to make a trade-off:
+
+- `Unsafe`
+  - enhances performance as fewer syscalls and IO operations are performed when
+    running workloads
+  - sacrifices data integrity in situations where the host simply loses the
+    contents of the page cache without committing them to the backing storage
+    (such as a power outage)
+  - recommended for use cases with ephemeral storage, such as serverless
+    environments
+- `Writeback`
+  - ensures that once a flush request was acknowledged by the host, the data
+    is committed to the backing storage
+  - sacrifices performance, from boot time increases to greater
+    emulation-related latencies when running workloads
+  - recommended for use cases with low power environments, such as embedded
+    environments
+
+## How to configure it
+
+Example sequence that configures a block device with a caching strategy:
+
+```bash
+curl --unix-socket ${socket} -i \
+     -X PUT "http://localhost/drives/dummy" \
+     -H "accept: application/json" \
+     -H "Content-Type: application/json" \
+     -d "{
+             \"drive_id\": \"dummy\",
+             \"path_on_host\": \"${drive_path}\",
+             \"is_root_device\": false,
+             \"is_read_only\": false,
+             \"cache_type\": \"Writeback\"
+         }"
+```

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -643,6 +643,7 @@ pub(crate) mod tests {
             \"is_root_device\": true, \
             \"partuuid\": \"string\", \
             \"is_read_only\": true, \
+            \"cache_type\": \"Unsafe\", \
             \"rate_limiter\": { \
                 \"bandwidth\": { \
                     \"size\": 0, \

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -216,20 +216,33 @@ mod tests {
         assert!(parse_put_drive(&Body::new("invalid_payload"), None).is_err());
         assert!(parse_put_drive(&Body::new("invalid_payload"), Some(&"id")).is_err());
 
-        // PATCH with invalid fields.
+        // PUT with invalid fields.
         let body = r#"{
                 "drive_id": "bar",
                 "is_read_only": false
               }"#;
         assert!(parse_put_drive(&Body::new(body), Some(&"2")).is_err());
 
-        // PATCH with invalid types on fields. Adding a drive_id as number instead of string.
+        // PUT with missing all optional fields.
+        let body = r#"{
+            "drive_id": "1000",
+            "path_on_host": "dummy",
+            "is_root_device": true,
+            "is_read_only": true
+        }"#;
+        assert!(parse_put_drive(&Body::new(body), Some(&"1000")).is_ok());
+
+        // PUT with invalid types on fields. Adding a drive_id as number instead of string.
+        assert!(parse_put_drive(&Body::new(body), Some(&"foo")).is_err());
+
+        // PUT with the complete configuration.
         let body = r#"{
                 "drive_id": "1000",
                 "path_on_host": "dummy",
                 "is_root_device": true,
                 "partuuid": "string",
                 "is_read_only": true,
+                "cache_type": "Unsafe",
                 "rate_limiter": {
                     "bandwidth": {
                         "size": 0,
@@ -244,7 +257,5 @@ mod tests {
                 }
             }"#;
         assert!(parse_put_drive(&Body::new(body), Some(&"1000")).is_ok());
-
-        assert!(parse_put_drive(&Body::new(body), Some(&"foo")).is_err());
     }
 }

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -753,6 +753,11 @@ definitions:
     properties:
       drive_id:
         type: string
+      cache_type:
+        type: string
+        description:
+          Represents the caching strategy for the block device.
+        default: "Unsafe"
       is_read_only:
         type: boolean
       is_root_device:

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -7,7 +7,7 @@ pub mod persist;
 pub mod request;
 pub mod test_utils;
 
-pub use self::device::Block;
+pub use self::device::{Block, CacheType};
 pub use self::event_handler::*;
 pub use self::request::*;
 

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -7,9 +7,10 @@ use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
+use logger::warn;
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
-use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_gen::virtio_blk::VIRTIO_BLK_F_RO;
 use vm_memory::GuestMemoryMmap;
@@ -19,15 +20,63 @@ use super::*;
 use crate::virtio::persist::VirtioDeviceState;
 use crate::virtio::{DeviceState, TYPE_BLOCK};
 
+#[derive(Clone, Copy, Debug, Versionize, PartialEq)]
+// NOTICE: Any changes to this structure require a snapshot version bump.
+pub enum CacheTypeState {
+    Unsafe,
+    Writeback,
+}
+
+impl From<CacheType> for CacheTypeState {
+    fn from(cache_type: CacheType) -> Self {
+        match cache_type {
+            CacheType::Unsafe => CacheTypeState::Unsafe,
+            CacheType::Writeback => CacheTypeState::Writeback,
+        }
+    }
+}
+
+impl Into<CacheType> for CacheTypeState {
+    fn into(self) -> CacheType {
+        match self {
+            CacheTypeState::Unsafe => CacheType::Unsafe,
+            CacheTypeState::Writeback => CacheType::Writeback,
+        }
+    }
+}
+
 #[derive(Clone, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct BlockState {
     id: String,
     partuuid: Option<String>,
+    #[version(
+        start = 2,
+        ser_fn = "block_cache_type_ser",
+        default_fn = "default_cache_type_flush"
+    )]
+    cache_type: CacheTypeState,
     root_device: bool,
     disk_path: String,
     virtio_state: VirtioDeviceState,
     rate_limiter_state: RateLimiterState,
+}
+
+impl BlockState {
+    fn block_cache_type_ser(&mut self, target_version: u16) -> VersionizeResult<()> {
+        if target_version < 3 && self.cache_type != CacheTypeState::Unsafe {
+            warn!(
+                "Target version does not implement the current cache type. \
+                Defaulting to \"unsafe\" mode."
+            );
+        }
+
+        Ok(())
+    }
+
+    fn default_cache_type_flush(_source_version: u16) -> CacheTypeState {
+        CacheTypeState::Unsafe
+    }
 }
 
 pub struct BlockConstructorArgs {
@@ -43,6 +92,7 @@ impl Persist<'_> for Block {
         BlockState {
             id: self.id.clone(),
             partuuid: self.partuuid.clone(),
+            cache_type: CacheTypeState::from(self.cache_type()),
             root_device: self.root_device,
             disk_path: self.disk.file_path().clone(),
             virtio_state: VirtioDeviceState::from_device(self),
@@ -60,6 +110,7 @@ impl Persist<'_> for Block {
         let mut block = Block::new(
             state.id.clone(),
             state.partuuid.clone(),
+            state.cache_type.into(),
             state.disk_path.clone(),
             is_disk_read_only,
             state.root_device,
@@ -92,6 +143,67 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     #[test]
+    fn test_cache_type_state_from() {
+        assert_eq!(
+            CacheTypeState::Unsafe,
+            CacheTypeState::from(CacheType::Unsafe)
+        );
+        assert_eq!(
+            CacheTypeState::Writeback,
+            CacheTypeState::from(CacheType::Writeback)
+        );
+    }
+
+    #[test]
+    fn test_cache_type_state_into() {
+        assert_eq!(CacheType::Unsafe, CacheTypeState::Unsafe.into());
+        assert_eq!(CacheType::Writeback, CacheTypeState::Writeback.into());
+    }
+
+    #[test]
+    fn test_default_cache_type_flush() {
+        assert_eq!(
+            BlockState::default_cache_type_flush(2),
+            CacheTypeState::Unsafe
+        );
+        assert_eq!(
+            BlockState::default_cache_type_flush(3),
+            CacheTypeState::Unsafe
+        );
+    }
+
+    #[test]
+    fn test_cache_semantic_ser() {
+        // We create the backing file here so that it exists for the whole lifetime of the test.
+        let f = TempFile::new().unwrap();
+        f.as_file().set_len(0x1000).unwrap();
+
+        let id = "test".to_string();
+        let block = Block::new(
+            id,
+            None,
+            CacheType::Writeback,
+            f.as_path().to_str().unwrap().to_string(),
+            false,
+            false,
+            RateLimiter::default(),
+        )
+        .unwrap();
+
+        // Save the block device.
+        let mut mem = vec![0; 4096];
+        let version_map = VersionMap::new();
+
+        assert!(<Block as Persist>::save(&block)
+            .serialize(&mut mem.as_mut_slice(), &version_map, 2)
+            .is_ok());
+
+        assert!(<Block as Persist>::save(&block)
+            .serialize(&mut mem.as_mut_slice(), &version_map, 3)
+            .is_ok());
+    }
+
+    #[test]
     fn test_persistence() {
         // We create the backing file here so that it exists for the whole lifetime of the test.
         let f = TempFile::new().unwrap();
@@ -101,6 +213,7 @@ mod tests {
         let block = Block::new(
             id,
             None,
+            CacheType::Unsafe,
             f.as_path().to_str().unwrap().to_string(),
             false,
             false,

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -3,7 +3,7 @@
 
 use std::os::unix::io::AsRawFd;
 
-use crate::virtio::{Block, Queue};
+use crate::virtio::{Block, CacheType, Queue};
 use polly::event_manager::{EventManager, Subscriber};
 use rate_limiter::RateLimiter;
 use utils::epoll::{EpollEvent, EventSet};
@@ -25,7 +25,16 @@ pub fn default_block_with_path(path: String) -> Block {
 
     let id = "test".to_string();
     // The default block device is read-write and non-root.
-    Block::new(id, None, path, false, false, rate_limiter).unwrap()
+    Block::new(
+        id,
+        None,
+        CacheType::Unsafe,
+        path,
+        false,
+        false,
+        rate_limiter,
+    )
+    .unwrap()
 }
 
 pub fn invoke_handler_for_queue_event(b: &mut Block) {

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -158,6 +158,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                 libc::SYS_timerfd_settime,
                 or![and![Cond::new(1, ArgLen::DWORD, Eq, 0u64)?],],
             ),
+            allow_syscall(libc::SYS_fsync),
             allow_syscall(libc::SYS_write),
         ]
         .into_iter()

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -401,6 +401,7 @@ mod tests {
     use crate::vmm_config::balloon::BalloonDeviceConfig;
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::vsock::VsockDeviceConfig;
+    use devices::virtio::block::CacheType;
     use polly::event_manager::EventManager;
     use utils::tempfile::TempFile;
 
@@ -547,7 +548,13 @@ mod tests {
             insert_balloon_device(&mut vmm, &mut cmdline, &mut event_manager, balloon_cfg);
             // Add a block device.
             let drive_id = String::from("root");
-            let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
+            let block_configs = vec![CustomBlockConfig::new(
+                drive_id,
+                true,
+                None,
+                true,
+                CacheType::Unsafe,
+            )];
             _block_files =
                 insert_block_devices(&mut vmm, &mut cmdline, &mut event_manager, block_configs);
             // Add a net device.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -415,6 +415,7 @@ mod tests {
     use crate::memory_snapshot::SnapshotMemory;
     use crate::version_map::{FC_VERSION_TO_SNAP_VERSION, VERSION_MAP};
     use crate::vmm_config::balloon::BalloonDeviceConfig;
+    use crate::vmm_config::drive::CacheType;
     use crate::vmm_config::net::NetworkInterfaceConfig;
     use crate::vmm_config::vsock::tests::default_config;
     use crate::Vmm;
@@ -441,7 +442,13 @@ mod tests {
 
         // Add a block device.
         let drive_id = String::from("root");
-        let block_configs = vec![CustomBlockConfig::new(drive_id, true, None, true)];
+        let block_configs = vec![CustomBlockConfig::new(
+            drive_id,
+            true,
+            None,
+            true,
+            CacheType::Unsafe,
+        )];
         insert_block_devices(&mut vmm, &mut cmdline, &mut event_manager, block_configs);
 
         // Add net device.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -395,6 +395,7 @@ mod tests {
                 path_on_host: tmp_file.as_path().to_str().unwrap().to_string(),
                 is_root_device: false,
                 partuuid: Some("0eaa91a0-01".to_string()),
+                cache_type: CacheType::Unsafe,
                 is_read_only: false,
                 rate_limiter: Some(RateLimiterConfig::default()),
             },

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -653,6 +653,7 @@ impl RuntimeApiController {
 mod tests {
     use super::*;
     use crate::vmm_config::balloon::BalloonBuilder;
+    use crate::vmm_config::drive::CacheType;
     use crate::vmm_config::logger::LoggerLevel;
     use crate::vmm_config::vsock::VsockBuilder;
     use devices::virtio::balloon::{BalloonConfig, Error as BalloonError};
@@ -1052,6 +1053,7 @@ mod tests {
             path_on_host: String::new(),
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::new(),
             rate_limiter: None,
@@ -1065,6 +1067,7 @@ mod tests {
             path_on_host: String::new(),
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::new(),
             rate_limiter: None,
@@ -1498,6 +1501,7 @@ mod tests {
                 path_on_host: String::new(),
                 is_root_device: false,
                 partuuid: None,
+                cache_type: CacheType::Unsafe,
                 is_read_only: false,
                 drive_id: String::new(),
                 rate_limiter: None,
@@ -1587,6 +1591,7 @@ mod tests {
             path_on_host: String::new(),
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::new(),
             rate_limiter: None,

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::device_manager::persist::DeviceStates;
+use devices::virtio::block::persist::BlockState;
 
 use lazy_static::lazy_static;
 use versionize::VersionMap;
@@ -17,6 +18,7 @@ lazy_static! {
     pub static ref VERSION_MAP: VersionMap = {
         let mut version_map = VersionMap::new();
         version_map.new_version().set_type_version(DeviceStates::type_id(), 2);
+        version_map.new_version().set_type_version(BlockState::type_id(), 2);
         version_map
     };
 
@@ -26,6 +28,7 @@ lazy_static! {
         let mut mapping = HashMap::new();
         mapping.insert(String::from("0.23.0"), 1);
         mapping.insert(String::from("0.24.0"), 2);
+        mapping.insert(String::from("0.25.0"), 3);
 
         mapping
     };

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -13,6 +13,8 @@ use super::RateLimiterConfig;
 use crate::Error as VmmError;
 use devices::virtio::Block;
 
+pub use devices::virtio::CacheType;
+
 use serde::Deserialize;
 
 type Result<T> = result::Result<T, DriveError>;
@@ -79,6 +81,10 @@ pub struct BlockDeviceConfig {
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
     /// drive is opened as read-write.
     pub is_read_only: bool,
+    /// If set to true, the drive will ignore flush requests coming from
+    /// the guest driver.
+    #[serde(default = "CacheType::default")]
+    pub cache_type: CacheType,
     /// Rate Limiter for I/O operations.
     pub rate_limiter: Option<RateLimiterConfig>,
 }
@@ -189,6 +195,7 @@ impl BlockBuilder {
         devices::virtio::Block::new(
             block_device_config.drive_id,
             block_device_config.partuuid,
+            block_device_config.cache_type,
             block_device_config.path_on_host,
             block_device_config.is_read_only,
             block_device_config.is_root_device,
@@ -218,6 +225,7 @@ mod tests {
                 path_on_host: self.path_on_host.clone(),
                 is_root_device: self.is_root_device,
                 partuuid: self.partuuid.clone(),
+                cache_type: self.cache_type,
                 is_read_only: self.is_read_only,
                 drive_id: self.drive_id.clone(),
                 rate_limiter: None,
@@ -240,6 +248,7 @@ mod tests {
             path_on_host: dummy_path,
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Writeback,
             is_read_only: false,
             drive_id: dummy_id.clone(),
             rate_limiter: None,
@@ -269,6 +278,7 @@ mod tests {
             path_on_host: dummy_path,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: true,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -295,6 +305,7 @@ mod tests {
             path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -306,6 +317,7 @@ mod tests {
             path_on_host: dummy_path_2,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("2"),
             rate_limiter: None,
@@ -328,6 +340,7 @@ mod tests {
             path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -339,6 +352,7 @@ mod tests {
             path_on_host: dummy_path_2,
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("2"),
             rate_limiter: None,
@@ -350,6 +364,7 @@ mod tests {
             path_on_host: dummy_path_3,
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("3"),
             rate_limiter: None,
@@ -386,6 +401,7 @@ mod tests {
             path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -397,6 +413,7 @@ mod tests {
             path_on_host: dummy_path_2,
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("2"),
             rate_limiter: None,
@@ -408,6 +425,7 @@ mod tests {
             path_on_host: dummy_path_3,
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("3"),
             rate_limiter: None,
@@ -445,6 +463,7 @@ mod tests {
             path_on_host: dummy_path_1.clone(),
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -456,6 +475,7 @@ mod tests {
             path_on_host: dummy_path_2.clone(),
             is_root_device: false,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("2"),
             rate_limiter: None,
@@ -514,6 +534,7 @@ mod tests {
             path_on_host: dummy_path_1,
             is_root_device: true,
             partuuid: None,
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("1"),
             rate_limiter: None,
@@ -525,6 +546,7 @@ mod tests {
             path_on_host: dummy_path_2,
             is_root_device: true,
             partuuid: Some("0eaa91a0-01".to_string()),
+            cache_type: CacheType::Unsafe,
             is_read_only: false,
             drive_id: String::from("2"),
             rate_limiter: None,
@@ -548,6 +570,7 @@ mod tests {
             path_on_host: dummy_block_file.as_path().to_str().unwrap().to_string(),
             is_root_device: false,
             partuuid: Some("0eaa91a0-01".to_string()),
+            cache_type: CacheType::Unsafe,
             is_read_only: true,
             rate_limiter: None,
         };

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -611,6 +611,7 @@ class Microvm:
             root_device=False,
             is_read_only=False,
             partuuid=None,
+            cache_type=None,
     ):
         """Add a block device."""
         response = self.drive.put(
@@ -618,7 +619,8 @@ class Microvm:
             path_on_host=self.create_jailed_resource(file_path),
             is_root_device=root_device,
             is_read_only=is_read_only,
-            partuuid=partuuid
+            partuuid=partuuid,
+            cache_type=cache_type
         )
         assert self.api_session.is_status_no_content(response.status_code)
 

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -231,7 +231,8 @@ class Drive():
             is_root_device=None,
             partuuid=None,
             is_read_only=None,
-            rate_limiter=None):
+            rate_limiter=None,
+            cache_type=None):
         """Compose the json associated to this type of API request."""
         datax = {}
 
@@ -249,6 +250,9 @@ class Drive():
 
         if is_read_only is not None:
             datax['is_read_only'] = is_read_only
+
+        if cache_type is not None:
+            datax['cache_type'] = cache_type
 
         if rate_limiter is not None:
             datax['rate_limiter'] = rate_limiter

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.44, "AMD": 84.77, "ARM": 83.42}
+COVERAGE_DICT = {"Intel": 85.44, "AMD": 84.74, "ARM": 83.60}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

#2172 

## Description of Changes

This commit introduces the notion of cache type to the virtio block device implementation. This allows users to choose from two cache types:

- `unsafe`: this option will advertise the flush virtio capability to the guest block driver, but will acknowledge and ignore incoming flush requests;
- `writethrough`: this option will advertise the flush virtio capability to the guest block driver and will perform a `fsync` syscall on incoming flush requests;

This functionality is exposed to users through an optional `ignore_flush` field in the block configuration API request. When absent, this field defaults to `true`, ignoring incoming flush requests from the guest driver and keeping the behavior of the block device the same as before this change. Setting it to `false` will make the device call `fsync` on the backing file when processing flush requests. 

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
