### PR TITLE
[feature/file_based_seccomp] documentation, performance startup test and small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The **API endpoint** can be used to:
 **Built-in Capabilities**:
 
 - Demand fault paging and CPU oversubscription enabled by default.
-- Advanced seccomp filters for enhanced security.
+- Advanced, thread-specific seccomp filters for enhanced security.
 - [Jailer](docs/jailer.md) process for starting Firecracker in production
   scenarios; applies a cgroup/namespace isolation barrier and then
   drops privileges.

--- a/docs/design.md
+++ b/docs/design.md
@@ -149,13 +149,14 @@ service is fully configured by users.
 
 ##### Seccomp
 
-Seccomp filters are used by default to further limit the system calls Firecracker
-can use. There are 3 possible levels of seccomp filtering, configurable by passing
-a command line argument to Firecracker: 0 (disabled), 1 (whitelists a set of
-trusted system calls by their identifiers) and 2 (whitelists a set of trusted
-system calls with trusted parameter values), the latter being the most
-restrictive and the recommended one. The filters are loaded in the Firecracker
-process, immediately before the execution of the untrusted guest code starts.
+Seccomp filters are used by default to limit the host system calls Firecracker
+can use. The default filters only allow the bare minimum set of system calls and
+parameters that Firecracker needs in order to function correctly.
+
+The filters are loaded in the Firecracker process, on a per-thread basis,
+before executing any guest code.
+
+For more information, check out the [seccomp documentation](seccomp.md).
 
 #### __Jailer process__
 

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -50,14 +50,7 @@ jailer --id <id> \
   example, this can be paired with the `--config-file` Firecracker argument to
   specify a configuration file when starting Firecracker via the jailer (the
   file path and the resources referenced within must be valid relative to a
-  jailed Firecracker). Another argument that can be passed in this way is
-  `--seccomp-level`, which specifies whether seccomp filters should be installed
-  and how restrictive they should be. Possible values are:
-  - 0 : disabled.
-  - 1 : basic filtering. This prohibits syscalls not whitelisted by
-    Firecracker.
-  - 2 (default): advanced filtering. This adds further checks on some of the
-    parameters of the allowed syscalls.
+  jailed Firecracker).
   Please note the jailer already passes `--id` parameter to the
   Firecracker process.
 

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -9,10 +9,11 @@ Firecracker uses
 filters to limit the system calls allowed by the host OS to the required
 minimum.
 
-By default, Firecracker uses advanced filtering, which is the most restrictive
-option, and the recommended setting for production workloads.
-This can also be explicitly requested by supplying `--seccomp-level=2` to the
-Firecracker executable.
+By default, Firecracker uses the most restrictive filters, which is the
+recommended option for production usage.
+
+Production usage of the `--seccomp-filter` or `--no-seccomp` parameters is not
+recommended.
 
 ### 8250 Serial Device
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -1,0 +1,67 @@
+# Seccomp in Firecracker
+
+Seccomp filters are used by default to limit the host system calls Firecracker
+can use. The default filters only allow the bare minimum set of system calls
+and parameters that Firecracker needs in order to function correctly.
+
+The filters are loaded in the Firecracker process, on a per-thread basis,
+as follows:
+
+- VMM (main) - right before executing guest code on the VCPU threads;
+- API - right before launching the HTTP server;
+- VCPUs - right before executing guest code.
+
+**Note**: On experimental GNU targets, there are no default seccomp filters
+installed, since they are not intended for production use.
+
+Firecracker uses JSON files for expressing the filter rules and relies on the
+[seccompiler](seccompiler.md) tool for all the seccomp functionality.
+
+## Default filters (recommended)
+
+At build time, the default target-specific JSON file is compiled into the
+serialized binary file, using seccompiler, and gets embedded in the Firecracker
+binary.
+
+This process is performed automatically, when building the executable.
+
+To minimise the overhead of succesive builds, the compiled filter file is
+cached in the build folder and is only recompiled if modified.
+
+You can find the default seccomp filters under `resources/seccomp`.
+
+## Custom filters (advanced users only)
+
+**Note**: This feature overrides the default filters and can be dangerous.
+Filter misconfiguration can result in abruptly terminating the process or
+disabling the seccomp security boundary altogether.
+We recommend using the default filters instead.
+
+Firecracker exposes a way for advanced users to override the default filters
+with fully customisable alternatives, leveraging the same JSON/seccompiler
+tooling, at startup time.
+
+Via Firecracker's optional `--seccomp-filter` parameter, one can supply
+the path to a custom filter file compiled with seccompiler.
+
+Potential use cases:
+
+- Users of experimentally-supported targets (like GNU libc builds) may be able
+    to use this feature to implement seccomp filters without needing to have a
+    custom build of Firecracker.
+- Faced with a _theoretical_ production issue, due to a syscall that was
+    issued by the Firecracker process, but not allowed by the seccomp policy,
+    one may use a custom filter in order to quickly mitigate the issue. This
+    can speed up the resolution time, by not needing to build and deploy a new
+    Firecracker binary.
+    However, as the note above states, this needs to be thoroughly tested and
+    should not be a long-term solution.
+
+## Disabling seccomp (not recommended)
+
+Firecracker also has support for a `--no-seccomp` parameter, which disables all
+seccomp filtering.
+It can be helpful when quickly prototyping changes in Firecracker that use new
+system calls.
+
+Do **not** use in production.

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -30,6 +30,10 @@ cached in the build folder and is only recompiled if modified.
 
 You can find the default seccomp filters under `resources/seccomp`.
 
+For a certain release, the default JSON filters used to build Firecracker are also
+included in the respective release archive, viewable on the
+[releases page](https://github.com/firecracker-microvm/firecracker/releases).
+
 ## Custom filters (advanced users only)
 
 **Note**: This feature overrides the default filters and can be dangerous.

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -46,6 +46,12 @@ workspace. The code is located at `firecracker/src/seccomp/src`.
 Seccompiler is supported on the
 [same platforms as Firecracker](../README.md#supported-platforms).
 
+## Release policy
+
+Seccompiler follows Firecracker's [release policy](RELEASE_POLICY.md) and
+version (it's released at the same time, with the same version number and
+adheres to the same support window).
+
 ## JSON file format
 
 A JSON file expresses the seccomp policy for the entire Firecracker process. It

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -1,0 +1,159 @@
+# Seccompiler - overview and user guide
+
+## Overview
+
+Seccompiler is a tool that compiles seccomp filters expressed as JSON files
+into serialized, binary BPF code that is directly consumed by Firecracker,
+at build or launch time.
+
+Seccompiler defines a custom [JSON file structure](#json-file-format), detailed
+further below, that the filters must adhere to.
+
+Besides the compiler binary, seccompiler also exports a small library
+interface, with a couple of helper functions, for deserializing and installing
+the binary filters.
+
+## Usage
+
+### Seccompiler binary
+
+To view the seccompiler command line arguments, pass the `--help` parameter to
+the executable.
+
+Example usage:
+
+```bash
+./seccompiler
+    --target-arch "x86_64"  # The CPU arch where the BPF program will run.
+                            # Supported architectures: x86_64, aarch64.
+    --input-file "x86_64_musl.json" # File path of the JSON input.
+    --output-file "bpf_x86_64_musl" # Optional path of the output file.
+                                    # [default: "seccomp_binary_filter.out"]
+```
+
+### Seccompiler library
+
+To view the library documentation, navigate to the seccompiler source code, in
+`firecracker/src/seccomp/src` and run `cargo doc --lib --open`.
+
+## Where is seccompiler implemented?
+
+Seccompiler is implemented as another package in the Firecracker cargo
+workspace. The code is located at `firecracker/src/seccomp/src`.
+
+## Supported platforms
+
+Seccompiler is supported on the
+[same platforms as Firecracker](../README.md#supported-platforms).
+
+## JSON file format
+
+A JSON file expresses the seccomp policy for the entire Firecracker process. It
+contains multiple filters, one per each thread category and is specific to just
+one target platform.
+
+This means that Firecracker has a JSON file for each supported target
+(currently determined by the arch-libc combinations). You can view them in
+`resources/seccomp`.
+
+At the top level, the file requires an object that maps thread categories
+(vmm, api and vcpu) to seccomp filters:
+
+```json
+{
+    "vmm": {
+       "default_action": {
+            "errno" : -1
+       },
+       "filter_action": "allow",
+       "filter": [...]
+    },
+    "api": {...},
+    "vcpu": {...},
+}
+```
+
+The associated filter is a JSON object containing the `default_action`,
+`filter_action` and `filter`.
+
+The `default_action` represents the action we have to execute if none of the
+rules in `filter` matches, and `filter_action` is what gets executed if a rule
+in the filter matches
+(e.g: `"Allow"` in the case of implementing an allowlist).
+
+An **action** is the JSON representation of the following enum:
+
+```rust
+pub enum SeccompAction {
+    Allow, // Allows syscall.
+    Errno(u32), // Returns from syscall with specified error number.
+    Kill, // Kills calling process.
+    Log, // Same as allow but logs call.
+    Trace(u32), // Notifies tracing process of the caller with respective number.
+    Trap, // Sends `SIGSYS` to the calling process.
+}
+```
+
+The `filter` property specifies the set of rules that would trigger a match.
+This is an array containing multiple **or-bound SyscallRule** **objects**
+(if one of them matches, the corresponding action gets triggered).
+
+The **SyscallRule** object is used for adding a rule to a syscall.
+It has an optional `args` property that is used to specify a vector of
+and-bound conditions that the syscall arguments must satisfy in order for the
+rule to match.
+
+In the absence of the `args` property, the corresponding action will get
+triggered by any call that matches that name, irrespective of the argument
+values.
+
+Here is the structure of the object:
+
+```json
+{
+    "syscall": "accept4", // mandatory, the syscall name
+    "action": "allow", // optional, overrides the filter_action if present
+    "comment": "Used by vsock & api thread", // optional, for adding meaningful comments
+    "args": [...] // optional, vector of and-bound conditions for the parameters
+}
+```
+
+Note that the file format expects syscall names, not arch-specific numbers, for
+increased usability. This is not true, however for the syscall arguments, which
+are expected as base-10 integers.
+
+In order to allow a syscall with multiple alternatives for the same parameters,
+you can write multiple syscall rule objects at the filter-level, each with its
+own rules.
+
+A **condition object** is made up of the following mandatory properties:
+
+- `arg_index` (0-based index of the syscall argument we want to check)
+- `arg_type` (`dword` or `qword`, which specifies the argument size - 4 or 8
+    bytes respectively)
+- `op`, which is one of `eq, ge, gt, ge, lt, masked_eq, ne` (the operator used
+    for comparing the parameter to `val`)
+- `val` is the integer value being checked against
+
+As mentioned eariler, we don’t support any named parameters, but only numeric
+constants in the JSON file. You may however add an optional `comment` property
+to each condition object. This way, you can provide meaning to each numeric
+value, much like when using named parameters, like so:
+
+```json
+{
+    "syscall": "accept4",
+    "args": [
+        {
+            "arg_index": 3,
+            "arg_type": "dword",
+            "op": "eq",
+            "val": 1,
+            "comment": "libc::AF_UNIX"
+        }
+    ]
+}
+```
+
+To see example filters, look over Firecracker's JSON filters in
+`resources/seccomp`.

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -202,7 +202,7 @@ impl ApiServer {
         }
 
         // Load seccomp filters on the API thread.
-        // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
+        // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
         // altogether is the desired behaviour.
         if let Err(e) = seccomp::apply_filter(seccomp_filter) {
             panic!(

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -369,7 +369,7 @@ pub fn build_microvm_for_boot(
     .map_err(Internal)?;
 
     // Load seccomp filters for the VMM thread.
-    // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
+    // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
     // altogether is the desired behaviour.
     // Keep this as the last step before resuming vcpus.
     seccomp::apply_filter(

--- a/src/vmm/src/seccomp_filters/mod.rs
+++ b/src/vmm/src/seccomp_filters/mod.rs
@@ -77,7 +77,7 @@ fn filter_thread_categories(map: BpfThreadMap) -> Result<BpfThreadMap, FilterErr
 pub fn get_default_filters() -> Result<BpfThreadMap, FilterError> {
     // Retrieve, at compile-time, the serialized binary filter generated with seccompiler.
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/seccomp_filter.bpf"));
-    let map = deserialize_binary(&mut &bytes[..], DESERIALIZATION_BYTES_LIMIT)
+    let map = deserialize_binary(&bytes[..], DESERIALIZATION_BYTES_LIMIT)
         .map_err(FilterError::Deserialization)?;
     filter_thread_categories(map)
 }
@@ -93,8 +93,7 @@ pub fn get_empty_filters() -> BpfThreadMap {
 
 /// Retrieve custom seccomp filters.
 pub fn get_custom_filters(file: File) -> Result<BpfThreadMap, FilterError> {
-    let mut reader = BufReader::new(file);
-    let map = deserialize_binary(&mut reader, DESERIALIZATION_BYTES_LIMIT)
+    let map = deserialize_binary(BufReader::new(file), DESERIALIZATION_BYTES_LIMIT)
         .map_err(FilterError::Deserialization)?;
     filter_thread_categories(map)
 }

--- a/src/vmm/src/seccomp_filters/mod.rs
+++ b/src/vmm/src/seccomp_filters/mod.rs
@@ -3,6 +3,7 @@
 use seccomp::{deserialize_binary, BpfThreadMap, DeserializationError, InstallationError};
 use std::fmt;
 use std::fs::File;
+use std::io::BufReader;
 
 const THREAD_CATEGORIES: [&str; 3] = ["vmm", "api", "vcpu"];
 
@@ -91,8 +92,9 @@ pub fn get_empty_filters() -> BpfThreadMap {
 }
 
 /// Retrieve custom seccomp filters.
-pub fn get_custom_filters(mut file: File) -> Result<BpfThreadMap, FilterError> {
-    let map = deserialize_binary(&mut file, DESERIALIZATION_BYTES_LIMIT)
+pub fn get_custom_filters(file: File) -> Result<BpfThreadMap, FilterError> {
+    let mut reader = BufReader::new(file);
+    let map = deserialize_binary(&mut reader, DESERIALIZATION_BYTES_LIMIT)
         .map_err(FilterError::Deserialization)?;
     filter_thread_categories(map)
 }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -264,7 +264,7 @@ impl Vcpu {
     /// anything useful.
     pub fn run(&mut self, seccomp_filter: BpfProgramRef) {
         // Load seccomp filters for this vCPU thread.
-        // Execution panics if filters cannot be loaded, use --seccomp-level=0 if skipping filters
+        // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
         // altogether is the desired behaviour.
         if let Err(e) = seccomp::apply_filter(seccomp_filter) {
             panic!(

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.7, "AMD": 85.04, "ARM": 84.02}
+COVERAGE_DICT = {"Intel": 85.7, "AMD": 85.04, "ARM": 83.8}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -5,7 +5,7 @@
 import json
 import os
 import platform
-import time
+import framework.utils as utils
 
 import host_tools.logging as log_tools
 
@@ -14,13 +14,7 @@ MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2600}
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 
 
-def test_startup_time(test_microvm_with_api):
-    """Check the startup time for jailer and Firecracker up to socket bind."""
-    microvm = test_microvm_with_api
-    microvm.spawn()
-
-    microvm.basic_config(vcpu_count=2, mem_size_mib=1024)
-
+def _startup_time_util(microvm):
     # Configure metrics.
     metrics_fifo_path = os.path.join(microvm.path, 'metrics_fifo')
     metrics_fifo = log_tools.Fifo(metrics_fifo_path)
@@ -31,7 +25,6 @@ def test_startup_time(test_microvm_with_api):
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     microvm.start()
-    time.sleep(0.4)
 
     # The metrics fifo should be at index 1.
     # Since metrics are flushed at InstanceStart, the first line will suffice.
@@ -40,7 +33,57 @@ def test_startup_time(test_microvm_with_api):
     startup_time_us = metrics['api_server']['process_startup_time_us']
     cpu_startup_time_us = metrics['api_server']['process_startup_time_cpu_us']
 
+    return startup_time_us, cpu_startup_time_us
+
+
+def _custom_filter_setup(test_microvm):
+    bpf_path = os.path.join(test_microvm.path, 'bpf.out')
+
+    cargo_target = '{}-unknown-linux-musl'.format(platform.machine())
+    json_path = '../resources/seccomp/{}.json'.format(cargo_target)
+
+    cmd = 'cargo run -p seccomp --target {} -- --input-file {} --target-arch\
+        {} --output-file {}'.format(cargo_target, json_path,
+                                    platform.machine(), bpf_path)
+
+    utils.run_cmd(cmd)
+
+    test_microvm.create_jailed_resource(bpf_path)
+    test_microvm.jailer.extra_args.update({"seccomp-filter": 'bpf.out'})
+
+
+def test_startup_time(test_microvm_with_api):
+    """Check the startup time for jailer and Firecracker up to socket bind."""
+    microvm = test_microvm_with_api
+    microvm.spawn()
+
+    microvm.basic_config(vcpu_count=2, mem_size_mib=1024)
+
+    startup_time_us, cpu_startup_time_us = _startup_time_util(microvm)
+
     print('Process startup time is: {} us ({} CPU us)'
+          .format(startup_time_us, cpu_startup_time_us))
+
+    assert cpu_startup_time_us > 0
+    assert cpu_startup_time_us <= MAX_STARTUP_TIME_CPU_US[platform.machine()]
+
+
+def test_startup_time_custom_seccomp(test_microvm_with_api):
+    """Check the startup time for jailer and Firecracker up to socket bind, ...
+
+    when using custom seccomp filters via the `--seccomp-filter` param.
+    """
+    microvm = test_microvm_with_api
+
+    _custom_filter_setup(microvm)
+
+    microvm.spawn()
+
+    microvm.basic_config(vcpu_count=2, mem_size_mib=1024)
+
+    startup_time_us, cpu_startup_time_us = _startup_time_util(microvm)
+
+    print('Process startup time with custom seccomp is: {} us ({} CPU us)'
           .format(startup_time_us, cpu_startup_time_us))
 
     assert cpu_startup_time_us > 0

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_jailer.rs
@@ -12,8 +12,8 @@ fn main() {
     let exec_file = &args[1];
     let bpf_path = &args[2];
 
-    let mut filter_file = File::open(bpf_path).unwrap();
-    let mut map = deserialize_binary(&mut filter_file, None).unwrap();
+    let filter_file = File::open(bpf_path).unwrap();
+    let map = deserialize_binary(&filter_file, None).unwrap();
 
     // Loads filters.
     apply_filter(map.get("main").unwrap()).unwrap();

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -70,7 +70,6 @@ def test_allow_all(test_microvm_with_api):
         }
     }""".encode('utf-8'))
 
-    test_microvm.jailer.extra_args.update({"seccomp-filter": 'bpf.out'})
     test_microvm.spawn()
 
     test_microvm.basic_config()
@@ -126,7 +125,6 @@ def test_working_filter(test_microvm_with_api):
         }
     }""".encode("utf-8"))
 
-    test_microvm.jailer.extra_args.update({"seccomp-filter": 'bpf.out'})
     test_microvm.spawn()
 
     test_microvm.basic_config()


### PR DESCRIPTION
# Reason for This PR

- The documentation in regards to seccomp was outdated.
- There was also no documentation about seccompiler.
- There was no performance test measuring the impact of using a custom seccomp filter.

## Description of Changes

- Add & update documentation
- Add perf startup time test for custom filters
- Replace the regular file Reader with a BufReader for custom filter support. this speeds up the startup time considerably.
- Other small fixes

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
