### PR TITLE
[Performance tests] Fixed bug in error propagation

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -280,6 +280,9 @@ class ExceptionAggregator(Exception):
 
     def has_any(self) -> bool:
         """Return whether there are failures or not."""
+        if len(self.failures) == 1:
+            return self.failures[0] != ""
+
         return len(self.failures) > 1
 
     def __str__(self):


### PR DESCRIPTION
Signed-off-by: George Pisaltu <gpl@amazon.com>

# Reason for This PR

There is a bug in the [decision making logic for when to propagate an error](https://github.com/firecracker-microvm/firecracker/blob/master/tests/framework/utils.py#L283): when a new line was not added at the beginning of the ExceptionAggregator, but there is exactly one error in the list, the error would go unreported.

## Description of Changes

Checked for the case where the line was not added and there was exactly one error in the list.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
