### PR TITLE
feature/file_based_seccomp: Triage allowlist for thread categories

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -41,7 +41,7 @@
             },
             {
                 "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
+                "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "ftruncate",
@@ -61,7 +61,7 @@
             },
             {
                 "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
+                "comment": "Used by vsock to retrieve data from the socket"
             },
             {
                 "syscall": "rt_sigreturn",
@@ -69,7 +69,7 @@
             },
             {
                 "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
+                "comment": "Called to accept vsock connections",
                 "args": [
                     {
                         "arg_index": 3,
@@ -128,7 +128,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
+                "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
                         "arg_index": 2,
@@ -136,19 +136,6 @@
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used for reading the timezone in LocalTime::now()",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::MAP_SHARED"
                     }
                 ]
             },
@@ -167,7 +154,7 @@
             },
             {
                 "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
+                "comment": "Called to open the vsock UDS",
                 "args": [
                     {
                         "arg_index": 0,
@@ -206,7 +193,7 @@
             },
             {
                 "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
                         "arg_index": 0,
@@ -226,7 +213,7 @@
             },
             {
                 "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
                         "arg_index": 1,
@@ -238,30 +225,7 @@
             },
             {
                 "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 44672,
-                        "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
+                "comment": "Used to make vsock UDS nonblocking",
                 "args": [
                     {
                         "arg_index": 1,
@@ -318,116 +282,8 @@
                         "arg_index": 1,
                         "arg_type": "dword",
                         "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2147790488,
-                        "comment": "KVM_GET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074048665,
-                        "comment": "KVM_SET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2151722655,
-                        "comment": "KVM_GET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1077980832,
-                        "comment": "KVM_SET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835115,
-                        "comment": "KVM_GET_ONE_REG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835116,
-                        "comment": "KVM_SET_ONE_REG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794480,
-                        "comment": "KVM_GET_REG_LIST"
+                        "val": 1074835010,
+                        "comment": "KVM_GET_DIRTY_LOG"
                     }
                 ]
             },
@@ -494,20 +350,8 @@
                 "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
             },
             {
-                "syscall": "connect",
-                "comment": "Needed for vsock"
-            },
-            {
                 "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
-            },
-            {
-                "syscall": "ftruncate",
-                "comment": "Used for snapshotting"
-            },
-            {
-                "syscall": "lseek",
-                "comment": "Used by the block device"
+                "comment": "Used for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "mremap",
@@ -519,15 +363,11 @@
             },
             {
                 "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
-            },
-            {
-                "syscall": "rt_sigreturn",
-                "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
+                "comment": "Used to retrieve data from the socket"
             },
             {
                 "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
+                "comment": "Called to accept socket connections",
                 "args": [
                     {
                         "arg_index": 3,
@@ -535,26 +375,6 @@
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by snapshotting, drive patching and rescanning",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2,
-                        "comment": "FCNTL_F_SETFD"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "FCNTL_FD_CLOEXEC"
                     }
                 ]
             },
@@ -585,19 +405,6 @@
                 ]
             },
             {
-                "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
-                "args": [
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
                 "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
@@ -611,21 +418,8 @@
                 ]
             },
             {
-                "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
-                    }
-                ]
-            },
-            {
                 "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
+                "comment": "Called to open the unix domain socket",
                 "args": [
                     {
                         "arg_index": 0,
@@ -650,76 +444,8 @@
                 ]
             },
             {
-                "syscall": "tkill",
-                "comment": "Used to kick vcpus",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 35,
-                        "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 0
-                    }
-                ]
-            },
-            {
                 "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 44672,
-                        "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
+                "comment": "Used to make api socket nonblocking",
                 "args": [
                     {
                         "arg_index": 1,
@@ -727,189 +453,6 @@
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21523,
-                        "comment": "TIOCGWINSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21505,
-                        "comment": "TCGETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21506,
-                        "comment": "TCSETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2147790488,
-                        "comment": "KVM_GET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074048665,
-                        "comment": "KVM_SET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2151722655,
-                        "comment": "KVM_GET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1077980832,
-                        "comment": "KVM_SET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835115,
-                        "comment": "KVM_GET_ONE_REG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835116,
-                        "comment": "KVM_SET_ONE_REG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794480,
-                        "comment": "KVM_GET_REG_LIST"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1075359457,
-                        "comment": "KVM_SET_DEVICE_ATTR"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1075359458,
-                        "comment": "KVM_GET_DEVICE_ATTR"
                     }
                 ]
             }
@@ -920,22 +463,10 @@
         "filter_action": "allow",
         "filter": [
             {
-                "syscall": "epoll_ctl"
-            },
-            {
-                "syscall": "epoll_pwait"
-            },
-            {
                 "syscall": "exit"
             },
             {
                 "syscall": "exit_group"
-            },
-            {
-                "syscall": "openat"
-            },
-            {
-                "syscall": "read"
             },
             {
                 "syscall": "write"
@@ -952,22 +483,6 @@
                 "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
             },
             {
-                "syscall": "connect",
-                "comment": "Needed for vsock"
-            },
-            {
-                "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
-            },
-            {
-                "syscall": "ftruncate",
-                "comment": "Used for snapshotting"
-            },
-            {
-                "syscall": "lseek",
-                "comment": "Used by the block device"
-            },
-            {
                 "syscall": "mremap",
                 "comment": "Used for re-allocating large memory regions, for example vectors"
             },
@@ -976,45 +491,8 @@
                 "comment": "Used for freeing memory"
             },
             {
-                "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
-            },
-            {
                 "syscall": "rt_sigreturn",
                 "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
-            },
-            {
-                "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 524288,
-                        "comment": "libc::SOCK_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by snapshotting, drive patching and rescanning",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2,
-                        "comment": "FCNTL_F_SETFD"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "FCNTL_FD_CLOEXEC"
-                    }
-                ]
             },
             {
                 "syscall": "futex",
@@ -1043,106 +521,8 @@
                 ]
             },
             {
-                "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
-                "args": [
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used for reading the timezone in LocalTime::now()",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::MAP_SHARED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::AF_UNIX"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 524289,
-                        "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 0
-                    }
-                ]
-            },
-            {
-                "syscall": "tkill",
-                "comment": "Used to kick vcpus",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 35,
-                        "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
                 "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for updating the balloon statistics interval",
                 "args": [
                     {
                         "arg_index": 1,
@@ -1161,105 +541,6 @@
                         "op": "eq",
                         "val": 44672,
                         "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21537,
-                        "comment": "FIONBIO"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21523,
-                        "comment": "TIOCGWINSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21505,
-                        "comment": "TCGETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21506,
-                        "comment": "TCSETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
                     }
                 ]
             },
@@ -1344,30 +625,6 @@
                         "op": "eq",
                         "val": 3221794480,
                         "comment": "KVM_GET_REG_LIST"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1075359457,
-                        "comment": "KVM_SET_DEVICE_ATTR"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1075359458,
-                        "comment": "KVM_GET_DEVICE_ATTR"
                     }
                 ]
             }

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -41,7 +41,7 @@
             },
             {
                 "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
+                "comment": "Used for drive patching & rescanning, for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "ftruncate",
@@ -61,7 +61,7 @@
             },
             {
                 "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
+                "comment": "Used by vsock to retrieve data from the socket"
             },
             {
                 "syscall": "rt_sigreturn",
@@ -69,7 +69,7 @@
             },
             {
                 "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
+                "comment": "Called to accept vsock connections",
                 "args": [
                     {
                         "arg_index": 3,
@@ -128,7 +128,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
+                "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
                         "arg_index": 2,
@@ -136,19 +136,6 @@
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used for reading the timezone in LocalTime::now()",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::MAP_SHARED"
                     }
                 ]
             },
@@ -167,7 +154,7 @@
             },
             {
                 "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
+                "comment": "Called to open the vsock UDS",
                 "args": [
                     {
                         "arg_index": 0,
@@ -206,7 +193,7 @@
             },
             {
                 "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
                         "arg_index": 0,
@@ -226,7 +213,7 @@
             },
             {
                 "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
                         "arg_index": 1,
@@ -238,30 +225,7 @@
             },
             {
                 "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 44672,
-                        "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
+                "comment": "Used to make vsock UDS nonblocking",
                 "args": [
                     {
                         "arg_index": 1,
@@ -318,164 +282,8 @@
                         "arg_index": 1,
                         "arg_type": "dword",
                         "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2147790488,
-                        "comment": "KVM_GET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074048665,
-                        "comment": "KVM_SET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2151722655,
-                        "comment": "KVM_GET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1077980832,
-                        "comment": "KVM_SET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2214637198,
-                        "comment": "KVM_GET_LAPIC"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2167975555,
-                        "comment": "KVM_GET_SREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074310800,
-                        "comment": "KVM_SET_CPUID2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1140895375,
-                        "comment": "KVM_SET_LAPIC"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074310793,
-                        "comment": "KVM_SET_MSRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1083223682,
-                        "comment": "KVM_SET_REGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1094233732,
-                        "comment": "KVM_SET_SREGS"
+                        "val": 1074835010,
+                        "comment": "KVM_GET_DIRTY_LOG"
                     }
                 ]
             },
@@ -512,114 +320,6 @@
                         "op": "eq",
                         "val": 2154868383,
                         "comment": "KVM_GET_PIT2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2156965505,
-                        "comment": "KVM_GET_REGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794440,
-                        "comment": "KVM_GET_MSRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794449,
-                        "comment": "KVM_GET_CPUID2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2155916961,
-                        "comment": "KVM_GET_DEBUGREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1082175138,
-                        "comment": "KVM_SET_DEBUGREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2415963812,
-                        "comment": "KVM_GET_XSAVE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1342221989,
-                        "comment": "KVM_SET_XSAVE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2173218470,
-                        "comment": "KVM_GET_XCRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1099476647,
-                        "comment": "KVM_SET_XCRS"
                     }
                 ]
             }
@@ -662,20 +362,8 @@
                 "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
             },
             {
-                "syscall": "connect",
-                "comment": "Needed for vsock"
-            },
-            {
                 "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
-            },
-            {
-                "syscall": "ftruncate",
-                "comment": "Used for snapshotting"
-            },
-            {
-                "syscall": "lseek",
-                "comment": "Used by the block device"
+                "comment": "Used for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "mremap",
@@ -687,15 +375,11 @@
             },
             {
                 "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
-            },
-            {
-                "syscall": "rt_sigreturn",
-                "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
+                "comment": "Used to retrieve data from the socket"
             },
             {
                 "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
+                "comment": "Called to accept socket connections",
                 "args": [
                     {
                         "arg_index": 3,
@@ -703,26 +387,6 @@
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by snapshotting, drive patching and rescanning",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2,
-                        "comment": "FCNTL_F_SETFD"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "FCNTL_FD_CLOEXEC"
                     }
                 ]
             },
@@ -753,19 +417,6 @@
                 ]
             },
             {
-                "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
-                "args": [
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
                 "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
@@ -779,21 +430,8 @@
                 ]
             },
             {
-                "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
-                    }
-                ]
-            },
-            {
                 "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
+                "comment": "Called to open the unix domain socket",
                 "args": [
                     {
                         "arg_index": 0,
@@ -818,76 +456,8 @@
                 ]
             },
             {
-                "syscall": "tkill",
-                "comment": "Used to kick vcpus",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 35,
-                        "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 0
-                    }
-                ]
-            },
-            {
                 "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 44672,
-                        "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
+                "comment": "Used to make api socket nonblocking",
                 "args": [
                     {
                         "arg_index": 1,
@@ -895,357 +465,6 @@
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21523,
-                        "comment": "TIOCGWINSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21505,
-                        "comment": "TCGETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21506,
-                        "comment": "TCSETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2147790488,
-                        "comment": "KVM_GET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074048665,
-                        "comment": "KVM_SET_MP_STATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2151722655,
-                        "comment": "KVM_GET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1077980832,
-                        "comment": "KVM_SET_VCPU_EVENTS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2214637198,
-                        "comment": "KVM_GET_LAPIC"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2167975555,
-                        "comment": "KVM_GET_SREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074310800,
-                        "comment": "KVM_SET_CPUID2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1140895375,
-                        "comment": "KVM_SET_LAPIC"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074310793,
-                        "comment": "KVM_SET_MSRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1083223682,
-                        "comment": "KVM_SET_REGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1094233732,
-                        "comment": "KVM_SET_SREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3255348834,
-                        "comment": "KVM_GET_IRQCHIP"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2150674044,
-                        "comment": "KVM_GET_CLOCK"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2154868383,
-                        "comment": "KVM_GET_PIT2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2156965505,
-                        "comment": "KVM_GET_REGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794440,
-                        "comment": "KVM_GET_MSRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3221794449,
-                        "comment": "KVM_GET_CPUID2"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2155916961,
-                        "comment": "KVM_GET_DEBUGREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1082175138,
-                        "comment": "KVM_SET_DEBUGREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2415963812,
-                        "comment": "KVM_GET_XSAVE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1342221989,
-                        "comment": "KVM_SET_XSAVE"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2173218470,
-                        "comment": "KVM_GET_XCRS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1099476647,
-                        "comment": "KVM_SET_XCRS"
                     }
                 ]
             }
@@ -1256,22 +475,10 @@
         "filter_action": "allow",
         "filter": [
             {
-                "syscall": "epoll_ctl"
-            },
-            {
-                "syscall": "epoll_pwait"
-            },
-            {
                 "syscall": "exit"
             },
             {
                 "syscall": "exit_group"
-            },
-            {
-                "syscall": "open"
-            },
-            {
-                "syscall": "read"
             },
             {
                 "syscall": "write"
@@ -1288,22 +495,6 @@
                 "comment": "Used for metrics and logging, via the helpers in utils/src/time.rs. It's not called on some platforms, because of vdso optimisations."
             },
             {
-                "syscall": "connect",
-                "comment": "Needed for vsock"
-            },
-            {
-                "syscall": "fstat",
-                "comment": "Used for drive patching & rescanning, for reading the local timezone"
-            },
-            {
-                "syscall": "ftruncate",
-                "comment": "Used for snapshotting"
-            },
-            {
-                "syscall": "lseek",
-                "comment": "Used by the block device"
-            },
-            {
                 "syscall": "mremap",
                 "comment": "Used for re-allocating large memory regions, for example vectors"
             },
@@ -1312,45 +503,8 @@
                 "comment": "Used for freeing memory"
             },
             {
-                "syscall": "recvfrom",
-                "comment": "Used by the API thread and vsock"
-            },
-            {
                 "syscall": "rt_sigreturn",
                 "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
-            },
-            {
-                "syscall": "accept4",
-                "comment": "Called by the api thread to receive data on socket",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 524288,
-                        "comment": "libc::SOCK_CLOEXEC"
-                    }
-                ]
-            },
-            {
-                "syscall": "fcntl",
-                "comment": "Used by snapshotting, drive patching and rescanning",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2,
-                        "comment": "FCNTL_F_SETFD"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "FCNTL_FD_CLOEXEC"
-                    }
-                ]
             },
             {
                 "syscall": "futex",
@@ -1379,106 +533,8 @@
                 ]
             },
             {
-                "syscall": "madvise",
-                "comment": "Triggered by musl for some customer workloads",
-                "args": [
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 4,
-                        "comment": "libc::MADV_DONTNEED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used for reading the timezone in LocalTime::now()",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::MAP_SHARED"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
-                "comment": "Used by the VirtIO balloon device",
-                "args": [
-                    {
-                        "arg_index": 3,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 50,
-                        "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "socket",
-                "comment": "Used by the API thread and vsock",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::AF_UNIX"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 524289,
-                        "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
-                    },
-                    {
-                        "arg_index": 2,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 0
-                    }
-                ]
-            },
-            {
-                "syscall": "tkill",
-                "comment": "Used to kick vcpus",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 35,
-                        "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
-                    }
-                ]
-            },
-            {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
                 "syscall": "timerfd_settime",
-                "comment": "Needed for rate limiting",
+                "comment": "Needed for updating the balloon statistics interval",
                 "args": [
                     {
                         "arg_index": 1,
@@ -1497,105 +553,6 @@
                         "op": "eq",
                         "val": 44672,
                         "comment": "KVM_RUN"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074835010,
-                        "comment": "KVM_GET_DIRTY_LOG"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21537,
-                        "comment": "FIONBIO"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21523,
-                        "comment": "TIOCGWINSZ"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21505,
-                        "comment": "TCGETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 21506,
-                        "comment": "TCSETS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025674,
-                        "comment": "TUNSETIFF"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025680,
-                        "comment": "TUNSETOFFLOAD"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1074025688,
-                        "comment": "TUNSETVNETHDRSZ"
                     }
                 ]
             },
@@ -1728,30 +685,6 @@
                         "op": "eq",
                         "val": 1094233732,
                         "comment": "KVM_SET_SREGS"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 3255348834,
-                        "comment": "KVM_GET_IRQCHIP"
-                    }
-                ]
-            },
-            {
-                "syscall": "ioctl",
-                "args": [
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 2150674044,
-                        "comment": "KVM_GET_CLOCK"
                     }
                 ]
             },


### PR DESCRIPTION
# Reason for This PR

Given the fact that seccompiler and Firecracker now have support for different allowlists per thread category, we can now restrict the seccomp filters even further.

Before this PR, the same filter was used irrespective of the thread category

## Description of Changes

Split and audit the allowlist for each thread category for x86 and aarch64 musl targets.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
