### PR TITLE
Update devctr image and small build_devctr fix

### DIFF
--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -66,7 +66,7 @@ registry. The Firecracker CI suite must also be updated to use the new image.
     ```bash
     docker images
     REPOSITORY                         TAG       IMAGE ID         CREATED       SIZE
-    fcuvm                              latest    1f9852368efb     2 weeks ago   2.36GB
+    public.ecr.aws/firecracker/fcuvm   latest    1f9852368efb     2 weeks ago   2.36GB
     public.ecr.aws/firecracker/fcuvm   v26       8d00deb17f7a     2 weeks ago   2.41GB
     ```
 
@@ -78,7 +78,7 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 
     docker images
     REPOSITORY                         TAG          IMAGE ID       CREATED
-    fcuvm                              latest       1f9852368efb   1 week ago
+    public.ecr.aws/firecracker/fcuvm   latest       1f9852368efb   1 week ago
     public.ecr.aws/firecracker/fcuvm   v27_x86_64   1f9852368efb   1 week ago
     public.ecr.aws/firecracker/fcuvm   v26          8d00deb17f7a   2 weeks ago
     ```
@@ -108,7 +108,7 @@ Then continue with the above steps:
     ```bash
     docker images
     REPOSITORY                         TAG        IMAGE ID            CREATED
-    fcuvm                              latest     1f9852368efb        2 minutes ago
+    public.ecr.aws/firecracker/fcuvm   latest     1f9852368efb        2 minutes ago
     public.ecr.aws/firecracker/fcuvm   v26        8d00deb17f7a        2 weeks ago
     ```
 
@@ -120,7 +120,7 @@ Then continue with the above steps:
 
     docker images
     REPOSITORY                         TAG            IMAGE ID
-    fcuvm                              latest         1f9852368efb
+    public.ecr.aws/firecracker/fcuvm   latest         1f9852368efb
     public.ecr.aws/firecracker/fcuvm   v27_aarch64    1f9852368efb
     public.ecr.aws/firecracker/fcuvm   v26            8d00deb17f7a
     ```
@@ -136,7 +136,7 @@ Then continue with the above steps:
 
     ```bash
     docker manifest create public.ecr.aws/firecracker/fcuvm:v27 \
-    public.ecr.aws/firecracker/fcuvm:v27_x86_64 public.ecr.aws/firecracker/fcuvm:v27_aarch64
+        public.ecr.aws/firecracker/fcuvm:v27_x86_64 public.ecr.aws/firecracker/fcuvm:v27_aarch64
 
     docker manifest push public.ecr.aws/firecracker/fcuvm:v27
     ```
@@ -146,10 +146,9 @@ Then continue with the above steps:
    Commit and push the change.
 
     ```bash
-    PREV_IMAGE=public.ecr.aws/firecracker/fcuvm:v26
-    CURR_IMAGE=public.ecr.aws/firecracker/fcuvm:v27
-    sed -i "s%DEVCTR_IMAGE=\"$PREV_IMAGE\"%DEVCTR_IMAGE=\"$CURR_IMAGE\"%" \
-    tools/devtool
+    PREV_TAG=v26
+    CURR_TAG=v27
+    sed -i "s%DEVCTR_IMAGE_TAG=\"$PREV_TAG\"%DEVCTR_IMAGE_TAG=\"$CURR_TAG\"%" tools/devtool
     ```
 
 ## Troubleshooting

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -54,6 +54,7 @@ RUN apt-get update \
         tzdata \
     && python3 -m pip install \
         setuptools \
+        setuptools_rust \
         wheel \
     && python3 -m pip install --upgrade pip \ 
     && rm -rf /var/lib/apt/lists/*

--- a/tools/devctr/poetry.lock
+++ b/tools/devctr/poetry.lock
@@ -55,29 +55,29 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "boto3"
-version = "1.16.62"
+version = "1.17.4"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = ">=1.19.62,<1.20.0"
+botocore = ">=1.20.4,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
 [[package]]
 name = "botocore"
-version = "1.19.62"
+version = "1.20.4"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = {version = ">=1.25.4,<1.27", markers = "python_version != \"3.4\""}
+urllib3 = ">=1.25.4,<1.27"
 
 [[package]]
 name = "certifi"
@@ -232,7 +232,7 @@ pathlib = "*"
 
 [[package]]
 name = "packaging"
-version = "20.8"
+version = "20.9"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
@@ -537,12 +537,12 @@ attrs = [
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 boto3 = [
-    {file = "boto3-1.16.62-py2.py3-none-any.whl", hash = "sha256:a280123db79e73478bd23933486f3a0ffa2397d1a6381f32573f2731ff48c59a"},
-    {file = "boto3-1.16.62.tar.gz", hash = "sha256:bb91fecf982e1bbfb68bb6bd2c9a0cce3c84ac6f97dd338d1ef9e47780679091"},
+    {file = "boto3-1.17.4-py2.py3-none-any.whl", hash = "sha256:af87efaa772f95de67f72ed91aed2feef63593b5290696f669799202bc484b99"},
+    {file = "boto3-1.17.4.tar.gz", hash = "sha256:65514427f5f849245c9a272fa06a5a014ae3945333f4f407489d034fb99dc61f"},
 ]
 botocore = [
-    {file = "botocore-1.19.62-py2.py3-none-any.whl", hash = "sha256:1046c152e5865aabbe6b10b2d33e652b3dd072516f3976e96cacc6b7c4460d02"},
-    {file = "botocore-1.19.62.tar.gz", hash = "sha256:29b4b9be5b40f392a033926c08c004c01bd6471384ef6f12eaa49ee3870a010c"},
+    {file = "botocore-1.20.4-py2.py3-none-any.whl", hash = "sha256:96f9e0920ac91b6caae3039e5de09b80648ad57b4a97fc7d81a369afae34fb10"},
+    {file = "botocore-1.20.4.tar.gz", hash = "sha256:61657a1e4b3cdda9627084184bdf9dca4637c1523daead31a36974be0d51686d"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -628,8 +628,8 @@ nsenter = [
     {file = "nsenter-0.2.tar.gz", hash = "sha256:876a18cb03de85948e4cd72fd4cfda4879561b7264f5722603f6437d452a25cb"},
 ]
 packaging = [
-    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
-    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pathlib = [
     {file = "pathlib-1.0.1.tar.gz", hash = "sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f"},

--- a/tools/devtool
+++ b/tools/devtool
@@ -68,10 +68,16 @@
 #   - Look into caching the Cargo registry within the container and if that
 #     would help with reproducible builds (in addition to pinning Cargo.lock)
 
+# Development container image (without tag)
+DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
+
+# Development container tag
+DEVCTR_IMAGE_TAG="v28"
+
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v28"
+DEVCTR_IMAGE="${DEVCTR_IMAGE_NO_TAG}:${DEVCTR_IMAGE_TAG}"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"
@@ -320,7 +326,7 @@ cmd_build_devctr() {
         shift
     done
 
-    docker build -t "$DEVCTR_IMAGE" -f "$FC_DEVCTR_DIR/$docker_file_name" .
+    docker build -t "$DEVCTR_IMAGE_NO_TAG" -f "$FC_DEVCTR_DIR/$docker_file_name" .
 
     if [ "$should_update_python_packages" = true ]; then
         update_python_package_version
@@ -460,7 +466,7 @@ update_python_package_version() {
     # defined in Dockerfile
     poetry_dir_on_container="/tmp/poetry"
     lock_file_location_on_host="$FC_DEVCTR_DIR/poetry.lock"
-    image_id=$(docker images -q "$DEVCTR_IMAGE" | head -n 1)
+    image_id=$(docker images -q "$DEVCTR_IMAGE_NO_TAG" | head -n 1)
     dummy_container_name=$(uuidgen)
     dummy_container_id=$(docker create -ti --name \
         "$dummy_container_name" \
@@ -473,7 +479,7 @@ update_python_package_version() {
     docker cp \
         "$dummy_container_id":/tmp/poetry/poetry.lock \
         "$lock_file_location_on_host"
-    docker commit "$dummy_container_id" "$DEVCTR_IMAGE"
+    docker commit "$dummy_container_id" "$DEVCTR_IMAGE_NO_TAG"
 
     docker stop "$dummy_container_id"
     docker rm -f "$dummy_container_name"

--- a/tools/devtool
+++ b/tools/devtool
@@ -71,7 +71,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v27"
+DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v28"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
# Reason for This PR

The `build_devctr` command was returning an error on aarch64, due to the lack of the `setuptools_rust` package.
The `build_devctr` command was also overriding the latest `v*` tag instead of creating a new one called `latest`

## Description of Changes

Update aarch64 Dockerfile.
Update python dependencies versions.
Switch devtool versions.
Modify `devtool build_devctr` command to create a new tag called `latest`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
