### PR TITLE
Add x86_64 TSC scaling support.

### DIFF
--- a/src/vmm/src/default_syscalls/mod.rs
+++ b/src/vmm/src/default_syscalls/mod.rs
@@ -108,6 +108,18 @@ fn create_arch_specific_ioctl_conditions() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XCRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS)?],
+        and![Cond::new(
+            1,
+            ArgLen::DWORD,
+            Eq,
+            kvm_ioctls::kvm_ioctls::KVM_GET_TSC_KHZ()
+        )?],
+        and![Cond::new(
+            1,
+            ArgLen::DWORD,
+            Eq,
+            kvm_ioctls::kvm_ioctls::KVM_SET_TSC_KHZ()
+        )?],
     ]);
 
     #[cfg(target_arch = "aarch64")]

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::device_manager::persist::DeviceStates;
+use crate::vstate::vcpu::VcpuState;
 use devices::virtio::block::persist::BlockState;
 
 use lazy_static::lazy_static;
@@ -16,9 +17,18 @@ lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
     /// Static instance used for handling microVM state versions.
     pub static ref VERSION_MAP: VersionMap = {
+        // v0.23 - all structs and root version are set to 1.
         let mut version_map = VersionMap::new();
+
+        // v0.24 state change mappings.Versionize
         version_map.new_version().set_type_version(DeviceStates::type_id(), 2);
+
+        // v0.25 state change mappings.
         version_map.new_version().set_type_version(BlockState::type_id(), 2);
+        // x86 TSC freq scaling support.
+        #[cfg(target_arch = "x86_64")]
+        version_map.set_type_version(VcpuState::type_id(), 2);
+
         version_map
     };
 


### PR DESCRIPTION
# Draft PR

Enable snapshot compatibility across hosts with different TSC frequencies.
**TODO PR rust-vmm/kvm-ioctls: Add KVM_SET_TSC_KHZ and KVM_GET_TSC_KHZ APIs wrappers**

Host CPU requirements for TSC scaling:
- KVM_SET_TSC_KHZ requires CPU TSC scaling feature on destination host if freq falls out of tolerance level vs snapshot recorded TSC.
- KVM_GET_TSC_KHZ requires that TSC is constant on source host - guaranteed by these CPU features:

``` 
[ec2-user@ip-172-31-26-227 ~]$ egrep -o '(constant_tsc|nonstop_tsc|rdtscp)' /proc/cpuinfo | sort -u
constant_tsc
nonstop_tsc
rdtscp
```

TBD: dive deep on options of exposing this functionality and sanity checks wrt  snapshot API/UX. We probably want to allow create/restore even when the above requirements are not met.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.


