### PR TITLE
change wording of DeviceNotActive error message

### DIFF
--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -38,7 +38,10 @@ impl fmt::Display for BalloonConfigError {
         use self::BalloonConfigError::*;
         match self {
             DeviceNotFound => write!(f, "No balloon device found."),
-            DeviceNotActive => write!(f, "Device is inactive, check balloon driver is enabled."),
+            DeviceNotActive => write!(
+                f,
+                "Device is inactive, check if balloon driver is enabled in guest kernel."
+            ),
             InvalidStatsUpdate => write!(f, "Cannot enable/disable the statistics after boot."),
             TooManyPagesRequested => write!(f, "Amount of pages requested is too large."),
             StatsNotFound => write!(f, "Statistics for the balloon device are not enabled"),


### PR DESCRIPTION
# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

Issue #2490 has shown that there is confusion on user side when DeviceNotActive error is encountered.

## Description of Changes

`[Author TODO: add description of changes.]`

Extended error message to make it more explicit leaving no room for confusion or doubt

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
