### PR TITLE
ARM Snapshot Vendor Check

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.50, "AMD": 84.78, "ARM": 83.80}
+COVERAGE_DICT = {"Intel": 85.50, "AMD": 84.78, "ARM": 83.69}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -24,21 +24,21 @@ BASELINES = {
         "serialize": {
             "no-crc": {
                 "target": 0.146,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             },
             "crc": {
                 "target": 0.213,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             }
         },
         "deserialize": {
             "no-crc": {
                 "target": 0.034,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             },
             "crc": {
                 "target": 0.042,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             }
         }
     },
@@ -46,21 +46,21 @@ BASELINES = {
         "serialize": {
             "no-crc": {
                 "target": 0.096,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             },
             "crc": {
                 "target": 0.122,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             }
         },
         "deserialize": {
             "no-crc": {
                 "target": 0.034,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             },
             "crc": {
                 "target": 0.042,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             }
         }
     },
@@ -68,21 +68,21 @@ BASELINES = {
         "serialize": {
             "no-crc": {
                 "target": 0.096,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             },
             "crc": {
                 "target": 0.186,  # milliseconds
-                "delta": 0.020  # milliseconds
+                "delta": 0.025  # milliseconds
             }
         },
         "deserialize": {
             "no-crc": {
                 "target": 0.034,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             },
             "crc": {
                 "target": 0.042,  # milliseconds
-                "delta": 0.010  # milliseconds
+                "delta": 0.015  # milliseconds
             }
         }
     }


### PR DESCRIPTION
# Reason for This PR

Completes implementation for #2023.

## Description of Changes

On ARM, the Vendor ID is called Manufacturer ID and it is found inside the MIDR_EL1 system register [31:24].

For the Snapshot part, the MIDR_EL1  is located inside the **regs** field of each VCPUstate.
For the Host part, the MIDR_EL1 is located at the path _/sys/devices/system/cpu/cpu0/regs/identification/midr_el1_.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
