### PR TITLE
CI: fix bug in gitlint test

### DIFF
--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -12,6 +12,7 @@ def test_gitlint():
     os.environ['LANG'] = 'C.UTF-8'
     try:
         utils.run_cmd('gitlint --commits origin/master..HEAD'
+                      ' -C ../.gitlint'
                       ' --extra-path framework/gitlint_rules.py')
     except ChildProcessError as error:
         assert False, "Commit message violates gitlint rules: {}".format(error)


### PR DESCRIPTION
The default location for the config file
is .gitlint, however when run from the tests
directory this needs to be adjusted.

Signed-off-by: Diana Popa <dpopa@amazon.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
