### PR TITLE
Gracefully handle SIGPIPE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   git repositories.
 - Added option to configure block device flush.
 
+### Fixed
+
+- Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal
+  is still recorded in metrics and logs.
+
 ### Changed
 
 - Changed Docker images repository from DockerHub to Amazon ECR.

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -17,12 +17,15 @@ In order to test the vsock device connection state machine, these tests will:
 import os.path
 
 from framework.utils_vsock import make_blob, \
-    check_host_connections, check_guest_connections
+    check_host_connections, check_guest_connections, \
+    HostEchoWorker
 from host_tools.network import SSHConnection
+import host_tools.logging as log_tools
 
 VSOCK_UDS_PATH = "v.sock"
 ECHO_SERVER_PORT = 5252
 BLOB_SIZE = 20 * 1024 * 1024
+NEGATIVE_TEST_CONNECTION_COUNT = 100
 
 
 def test_vsock(
@@ -79,3 +82,100 @@ def test_vsock(
 def _make_host_port_path(uds_path, port):
     """Build the path for a Unix socket, mapped to host vsock port `port`."""
     return "{}_{}".format(uds_path, port)
+
+
+def negative_test_host_connections(vm, uds_path, blob_path, blob_hash):
+    """Negative test for host-initiated connections.
+
+    This will start a daemonized echo server on the guest VM, and then spawn
+    `NEGATIVE_TEST_CONNECTION_COUNT` `HostEchoWorker` threads.
+    Closes the UDS sockets while data is in flight.
+    """
+    conn = SSHConnection(vm.ssh_config)
+    cmd = "vsock_helper echosrv -d {}". format(ECHO_SERVER_PORT)
+    ecode, _, _ = conn.execute_command(cmd)
+    assert ecode == 0
+
+    workers = []
+    for _ in range(NEGATIVE_TEST_CONNECTION_COUNT):
+        worker = HostEchoWorker(uds_path, blob_path)
+        workers.append(worker)
+        worker.start()
+
+    for wrk in workers:
+        wrk.close_uds()
+        wrk.join()
+
+    # Validate that Firecracker is still up and running.
+    ecode, _, _ = conn.execute_command("sync")
+    # Should fail if Firecracker exited from SIGPIPE handler.
+    assert ecode == 0
+
+    # Validate vsock emulation still accepts connections and works
+    # as expected.
+    check_host_connections(vm, uds_path, blob_path, blob_hash)
+
+
+def test_vsock_epipe(
+        test_microvm_with_ssh,
+        network_config,
+        bin_vsock_path,
+        test_fc_session_root_path
+):
+    """Vsock negative test to validate SIGPIPE/EPIPE handling."""
+    vm = test_microvm_with_ssh
+    vm.spawn()
+
+    vm.basic_config()
+    _tap, _, _ = vm.ssh_network_config(network_config, '1')
+    vm.vsock.put(
+        vsock_id="vsock0",
+        guest_cid=3,
+        uds_path="/{}".format(VSOCK_UDS_PATH)
+    )
+
+    # Configure metrics to assert against `sigpipe` count.
+    metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
+    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+    response = vm.metrics.put(
+        metrics_path=vm.create_jailed_resource(metrics_fifo.path)
+    )
+    assert vm.api_session.is_status_no_content(response.status_code)
+
+    vm.start()
+
+    # Generate the random data blob file.
+    blob_path, blob_hash = make_blob(test_fc_session_root_path)
+    vm_blob_path = "/tmp/vsock/test.blob"
+
+    # Set up a tmpfs drive on the guest, so we can copy the blob there.
+    # Guest-initiated connections (echo workers) will use this blob.
+    conn = SSHConnection(vm.ssh_config)
+    cmd = "mkdir -p /tmp/vsock"
+    cmd += " && mount -t tmpfs tmpfs -o size={} /tmp/vsock".format(
+        BLOB_SIZE + 1024*1024
+    )
+    ecode, _, _ = conn.execute_command(cmd)
+    assert ecode == 0
+
+    # Copy `vsock_helper` and the random blob to the guest.
+    vsock_helper = bin_vsock_path
+    conn.scp_file(vsock_helper, '/bin/vsock_helper')
+    conn.scp_file(blob_path, vm_blob_path)
+
+    path = os.path.join(vm.jailer.chroot_path(), VSOCK_UDS_PATH)
+    # Negative test for host-initiated connections that
+    # are closed with in flight data.
+    negative_test_host_connections(vm, path, blob_path, blob_hash)
+
+    metrics = vm.flush_metrics(metrics_fifo)
+    # Validate that at least 1 `SIGPIPE` signal was received.
+    # Since we are reusing the existing echo server which triggers
+    # reads/writes on the UDS backend connections, these might be closed
+    # before a read() or a write() is about to be performed by the emulation.
+    # The test uses 100 connections it is enough to close at least one
+    # before write().
+    #
+    # If this ever fails due to 100 closes before read() we must
+    # add extra tooling that will trigger only writes().
+    assert metrics['signals']['sigpipe'] > 0


### PR DESCRIPTION
# Reason for This PR
Fixes #2464.

Don't exit VMM on SIGPIPE delivery. Recently we discovered that this can happen if the vsock emulation attempts to write() some guest app bytes to the UDS connection after it was closed by the host application. Metrics and errors are still being logged and the corresponding EPIPE error is handled at the vsock emulation layer.

Adds negative and regression test for vsock UDS connection close while there is inflight data from guest app to host app. 

## Description of Changes

Provided in commit messages.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
