### PR TITLE
snapshots: sync host resources as part of create-snapshot API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   is still recorded in metrics and logs.
 - Fixed ballooning API definitions by renaming all fields which mentioned "MB"
   to use "MiB" instead.
+- Snapshot related host files (vm-state, memory, block backing files) are now
+  flushed to their backing mediums as part of the CreateSnapshot operation.
 
 ### Changed
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -90,6 +90,10 @@ impl DiskProperties {
         })
     }
 
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
     pub fn file_mut(&mut self) -> &mut File {
         &mut self.file
     }

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -244,10 +244,6 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
             mem_full_path = os.path.join(snaps_dir, mem_file_name)
             vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
 
-        # Disable API timeout as the APIs for snapshot related procedures
-        # take longer.
-        self._microvm.api_session.untime()
-
         snaps_dir_name = os.path.basename(snaps_dir)
         self._microvm.pause_to_snapshot(
             mem_file_path=os.path.join('/', snaps_dir_name, mem_file_name),

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -69,6 +69,8 @@ class JailerContext:
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
+        self.ramfs_subdir_name = 'ramfs'
+        self._ramfs_path = None
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -140,6 +142,10 @@ class JailerContext:
         """Return the MicroVM chroot path."""
         return os.path.join(self.chroot_base_with_id(), 'root')
 
+    def chroot_ramfs_path(self):
+        """Return the MicroVM chroot ramfs subfolder path."""
+        return os.path.join(self.chroot_path(), self.ramfs_subdir_name)
+
     def jailed_path(self, file_path, create=False, create_jail=False):
         """Create a hard link or block special device owned by uid:gid.
 
@@ -204,19 +210,39 @@ class JailerContext:
             return 'ip netns exec {} '.format(self.netns)
         return ''
 
-    def setup(self):
+    def setup(self, use_ramdisk=False):
         """Set up this jailer context."""
         os.makedirs(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
             exist_ok=True
         )
+
+        if use_ramdisk:
+            self._ramfs_path = self.chroot_ramfs_path()
+            os.makedirs(self._ramfs_path, exist_ok=True)
+            ramdisk_name = 'ramfs-{}'.format(self.jailer_id)
+            utils.run_cmd(
+                'mount -t ramfs -o size=1M {} {}'.format(
+                    ramdisk_name, self._ramfs_path
+                )
+            )
+            cmd = 'chown {}:{} {}'.format(
+                self.uid, self.gid, self._ramfs_path
+            )
+            utils.run_cmd(cmd)
+
         if self.netns:
             utils.run_cmd('ip netns add {}'.format(self.netns))
 
     def cleanup(self):
         """Clean up this jailer context."""
         # pylint: disable=subprocess-run-check
+        if self._ramfs_path:
+            utils.run_cmd(
+                'umount {}'.format(self._ramfs_path), ignore_return_code=True
+            )
+
         if self.jailer_id:
             shutil.rmtree(self.chroot_base_with_id(), ignore_errors=True)
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -768,6 +768,7 @@ class Microvm:
         response = self.vm.patch(state='Paused')
         assert self.api_session.is_status_no_content(response.status_code)
 
+        self.api_session.untime()
         response = self.snapshot.create(mem_file_path=mem_file_path,
                                         snapshot_path=snapshot_path,
                                         diff=diff,

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -332,6 +332,7 @@ class SnapshotCreate():
 
     def put(self, **args):
         """Create a snapshot of the microvm."""
+        self._api_session.untime()
         datax = self.create_json(**args)
         return self._api_session.put(
             "{}".format(self._snapshot_cfg_url),

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -484,19 +484,26 @@ class MachineConfigure():
 
         self._machine_cfg_url = api_url + self.MACHINE_CFG_RESOURCE
         self._api_session = api_session
+        self._datax = {}
+
+    @property
+    def configuration(self):
+        """Return machine config dictionary."""
+        return self._datax
 
     def put(self, **args):
         """Specify the details of the machine configuration."""
-        datax = self.create_json(**args)
+        self._datax = self.create_json(**args)
 
         return self._api_session.put(
             "{}".format(self._machine_cfg_url),
-            json=datax
+            json=self._datax
         )
 
     def patch(self, **args):
         """Update the details of the machine configuration."""
         datax = self.create_json(**args)
+        self._datax.update(datax)
 
         return self._api_session.patch(
             "{}".format(self._machine_cfg_url),

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -88,6 +88,7 @@ def test_create_with_prev_device_count(test_microvm_with_ssh, network_config):
     snapshot_builder = SnapshotBuilder(test_microvm)
     # Create directory and files for saving snapshot state and memory.
     _snapshot_dir = snapshot_builder.create_snapshot_dir()
+
     # Pause and create a snapshot of the microVM. Firecracker v0.23 allowed a
     # maximum of `FC_V0_23_MAX_DEVICES_ATTACHED` virtio devices at a time.
     # This microVM has `FC_V0_23_MAX_DEVICES_ATTACHED` devices, including the

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -30,21 +30,21 @@ CREATE_LATENCY_BASELINES = {
     'x86_64': {
         '2vcpu_256mb.json': {
             'FULL':  180,
-            'DIFF':  50,
+            'DIFF':  70,
         },
         '2vcpu_512mb.json': {
             'FULL':  280,
-            'DIFF':  50,
+            'DIFF':  75,
         }
     },
     'aarch64': {
         '2vcpu_256mb.json': {
             'FULL':  160,
-            'DIFF':  14,
+            'DIFF':  70,
         },
         '2vcpu_512mb.json': {
             'FULL':  300,
-            'DIFF':  20,
+            'DIFF':  75,
         }
     },
 }
@@ -100,7 +100,8 @@ def _test_snapshot_create_latency(context):
                                   disks=[rw_disk],
                                   ssh_key=ssh_key,
                                   config=context.microvm,
-                                  enable_diff_snapshots=enable_diff_snapshots)
+                                  enable_diff_snapshots=enable_diff_snapshots,
+                                  use_ramdisk=True)
 
             # Configure metrics system.
             metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
@@ -134,7 +135,8 @@ def _test_snapshot_create_latency(context):
             snapshot_builder.create(disks=[rw_disk],
                                     ssh_key=ssh_key,
                                     snapshot_type=snapshot_type,
-                                    target_version=target_version)
+                                    target_version=target_version,
+                                    use_ramdisk=True)
             metrics = vm.flush_metrics(metrics_fifo)
             vm_name = context.microvm.name()
 


### PR DESCRIPTION
# Reason for This PR

Depending on the host FS configuration, snapshot-related files (memory, vm-state, block devices backing files) could get corrupted if the backing mediums are moved while snapshot data is in-flight.

## Description of Changes

To provide a safe and consistent CreateSnapshot operation, Firecracker now flushes all snapshot related host-file as part of the create snapshot operation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~Any newly added `unsafe` code is properly documented.~
- [ ] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
