### PR TITLE
feature/file_based_seccomp: add byte_limit to deserialization and other small improvements

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -24,7 +24,7 @@ pub use micro_http::{
 };
 use mmds::data_store;
 use mmds::data_store::Mmds;
-use seccomp::{BpfProgram, SeccompFilter};
+use seccomp::{BpfProgramRef, SeccompFilter};
 use utils::eventfd::EventFd;
 use vmm::rpc_interface::{VmmAction, VmmActionError, VmmData};
 use vmm::vmm_config::instance_info::InstanceInfo;
@@ -119,7 +119,7 @@ impl ApiServer {
     /// ```
     /// use api_server::ApiServer;
     /// use mmds::MMDS;
-    /// use seccomp::SeccompFilter;
+    /// use seccomp::{BpfProgram, SeccompFilter};
     /// use std::{
     ///     convert::TryInto, io::Read, io::Write, os::unix::net::UnixStream, path::PathBuf,
     ///     sync::mpsc::channel, thread, time::Duration,
@@ -143,6 +143,7 @@ impl ApiServer {
     /// let (api_request_sender, _from_api) = channel();
     /// let (to_api, vmm_response_receiver) = channel();
     /// let mmds_info = MMDS.clone();
+    /// let filter: BpfProgram = SeccompFilter::empty(ARCH).unwrap().try_into().unwrap();
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -158,7 +159,7 @@ impl ApiServer {
     ///             PathBuf::from(api_thread_path_to_socket),
     ///             Some(1),
     ///             Some(1),
-    ///             SeccompFilter::empty(ARCH).unwrap().try_into().unwrap(),
+    ///             &filter,
     ///         )
     ///         .unwrap();
     ///     })
@@ -176,7 +177,7 @@ impl ApiServer {
         path: PathBuf,
         start_time_us: Option<u64>,
         start_time_cpu_us: Option<u64>,
-        seccomp_filter: BpfProgram,
+        seccomp_filter: BpfProgramRef,
     ) -> Result<()> {
         let mut server = HttpServer::new(path).unwrap_or_else(|e| {
             error!("Error creating the HTTP server: {}", e);
@@ -419,6 +420,7 @@ mod tests {
     use super::*;
     use micro_http::HttpConnection;
     use mmds::MMDS;
+    use seccomp::BpfProgram;
     use utils::tempfile::TempFile;
     use utils::time::ClockType;
     use vmm::builder::StartMicrovmError;
@@ -751,6 +753,7 @@ mod tests {
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
         let mmds_info = MMDS.clone();
+        let seccomp_filter: BpfProgram = SeccompFilter::empty(ARCH).unwrap().try_into().unwrap();
 
         thread::Builder::new()
             .name("fc_api_test".to_owned())
@@ -766,7 +769,7 @@ mod tests {
                     PathBuf::from(api_thread_path_to_socket),
                     Some(1),
                     Some(1),
-                    SeccompFilter::empty(ARCH).unwrap().try_into().unwrap(),
+                    &seccomp_filter,
                 )
                 .unwrap();
             })

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -142,7 +142,6 @@ pub(crate) fn run_with_api(
     let to_vmm_event_fd = api_event_fd
         .try_clone()
         .expect("Failed to clone API event FD");
-
     let api_seccomp_filter = seccomp_filters
         .remove("api")
         .expect("Missing seccomp filter for API thread.");
@@ -161,7 +160,7 @@ pub(crate) fn run_with_api(
                 bind_path,
                 start_time_us,
                 start_time_cpu_us,
-                api_seccomp_filter,
+                &api_seccomp_filter,
             ) {
                 Ok(_) => (),
                 Err(api_server::Error::Io(inner)) => match inner.kind() {

--- a/src/seccomp/src/seccompiler.rs
+++ b/src/seccomp/src/seccompiler.rs
@@ -739,7 +739,7 @@ mod tests {
 
             // deserialize and compare
             assert_eq!(
-                deserialize_binary(&mut out_file.into_file()).unwrap(),
+                deserialize_binary(&mut out_file.into_file(), None).unwrap(),
                 bpf_data
             );
         }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -373,7 +373,7 @@ pub fn build_microvm_for_boot(
     // altogether is the desired behaviour.
     // Keep this as the last step before resuming vcpus.
     SeccompFilter::apply(
-        seccomp_filters
+        &seccomp_filters
             .remove("vmm")
             .ok_or_else(|| MissingSeccompFilters("vmm".to_string()))?,
     )
@@ -464,7 +464,7 @@ pub fn build_microvm_from_snapshot(
     // Load seccomp filters for the VMM thread.
     // Keep this as the last step of the building process.
     SeccompFilter::apply(
-        seccomp_filters
+        &seccomp_filters
             .remove("vmm")
             .ok_or_else(|| MissingSeccompFilters("vmm".to_string()))?,
     )

--- a/src/vmm/src/seccomp_filters/mod.rs
+++ b/src/vmm/src/seccomp_filters/mod.rs
@@ -6,6 +6,12 @@ use std::fs::File;
 
 const THREAD_CATEGORIES: [&str; 3] = ["vmm", "api", "vcpu"];
 
+// This byte limit is passed to `bincode` to guard against a potential memory
+// allocation DOS caused by binary filters that are too large.
+// This limit can be safely determined since the maximum length of a BPF
+// filter is 4096 instructions and Firecracker has a finite number of threads.
+const DESERIALIZATION_BYTES_LIMIT: Option<u64> = Some(100_000);
+
 /// Error retrieving seccomp filters.
 #[derive(fmt::Debug)]
 pub enum FilterError {
@@ -70,7 +76,8 @@ fn filter_thread_categories(map: BpfThreadMap) -> Result<BpfThreadMap, FilterErr
 pub fn get_default_filters() -> Result<BpfThreadMap, FilterError> {
     // Retrieve, at compile-time, the serialized binary filter generated with seccompiler.
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/seccomp_filter.bpf"));
-    let map = deserialize_binary(&mut &bytes[..]).map_err(FilterError::Deserialization)?;
+    let map = deserialize_binary(&mut &bytes[..], DESERIALIZATION_BYTES_LIMIT)
+        .map_err(FilterError::Deserialization)?;
     filter_thread_categories(map)
 }
 
@@ -85,7 +92,8 @@ pub fn get_empty_filters() -> BpfThreadMap {
 
 /// Retrieve custom seccomp filters.
 pub fn get_custom_filters(mut file: File) -> Result<BpfThreadMap, FilterError> {
-    let map = deserialize_binary(&mut file).map_err(FilterError::Deserialization)?;
+    let map = deserialize_binary(&mut file, DESERIALIZATION_BYTES_LIMIT)
+        .map_err(FilterError::Deserialization)?;
     filter_thread_categories(map)
 }
 

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -325,7 +325,7 @@ mod tests {
                 },
             ];
 
-            assert!(SeccompFilter::apply(bpf_filter).is_ok());
+            assert!(SeccompFilter::apply(&bpf_filter).is_ok());
             assert_eq!(METRICS.seccomp.num_faults.count(), 0);
             // Call the forbidden `SYS_mkdirat`.
             unsafe { syscall(libc::SYS_mkdirat, "/foo/bar\0") };

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
@@ -13,7 +13,7 @@ fn main() {
     let bpf_path = &args[2];
 
     let mut filter_file = File::open(bpf_path).unwrap();
-    let mut map = deserialize_binary(&mut filter_file).unwrap();
+    let mut map = deserialize_binary(&mut filter_file, None).unwrap();
 
     // Loads filters.
     SeccompFilter::apply(map.get("main").unwrap()).unwrap();

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
@@ -16,7 +16,7 @@ fn main() {
     let mut map = deserialize_binary(&mut filter_file).unwrap();
 
     // Loads filters.
-    SeccompFilter::apply(map.remove("main").unwrap()).unwrap();
+    SeccompFilter::apply(map.get("main").unwrap()).unwrap();
 
     Command::new(exec_file)
         .stdin(Stdio::inherit())


### PR DESCRIPTION
# Reason for This PR

 1. The BPF deserialization helper was not passing any byte limit for allocation to `bincode`, the deserialization backend. This could potentially mean an uncontrolled amount of memory allocation for a filter deserialization. This can be constrained in Firecracker because we know the max filter length and the thread categories.

 1. After some investigation, it turns out that the `prctl` syscall, that receives a the filter pointer, actually does a `copy_from_user` and leaves that memory region untouched. This is an opportunity to reuse the same filter reference for all VCPU threads, avoiding additional clones.

1. One other small fix that makes the `FilterTooLarge` error a little more understandable

## Description of Changes

View commit messages.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
