### PR TITLE
Add Jailer parameter to allow spawning the firecracker process into a new PID namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added devtool build `--ssh-keys` flag to support fetching from private
   git repositories.
 - Added option to configure block device flush.
+- Added `--new-pid-ns` flag to the Jailer in order to spawn the Firecracker
+  process in a new PID namespace.
 
 ### Fixed
 

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -143,7 +143,7 @@ impl ApiServer {
     /// let (api_request_sender, _from_api) = channel();
     /// let (to_api, vmm_response_receiver) = channel();
     /// let mmds_info = MMDS.clone();
-    /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1));
+    /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1), Some(1));
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -751,7 +751,7 @@ mod tests {
                 )
                 .bind_and_run(
                     PathBuf::from(api_thread_path_to_socket),
-                    ProcessTimeReporter::new(Some(1), Some(1)),
+                    ProcessTimeReporter::new(Some(1), Some(1), Some(1)),
                     SeccompFilter::empty().try_into().unwrap(),
                 )
                 .unwrap();

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use api_server::{ApiRequest, ApiResponse, ApiServer};
-use logger::{error, warn};
+use logger::{error, warn, ProcessTimeReporter};
 use mmds::MMDS;
 use polly::event_manager::{EventManager, Subscriber};
 use seccomp::BpfProgram;
@@ -125,8 +125,7 @@ pub(crate) fn run_with_api(
     config_json: Option<String>,
     bind_path: PathBuf,
     instance_info: InstanceInfo,
-    start_time_us: Option<u64>,
-    start_time_cpu_us: Option<u64>,
+    process_time_reporter: ProcessTimeReporter,
     boot_timer_enabled: bool,
 ) {
     // FD to notify of API events. This is a blocking eventfd by design.
@@ -158,12 +157,8 @@ pub(crate) fn run_with_api(
                 from_vmm,
                 to_vmm_event_fd,
             )
-            .bind_and_run(
-                bind_path,
-                start_time_us,
-                start_time_cpu_us,
-                api_seccomp_filter,
-            ) {
+            .bind_and_run(bind_path, process_time_reporter, api_seccomp_filter)
+            {
                 Ok(_) => (),
                 Err(api_server::Error::Io(inner)) => match inner.kind() {
                     std::io::ErrorKind::AddrInUse => panic!(

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::process;
 use std::sync::{Arc, Mutex};
 
-use logger::{error, info, IncMetric, LOGGER, METRICS};
+use logger::{error, info, IncMetric, ProcessTimeReporter, LOGGER, METRICS};
 use polly::event_manager::EventManager;
 use seccomp::{BpfProgram, SeccompLevel};
 use utils::arg_parser::{ArgParser, Argument};
@@ -86,12 +86,12 @@ fn main() {
         .arg(
             Argument::new("start-time-us")
                 .takes_value(true)
-                .help("Process start time (wall clock, microseconds)."),
+                .help("Process start time (wall clock, microseconds). This parameter is optional."),
         )
         .arg(
             Argument::new("start-time-cpu-us")
                 .takes_value(true)
-                .help("Process start CPU time (wall clock, microseconds)."),
+                .help("Process start CPU time (wall clock, microseconds). This parameter is optional."),
         )
         .arg(
             Argument::new("config-file")
@@ -234,13 +234,13 @@ fn main() {
             s.parse::<u64>()
                 .expect("'start-time-cpu-us' parameter expected to be of 'u64' type.")
         });
+        let process_time_reporter = ProcessTimeReporter::new(start_time_us, start_time_cpu_us);
         api_server_adapter::run_with_api(
             seccomp_filter,
             vmm_config_json,
             bind_path,
             instance_info,
-            start_time_us,
-            start_time_cpu_us,
+            process_time_reporter,
             boot_timer_enabled,
         );
     } else {

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -94,6 +94,11 @@ fn main() {
                 .help("Process start CPU time (wall clock, microseconds). This parameter is optional."),
         )
         .arg(
+            Argument::new("parent-cpu-time-us")
+                .takes_value(true)
+                .help("Parent process CPU time (wall clock, microseconds). This parameter is optional."),
+        )
+        .arg(
             Argument::new("config-file")
                 .takes_value(true)
                 .help("Path to a file that contains the microVM configuration in JSON format."),
@@ -234,7 +239,14 @@ fn main() {
             s.parse::<u64>()
                 .expect("'start-time-cpu-us' parameter expected to be of 'u64' type.")
         });
-        let process_time_reporter = ProcessTimeReporter::new(start_time_us, start_time_cpu_us);
+
+        let parent_cpu_time_us = arguments.single_value("parent-cpu-time-us").map(|s| {
+            s.parse::<u64>()
+                .expect("'parent-cpu-time-us' parameter expected to be of 'u64' type.")
+        });
+
+        let process_time_reporter =
+            ProcessTimeReporter::new(start_time_us, start_time_cpu_us, parent_cpu_time_us);
         api_server_adapter::run_with_api(
             seccomp_filter,
             vmm_config_json,

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -8,7 +8,8 @@ use std::sync::LockResult;
 
 pub use crate::logger::{LoggerError, LOGGER};
 pub use crate::metrics::{
-    IncMetric, MetricsError, SharedIncMetric, SharedStoreMetric, StoreMetric, METRICS,
+    IncMetric, MetricsError, ProcessTimeReporter, SharedIncMetric, SharedStoreMetric, StoreMetric,
+    METRICS,
 };
 pub use log::Level::*;
 pub use log::*;

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -287,13 +287,20 @@ pub struct ProcessTimeReporter {
     start_time_us: Option<u64>,
     // Process CPU start time in us.
     start_time_cpu_us: Option<u64>,
+    // Firecracker's parent process CPU time.
+    parent_cpu_time_us: Option<u64>,
 }
 
 impl ProcessTimeReporter {
-    pub fn new(start_time_us: Option<u64>, start_time_cpu_us: Option<u64>) -> ProcessTimeReporter {
+    pub fn new(
+        start_time_us: Option<u64>,
+        start_time_cpu_us: Option<u64>,
+        parent_cpu_time_us: Option<u64>,
+    ) -> ProcessTimeReporter {
         ProcessTimeReporter {
             start_time_us,
             start_time_cpu_us,
+            parent_cpu_time_us,
         }
     }
 
@@ -309,8 +316,9 @@ impl ProcessTimeReporter {
 
     pub fn report_cpu_start_time(&self) {
         if let Some(cpu_start_time) = self.start_time_cpu_us {
-            let delta_us =
-                utils::time::get_time_us(utils::time::ClockType::ProcessCpu) - cpu_start_time;
+            let delta_us = utils::time::get_time_us(utils::time::ClockType::ProcessCpu)
+                - cpu_start_time
+                + self.parent_cpu_time_us.unwrap_or_default();
             METRICS
                 .api_server
                 .process_startup_time_cpu_us

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -32,6 +32,7 @@ class JailerContext:
     chroot_base = None
     netns = None
     daemonize = None
+    new_pid_ns = None
     extra_args = None
     api_socket_name = None
     cgroups = None
@@ -46,6 +47,7 @@ class JailerContext:
             chroot_base=DEFAULT_CHROOT_PATH,
             netns=None,
             daemonize=True,
+            new_pid_ns=False,
             cgroups=None,
             **extra_args
     ):
@@ -63,6 +65,7 @@ class JailerContext:
         self.chroot_base = chroot_base
         self.netns = netns if netns is not None else jailer_id
         self.daemonize = daemonize
+        self.new_pid_ns = new_pid_ns
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
@@ -103,6 +106,8 @@ class JailerContext:
             jailer_param_list.extend(['--netns', str(self.netns_file_path())])
         if self.daemonize:
             jailer_param_list.append('--daemonize')
+        if self.new_pid_ns:
+            jailer_param_list.append('--new-pid-ns')
         if self.cgroups is not None:
             for cgroup in self.cgroups:
                 jailer_param_list.extend(['--cgroup', str(cgroup)])

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.38, "AMD": 84.65, "ARM": 83.46}
+COVERAGE_DICT = {"Intel": 85.24, "AMD": 84.54, "ARM": 83.35}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -14,9 +14,21 @@ MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2800}
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 
 
-def test_startup_time(test_microvm_with_api):
-    """Check the startup time for jailer and Firecracker up to socket bind."""
+def test_startup_time_new_pid_ns(test_microvm_with_api):
+    """Check startup time when jailer is spawned in a new PID namespace."""
     microvm = test_microvm_with_api
+    microvm.bin_cloner_path = None
+    microvm.jailer.new_pid_ns = True
+    _test_startup_time(microvm)
+
+
+def test_startup_time_daemonize(test_microvm_with_api):
+    """Check startup time when jailer spawns Firecracker in a new PID ns."""
+    microvm = test_microvm_with_api
+    _test_startup_time(microvm)
+
+
+def _test_startup_time(microvm):
     microvm.spawn()
 
     microvm.basic_config(vcpu_count=2, mem_size_mib=1024)

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -3,8 +3,10 @@
 """Tests that verify the jailer's behavior."""
 import os
 import stat
+import subprocess
 
 from framework.defs import FC_BINARY_NAME
+
 
 # These are the permissions that all files/dirs inside the jailer have.
 REG_PERMS = stat.S_IRUSR | stat.S_IWUSR | \
@@ -15,6 +17,8 @@ FILE_STATS = stat.S_IFREG | REG_PERMS
 SOCK_STATS = stat.S_IFSOCK | REG_PERMS
 # These are the stats of the devices created by tha jailer.
 CHAR_STATS = stat.S_IFCHR | stat.S_IRUSR | stat.S_IWUSR
+# Name of the file that stores firecracker's PID.
+PID_FILE_NAME = "firecracker.pid"
 
 
 def check_stats(filepath, stats, uid, gid):
@@ -188,3 +192,42 @@ def test_args_cgroups(test_microvm_with_initrd):
         sys_cgroup,
         test_microvm.jailer.jailer_id
     )
+
+
+def test_new_pid_namespace(test_microvm_with_ssh):
+    """Test that Firecracker is spawned in a new PID namespace if requested."""
+    test_microvm = test_microvm_with_ssh
+
+    test_microvm.jailer.daemonize = False
+    test_microvm.jailer.new_pid_ns = True
+
+    test_microvm.spawn()
+
+    # Check that the PID file exists.
+    pid_file_path = "{}/{}".format(test_microvm.jailer.chroot_path(),
+                                   PID_FILE_NAME)
+    assert os.path.exists(pid_file_path)
+
+    # Read the PID stored inside the file.
+    with open(pid_file_path) as file:
+        fc_pid = int(file.readline())
+    file.close()
+
+    # Validate the PID.
+    stdout = subprocess.check_output("pidof firecracker", shell=True)
+    assert str(fc_pid) in stdout.strip().decode()
+
+    # Get the thread group IDs in each of the PID namespaces of which
+    # Firecracker process is a member of.
+    nstgid_cmd = "cat /proc/{}/status | grep NStgid".format(fc_pid)
+    nstgid_list = subprocess.check_output(
+                    nstgid_cmd,
+                    shell=True
+                ).decode('utf-8').strip().split("\t")[1:]
+
+    # Check that Firecracker's PID namespace is nested. `NStgid` should
+    # report two values and the last one should be 1, because Firecracker
+    # becomes the init(1) process of the new PID namespace it is spawned in.
+    assert len(nstgid_list) == 2
+    assert int(nstgid_list[1]) == 1
+    assert int(nstgid_list[0]) == fc_pid


### PR DESCRIPTION
# Reason for This PR

The [Jailer documentation](https://github.com/firecracker-microvm/firecracker/blob/master/docs/jailer.md) recommends that the user spawns the jailer process is into a new PID namespace, for extra resilience. This PR implements a mechanism which takes the burden off the users and allows the Jailer to spawn the Firecracker process into a new PID namespace.

## Description of Changes

Added a bool optional parameter to the Jailer: `--new-pid-ns`, which enables the jailer to exec into the provided binary in a new PID namespace.


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
