### PR TITLE
[feature/file_based_seccomp] add graceful error handling

### DIFF
--- a/src/seccompiler/src/seccompiler.rs
+++ b/src/seccompiler/src/seccompiler.rs
@@ -53,6 +53,7 @@ use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag};
 
 const SECCOMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";
+const EXIT_CODE_ERROR: i32 = 1;
 
 #[derive(Debug)]
 enum Error {
@@ -172,29 +173,32 @@ fn main() {
              For more information try --help.",
             err
         );
-        process::exit(1);
+        process::exit(EXIT_CODE_ERROR);
     }
 
     if arg_parser.arguments().flag_present("help") {
         println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
         println!("{}", arg_parser.formatted_help());
-        process::exit(0);
+        return;
     }
     if arg_parser.arguments().flag_present("version") {
         println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
-        process::exit(0);
+        return;
     }
 
     let args = get_argument_values(arg_parser.arguments()).unwrap_or_else(|err| {
-        println!(
+        eprintln!(
             "{} \n\n\
             For more information try --help.",
             err
         );
-        process::exit(1);
+        process::exit(EXIT_CODE_ERROR);
     });
 
-    compile(&args).expect("Seccompiler error");
+    if let Err(err) = compile(&args) {
+        eprintln!("Seccompiler error: {}", err);
+        process::exit(EXIT_CODE_ERROR);
+    }
 
     println!("Filter successfully compiled into: {}", args.output_file);
 }

--- a/src/vmm/src/seccomp_filters/mod.rs
+++ b/src/vmm/src/seccomp_filters/mod.rs
@@ -24,6 +24,8 @@ pub enum FilterError {
     MissingThreadCategory(String),
     /// Filter installation error.
     Install(InstallationError),
+    /// File open error.
+    FileOpen(std::io::Error),
 }
 
 impl fmt::Display for FilterError {
@@ -31,7 +33,7 @@ impl fmt::Display for FilterError {
         use self::FilterError::*;
 
         match *self {
-            Deserialization(ref err) => write!(f, "Filter (de)serialization failed: {}", err),
+            Deserialization(ref err) => write!(f, "Filter deserialization failed: {}", err),
             ThreadCategories(ref categories) => {
                 write!(f, "Invalid thread categories: {}", categories)
             }
@@ -39,6 +41,7 @@ impl fmt::Display for FilterError {
                 write!(f, "Missing thread category: {}", category)
             }
             Install(ref err) => write!(f, "Filter installation error: {}", err),
+            FileOpen(ref err) => write!(f, "Filter file open error: {}", err),
         }
     }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.7, "AMD": 85.04, "ARM": 83.8}
+COVERAGE_DICT = {"Intel": 85.7, "AMD": 84.98, "ARM": 83.98}
 PROC_MODEL = proc.proc_type()
 
 COVERAGE_MAX_DELTA = 0.05


### PR DESCRIPTION
# Reason for This PR

- Errors in the seccompiler binary were bubbled up to the `main()` level and then unwrapped, causing ugly panics instead of gracefully exiting.
- Similar situation in Firecracker in regards to seccomp parameters.

## Description of Changes

Replaced the panic mechanism with logging + `exit(error_code)`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
