### PR TITLE
Add `describe-snapshot` parameter to fetch snapshot data version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Added `--new-pid-ns` flag to the Jailer in order to spawn the Firecracker
   process in a new PID namespace.
 - Added API metrics for `GET`, `PUT` and `PATCH` requests on `/mmds` endpoint.
+- Added `--describe-snapshot` flag to Firecracker to fetch the data format
+  version of a snapshot state file provided as argument.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "mmds",
  "polly",
  "seccomp",
+ "snapshot",
  "timerfd",
  "utils",
  "vmm",

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -14,5 +14,6 @@ logger = { path = "../logger" }
 mmds = { path = "../mmds" }
 polly = { path = "../polly" }
 seccomp = { path = "../seccomp" }
+snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -339,7 +339,7 @@ impl<'a> Arguments<'a> {
     }
 
     /// Clear split between the actual arguments of the process, the extra arguments if any
-    /// and the `--help` argument if present.
+    /// and the `--help` and `--version` arguments if present.
     pub fn parse(&mut self, args: &[String]) -> Result<()> {
         // Skipping the first element of `args` as it is the name of the binary.
         let (args, extra_args) = Arguments::split_args(&args[1..]);
@@ -499,6 +499,11 @@ mod tests {
                     .takes_value(true)
                     .help("'config-file' info."),
             )
+            .arg(
+                Argument::new("describe-snapshot")
+                    .takes_value(true)
+                    .help("'describe-snapshot' info."),
+            )
     }
 
     #[test]
@@ -651,6 +656,36 @@ mod tests {
 
         assert!(arguments.parse(&args).is_ok());
         assert!(arguments.args.contains_key("version"));
+
+        arguments = arg_parser.arguments().clone();
+
+        let args = vec!["binary-name", "--exec-file", "foo", "--describe-snapshot"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingValue("describe-snapshot".to_string()))
+        );
+
+        arguments = arg_parser.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--describe-snapshot",
+            "--",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::MissingValue("describe-snapshot".to_string()))
+        );
 
         arguments = arg_parser.arguments().clone();
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.73, "AMD": 83.98, "ARM": 82.91}
+COVERAGE_DICT = {"Intel": 84.56, "AMD": 83.81, "ARM": 82.76}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -324,7 +324,7 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
 
 # pylint: disable=C0103
 def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
-    """Verify that repeatedly inflating and deflating the baloon works."""
+    """Verify that repeatedly inflating and deflating the balloon works."""
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that ensure the correctness of the command line parameters."""
+
+import logging
+import platform
+
+from host_tools.cargo_build import get_firecracker_binaries
+from conftest import _test_images_s3_bucket
+from framework.artifacts import ArtifactCollection
+from framework.builder import SnapshotBuilder, SnapshotType
+from framework.microvms import VMNano
+from framework.utils import get_firecracker_version_from_toml, run_cmd
+
+
+def test_describe_snapshot_all_versions(bin_cloner_path):
+    """Test `--describe-snapshot` correctness for all snapshot versions."""
+    logger = logging.getLogger("describe_snapshot")
+
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all firecracker binaries.
+    # For each binary create a snapshot and verify the data version
+    # of the snapshot state file.
+    firecracker_artifacts = artifacts.firecrackers(
+        older_than=get_firecracker_version_from_toml())
+
+    for firecracker in firecracker_artifacts:
+        firecracker.download()
+        jailer = firecracker.jailer()
+        jailer.download()
+
+        target_version = firecracker.base_name()[1:]
+        # Skip for aarch64, since the snapshotting feature
+        # was introduced in v0.24.0.
+        if platform.machine() == "aarch64" and "v0.23" in target_version:
+            continue
+
+        logger.info("Creating snapshot with Firecracker: %s",
+                    firecracker.local_path())
+        logger.info("Using Jailer: %s", jailer.local_path())
+        logger.info("Using target version: %s", target_version)
+
+        # v0.23 does not support creating diff snapshots.
+        diff_snapshots = "0.23" not in target_version
+        vm_instance = VMNano.spawn(bin_cloner_path, False,
+                                   fc_binary=firecracker.local_path(),
+                                   jailer_binary=jailer.local_path(),
+                                   diff_snapshots=diff_snapshots)
+        vm = vm_instance.vm
+        vm.start()
+
+        # Create a snapshot builder from a microvm.
+        snapshot_builder = SnapshotBuilder(vm)
+        disks = [vm_instance.disks[0].local_path()]
+
+        # Version 0.24 and greater have Diff support.
+        snap_type = SnapshotType.DIFF if diff_snapshots else SnapshotType.FULL
+
+        snapshot = snapshot_builder.create(disks,
+                                           vm_instance.ssh_key,
+                                           target_version=target_version,
+                                           snapshot_type=snap_type)
+        logger.debug("========== Firecracker create snapshot log ==========")
+        logger.debug(vm.log_data)
+        vm.kill()
+
+        # Fetch Firecracker binary for the latest version
+        fc_binary, _ = get_firecracker_binaries()
+        # Verify the output of `--describe-snapshot` command line parameter
+        cmd = [fc_binary] + ["--describe-snapshot", snapshot.vmstate]
+
+        code, stdout, stderr = run_cmd(cmd)
+        assert code == 0
+        assert stderr == ''
+        assert target_version in stdout

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -40,7 +40,7 @@ scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
 )
 def test_restore_old_snapshot_all_devices(bin_cloner_path):
     """Test scenario: restore previous version snapshots in current version."""
-    # Microvm: 2vCPU 256MB RAM, baloon, 4 disks and 4 netdevices.
+    # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("snapshot_many_devices")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -91,7 +91,7 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
 )
 def test_restore_old_version_all_devices(bin_cloner_path):
     """Test scenario: restore snapshot in previous versions of Firecracker."""
-    # Microvm: 2vCPU 256MB RAM, baloon, 4 disks and 4 netdevices.
+    # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("snapshot_many_devices")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -109,7 +109,7 @@ def test_restore_old_version_all_devices(bin_cloner_path):
 
         # Old version from artifact.
         target_version = firecracker.base_name()[1:]
-        # v0.23 does not have a ballon device.
+        # v0.23 does not have a balloon device.
         balloon = "0.23" not in target_version
 
         legacy = "0.24" in target_version
@@ -181,7 +181,7 @@ def validate_all_devices(
 
     if balloon is True:
         logger.info("Testing balloon memory reclaim.")
-        # Call helper fn from ballon integration tests.
+        # Call helper fn from balloon integration tests.
         _test_rss_memory_lower(microvm, use_legacy_api=legacy_api)
 
 
@@ -199,7 +199,7 @@ def create_snapshot_helper(bin_cloner_path, logger, target_version=None,
     if diff_snapshots is False:
         snapshot_type = SnapshotType.FULL
     else:
-        # Version 0.24 and greater has Diff and ballon support.
+        # Version 0.24 and greater has Diff and balloon support.
         snapshot_type = SnapshotType.DIFF
 
     if balloon:

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -74,7 +74,7 @@ def _test_seq_snapshots(context):
     root_disk = context.disk.copy()
     # Get ssh key from read-only artifact.
     ssh_key = context.disk.ssh_key()
-    # Create a fresh microvm from aftifacts.
+    # Create a fresh microvm from artifacts.
     basevm = vm_builder.build(kernel=context.kernel,
                               disks=[root_disk],
                               ssh_key=ssh_key,


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

As snapshot format versions evolve, we need a mechanism to fetch the data version of a snapshot state file.

## Description of Changes

Added `describe-snapshot` parameter to fetch data version of the snapshot state file provided. Example:

```
$ ./firecracker --describe-snapshot full_snap.image
v0.23.0
```

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
