### PR TITLE
Changed master branch's name to *main*

### DIFF
--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -142,7 +142,7 @@ Then continue with the above steps:
     ```
 
 1. Update the image tag in the
-   [`devtool` script](https://github.com/firecracker-microvm/firecracker/blob/master/tools/devtool).
+   [`devtool` script](https://github.com/firecracker-microvm/firecracker/blob/main/tools/devtool).
    Commit and push the change.
 
     ```bash

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -11,8 +11,7 @@ def test_gitlint():
     os.environ['LC_ALL'] = 'C.UTF-8'
     os.environ['LANG'] = 'C.UTF-8'
     try:
-        # TODO: update this line once the master branch is renamed
-        utils.run_cmd('gitlint --commits origin/master..HEAD'
+        utils.run_cmd('gitlint --commits origin/main..HEAD'
                       ' -C ../.gitlint'
                       ' --extra-path framework/gitlint_rules.py')
     except ChildProcessError as error:


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Firecracker needs to use inclusive language. Documentation and code have been updated to use inclusive terms. The next step is to replace all occurrences of the *master* branch to *main*.

## Description of Changes

Renamed the *master* branch to *main*.
Fixes #2517 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
