### PR TITLE
Fix non-compliant checks inside the RTC PL031 device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - Changed Docker images repository from DockerHub to Amazon ECR.
 - Fixed off-by-one error in virtio-block descriptor address validation.
 
+### Fixed
+
+- Fixed non-compliant check for the RTC device ensuring a fixed
+  4-sized data buffer.
+- Unnecessary interrupt assertion was removed from the RTC.
+  However, a dummy interrupt is still allocated for snapshot
+  compatibility reasons.
+
 ## [0.24.0]
 
 ### Added

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -599,8 +599,7 @@ pub fn setup_serial_device(
 #[cfg(target_arch = "aarch64")]
 /// Sets up the RTC device.
 pub fn setup_rtc_device() -> super::Result<Arc<Mutex<devices::legacy::RTC>>> {
-    let rtc_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-    let rtc = Arc::new(Mutex::new(devices::legacy::RTC::new(rtc_evt)));
+    let rtc = Arc::new(Mutex::new(devices::legacy::RTC::default()));
     Ok(rtc)
 }
 
@@ -641,7 +640,7 @@ fn attach_legacy_devices_aarch64(
 
     let rtc = setup_rtc_device()?;
     vmm.mmio_device_manager
-        .register_mmio_rtc(vmm.vm.fd(), rtc, None)
+        .register_mmio_rtc(rtc, None)
         .map_err(Error::RegisterMMIODevice)
 }
 

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -285,18 +285,13 @@ impl MMIODeviceManager {
     /// otherwise allocate a new MMIO slot for it.
     pub fn register_mmio_rtc(
         &mut self,
-        vm: &VmFd,
         rtc: Arc<Mutex<devices::legacy::RTC>>,
         dev_info_opt: Option<MMIODeviceInfo>,
     ) -> Result<()> {
         // Create and attach a new RTC device.
+        // We allocate an IRQ even though we do not need it so that
+        // we do not break snapshot compatibility.
         let slot = dev_info_opt.unwrap_or(self.allocate_new_slot(1)?);
-
-        vm.register_irqfd(
-            &rtc.lock().expect("Poisoned lock").interrupt_evt(),
-            slot.irqs[0],
-        )
-        .map_err(Error::RegisterIrqFd)?;
 
         let identifier = (DeviceType::RTC, DeviceType::RTC.to_string());
         self.register_mmio_device(identifier, slot, rtc)

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -276,7 +276,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 if state.type_ == DeviceType::RTC {
                     let rtc = crate::builder::setup_rtc_device().map_err(Error::Legacy)?;
                     dev_manager
-                        .register_mmio_rtc(vm, rtc, Some(state.mmio_slot.clone()))
+                        .register_mmio_rtc(rtc, Some(state.mmio_slot.clone()))
                         .map_err(Error::DeviceManager)?;
                 }
             }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.50, "AMD": 84.78, "ARM": 83.75}
+COVERAGE_DICT = {"Intel": 85.50, "AMD": 84.78, "ARM": 83.80}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

This PR solves 2 problems:
* The RTC Pl031 implementation uses an u32 counter and our implementation would not check for a fixed 4-sized buffer.
* Removes unnecessary interrupt assertion

## Description of Changes

- unify appearance for read/write function
- cover corner cases in unit tests
- check for a fixed 4-sized buffer like the RTC PL031 specification asks for

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
