### PR TITLE
[Balloon] Update `deflate_on_oom` documentation

### DIFF
--- a/docs/ballooning.md
+++ b/docs/ballooning.md
@@ -23,10 +23,20 @@ The device can be configured with the following options:
   allocate some memory which would make the guest enter an out-of-memory state,
   the kernel will take some pages from the balloon and give them to said
   process instead asking the OOM killer process to kill some processes to free
-  memory. Note that this applies to allocations from guest processes which would
-  make the system enter an OOM state. This does not apply to instances when the
-  kernel needs memory for its activities (i.e. constructing caches), or when the
-  user requests more memory than the amount available through an inflate.
+  memory. Note that this applies to physical page allocations in the kernel
+  which belong to guest processes. This does not apply to instances when the
+  kernel needs memory for its activities (i.e. constructing caches), when the
+  user requests more memory than the currently available to the balloon for
+  releasing, or when guest processes try to allocate large amounts of memory
+  that are refused by the guest memory manager, which is possible when the
+  guest runs with `vm.overcommit_memory=0` and the allocation does not pass
+  the MM basic checks. Setting `vm.memory_overcommit` to 1 would make the MM
+  approve all allocations, no matter how large, and using the memory mapped
+  for those allocations will always deflate the balloon instead of making the
+  guest enter an OOM state. Note: we do not recommend running with
+  `vm.overcommit_memory=1` because it requires complete control over what
+  allocations are done in the guest and can easily result in unexpected OOM
+  scenarios.
 * `stats_polling_interval_s`: unsigned integer value which if set to 0
   disables the virtio balloon statistics and otherwise represents the interval
   of time in seconds at which the balloon statistics are updated.


### PR DESCRIPTION
Signed-off-by: George Pisaltu <gpl@amazon.com>

# Reason for This PR

The ballooning documentation was misleading with regards to the `deflate_on_oom` setting.

## Description of Changes

Clarified the behavior of `deflate_on_oom` in `ballooning.md`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
