### PR TITLE
Docs: Suggestion against warning message

### DIFF
--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -119,9 +119,15 @@ Alpine Linux:
 
    # Then, copy the newly configured system to the rootfs image:
    for d in bin etc lib root sbin usr; do tar c "/$d" | tar x -C /my-rootfs; done
+
+   # The above command may trigger the following message:
+   # tar: Removing leading "/" from member names
+   # However, this is just a warning, so you should be able to
+   # proceed with the setup process.
+
    for dir in dev proc run sys var; do mkdir /my-rootfs/${dir}; done
 
-   # All done, exit docker shell
+   # All done, exit docker shell.
    exit
    ```
 


### PR DESCRIPTION
# Reason for This PR
I have added little detail about this command 'for d in bin etc lib root sbin usr; do tar c "/$d" | tar x -C /my-rootfs; done' .  Some of the people might be confused about it. For example me :) I was confused about that command result and I created this issue (https://github.com/firecracker-microvm/firecracker/issues/2473). Thank you so much @gc-plp @twitchyliquid64

## Description of Changes

 1. An Added explanation and a warning message that is the result of 'for d in bin etc lib root sbin usr; do tar c "/$d" | tar x -C /my-rootfs; done' command.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
