### PR TITLE
snapshots: sync host resources as part of create-snapshot API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal
   is still recorded in metrics and logs.
+- Snapshot related host files (vm-state, memory, block backing files) are now
+  flushed to their backing mediums as part of the CreateSnapshot operation.
 
 ### Changed
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -90,6 +90,10 @@ impl DiskProperties {
         })
     }
 
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
     pub fn file_mut(&mut self) -> &mut File {
         &mut self.file
     }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -116,12 +116,16 @@ pub enum CreateSnapshotError {
     Memory(memory_snapshot::Error),
     /// Failed to open memory backing file.
     MemoryBackingFile(io::Error),
+    /// Failed to flush memory backing file contents.
+    MemoryFileFlush(io::Error),
     /// Failed to save MicrovmState.
     MicrovmState(MicrovmStateError),
     /// Failed to serialize microVM state.
     SerializeMicrovmState(snapshot::Error),
     /// Failed to open the snapshot backing file.
     SnapshotBackingFile(io::Error),
+    /// Failed to flush the snapshot backing file.
+    SnapshotFileFlush(io::Error),
     #[cfg(target_arch = "x86_64")]
     /// Number of devices exceeds the maximum supported devices for the snapshot data version.
     TooManyDevices(usize),
@@ -139,9 +143,11 @@ impl Display for CreateSnapshotError {
             InvalidVmState(err) => write!(f, "Cannot save Vm state. Error: {:?}", err),
             Memory(err) => write!(f, "Cannot write memory file: {:?}", err),
             MemoryBackingFile(err) => write!(f, "Cannot open memory file: {:?}", err),
+            MemoryFileFlush(err) => write!(f, "Cannot flush memory file contents: {:?}", err),
             MicrovmState(err) => write!(f, "Cannot save microvm state: {}", err),
             SerializeMicrovmState(err) => write!(f, "Cannot serialize MicrovmState: {:?}", err),
             SnapshotBackingFile(err) => write!(f, "Cannot open snapshot file: {:?}", err),
+            SnapshotFileFlush(err) => write!(f, "Cannot flush snapshot file: {:?}", err),
             #[cfg(target_arch = "x86_64")]
             TooManyDevices(val) => write!(
                 f,
@@ -234,8 +240,7 @@ fn snapshot_state_to_file(
     snapshot
         .save(&mut snapshot_file, microvm_state)
         .map_err(SerializeMicrovmState)?;
-
-    Ok(())
+    snapshot_file.sync_all().map_err(SnapshotFileFlush)
 }
 
 fn snapshot_memory_to_file(
@@ -264,7 +269,8 @@ fn snapshot_memory_to_file(
                 .map_err(Memory)
         }
         SnapshotType::Full => vmm.guest_memory().dump(&mut file).map_err(Memory),
-    }
+    }?;
+    file.sync_all().map_err(MemoryFileFlush)
 }
 
 /// Validate the microVM version and translate it to its corresponding snapshot data format.
@@ -608,6 +614,9 @@ mod tests {
         let err = MemoryBackingFile(io::Error::from_raw_os_error(0));
         let _ = format!("{}{:?}", err, err);
 
+        let err = MemoryFileFlush(io::Error::from_raw_os_error(0));
+        let _ = format!("{}{:?}", err, err);
+
         let err = MicrovmState(MicrovmStateError::UnexpectedVcpuResponse);
         let _ = format!("{}{:?}", err, err);
 
@@ -615,6 +624,9 @@ mod tests {
         let _ = format!("{}{:?}", err, err);
 
         let err = SnapshotBackingFile(io::Error::from_raw_os_error(0));
+        let _ = format!("{}{:?}", err, err);
+
+        let err = SnapshotFileFlush(io::Error::from_raw_os_error(0));
         let _ = format!("{}{:?}", err, err);
 
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
# Reason for This PR

Depending on the host FS configuration, snapshot-related files (memory, vm-state, block devices backing files) could get corrupted if the backing mediums are moved while snapshot data is in-flight.

## Description of Changes

To provide a safe and consistent CreateSnapshot operation, Firecracker now flushes all snapshot related host-file as part of the create snapshot operation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~Any newly added `unsafe` code is properly documented.~
- [ ] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] ~All added/changed functionality is tested.~
