### PR TITLE
Balloon API correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal
   is still recorded in metrics and logs.
+- Fixed ballooning API definitions by renaming all fields which mentioned "MB"
+  to use "MiB" instead.
 
 ### Changed
 

--- a/docs/ballooning.md
+++ b/docs/ballooning.md
@@ -106,7 +106,7 @@ Here is an example command on how to install the balloon through the API:
 
 ```console
 socket_location=...
-amount_mb=...
+amount_mib=...
 deflate_on_oom=...
 polling_interval=...
 
@@ -115,15 +115,15 @@ curl --unix-socket $socket_location -i \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json' \
     -d "{
-        \"amount_mb\": $amount_mb, \
+        \"amount_mib\": $amount_mib, \
         \"deflate_on_oom\": $deflate_on_oom, \
         \"stats_polling_interval_s\": $polling_interval \
     }"
 ```
 
 To use this, set `socket_location` to the location of the firecracker socket
-(by default, at `/run/firecracker.socket`. Then, set `amount_mb`,
-`deflate_on_oom` and `stats_polling_interval_s` as desired: `amount_mb`
+(by default, at `/run/firecracker.socket`. Then, set `amount_mib`,
+`deflate_on_oom` and `stats_polling_interval_s` as desired: `amount_mib`
 represents the target size of the balloon, and `deflate_on_oom` and
 `stats_polling_interval_s` represent the options mentioned before.
 
@@ -132,7 +132,7 @@ object into your configuration file:
 
 ```console
 "balloon": {
-    "amount_mb": 0,
+    "amount_mib": 0,
     "deflate_on_oom": false,
     "stats_polling_interval_s": 1
 },
@@ -160,7 +160,7 @@ API through the following command:
 
 ```console
 socket_location=...
-amount_mb=...
+amount_mib=...
 polling_interval=...
 
 curl --unix-socket $socket_location -i \
@@ -168,12 +168,12 @@ curl --unix-socket $socket_location -i \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json' \
     -d "{
-        \"amount_mb\": $amount_mb, \
+        \"amount_mib\": $amount_mib, \
         \"stats_polling_interval_s\": $polling_interval \
     }"
 ```
 
-This will update the target size of the balloon to `amount_mb` and the
+This will update the target size of the balloon to `amount_mib` and the
 statistics polling interval to `polling_interval`.
 
 ## Virtio balloon statistics
@@ -199,8 +199,8 @@ The target and actual sizes of the balloon are expressed as follows:
 
 * `target_pages`: The target size of the balloon, in 4K pages.
 * `actual_pages`: The number of 4K pages the device is currently holding.
-* `target_mb`: The target size of the balloon, in MiB.
-* `actual_mb`: The number of MiB the device is currently holding.
+* `target_mib`: The target size of the balloon, in MiB.
+* `actual_mib`: The number of MiB the device is currently holding.
 
 These values are taken directly from the config space of the device and are
 always up to date, in the sense that they are exactly what the Firecracker

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -605,7 +605,7 @@ pub(crate) mod tests {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
         let body = "{ \
-            \"amount_mb\": 0, \
+            \"amount_mib\": 0, \
             \"deflate_on_oom\": false, \
             \"stats_polling_interval_s\": 0 \
             }";
@@ -841,7 +841,7 @@ pub(crate) mod tests {
     fn test_try_from_patch_balloon() {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
-        let body = "{ \"amount_mb\": 1 }";
+        let body = "{ \"amount_mib\": 1 }";
         sender
             .write_all(http_request("PATCH", "/balloon", Some(&body)).as_bytes())
             .unwrap();

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -69,22 +69,22 @@ mod tests {
 
         // PATCH with invalid fields.
         let body = r#"{
-                "amount_mb": "bar",
+                "amount_mib": "bar",
                 "foo": "bar"
               }"#;
         assert!(parse_patch_balloon(&Body::new(body), None).is_err());
 
         // PATCH with invalid types on fields. Adding a polling interval as string instead of bool.
         let body = r#"{
-                "amount_mb": 1000,
+                "amount_mib": 1000,
                 "stats_polling_interval_s": "false"
               }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
         assert!(res.is_err());
 
-        // PATCH with invalid types on fields. Adding a amount_mb as a negative number.
+        // PATCH with invalid types on fields. Adding a amount_mib as a negative number.
         let body = r#"{
-                "amount_mb": -1000,
+                "amount_mib": -1000,
                 "stats_polling_interval_s": true
               }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
@@ -92,12 +92,12 @@ mod tests {
 
         // PATCH on statistics with missing ppolling interval field.
         let body = r#"{
-                "amount_mb": 100
+                "amount_mib": 100
               }"#;
         let res = parse_patch_balloon(&Body::new(body), Some(&"statistics"));
         assert!(res.is_err());
 
-        // PATCH with missing amount_mb field.
+        // PATCH with missing amount_mib field.
         let body = r#"{
                 "stats_polling_interval_s": 0
               }"#;
@@ -106,7 +106,7 @@ mod tests {
 
         // PATCH that tries to update something else other than allowed fields.
         let body = r#"{
-                "amount_mb": "dummy_id",
+                "amount_mib": "dummy_id",
                 "stats_polling_interval_s": "dummy_host"
               }"#;
         let res = parse_patch_balloon(&Body::new(body), None);
@@ -125,11 +125,11 @@ mod tests {
         assert!(parse_patch_balloon(&Body::new(body), Some(&"config")).is_err());
 
         let body = r#"{
-                "amount_mb": 1
+                "amount_mib": 1
               }"#;
         #[allow(clippy::match_wild_err_arm)]
         match vmm_action_from_request(parse_patch_balloon(&Body::new(body), None).unwrap()) {
-            VmmAction::UpdateBalloon(balloon_cfg) => assert_eq!(balloon_cfg.amount_mb, 1),
+            VmmAction::UpdateBalloon(balloon_cfg) => assert_eq!(balloon_cfg.amount_mib, 1),
             _ => panic!("Test failed: Invalid parameters"),
         };
 
@@ -153,14 +153,14 @@ mod tests {
 
         // PUT with invalid fields.
         let body = r#"{
-                "amount_mb": "bar",
+                "amount_mib": "bar",
                 "is_read_only": false
               }"#;
         assert!(parse_put_balloon(&Body::new(body)).is_err());
 
         // PUT with valid input fields.
         let body = r#"{
-                "amount_mb": 1000,
+                "amount_mib": 1000,
                 "deflate_on_oom": true,
                 "stats_polling_interval_s": 0
             }"#;

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -617,14 +617,14 @@ definitions:
   Balloon:
     type: object
     required:
-      - amount_mb
+      - amount_mib
       - deflate_on_oom
     description:
       Balloon device descriptor.
     properties:
-      amount_mb:
+      amount_mib:
         type: integer
-        description: Target balloon size in MB.
+        description: Target balloon size in MiB.
       deflate_on_oom:
         type: boolean
         description: Whether the balloon should deflate when the guest has memory pressure.
@@ -635,13 +635,13 @@ definitions:
   BalloonUpdate:
     type: object
     required:
-      - amount_mb
+      - amount_mib
     description:
       Balloon device descriptor.
     properties:
-      amount_mb:
+      amount_mib:
         type: integer
-        description: Target balloon size in MB.
+        description: Target balloon size in MiB.
 
   BalloonStats:
     type: object
@@ -650,8 +650,8 @@ definitions:
     required:
       - target_pages
       - actual_pages
-      - target_mb
-      - actual_mb
+      - target_mib
+      - actual_mib
     properties:
       target_pages:
         description: Target number of pages the device aims to hold.
@@ -659,11 +659,11 @@ definitions:
       actual_pages:
         description: Actual number of pages the device is holding.
         type: integer
-      target_mb:
-        description: Target amount of memory (in MB) the device aims to hold.
+      target_mib:
+        description: Target amount of memory (in MiB) the device aims to hold.
         type: integer
-      actual_mb:
-        description: Actual amount of memory (in MB) the device is holding.
+      actual_mib:
+        description: Actual amount of memory (in MiB) the device is holding.
         type: integer
       swap_in:
         description: The amount of memory that has been swapped in (in bytes).

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -21,8 +21,8 @@ pub const CONFIG_SPACE_SIZE: usize = 8;
 pub const QUEUE_SIZE: u16 = 256;
 pub const NUM_QUEUES: usize = 3;
 pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE, QUEUE_SIZE, QUEUE_SIZE];
-// Number of 4K pages in a MB.
-pub const MB_TO_4K_PAGES: u32 = 256;
+// Number of 4K pages in a MiB.
+pub const MIB_TO_4K_PAGES: u32 = 256;
 // The maximum number of pages that can be received in a single descriptor.
 pub const MAX_PAGES_IN_DESC: usize = 256;
 // The maximum number of pages that can be compacted into ranges during process_inflate().

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -62,8 +62,8 @@ impl BalloonStatsState {
         BalloonStats {
             target_pages: 0,
             actual_pages: 0,
-            target_mb: 0,
-            actual_mb: 0,
+            target_mib: 0,
+            actual_mib: 0,
             swap_in: self.swap_in,
             swap_out: self.swap_out,
             major_faults: self.major_faults,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1345,7 +1345,7 @@ pub mod tests {
         let mut vmm = default_vmm();
 
         let balloon_config = BalloonDeviceConfig {
-            amount_mb: 0,
+            amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -541,7 +541,7 @@ mod tests {
 
             // Add a balloon device.
             let balloon_cfg = BalloonDeviceConfig {
-                amount_mb: 123,
+                amount_mib: 123,
                 deflate_on_oom: false,
                 stats_polling_interval_s: 1,
             };

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -614,11 +614,11 @@ impl Vmm {
     /// Updates configuration for the balloon device target size.
     pub fn update_balloon_config(
         &mut self,
-        amount_mb: u32,
+        amount_mib: u32,
     ) -> std::result::Result<(), BalloonError> {
         // The balloon cannot have a target size greater than the size of
         // the guest memory.
-        if amount_mb as u64 > mem_size_mib(self.guest_memory()) {
+        if amount_mib as u64 > mem_size_mib(self.guest_memory()) {
             return Err(BalloonError::TooManyPagesRequested);
         }
 
@@ -640,7 +640,7 @@ impl Vmm {
                     .as_mut_any()
                     .downcast_mut::<Balloon>()
                     .unwrap()
-                    .update_size(amount_mb)?;
+                    .update_size(amount_mib)?;
             }
 
             let locked_dev = busdev.lock().expect("Poisoned lock");

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -468,7 +468,7 @@ mod tests {
 
         // Add a balloon device.
         let balloon_config = BalloonDeviceConfig {
-            amount_mb: 0,
+            amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -198,7 +198,7 @@ impl VmResources {
                     .balloon
                     .get_config()
                     .map_err(|_| VmConfigError::InvalidVmState)?
-                    .amount_mb as usize
+                    .amount_mib as usize
         {
             return Err(VmConfigError::IncompatibleBalloonSize);
         }
@@ -245,7 +245,7 @@ impl VmResources {
     ) -> Result<BalloonConfigError> {
         // The balloon cannot have a target size greater than the size of
         // the guest memory.
-        if config.amount_mb as usize
+        if config.amount_mib as usize
             > self
                 .vm_config
                 .mem_size_mib
@@ -722,7 +722,7 @@ mod tests {
         json = format!(
             r#"{{
                     "balloon": {{
-                        "amount_mb": 0,
+                        "amount_mib": 0,
                         "deflate_on_oom": false,
                         "stats_polling_interval_s": 0
                     }},
@@ -818,7 +818,7 @@ mod tests {
         vm_resources.vm_config.mem_size_mib = Some(128);
         vm_resources
             .set_balloon_device(BalloonDeviceConfig {
-                amount_mb: 100,
+                amount_mib: 100,
                 deflate_on_oom: false,
                 stats_polling_interval_s: 0,
             })
@@ -847,7 +847,7 @@ mod tests {
             boot_timer: false,
         };
         let mut new_balloon_cfg = BalloonDeviceConfig {
-            amount_mb: 100,
+            amount_mib: 100,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };
@@ -857,7 +857,7 @@ mod tests {
             .unwrap();
 
         let actual_balloon_cfg = vm_resources.balloon.get_config().unwrap();
-        assert_eq!(actual_balloon_cfg.amount_mb, new_balloon_cfg.amount_mb);
+        assert_eq!(actual_balloon_cfg.amount_mib, new_balloon_cfg.amount_mib);
         assert_eq!(
             actual_balloon_cfg.deflate_on_oom,
             new_balloon_cfg.deflate_on_oom
@@ -877,7 +877,7 @@ mod tests {
             mmds_config: None,
             boot_timer: false,
         };
-        new_balloon_cfg.amount_mb = 256;
+        new_balloon_cfg.amount_mib = 256;
         assert!(vm_resources.set_balloon_device(new_balloon_cfg).is_err());
     }
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -474,7 +474,7 @@ impl RuntimeApiController {
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
-                .update_balloon_config(balloon_update.amount_mb)
+                .update_balloon_config(balloon_update.amount_mib)
                 .map(|_| VmmData::Empty)
                 .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
             UpdateBalloonStatistics(balloon_stats_update) => self
@@ -1204,7 +1204,7 @@ mod tests {
             VmmActionError::OperationNotSupportedPreBoot,
         );
         check_preboot_request_err(
-            VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mb: 0 }),
+            VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mib: 0 }),
             VmmActionError::OperationNotSupportedPreBoot,
         );
         check_preboot_request_err(
@@ -1395,13 +1395,13 @@ mod tests {
 
     #[test]
     fn test_runtime_update_balloon_config() {
-        let req = VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mb: 0 });
+        let req = VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mib: 0 });
         check_runtime_request(req, |result, vmm| {
             assert_eq!(result, Ok(VmmData::Empty));
             assert!(vmm.update_balloon_config_called)
         });
 
-        let req = VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mb: 0 });
+        let req = VmmAction::UpdateBalloon(BalloonUpdateConfig { amount_mib: 0 });
         check_runtime_request_err(
             req,
             VmmActionError::BalloonConfig(BalloonConfigError::DeviceNotFound),

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -76,8 +76,8 @@ type Result<T> = std::result::Result<T, BalloonConfigError>;
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BalloonDeviceConfig {
-    /// Target balloon size in MB.
-    pub amount_mb: u32,
+    /// Target balloon size in MiB.
+    pub amount_mib: u32,
     /// Option to deflate the balloon in case the guest is out of memory.
     pub deflate_on_oom: bool,
     /// Interval in seconds between refreshing statistics.
@@ -88,7 +88,7 @@ pub struct BalloonDeviceConfig {
 impl From<BalloonConfig> for BalloonDeviceConfig {
     fn from(state: BalloonConfig) -> Self {
         BalloonDeviceConfig {
-            amount_mb: state.amount_mb,
+            amount_mib: state.amount_mib,
             deflate_on_oom: state.deflate_on_oom,
             stats_polling_interval_s: state.stats_polling_interval_s,
         }
@@ -100,8 +100,8 @@ impl From<BalloonConfig> for BalloonDeviceConfig {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BalloonUpdateConfig {
-    /// Target balloon size in MB.
-    pub amount_mb: u32,
+    /// Target balloon size in MiB.
+    pub amount_mib: u32,
 }
 
 /// The data fed into a balloon statistics interval update request.
@@ -138,7 +138,7 @@ impl BalloonBuilder {
     pub fn set(&mut self, cfg: BalloonDeviceConfig) -> Result<()> {
         self.inner = Some(Arc::new(Mutex::new(
             Balloon::new(
-                cfg.amount_mb,
+                cfg.amount_mib,
                 cfg.deflate_on_oom,
                 cfg.stats_polling_interval_s,
                 // `restored` flag is false because this code path
@@ -171,7 +171,7 @@ pub(crate) mod tests {
 
     pub(crate) fn default_config() -> BalloonDeviceConfig {
         BalloonDeviceConfig {
-            amount_mb: 0,
+            amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         }
@@ -189,7 +189,7 @@ pub(crate) mod tests {
     fn test_balloon_create() {
         let default_balloon_config = default_config();
         let balloon_config = BalloonDeviceConfig {
-            amount_mb: 0,
+            amount_mib: 0,
             deflate_on_oom: false,
             stats_polling_interval_s: 0,
         };
@@ -201,7 +201,7 @@ pub(crate) mod tests {
         assert_eq!(builder.get().unwrap().lock().unwrap().num_pages(), 0);
         assert_eq!(builder.get_config().unwrap(), default_balloon_config);
 
-        let _update_config = BalloonUpdateConfig { amount_mb: 5 };
+        let _update_config = BalloonUpdateConfig { amount_mib: 5 };
         let _stats_update_config = BalloonUpdateStatsConfig {
             stats_polling_interval_s: 5,
         };
@@ -210,13 +210,13 @@ pub(crate) mod tests {
     #[test]
     fn test_from_balloon_state() {
         let expected_balloon_config = BalloonDeviceConfig {
-            amount_mb: 5,
+            amount_mib: 5,
             deflate_on_oom: false,
             stats_polling_interval_s: 3,
         };
 
         let actual_balloon_config = BalloonDeviceConfig::from(BalloonConfig {
-            amount_mb: 5,
+            amount_mib: 5,
             deflate_on_oom: false,
             stats_polling_interval_s: 3,
         });

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -94,14 +94,18 @@ class Balloon():
     @staticmethod
     def create_json(
             amount_mb=None,
+            amount_mib=None,
             deflate_on_oom=None,
             stats_polling_interval_s=None
     ):
         """Compose the json associated to this type of API request."""
         datax = {}
 
-        if amount_mb is not None:
+        if amount_mib is None and amount_mb is not None:
             datax['amount_mb'] = amount_mb
+
+        if amount_mb is None and amount_mib is not None:
+            datax['amount_mib'] = amount_mib
 
         if deflate_on_oom is not None:
             datax['deflate_on_oom'] = deflate_on_oom

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -843,19 +843,19 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     test_microvm.basic_config()
 
     # Updating an inexistent balloon device should give an error.
-    response = test_microvm.balloon.patch(amount_mb=0)
+    response = test_microvm.balloon.patch(amount_mib=0)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
     # Adding a memory balloon should be OK.
     response = test_microvm.balloon.put(
-        amount_mb=1,
+        amount_mib=1,
         deflate_on_oom=True
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # As is overwriting one.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=False,
         stats_polling_interval_s=5
     )
@@ -864,18 +864,18 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     # Getting the device configuration should be available pre-boot.
     response = test_microvm.balloon.get()
     assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json()['amount_mb'] == 0
+    assert response.json()['amount_mib'] == 0
     assert response.json()['deflate_on_oom'] is False
     assert response.json()['stats_polling_interval_s'] == 5
 
     # Updating an existing balloon device is forbidden before boot.
-    response = test_microvm.balloon.patch(amount_mb=2)
+    response = test_microvm.balloon.patch(amount_mib=2)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
     # We can't have a balloon device with a target size greater than
     # the available amount of memory.
     response = test_microvm.balloon.put(
-        amount_mb=1024,
+        amount_mib=1024,
         deflate_on_oom=False,
         stats_polling_interval_s=5
     )
@@ -885,12 +885,12 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     test_microvm.start()
 
     # Updating should fail as driver didn't have time to initialize.
-    response = test_microvm.balloon.patch(amount_mb=4)
+    response = test_microvm.balloon.patch(amount_mib=4)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
     # Overwriting the existing device should give an error now.
     response = test_microvm.balloon.put(
-        amount_mb=3,
+        amount_mib=3,
         deflate_on_oom=False,
         stats_polling_interval_s=3
     )
@@ -901,11 +901,11 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     time.sleep(0.5)
 
     # But updating should be OK.
-    response = test_microvm.balloon.patch(amount_mb=4)
+    response = test_microvm.balloon.patch(amount_mib=4)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # Check we can't request more than the total amount of VM memory.
-    response = test_microvm.balloon.patch(amount_mb=300)
+    response = test_microvm.balloon.patch(amount_mib=300)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
     # Check we can't disable statistics as they were enabled at boot.
@@ -916,14 +916,14 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
     # Getting the device configuration should be available post-boot.
     response = test_microvm.balloon.get()
     assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json()['amount_mb'] == 4
+    assert response.json()['amount_mib'] == 4
     assert response.json()['deflate_on_oom'] is False
     assert response.json()['stats_polling_interval_s'] == 5
 
     # Check we can't overflow the `num_pages` field in the config space by
     # requesting too many MB. There are 256 4K pages in a MB. Here, we are
     # requesting u32::MAX / 128.
-    response = test_microvm.balloon.patch(amount_mb=33554432)
+    response = test_microvm.balloon.patch(amount_mib=33554432)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -119,31 +119,54 @@ def copy_util_to_rootfs(rootfs_path, util):
     subprocess.check_call("rmdir tmpfs", shell=True)
 
 
-def _test_rss_memory_lower(test_microvm):
+def _test_rss_memory_lower(test_microvm, use_legacy_api=False):
     """Check inflating the balloon makes guest use less rss memory."""
     # Get the firecracker pid, and open an ssh connection.
     firecracker_pid = test_microvm.jailer_clone_pid
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Using deflate_on_oom, get the RSS as low as possible
-    response = test_microvm.balloon.patch(amount_mb=200)
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    if use_legacy_api:
+        response = test_microvm.balloon.patch(amount_mb=200)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
+    else:
+        response = test_microvm.balloon.patch(amount_mib=200)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
 
     # Get initial rss consumption.
     init_rss = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Get the balloon back to 0.
-    response = test_microvm.balloon.patch(amount_mb=0)
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    if use_legacy_api:
+        response = test_microvm.balloon.patch(amount_mb=0)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
+    else:
+        response = test_microvm.balloon.patch(amount_mib=0)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Dirty memory, then inflate balloon and get ballooned rss consumption.
     make_guest_dirty_memory(ssh_connection)
 
-    response = test_microvm.balloon.patch(amount_mb=200)
-
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    if use_legacy_api:
+        response = test_microvm.balloon.patch(amount_mb=200)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
+    else:
+        response = test_microvm.balloon.patch(amount_mib=200)
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code
+        )
     balloon_rss = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Check that the ballooning reclaimed the memory.
@@ -164,7 +187,7 @@ def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
 
     # Add a memory balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=0
     )
@@ -191,7 +214,7 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
 
     # Install deflated balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=False,
         stats_polling_interval_s=1
     )
@@ -208,7 +231,7 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
     available_mem_deflated = get_free_mem_ssh(ssh_connection)
 
     # Inflate 64 MB == 16384 page balloon.
-    response = test_microvm.balloon.patch(amount_mb=64)
+    response = test_microvm.balloon.patch(amount_mib=64)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -235,7 +258,7 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
 
     # Add a deflated memory balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=0
     )
@@ -249,7 +272,7 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon
-    response = test_microvm.balloon.patch(amount_mb=172)
+    response = test_microvm.balloon.patch(amount_mib=172)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -276,7 +299,7 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
 
     # Add a memory balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=False,
         stats_polling_interval_s=0
     )
@@ -290,7 +313,7 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon.
-    response = test_microvm.balloon.patch(amount_mb=172)
+    response = test_microvm.balloon.patch(amount_mib=172)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -313,7 +336,7 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
 
     # Add a deflated memory balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=0
     )
@@ -329,12 +352,12 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
     # First inflate the balloon to free up the uncertain amount of memory
     # used by the kernel at boot and establish a baseline, then give back
     # the memory.
-    response = test_microvm.balloon.patch(amount_mb=200)
+    response = test_microvm.balloon.patch(amount_mib=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
-    response = test_microvm.balloon.patch(amount_mb=0)
+    response = test_microvm.balloon.patch(amount_mib=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -344,12 +367,12 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
     first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon.
-    response = test_microvm.balloon.patch(amount_mb=200)
+    response = test_microvm.balloon.patch(amount_mib=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     second_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now deflate the balloon.
-    response = test_microvm.balloon.patch(amount_mb=0)
+    response = test_microvm.balloon.patch(amount_mib=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -359,7 +382,7 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
     third_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon again.
-    response = test_microvm.balloon.patch(amount_mb=200)
+    response = test_microvm.balloon.patch(amount_mib=200)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     fourth_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
@@ -385,7 +408,7 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
 
     # Add a memory balloon.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=0
     )
@@ -406,7 +429,7 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
     time.sleep(5)
 
     # Now inflate the balloon.
-    response = test_microvm.balloon.patch(amount_mb=40)
+    response = test_microvm.balloon.patch(amount_mib=40)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # Check memory usage again.
@@ -430,7 +453,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
 
     # Add a memory balloon with stats enabled.
     response = test_microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=1
     )
@@ -458,7 +481,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
     assert initial_stats['major_faults'] < after_workload_stats['major_faults']
 
     # Now inflate the balloon with 10MB of pages.
-    response = test_microvm.balloon.patch(amount_mb=10)
+    response = test_microvm.balloon.patch(amount_mib=10)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -478,7 +501,7 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
 
     # Deflate the balloon.check that the stats show the increase in
     # available memory.
-    response = test_microvm.balloon.patch(amount_mb=0)
+    response = test_microvm.balloon.patch(amount_mib=0)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -537,7 +560,7 @@ def _test_balloon_snapshot(context):
 
     # Add a memory balloon with stats enabled.
     response = basevm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=1
     )
@@ -557,7 +580,7 @@ def _test_balloon_snapshot(context):
     first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Now inflate the balloon with 20MB of pages.
-    response = basevm.balloon.patch(amount_mb=20)
+    response = basevm.balloon.patch(amount_mib=20)
     assert basevm.api_session.is_status_no_content(response.status_code)
 
     # Check memory usage again.
@@ -601,7 +624,7 @@ def _test_balloon_snapshot(context):
     assert fourth_reading > third_reading
 
     # Inflate the balloon with another 20MB of pages.
-    response = microvm.balloon.patch(amount_mb=40)
+    response = microvm.balloon.patch(amount_mib=40)
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     fifth_reading = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -653,7 +676,7 @@ def _test_snapshot_compatibility(context):
 
     # Add a memory balloon with stats enabled.
     response = microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=1
     )
@@ -731,7 +754,7 @@ def _test_memory_scrub(context):
 
     # Add a memory balloon with stats enabled.
     response = microvm.balloon.put(
-        amount_mb=0,
+        amount_mib=0,
         deflate_on_oom=True,
         stats_polling_interval_s=1
     )
@@ -745,7 +768,7 @@ def _test_memory_scrub(context):
     make_guest_dirty_memory(ssh_connection, amount=(60 * MB_TO_PAGES))
 
     # Now inflate the balloon with 60MB of pages.
-    response = microvm.balloon.patch(amount_mb=60)
+    response = microvm.balloon.patch(amount_mib=60)
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     # Get the firecracker pid, and open an ssh connection.
@@ -755,7 +778,7 @@ def _test_memory_scrub(context):
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
 
     # Deflate the balloon completely.
-    response = microvm.balloon.patch(amount_mb=0)
+    response = microvm.balloon.patch(amount_mib=0)
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     # Wait for the deflate to complete.


### PR DESCRIPTION
# Reason for This PR

#2482 

## Description of Changes

Changed the API definition to reflect the correct units of memory (MiB).

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
