### PR TITLE
Adjust performance test baselines

### DIFF
--- a/tests/integration_tests/performance/configs/block_performance_test_config.json
+++ b/tests/integration_tests/performance/configs/block_performance_test_config.json
@@ -112,7 +112,7 @@
                         }
                       }
                     },
-                    "1vcpu_1024mb.json": {
+                    "2vcpu_1024mb.json": {
                       "Avg": {
                         "randrw-bs4096": {
                           "target": 65,

--- a/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.json
+++ b/tests/integration_tests/performance/configs/network_tcp_throughput_test_config.json
@@ -31,40 +31,50 @@
   "measurements": {
     "throughput": {
       "unit": "Mbps",
-      "statistics": [{
-        "name": "total",
-        "function": "Sum",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "total",
+          "function": "Sum",
+          "criteria": "EqualWith"
+        }
+      ]
     },
     "duration": {
       "unit": "seconds",
-      "statistics": [{
-        "function": "Avg"
-      }]
+      "statistics": [
+        {
+          "function": "Avg"
+        }
+      ]
     },
     "retransmits": {
       "unit": "#",
-      "statistics": [{
-        "name": "total",
-        "function": "Sum"
-      }]
+      "statistics": [
+        {
+          "name": "total",
+          "function": "Sum"
+        }
+      ]
     },
     "cpu_utilization_vmm": {
       "unit": "percentage",
-      "statistics": [{
-        "name": "Avg",
-        "function": "ValuePlaceholder",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "Avg",
+          "function": "ValuePlaceholder",
+          "criteria": "EqualWith"
+        }
+      ]
     },
     "cpu_utilization_vcpus_total": {
       "unit": "percentage",
-      "statistics": [{
-        "name": "Avg",
-        "function": "ValuePlaceholder",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "Avg",
+          "function": "ValuePlaceholder",
+          "criteria": "EqualWith"
+        }
+      ]
     }
   },
   "hosts": {
@@ -228,8 +238,8 @@
                           "delta_percentage": 5
                         },
                         "tcp-p1024K-ws256K-g2h": {
-                          "target": 3,
-                          "delta_percentage": 4
+                          "target": 25913,
+                          "delta_percentage": 5
                         },
                         "tcp-p1024K-wsDEFAULT-g2h": {
                           "target": 28344,

--- a/tests/integration_tests/performance/configs/vsock_throughput_test_config.json
+++ b/tests/integration_tests/performance/configs/vsock_throughput_test_config.json
@@ -28,33 +28,41 @@
   "measurements": {
     "throughput": {
       "unit": "Mbps",
-      "statistics": [{
-        "name": "total",
-        "function": "Sum",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "total",
+          "function": "Sum",
+          "criteria": "EqualWith"
+        }
+      ]
     },
     "duration": {
       "unit": "seconds",
-      "statistics": [{
-        "function": "Avg"
-      }]
+      "statistics": [
+        {
+          "function": "Avg"
+        }
+      ]
     },
     "cpu_utilization_vmm": {
       "unit": "percentage",
-      "statistics": [{
-        "name": "Avg",
-        "function": "ValuePlaceholder",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "Avg",
+          "function": "ValuePlaceholder",
+          "criteria": "EqualWith"
+        }
+      ]
     },
     "cpu_utilization_vcpus_total": {
       "unit": "percentage",
-      "statistics": [{
-        "name": "Avg",
-        "function": "ValuePlaceholder",
-        "criteria": "EqualWith"
-      }]
+      "statistics": [
+        {
+          "name": "Avg",
+          "function": "ValuePlaceholder",
+          "criteria": "EqualWith"
+        }
+      ]
     }
   },
   "hosts": {
@@ -266,7 +274,7 @@
                           "delta_percentage": 6
                         },
                         "vsock-p1024-h2g": {
-                          "target": 7,
+                          "target": 176,
                           "delta_percentage": 6
                         },
                         "vsock-p1024K-bd": {

--- a/tools/parse_baselines/providers/types.py
+++ b/tools/parse_baselines/providers/types.py
@@ -53,7 +53,9 @@ class DataParser(ABC):
 
         for cpu_model in self._data:
             baselines[cpu_model] = {
-                'model': cpu_model, **self._data[cpu_model]}
+                'model': cpu_model,
+                'baselines': self._data[cpu_model]
+            }
 
         temp_baselines = baselines
         baselines = []


### PR DESCRIPTION
# Reason for This PR

Due to a bug in the performance testing framework, some failures were not properly reported. This was fixed by this PR: https://github.com/firecracker-microvm/firecracker/pull/2498 

Now, this surfaced some typos/mistakes in the baselines for some performance tests.

## Description of Changes

- regather baselines for the statistics that were causing failures (fortunatelty, they were obviously off, due to human error from previous PRs)
- fixed a duplication in the block performance baseline that was also causing failures
- small adaptation of the baseline parser scripts to match the expected baseline format

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
