### PR TITLE
Send transport_reset event on vsock snapshot create path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Snapshotting support for GICv2 enabled guests.
 - Added `devtool install` to deploy built binaries in `/usr/local/bin` or a
   given path.
+- Added code logic to send `VIRTIO_VSOCK_EVENT_TRANSPORT_RESET` on snapshot
+  creation, when the Vsock device is active. The event will close active
+  connections on the guest.
 
 ### Changed
 

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -532,8 +532,20 @@ Firecracker.
 to vsock packet loss, leads to Vsock device breakage when doing a snapshot while
 there are active Vsock connections.
 
-   _**Workaround**_: Close all active Vsock connections prior to snapshotting
-   the VM.
+   As a solution to the above issue, active Vsock connections prior to
+snapshotting the VM are forcibly closed by sending a specific event called
+`VIRTIO_VSOCK_EVENT_TRANSPORT_RESET`. The event is sent on `SnapshotCreate`.
+On `SnapshotResume`, when the VM becomes active again,
+the vsock driver closes all existing connections.
+Listen sockets still remain active. Users wanting to build vsock applications that
+use the snapshot capability have to take this into consideration. More details
+about this event can be found in the official Virtio document
+[here](https://docs.oasis-open.org/virtio/virtio/v1.1/virtio-v1.1.pdf),
+section 5.10.6.6 Device Events.
+
+   Firecracker handles sending the `reset` event to the vsock driver,
+thus the customers are no longer responsible for closing
+active connections.
 
 1. _Incremental/diff_ snapshots are not yet supported for Vsock devices.
    Creating a `diff` snapshot on a microVM with a `vsock` device configured

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -14,7 +14,7 @@ pub mod pseudo;
 pub mod virtio;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};
-use crate::virtio::QueueError;
+use crate::virtio::{QueueError, VsockError};
 use logger::{error, IncMetric, METRICS};
 
 // Function used for reporting error in terms of logging
@@ -43,4 +43,6 @@ pub enum Error {
     MalformedDescriptor,
     /// Error during queue processing.
     QueueError(QueueError),
+    /// Vsock device error.
+    VsockError(VsockError),
 }

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -99,6 +99,8 @@ pub enum VsockError {
     BufDescTooSmall,
     /// The vsock data/buffer virtio descriptor is expected, but missing.
     BufDescMissing,
+    /// Empty queue
+    EmptyQueue,
     /// EventFd error
     EventFd(std::io::Error),
     /// Chained GuestMemoryMmap error.

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use super::mmio::*;
 use crate::EventManager;
+use logger::error;
 
 #[cfg(target_arch = "aarch64")]
 use arch::DeviceType;
@@ -187,7 +188,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 
             let transport_state = mmio_transport.save();
 
-            let locked_device = mmio_transport.locked_device();
+            let mut locked_device = mmio_transport.locked_device();
             match locked_device.device_type() {
                 TYPE_BALLOON => {
                     let balloon_state = locked_device
@@ -226,14 +227,24 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                 }
                 TYPE_VSOCK => {
                     let vsock = locked_device
-                        .as_any()
+                        .as_mut_any()
                         // Currently, VsockUnixBackend is the only implementation of VsockBackend.
-                        .downcast_ref::<Vsock<VsockUnixBackend>>()
+                        .downcast_mut::<Vsock<VsockUnixBackend>>()
                         .unwrap();
+
                     let vsock_state = VsockState {
                         backend: vsock.backend().save(),
                         frontend: vsock.save(),
                     };
+
+                    // Send Transport event to reset connections if device
+                    // is activated.
+                    if vsock.is_activated() {
+                        vsock.send_transport_reset_event().unwrap_or_else(|e| {
+                            error!("Failed to send reset transport event: {:?}", e);
+                        });
+                    }
+
                     states.vsock_device = Some(ConnectedVsockState {
                         device_id: devid.clone(),
                         device_state: vsock_state,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.93, "AMD": 84.36, "ARM": 83.26}
+COVERAGE_DICT = {"Intel": 84.82, "AMD": 84.22, "ARM": 83.14}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
Fixes #2218 .

Signed-off-by: berciuliviu <lberciu@amazon.com>

# Reason for This PR

With this PR, we want to send the VIRTIO_VSOCK_EVENT_TRANSPORT_RESET event to the
vsock driver when we create a snapshot. The event is sent only if the device is active.

## Description of Changes

Send VIRTIO_VSOCK_EVENT_TRANSPORT_RESET by filling a descriptor in the
event queue and signaling an interrupt event to the driver.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
