### PR TITLE
[v0.24 patch] snapshots: sync host resources as part of create-snapshot API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
 ### Changed
 
 - Changed Docker images repository from DockerHub to Amazon ECR.
+
+### Fixed
+
+- Snapshot related host files (vm-state, memory, block backing files) are now
+  flushed to their backing mediums as part of the CreateSnapshot operation.
 
 ## [0.24.2]
 
@@ -10,6 +17,8 @@
 
 - Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal
 is still recorded in metrics and logs.
+- Snapshot related host files (vm-state, memory, block backing files) are now
+  flushed to their backing mediums as part of the CreateSnapshot operation.
 
 ## [0.24.1]
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -64,6 +64,10 @@ impl DiskProperties {
         })
     }
 
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
     pub fn file_mut(&mut self) -> &mut File {
         &mut self.file
     }

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -3,10 +3,11 @@
 
 //! Defines the structures needed for saving/restoring block devices.
 
-use std::io;
+use std::io::{self, Write};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
+use logger::error;
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
@@ -40,6 +41,14 @@ impl Persist<'_> for Block {
     type Error = io::Error;
 
     fn save(&self) -> Self::State {
+        if let Err(e) = self.disk.file().flush() {
+            error!("Failed to flush block data on serialization. Error: {}", e);
+        }
+        // Sync data out to backing file on host.
+        if let Err(e) = self.disk.file().sync_all() {
+            error!("Failed to sync block data on serialization. Error: {}", e);
+        }
+        // Save device state.
         BlockState {
             id: self.id.clone(),
             partuuid: self.partuuid.clone(),

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -73,6 +73,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     )?],
                 ],
             ),
+            allow_syscall(libc::SYS_fsync),
             // Used by glibc's tgkill
             #[cfg(target_env = "gnu")]
             allow_syscall(libc::SYS_getpid),

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::{Display, Formatter};
 use std::fs::{File, OpenOptions};
-use std::io;
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -113,12 +113,16 @@ pub enum CreateSnapshotError {
     Memory(memory_snapshot::Error),
     /// Failed to open memory backing file.
     MemoryBackingFile(io::Error),
+    /// Failed to flush memory backing file contents.
+    MemoryFileFlush(io::Error),
     /// Failed to save MicrovmState.
     MicrovmState(MicrovmStateError),
     /// Failed to serialize microVM state.
     SerializeMicrovmState(snapshot::Error),
     /// Failed to open the snapshot backing file.
     SnapshotBackingFile(io::Error),
+    /// Failed to flush the snapshot backing file.
+    SnapshotFileFlush(io::Error),
     #[cfg(target_arch = "x86_64")]
     /// Number of devices exceeds the maximum supported devices for the snapshot data version.
     TooManyDevices(usize),
@@ -136,9 +140,11 @@ impl Display for CreateSnapshotError {
             InvalidVmState(err) => write!(f, "Cannot save Vm state. Error: {:?}", err),
             Memory(err) => write!(f, "Cannot write memory file: {:?}", err),
             MemoryBackingFile(err) => write!(f, "Cannot open memory file: {:?}", err),
+            MemoryFileFlush(err) => write!(f, "Cannot flush memory file contents: {:?}", err),
             MicrovmState(err) => write!(f, "Cannot save microvm state: {}", err),
             SerializeMicrovmState(err) => write!(f, "Cannot serialize MicrovmState: {:?}", err),
             SnapshotBackingFile(err) => write!(f, "Cannot open snapshot file: {:?}", err),
+            SnapshotFileFlush(err) => write!(f, "Cannot flush snapshot file: {:?}", err),
             #[cfg(target_arch = "x86_64")]
             TooManyDevices(val) => write!(
                 f,
@@ -231,8 +237,8 @@ fn snapshot_state_to_file(
     snapshot
         .save(&mut snapshot_file, microvm_state)
         .map_err(SerializeMicrovmState)?;
-
-    Ok(())
+    snapshot_file.flush().map_err(SnapshotFileFlush)?;
+    snapshot_file.sync_all().map_err(SnapshotFileFlush)
 }
 
 fn snapshot_memory_to_file(
@@ -261,7 +267,9 @@ fn snapshot_memory_to_file(
                 .map_err(Memory)
         }
         SnapshotType::Full => vmm.guest_memory().dump(&mut file).map_err(Memory),
-    }
+    }?;
+    file.flush().map_err(MemoryFileFlush)?;
+    file.sync_all().map_err(MemoryFileFlush)
 }
 
 /// Validate the microVM version and translate it to its corresponding snapshot data format.
@@ -568,6 +576,9 @@ mod tests {
         let err = MemoryBackingFile(io::Error::from_raw_os_error(0));
         let _ = format!("{}{:?}", err, err);
 
+        let err = MemoryFileFlush(io::Error::from_raw_os_error(0));
+        let _ = format!("{}{:?}", err, err);
+
         let err = MicrovmState(MicrovmStateError::UnexpectedVcpuResponse);
         let _ = format!("{}{:?}", err, err);
 
@@ -575,6 +586,9 @@ mod tests {
         let _ = format!("{}{:?}", err, err);
 
         let err = SnapshotBackingFile(io::Error::from_raw_os_error(0));
+        let _ = format!("{}{:?}", err, err);
+
+        let err = SnapshotFileFlush(io::Error::from_raw_os_error(0));
         let _ = format!("{}{:?}", err, err);
 
         #[cfg(target_arch = "x86_64")]

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -52,17 +52,21 @@ class MicrovmBuilder:
               config: Artifact,
               net_ifaces=None,
               enable_diff_snapshots=False,
-              cpu_template=None):
+              cpu_template=None,
+              use_ramdisk=False):
         """Build a fresh microvm."""
         vm = init_microvm(self.root_path, self.bin_cloner_path,
                           self._fc_binary, self._jailer_binary)
 
+        # Start firecracker.
+        vm.spawn(use_ramdisk=use_ramdisk)
+
         # Link the microvm to kernel, rootfs, ssh_key artifacts.
         vm.kernel_file = kernel.local_path()
         vm.rootfs_file = disks[0].local_path()
-
-        # Start firecracker.
-        vm.spawn()
+        # copy rootfs to ramdisk if needed
+        jailed_rootfs_path = vm.copy_to_jail_ramfs(vm.rootfs_file) if \
+            use_ramdisk else vm.create_jailed_resource(vm.rootfs_file)
 
         # Download ssh key into the microvm root.
         ssh_key.download(self.root_path)
@@ -93,7 +97,21 @@ class MicrovmBuilder:
         with open(config.local_path()) as microvm_config_file:
             microvm_config = json.load(microvm_config_file)
 
-        response = vm.basic_config(boot_args='console=ttyS0 reboot=k panic=1')
+        response = vm.basic_config(
+            add_root_device=False,
+            boot_args='console=ttyS0 reboot=k panic=1'
+        )
+
+        # Add the root file system with rw permissions.
+        response = vm.drive.put(
+            drive_id='rootfs',
+            path_on_host=jailed_rootfs_path,
+            is_root_device=True,
+            is_read_only=False
+        )
+        assert vm.api_session \
+            .is_status_no_content(response.status_code), \
+            response.text
 
         # Apply the microvm artifact configuration and template.
         response = vm.machine_cfg.put(
@@ -190,24 +208,45 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
                target_version: str = None,
                mem_file_name: str = "vm.mem",
                snapshot_name: str = "vm.vmstate",
-               net_ifaces=None):
+               net_ifaces=None,
+               use_ramdisk=False):
         """Create a Snapshot object from a microvm and artifacts."""
+        if use_ramdisk:
+            snaps_dir = self._microvm.jailer.chroot_ramfs_path()
+            mem_full_path = os.path.join(snaps_dir, mem_file_name)
+            vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
+
+            memsize = self._microvm.machine_cfg.configuration['mem_size_mib']
+            # Pre-allocate ram for memfile to eliminate allocation variability.
+            utils.run_cmd('dd if=/dev/zero of={} bs=1M count={}'.format(
+                mem_full_path, memsize
+            ))
+            cmd = 'chown {}:{} {}'.format(
+                self._microvm.jailer.uid,
+                self._microvm.jailer.gid,
+                mem_full_path
+            )
+            utils.run_cmd(cmd)
+        else:
+            snaps_dir = self.create_snapshot_dir()
+            mem_full_path = os.path.join(snaps_dir, mem_file_name)
+            vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
+
         # Disable API timeout as the APIs for snapshot related procedures
         # take longer.
         self._microvm.api_session.untime()
-        snapshot_dir = self.create_snapshot_dir()
+
+        snaps_dir_name = os.path.basename(snaps_dir)
         self._microvm.pause_to_snapshot(
-            mem_file_path="/snapshot/"+mem_file_name,
-            snapshot_path="/snapshot/"+snapshot_name,
+            mem_file_path=os.path.join('/', snaps_dir_name, mem_file_name),
+            snapshot_path=os.path.join('/', snaps_dir_name, snapshot_name),
             diff=snapshot_type == SnapshotType.DIFF,
             version=target_version)
 
         # Create a copy of the ssh_key artifact.
         ssh_key_copy = ssh_key.copy()
-        mem_path = os.path.join(snapshot_dir, mem_file_name)
-        vmstate_path = os.path.join(snapshot_dir, snapshot_name)
-        return Snapshot(mem=mem_path,
-                        vmstate=vmstate_path,
+        return Snapshot(mem=mem_full_path,
+                        vmstate=vmstate_full_path,
                         # TODO: To support more disks we need to figure out a
                         # simple and flexible way to store snapshot artifacts
                         # in S3. This should be done in a PR where we add tests

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -232,10 +232,6 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
             mem_full_path = os.path.join(snaps_dir, mem_file_name)
             vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
 
-        # Disable API timeout as the APIs for snapshot related procedures
-        # take longer.
-        self._microvm.api_session.untime()
-
         snaps_dir_name = os.path.basename(snaps_dir)
         self._microvm.pause_to_snapshot(
             mem_file_path=os.path.join('/', snaps_dir_name, mem_file_name),

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -65,6 +65,8 @@ class JailerContext:
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
+        self.ramfs_subdir_name = 'ramfs'
+        self._ramfs_path = None
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -134,6 +136,10 @@ class JailerContext:
         """Return the MicroVM chroot path."""
         return os.path.join(self.chroot_base_with_id(), 'root')
 
+    def chroot_ramfs_path(self):
+        """Return the MicroVM chroot ramfs subfolder path."""
+        return os.path.join(self.chroot_path(), self.ramfs_subdir_name)
+
     def jailed_path(self, file_path, create=False, create_jail=False):
         """Create a hard link or block special device owned by uid:gid.
 
@@ -198,19 +204,39 @@ class JailerContext:
             return 'ip netns exec {} '.format(self.netns)
         return ''
 
-    def setup(self):
+    def setup(self, use_ramdisk=False):
         """Set up this jailer context."""
         os.makedirs(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
             exist_ok=True
         )
+
+        if use_ramdisk:
+            self._ramfs_path = self.chroot_ramfs_path()
+            os.makedirs(self._ramfs_path, exist_ok=True)
+            ramdisk_name = 'ramfs-{}'.format(self.jailer_id)
+            utils.run_cmd(
+                'mount -t ramfs -o size=1M {} {}'.format(
+                    ramdisk_name, self._ramfs_path
+                )
+            )
+            cmd = 'chown {}:{} {}'.format(
+                self.uid, self.gid, self._ramfs_path
+            )
+            utils.run_cmd(cmd)
+
         if self.netns:
             utils.run_cmd('ip netns add {}'.format(self.netns))
 
     def cleanup(self):
         """Clean up this jailer context."""
         # pylint: disable=subprocess-run-check
+        if self._ramfs_path:
+            utils.run_cmd(
+                'umount {}'.format(self._ramfs_path), ignore_return_code=True
+            )
+
         if self.jailer_id:
             shutil.rmtree(self.chroot_base_with_id(), ignore_errors=True)
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import select
+import shutil
 import time
 
 from retry import retry
@@ -316,6 +317,22 @@ class Microvm:
         )
         self._cpu_load_monitor.start()
 
+    def copy_to_jail_ramfs(self, src):
+        """Copy a file to a jail ramfs."""
+        filename = os.path.basename(src)
+        dest_path = os.path.join(self.jailer.chroot_ramfs_path(), filename)
+        jailed_path = os.path.join(
+            '/', self.jailer.ramfs_subdir_name, filename
+        )
+        shutil.copy(src, dest_path)
+        cmd = 'chown {}:{} {}'.format(
+            self.jailer.uid,
+            self.jailer.gid,
+            dest_path
+        )
+        utils.run_cmd(cmd)
+        return jailed_path
+
     def create_jailed_resource(self, path, create_jail=False):
         """Create a hard link to some resource inside this microvm."""
         return self.jailer.jailed_path(path, create=True,
@@ -395,10 +412,11 @@ class Microvm:
             return True
         return False
 
-    def spawn(self, create_logger=True, log_file='log_fifo', log_level='Info'):
+    def spawn(self, create_logger=True,
+              log_file='log_fifo', log_level='Info', use_ramdisk=False):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
-        self._jailer.setup()
+        self._jailer.setup(use_ramdisk=use_ramdisk)
         self._api_socket = self._jailer.api_socket_path()
         self._api_session = Session()
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -750,6 +750,7 @@ class Microvm:
         response = self.vm.patch(state='Paused')
         assert self.api_session.is_status_no_content(response.status_code)
 
+        self.api_session.untime()
         response = self.snapshot.create(mem_file_path=mem_file_path,
                                         snapshot_path=snapshot_path,
                                         diff=diff,

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -476,19 +476,26 @@ class MachineConfigure():
 
         self._machine_cfg_url = api_url + self.MACHINE_CFG_RESOURCE
         self._api_session = api_session
+        self._datax = {}
+
+    @property
+    def configuration(self):
+        """Return machine config dictionary."""
+        return self._datax
 
     def put(self, **args):
         """Specify the details of the machine configuration."""
-        datax = self.create_json(**args)
+        self._datax = self.create_json(**args)
 
         return self._api_session.put(
             "{}".format(self._machine_cfg_url),
-            json=datax
+            json=self._datax
         )
 
     def patch(self, **args):
         """Update the details of the machine configuration."""
         datax = self.create_json(**args)
+        self._datax.update(datax)
 
         return self._api_session.patch(
             "{}".format(self._machine_cfg_url),

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -324,6 +324,7 @@ class SnapshotCreate():
 
     def put(self, **args):
         """Create a snapshot of the microvm."""
+        self._api_session.untime()
         datax = self.create_json(**args)
         return self._api_session.put(
             "{}".format(self._snapshot_cfg_url),

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -55,6 +55,7 @@ def test_create_with_past_version(test_microvm_with_ssh, network_config):
     snapshot_builder = SnapshotBuilder(test_microvm)
     # Create directory and files for saving snapshot state and memory.
     _snapshot_dir = snapshot_builder.create_snapshot_dir()
+
     # Pause and create a snapshot of the microVM. Firecracker v0.23 allowed a
     # maximum of `FC_V0_23_MAX_DEVICES_ATTACHED` virtio devices at a time.
     # This microVM has `FC_V0_23_MAX_DEVICES_ATTACHED` devices, including the

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -29,21 +29,21 @@ CREATE_LATENCY_BASELINES = {
     'x86_64': {
         '2vcpu_256mb.json': {
             'FULL':  180,
-            'DIFF':  50,
+            'DIFF':  70,
         },
         '2vcpu_512mb.json': {
             'FULL':  280,
-            'DIFF':  50,
+            'DIFF':  75,
         }
     },
     'aarch64': {
         '2vcpu_256mb.json': {
             'FULL':  160,
-            'DIFF':  14,
+            'DIFF':  70,
         },
         '2vcpu_512mb.json': {
             'FULL':  300,
-            'DIFF':  20,
+            'DIFF':  75,
         }
     },
 }
@@ -99,7 +99,8 @@ def _test_snapshot_create_latency(context):
                                   disks=[rw_disk],
                                   ssh_key=ssh_key,
                                   config=context.microvm,
-                                  enable_diff_snapshots=enable_diff_snapshots)
+                                  enable_diff_snapshots=enable_diff_snapshots,
+                                  use_ramdisk=True)
 
             # Configure metrics system.
             metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
@@ -133,7 +134,8 @@ def _test_snapshot_create_latency(context):
             snapshot_builder.create(disks=[rw_disk],
                                     ssh_key=ssh_key,
                                     snapshot_type=snapshot_type,
-                                    target_version=target_version)
+                                    target_version=target_version,
+                                    use_ramdisk=True)
             metrics = vm.flush_metrics(metrics_fifo)
             vm_name = context.microvm.name()
 


### PR DESCRIPTION
# Reason for This PR

Depending on the host FS configuration, snapshot-related files (memory, vm-state, block devices backing files) could get corrupted if the backing mediums are moved while snapshot data is in-flight.

## Description of Changes

To provide a safe and consistent CreateSnapshot operation, Firecracker now flushes all snapshot related host-file as part of the create snapshot operation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~Any newly added `unsafe` code is properly documented.~
- [ ] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
