### PR TITLE
Make stdout non-blocking

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -199,8 +199,16 @@ impl Serial {
                     }
                 } else {
                     if let Some(out) = self.out.as_mut() {
-                        out.write_all(&[value])?;
-                        METRICS.uart.write_count.inc();
+                        let res = out.write(&[value]);
+                        match res {
+                            Ok(_) => {
+                                METRICS.uart.write_count.inc();
+                            }
+                            Err(e) => {
+                                METRICS.uart.missed_write_count.inc();
+                                return Err(e);
+                            }
+                        }
                         out.flush()?;
                         METRICS.uart.flush_count.inc();
                     }

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -118,6 +118,7 @@ class Microvm:
         # Initialize the logging subsystem.
         self.logging_thread = None
         self._log_data = ""
+        self._screen_pid = None
 
         # The ssh config dictionary is populated with information about how
         # to connect to a microVM that has ssh capability. The path of the
@@ -365,6 +366,11 @@ class Microvm:
         return self._screen_log
 
     @property
+    def screen_pid(self):
+        """Get the screen PID."""
+        return self._screen_pid
+
+    @property
     def vcpus_count(self):
         """Get the vcpus count."""
         return self._vcpus_count
@@ -481,6 +487,8 @@ class Microvm:
                 exceptions=RuntimeError,
                 tries=30,
                 delay=1).group(1)
+
+            self._screen_pid = screen_pid
 
             self.jailer_clone_pid = int(open('/proc/{0}/task/{0}/children'
                                              .format(screen_pid)

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.38, "AMD": 84.65, "ARM": 83.53}
+COVERAGE_DICT = {"Intel": 85.38, "AMD": 84.65, "ARM": 83.46}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Firecracker stdout could block when trying to write from the serial if the buffer was full, blocking the vCPU trying to write to it.

## Description of Changes

Stdout is now non-blocking, also added an integration test for this behavior.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
