### PR TITLE
Remove extra logic from balloon API change

### DIFF
--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -93,7 +93,6 @@ class Balloon():
 
     @staticmethod
     def create_json(
-            amount_mb=None,
             amount_mib=None,
             deflate_on_oom=None,
             stats_polling_interval_s=None
@@ -101,10 +100,7 @@ class Balloon():
         """Compose the json associated to this type of API request."""
         datax = {}
 
-        if amount_mib is None and amount_mb is not None:
-            datax['amount_mb'] = amount_mb
-
-        if amount_mb is None and amount_mib is not None:
+        if amount_mib is not None:
             datax['amount_mib'] = amount_mib
 
         if deflate_on_oom is not None:

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -80,7 +80,7 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
                                                  resume=True,
                                                  enable_diff_snapshots=False)
         validate_all_devices(logger, microvm, net_ifaces, scratch_drives,
-                             diff_snapshots, legacy_api=False)
+                             diff_snapshots)
         logger.debug("========== Firecracker restore snapshot log ==========")
         logger.debug(microvm.log_data)
 
@@ -112,8 +112,6 @@ def test_restore_old_version_all_devices(bin_cloner_path):
         # v0.23 does not have a balloon device.
         balloon = "0.23" not in target_version
 
-        legacy = "0.24" in target_version
-
         # Create a snapshot with current FC version targeting the old version.
         snapshot = create_snapshot_helper(bin_cloner_path,
                                           logger,
@@ -135,7 +133,7 @@ def test_restore_old_version_all_devices(bin_cloner_path):
                                                  resume=True,
                                                  enable_diff_snapshots=False)
         validate_all_devices(logger, microvm, net_ifaces, scratch_drives,
-                             balloon, legacy_api=legacy)
+                             balloon)
         logger.debug("========== Firecracker restore snapshot log ==========")
         logger.debug(microvm.log_data)
 
@@ -145,8 +143,7 @@ def validate_all_devices(
     microvm,
     ifaces,
     drives,
-    balloon,
-    legacy_api=False
+    balloon
 ):
     """Perform a basic validation for all devices of a microvm."""
     # Test that net devices have connectivity after restore.
@@ -182,7 +179,7 @@ def validate_all_devices(
     if balloon is True:
         logger.info("Testing balloon memory reclaim.")
         # Call helper fn from balloon integration tests.
-        _test_rss_memory_lower(microvm, use_legacy_api=legacy_api)
+        _test_rss_memory_lower(microvm)
 
 
 def create_snapshot_helper(bin_cloner_path, logger, target_version=None,
@@ -203,24 +200,15 @@ def create_snapshot_helper(bin_cloner_path, logger, target_version=None,
         snapshot_type = SnapshotType.DIFF
 
     if balloon:
-        legacy_balloon = fc_binary is not None and "0.24" in fc_binary
-
         # Copy balloon test util.
         copy_util_to_rootfs(vm_instance.disks[0].local_path(), 'fillmem')
 
         # Add a memory balloon with stats enabled.
-        if legacy_balloon:
-            response = vm.balloon.put(
-                amount_mb=0,
-                deflate_on_oom=True,
-                stats_polling_interval_s=1
-            )
-        else:
-            response = vm.balloon.put(
-                amount_mib=0,
-                deflate_on_oom=True,
-                stats_polling_interval_s=1
-            )
+        response = vm.balloon.put(
+            amount_mib=0,
+            deflate_on_oom=True,
+            stats_polling_interval_s=1
+        )
         assert vm.api_session.is_status_no_content(response.status_code)
 
     # Disk path array needed when creating the snapshot later.


### PR DESCRIPTION
Signed-off-by: George Pisaltu <gpl@amazon.com>

# Reason for This PR

#2530 

## Description of Changes

The v0.24.3 ballooning API PR was merged and we updated the 0.24 binaries used in CI testing.
Changing the API in v0.24 broke the tests for the `main` branch, and this PR fixes this.

**This PR needs to be merged in order to unblock other PRs.**

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
