### PR TITLE
Feature/mmds metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added option to configure block device flush.
 - Added `--new-pid-ns` flag to the Jailer in order to spawn the Firecracker
   process in a new PID namespace.
+- Added API metrics for `GET`, `PUT` and `PATCH` requests on `/mmds` endpoint.
 
 ### Fixed
 

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -355,6 +355,10 @@ pub struct GetRequestsMetrics {
     pub machine_cfg_count: SharedIncMetric,
     /// Number of failures during GETs for getting information on the instance.
     pub machine_cfg_fails: SharedIncMetric,
+    /// Number of GETs for getting mmds.
+    pub mmds_count: SharedIncMetric,
+    /// Number of failures during GETs for getting mmds.
+    pub mmds_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PUT API Requests for counting user triggered actions and/or failures.
@@ -388,6 +392,10 @@ pub struct PutRequestsMetrics {
     pub network_count: SharedIncMetric,
     /// Number of failures in creating a new network interface.
     pub network_fails: SharedIncMetric,
+    /// Number of PUTs for creating mmds.
+    pub mmds_count: SharedIncMetric,
+    /// Number of failures in creating a new mmds.
+    pub mmds_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PATCH API Requests for counting user triggered actions and/or failures.
@@ -405,6 +413,10 @@ pub struct PatchRequestsMetrics {
     pub machine_cfg_count: SharedIncMetric,
     /// Number of failures in configuring the machine.
     pub machine_cfg_fails: SharedIncMetric,
+    /// Number of tries to PATCH an mmds.
+    pub mmds_count: SharedIncMetric,
+    /// Number of failures in PATCHing an mmds.
+    pub mmds_fails: SharedIncMetric,
 }
 
 /// Balloon Device associated metrics.


### PR DESCRIPTION
# Reason for This PR

Hello :). This PR addresses metrics part of this issue: https://github.com/firecracker-microvm/firecracker/issues/478

## Description of Changes

The changes introduce `mmds_count` and `mmds_fails` metrics for `GET`, `PUT` and `PATCH` requests to MMDS module.
In case of a failure in a parsing logic, `mmds_fails` of particular request type is increased. Each request increases `mmds_count` metric for this request type.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented. - N/A
- [x] Any API changes are reflected in `firecracker/swagger.yaml`. - N/A
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
