### PR TITLE
Backport devtool using ECR to v0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+### Changed
+
+- Changed Docker images repository from DockerHub to Amazon ECR.
+
 ## [0.24.2]
 
 ### Fixed
 
-- Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal 
+- Fixed the SIGPIPE signal handler so Firecracker no longer exits. The signal
 is still recorded in metrics and logs.
 
 ## [0.24.1]

--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -5,15 +5,13 @@
 Firecracker uses a [Docker container](https://www.docker.com/) to standardize
 the build process. This also fixes the build tools and dependencies to specific
 versions. Every once in a while, something needs to be updated. To do this, a
-new container image needs to be built locally, then published to the Docker
+new container image needs to be built locally, then published to the [AWS ECR](https://aws.amazon.com/ecr/)
 registry. The Firecracker CI suite must also be updated to use the new image.
 
 ## Prerequisites
 
-1. A Docker account. You must create this by yourself on
-   [Docker hub](https://hub.docker.com/).
 1. Access to the
-   [`fcuvm` Docker organization](https://cloud.docker.com/u/fcuvm/).
+   [`fcuvm` ECR repository](https://gallery.ecr.aws/firecracker/fcuvm).
 1. The `docker` package installed locally. You should already have this if
    you've ever built Firecracker from source.
 1. Access to both an `x86_64` and `aarch64` machines to build the container
@@ -23,11 +21,11 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 
 ### `x86_64`
 
-1. Login to the Docker organization in a shell. Use your username and password
-(not `fcuvm`).
+1. Login to the Docker organization in a shell. Make sure that your account has
+   access to the repository:
 
     ```bash
-    docker login
+    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
     ```
 
 1. Navigate to the Firecracker directory. Verify that you have the latest
@@ -35,8 +33,8 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Make your necessary changes, if any, to the
@@ -48,35 +46,35 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 1. Build a new container image with the updated Dockerfile.
 
    ```bash
-    docker build -t fcuvm/dev -f tools/devctr/Dockerfile.x86_64 .
+    docker build -t fcuvm -f tools/devctr/Dockerfile.x86_64 .
     ```
 
 1. Verify that the new image exists.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        2 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Tag the new image with the next available version and the architecture
    you're on.
 
     ```bash
-    docker tag 402b87586d11 fcuvm/dev:v15_x86_64
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_x86_64
 
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v15_x86_64          402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v27_x86_64          1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Push the image.
 
     ```bash
-    docker push fcuvm/dev:v15_x86_64
+    docker push public.ecr.aws/firecracker/fcuvm:v27_x86_64
     ```
 
 ### `aarch64`
@@ -90,45 +88,43 @@ Then:
 5. Build a new container image with the updated Dockerfile.
 
     ```bash
-    docker build -t fcuvm/dev -f tools/devctr/Dockerfile.aarch64  .
+    docker build -t fcuvm -f tools/devctr/Dockerfile.aarch64  .
     ```
 
 5. Verify that the new image exists.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 c8581789ead3        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        2 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 5. Tag the new image with the next available version and the architecture
    you're on.
 
     ```bash
-    docker tag 402b87586d11 fcuvm/dev:v15_aarch64
-    ```
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_aarch64
 
-    ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v15_aarch64         402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 c8581789ead3        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v27_aarch64         1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 5. Push the image.
 
     ```bash
-    docker push fcuvm/dev:v15_aarch64
+    docker push public.ecr.aws/firecracker/fcuvm:v27_aarch64
     ```
 
 5. Create a manifest to point the latest container version to each specialized
    image, per architecture.
 
     ```bash
-    docker manifest create fcuvm/dev:v15 fcuvm/dev:v15_x86_64 fcuvm/dev:v15_aarch64
-    docker manifest push fcuvm/dev:v15
+    docker manifest create public.ecr.aws/firecracker/fcuvm/dev:v27 public.ecr.aws/firecracker/fcuvm/dev:v27_x86_64 public.ecr.aws/firecracker/fcuvm/dev:v27_aarch64
+    docker manifest push public.ecr.aws/firecracker/fcuvm/dev:v27
     ```
 
 5. Update the image tag in the
@@ -136,7 +132,7 @@ Then:
    Commit and push the change.
 
     ```bash
-    sed -i 's%DEVCTR_IMAGE="fcuvm/dev:v14"%DEVCTR_IMAGE="fcuvm/dev:v15"%' tools/devtool
+    sed -i 's%DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v26"%DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v27"%' tools/devtool
     ```
 
 ## Troubleshooting
@@ -167,15 +163,15 @@ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 
 tools/devtool shell
-[Firecracker devtool] About to pull docker image fcuvm/dev:v15
+[Firecracker devtool] About to pull docker image public.ecr.aws/firecracker/fcuvm/dev:v15
 [Firecracker devtool] Continue?
 ```
 
-### I don't have access to the Docker registry
+### I don't have access to the AWS ECR registry
 
 ```bash
-docker push fcuvm/dev:v15
-The push refers to repository [docker.io/fcuvm/dev]
+docker push public.ecr.aws/firecracker/fcuvm:v27
+The push refers to repository [public.ecr.aws/firecracker/fcuvm]
 e2b5ee0c4e6b: Preparing
 0fbb5fd5f156: Preparing
 ...
@@ -184,12 +180,11 @@ denied: requested access to the resource is denied
 ```
 
 Only a Firecracker maintainer can update the container image. If you are one,
-ask a member of the team to add you to the `fcuvm` organization and retry.
+ask a member of the team to add you to the AWS ECR repository and retry.
 
 ### I pushed the wrong tag
 
-Tags can be deleted from the
-[Docker's repository WebUI](https://cloud.docker.com/u/fcuvm/repository/registry-1.docker.io/fcuvm/dev/tags).
+Tags can be deleted from the [AWS ECR interface](https://aws.amazon.com/ecr/).
 
 Also, pushing the same tag twice will overwrite the initial content.
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v25"
+DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v25"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"
@@ -532,7 +532,7 @@ cmd_build() {
     fi
 
     ret=$?
-    
+
     # If `cargo build` was successful, let's copy the binaries to a more
     # accessible location.
     [ $ret -eq 0 ] && {
@@ -791,7 +791,7 @@ cmd_prepare_release() {
         rm -f "${file}="
     done
 
-    # Run `cargo check` to update firecracker and jailer versions in 
+    # Run `cargo check` to update firecracker and jailer versions in
     # `Cargo.lock`.
     say "Updating lockfile..."
     run_devctr \

--- a/tools/devtool
+++ b/tools/devtool
@@ -189,6 +189,38 @@ ensure_docker() {
         "https://docs.docker.com/install/linux/linux-postinstall/"
 }
 
+# Run a command and retry multiple times if it fails. Once it stops
+# failing return to normal execution. If there are "retry count"
+# failures, set the last error code.
+# $1 - command
+# $2 - retry count
+# $3 - sleep interval between retries
+retry_cmd() {
+    command=$1
+    retry_cnt=$2
+    sleep_int=$3
+
+    {
+        $command
+    } || {
+        # Save error code
+        err_code=$?
+
+        # Command failed, substract one from retry_cnt
+        retry_cnt=$((retry_cnt - 1))
+
+        # If retry_cnt is larger than 0, sleep and call again
+        if [ "$retry_cnt" -gt 0 ]; then
+            echo "$command failed, retrying..."
+            sleep "$sleep_int"
+            retry_cmd "$command" "$retry_cnt" "$sleep_int"
+        fi
+
+        # Set what error code docker returned
+        $(exit "$err_code")
+    }
+}
+
 # Attempt to download our Docker image. Exit if that fails.
 # Upon returning from this call, the caller can be certain our Docker image is
 # available on this system.
@@ -204,7 +236,9 @@ ensure_devctr() {
         say "About to pull docker image $DEVCTR_IMAGE"
         get_user_confirmation || die "Aborted."
 
-        docker pull "${DEVCTR_IMAGE}"
+        # Run docker pull 5 times in case it fails - sleep 3 seconds
+        # between attempts
+        retry_cmd "docker pull $DEVCTR_IMAGE" 5 3
 
         ok_or_die "Error pulling docker image. Aborting."
     }


### PR DESCRIPTION
# Reason for This PR

This PR backports the changes did on the main branch where we moved from using DockerHub to ECR.

## Description of Changes

- Change the origin of docker pull commands
- Add retry loop to handle ECR limits.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist
- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
