### PR TITLE
Glibc SIGSYS patch for sandboxed localtime_r()

### DIFF
--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -84,6 +84,15 @@ impl LocalTime {
             nsec: timespec.tv_nsec,
         }
     }
+
+    // In the glibc implementation, if the TZ environment variable is not set, then the first
+    // call to localtime_r() will cache it.  Since this can involve fopen() on varied paths
+    // on the filesystem (including the root directory "/"), the first call to now() can't
+    // be on a sandboxed thread.
+    // 
+    pub fn setup_timezone() {
+        LocalTime::now();
+    }
 }
 
 impl fmt::Display for LocalTime {


### PR DESCRIPTION
## Reason for This PR

This permits the [alpine demo from the quick start](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md#running-firecracker) to appear to
run with glibc instead of musl...when some warnings are being
emitted by the logger that include timestamps.  Previously the
warning emission in a glibc build would cause SIGSYS.

## Description of Changes

The LocalTime::now() function is used by the logger for some
messages (such as warnings).  If the first case of calling
a log message that included the time happened in a sandboxed
thread, glibc would potentially read from the host filesystem
on that thread in response to the log message.

This effect arises from the implementation of how localtime_r()
obtains time zone information if the "TZ" environment variable
is not set.  A function called __tzfile_read() is called:

  https://sources.debian.org/src/glibc/2.28-10/time/tzset.c/#L584

Which triggers an fopen():

  https://sources.debian.org/src/glibc/2.28-10/time/tzfile.c/#L165

Because this information is cached, it appears possible to work
around the problem by making an early call to LocalTime::now()
during initialization.  Then if calls pertaining to logging
come later on the seccomp filtered thread the caching is done
already and problems don't occur.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [N/A] Any newly added `unsafe` code is properly documented.
- [N/A] Any API changes are reflected in `firecracker/swagger.yaml`.
- [N/A] Any user-facing changes are mentioned in `CHANGELOG.md`.

RE: "[ ] All added/changed functionality is tested", I am running this in VirtualBox as I do not have a non-virtual Linux machine at present to apply.  The musl-based version does not pass all the tests with that either.  This change improves the mentioned issue, without seeming to make anything worse.