### PR TITLE
Clean Shutdown on Debug Builds (Valgrind-friendly)

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -280,7 +280,10 @@ impl ApiServer {
             Ok(ParsedRequest::GetMMDS) => Some(self.get_mmds()),
             Ok(ParsedRequest::PatchMMDS(value)) => Some(self.patch_mmds(value)),
             Ok(ParsedRequest::PutMMDS(value)) => Some(self.put_mmds(value)),
+
+            #[cfg(debug_assertions)]
             Ok(ParsedRequest::ShutdownInternal) => None,
+
             Err(e) => {
                 error!("{}", e);
                 Some(e.into())

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -31,6 +31,7 @@ pub(crate) enum ParsedRequest {
     PatchMMDS(Value),
     PutMMDS(Value),
     Sync(Box<VmmAction>),
+    ShutdownInternal,  // !!! not an API, used by shutdown to thread::join the API thread
 }
 
 impl ParsedRequest {
@@ -57,6 +58,7 @@ impl ParsedRequest {
 
         match (request.method(), path, request.body.as_ref()) {
             (Method::Get, "", None) => parse_get_instance_info(),
+            (Method::Get, "shutdown-internal", None) => Ok(ParsedRequest::ShutdownInternal),
             (Method::Get, "balloon", None) => parse_get_balloon(path_tokens.get(1)),
             (Method::Get, "machine-config", None) => parse_get_machine_config(),
             (Method::Get, "mmds", None) => parse_get_mmds(),

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -31,6 +31,8 @@ pub(crate) enum ParsedRequest {
     PatchMMDS(Value),
     PutMMDS(Value),
     Sync(Box<VmmAction>),
+
+    #[cfg(debug_assertions)]
     ShutdownInternal,  // !!! not an API, used by shutdown to thread::join the API thread
 }
 
@@ -58,7 +60,16 @@ impl ParsedRequest {
 
         match (request.method(), path, request.body.as_ref()) {
             (Method::Get, "", None) => parse_get_instance_info(),
-            (Method::Get, "shutdown-internal", None) => Ok(ParsedRequest::ShutdownInternal),
+
+            #[cfg(debug_assertions)]
+            (Method::Get, "shutdown-internal", None) => {
+                //
+                // This isn't a user-facing API, and was added solely to facilitate clean shutdowns.
+                // Calling it manually will cause problems, so only enable it in debug builds.
+                //
+                Ok(ParsedRequest::ShutdownInternal)
+            },
+
             (Method::Get, "balloon", None) => parse_get_balloon(path_tokens.get(1)),
             (Method::Get, "machine-config", None) => parse_get_machine_config(),
             (Method::Get, "mmds", None) => parse_get_mmds(),

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -251,15 +251,16 @@ pub(crate) fn run_with_api(
         &mut event_manager,
     );
 
+    // Note: In the release build, this is never reached...because exit() is called
+    // abruptly (the OS does faster cleanup, and it reduces the risk of hanging).
+    // Top level main() will complain if the bubbling process happens in release builds.
+
     // We want to tell the API thread to shut down for a clean exit.  But this is after
     // the Vmm.stop() has been called, so it's a moment of internal finalization (as
     // opposed to be something the client might call to shut the Vm down).  Since it's
     // an internal signal implementing it with an HTTP request is probably not the ideal
     // way to do it...but having another way would involve waiting on the socket or some
     // other signal.  This leverages the existing wait.
-    //
-    // !!! Since the code is only needed for a "clean" shutdown mode, a non-clean mode
-    // could not respond to the request, making this effectively a debug-only feature.
     //
     let mut sock = UnixStream::connect(bind_path).unwrap();
     assert!(sock.write_all(b"GET /shutdown-internal HTTP/1.1\r\n\r\n").is_ok());

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -73,7 +73,7 @@ fn test_build_microvm() {
             let _ = event_manager.run_with_timeout(500).unwrap();
 
             #[cfg(target_arch = "x86_64")]
-            vmm.lock().unwrap().stop(-1); // If we got here, something went wrong.
+            vmm.lock().unwrap().stop(1); // If we got here, something went wrong.
             #[cfg(target_arch = "aarch64")]
             vmm.lock().unwrap().stop(0);
         }
@@ -104,7 +104,7 @@ fn test_vmm_seccomp() {
             // Give the vCPUs a chance to attempt KVM_RUN.
             thread::sleep(Duration::from_millis(200));
             // Should never get here.
-            vmm.lock().unwrap().stop(-1);
+            vmm.lock().unwrap().stop(1);
         }
         vmm_pid => {
             // Parent process: wait for the vmm to exit.
@@ -160,7 +160,7 @@ fn test_pause_resume_microvm() {
             let _ = event_manager.run_with_timeout(500).unwrap();
 
             #[cfg(target_arch = "x86_64")]
-            vmm.lock().unwrap().stop(-1); // If we got here, something went wrong.
+            vmm.lock().unwrap().stop(1); // If we got here, something went wrong.
             #[cfg(target_arch = "aarch64")]
             vmm.lock().unwrap().stop(0);
         }
@@ -193,7 +193,7 @@ fn test_dirty_bitmap_error() {
             let _ = event_manager.run_with_timeout(500).unwrap();
 
             #[cfg(target_arch = "x86_64")]
-            vmm.lock().unwrap().stop(-1); // If we got here, something went wrong.
+            vmm.lock().unwrap().stop(1); // If we got here, something went wrong.
             #[cfg(target_arch = "aarch64")]
             vmm.lock().unwrap().stop(0);
         }


### PR DESCRIPTION
#119 expresses the desire to use Valgrind.  However, Firecracker's only modality of exiting the process was from within nested stacks using `unsafe { libc::_exit(...) }` from the main thread.  This would mean not running destructors for anything on other threads, or above the stack on the main thread.  It also means that there may be many shutdown paths which have faulty logic and are never being tested.  *(Such was the case with `Vmm's Drop` and `VcpuHandle's Drop`, which could never run due to reference cycles.)*

However, abrupt exits are faster in release build situations, where one is not looking for leaks.  Also, adding clean exit mechanics means creating new code paths which may deadlock and not quit as reliably.

This PR attempts to bring the best of both approaches <strike>by adding a `--cleanup-level` switch</strike> by running a Valgrind-friendly exit mode in debug builds.

The result of Valgrind on running the Alpine Linux image through boot and shutdown is:

    ==52247== LEAK SUMMARY:
    ==52247==    definitely lost: 0 bytes in 0 blocks
    ==52247==    indirectly lost: 0 bytes in 0 blocks
    ==52247==      possibly lost: 0 bytes in 0 blocks
    ==52247==    still reachable: 8,594 bytes in 10 blocks
    ==52247==         suppressed: 0 bytes in 0 blocks

[Here are backtraces of the still reachable allocations.](https://gist.github.com/AE1020/11f96dd8c7dd8a8d48790858a84ef1cf)  They may not represent leaks, and should be in a suppression list if they don't.  As examples get larger, having a baseline gives much better odds of discerning what's a leak and what is not.

## Description of Changes

The changes are broken into 4 parts, each with a commit description detailing what they do:

* Basic methodology for bubbling up an ExitCode all the way up from detecting an exit condition to main(), so that all destructors on the main thread can run.  (Although they *could* run in theory, some didn't in practice, due to reference cycles which needed resolving.)
* Graceful exit mechanics for the API server thread.
* Graceful exit mechanics for the VCPU threads.
* <strike>Addition of a `--cleanup-level` switch, reintroducing the original exit semantics as the default behavior.</strike>
* Limiting the clean exit behavior to the debug build via `#[cfg(debug_assertions)]` annotations.

Open questions and comments are inline in the code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [N/A] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.

Regarding testing, my VirtualBox is very bad at that... sending PR for discussion and so that CI runs it.