### PR TITLE
Fix improrer state reported by GetInstanceInfo when config-file is used

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -766,7 +766,7 @@ mod tests {
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
-        let (_to_api, vmm_response_receiver) = channel();
+        let (to_api, vmm_response_receiver) = channel();
         let mmds_info = MMDS.clone();
 
         thread::Builder::new()
@@ -795,6 +795,10 @@ mod tests {
 
         // Send a GET instance-info request.
         assert!(sock.write_all(b"GET / HTTP/1.1\r\n\r\n").is_ok());
+        to_api
+            .send(Box::new(Ok(VmmData::State(VmState::Running))))
+            .unwrap();
+
         let mut buf: [u8; 100] = [0; 100];
         assert!(sock.read(&mut buf[..]).unwrap() > 0);
 

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -117,6 +117,14 @@ impl ParsedRequest {
                     response.set_body(Body::new(serde_json::to_string(stats).unwrap()));
                     response
                 }
+                VmmData::State(_) => {
+                    error!("Received an invalid vmm response. Status code: 400 Bad Request.");
+                    let mut response = Response::new(Version::Http11, StatusCode::BadRequest);
+                    response.set_body(Body::new(ApiServer::json_fault_message(
+                        "Invalid vmm response".to_string(),
+                    )));
+                    response
+                }
             },
             Err(vmm_action_error) => {
                 error!(

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -62,6 +62,8 @@ pub enum VmmAction {
     GetBalloonStats,
     /// Get the configuration of the microVM.
     GetVmConfiguration,
+    /// Get current state of the microVM
+    GetVmState,
     /// Flush the metrics. This action can only be called after the logger has been configured.
     FlushMetrics,
     /// Add a new block device or update one that already exists using the `BlockDeviceConfig` as
@@ -189,6 +191,15 @@ impl Display for VmmActionError {
     }
 }
 
+/// The vm state
+#[derive(Debug, PartialEq)]
+pub enum VmState {
+    /// vm not started (yet)
+    NotStarted,
+    /// vm is running (possibly paused)
+    Running,
+}
+
 /// The enum represents the response sent by the VMM in case of success. The response is either
 /// empty, when no data needs to be sent, or an internal VMM structure.
 #[derive(Debug, PartialEq)]
@@ -201,6 +212,8 @@ pub enum VmmData {
     Empty,
     /// The microVM configuration represented by `VmConfig`.
     MachineConfiguration(VmConfig),
+    /// The Vm State
+    State(VmState),
 }
 
 /// Shorthand result type for external VMM commands.
@@ -294,6 +307,7 @@ impl<'a> PrebootApiController<'a> {
             GetVmConfiguration => Ok(VmmData::MachineConfiguration(
                 self.vm_resources.vm_config().clone(),
             )),
+            GetVmState => Ok(VmmData::State(VmState::NotStarted)),
             InsertBlockDevice(config) => self.insert_block_device(config),
             InsertNetworkDevice(config) => self.insert_net_device(config),
             LoadSnapshot(config) => self.load_snapshot(&config),
@@ -466,6 +480,7 @@ impl RuntimeApiController {
             GetVmConfiguration => Ok(VmmData::MachineConfiguration(
                 self.vm_resources.vm_config().clone(),
             )),
+            GetVmState => Ok(VmmData::State(VmState::Running)),
             Pause => self.pause(),
             Resume => self.resume(),
             #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -192,7 +192,7 @@ impl Display for VmmActionError {
 }
 
 /// The vm state
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VmState {
     /// vm not started (yet)
     NotStarted,

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -1,9 +1,9 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// The strongly typed that contains general information about the microVM.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InstanceInfo {
     /// The ID of the microVM.
     pub id: String,


### PR DESCRIPTION
# Reason for This PR

When configured through `--config-file` the ApiServer improperly reports the VmState as "Not started" even when it actually is "Running".
(Note: This breaks integration with kata-runtime which does use `--config-file` and expects a "Running" VmState to be reported by the ApiServer).

## Description of Changes

This adds a new VmmAction `GetVmState` to query the VmState which is reported as `NotStarted` by the `PrebootApiController` and `Running` by the `RuntimeApiController`.
The ApiServer then uses this VmmAction to check if the vm is now Running. It still manages the Paused status on its own by listening to Pause/Resume requests.

When not using `--config-file`, VmState transition to "Running" occurs when the ApiServer handles the `InstanceStart` api request (translated to a `VmmAction::StartMicroVm`). This request is not supported when configured through a config-file.

This is a bit convoluted, mainly because the VmState is maintained at an ApiServer level and there's no Controller->ApiServer channel (only ApiServer->Controller).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
