### PR TITLE
make InstanceStart idempotent for seccomp filters

### DIFF
--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -200,14 +200,14 @@ pub(crate) fn run_with_api(
     // Configure, build and start the microVM.
     let (vm_resources, vmm) = match config_json {
         Some(json) => super::build_microvm_from_json(
-            seccomp_filters,
+            &seccomp_filters,
             &mut event_manager,
             json,
             &instance_info,
             boot_timer_enabled,
         ),
         None => PrebootApiController::build_microvm_from_requests(
-            seccomp_filters,
+            &seccomp_filters,
             &mut event_manager,
             instance_info,
             || {

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -290,12 +290,12 @@ fn main() {
             boot_timer_enabled,
         );
     } else {
-        let mut seccomp_filters: BpfThreadMap = seccomp_filters
+        let seccomp_filters: BpfThreadMap = seccomp_filters
             .into_iter()
             .filter(|(k, _)| k != "api")
             .collect();
         run_without_api(
-            &mut seccomp_filters,
+            &seccomp_filters,
             vmm_config_json,
             &instance_info,
             boot_timer_enabled,
@@ -367,7 +367,7 @@ fn print_snapshot_data_format(snapshot_path: &str) {
 
 // Configure and start a microVM as described by the command-line JSON.
 fn build_microvm_from_json(
-    seccomp_filters: &mut BpfThreadMap,
+    seccomp_filters: &BpfThreadMap,
     event_manager: &mut EventManager,
     config_json: String,
     instance_info: &InstanceInfo,
@@ -396,7 +396,7 @@ fn build_microvm_from_json(
 }
 
 fn run_without_api(
-    seccomp_filters: &mut BpfThreadMap,
+    seccomp_filters: &BpfThreadMap,
     config_json: Option<String>,
     instance_info: &InstanceInfo,
     bool_timer_enabled: bool,

--- a/src/seccompiler/src/common.rs
+++ b/src/seccompiler/src/common.rs
@@ -5,7 +5,6 @@
 //! and the seccompiler binary.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// The maximum seccomp-BPF program length allowed by the linux kernel.
 pub(crate) const BPF_MAX_LEN: usize = 4096;
@@ -24,6 +23,3 @@ pub struct sock_filter {
 
 /// Program made up of a sequence of BPF instructions.
 pub type BpfProgram = Vec<sock_filter>;
-
-/// Type that associates a thread category to a BPF program.
-pub type BpfThreadMap = HashMap<String, BpfProgram>;

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -25,7 +25,7 @@ use crate::backend::{
     Comment, Error as SeccompFilterError, SeccompAction, SeccompCondition, SeccompFilter,
     SeccompRule, SeccompRuleMap, TargetArch,
 };
-use crate::common::BpfThreadMap;
+use crate::common::BpfProgram;
 use crate::syscall_table::SyscallTable;
 use serde::Deserialize;
 
@@ -144,9 +144,9 @@ impl Compiler {
         &self,
         filters: HashMap<String, Filter>,
         is_basic: bool,
-    ) -> Result<BpfThreadMap> {
+    ) -> Result<HashMap<String, BpfProgram>> {
         self.validate_filters(&filters)?;
-        let mut bpf_map = BpfThreadMap::new();
+        let mut bpf_map: HashMap<String, BpfProgram> = HashMap::new();
 
         for (thread_name, filter) in filters.into_iter() {
             if is_basic {

--- a/src/seccompiler/src/seccompiler.rs
+++ b/src/seccompiler/src/seccompiler.rs
@@ -46,7 +46,7 @@ use std::{fmt, io, process};
 
 use backend::{TargetArch, TargetArchError};
 use bincode::Error as BincodeError;
-use common::BpfThreadMap;
+use common::BpfProgram;
 use compiler::{Compiler, Error as FilterFormatError, Filter};
 use serde_json::error::Error as JSONError;
 use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag};
@@ -162,7 +162,7 @@ fn compile(args: &Arguments) -> Result<()> {
     let compiler = Compiler::new(args.target_arch);
 
     // transform the IR into a Map of BPFPrograms
-    let bpf_data: BpfThreadMap = compiler
+    let bpf_data: HashMap<String, BpfProgram> = compiler
         .compile_blob(filters, args.is_basic)
         .map_err(Error::FileFormat)?;
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -365,12 +365,10 @@ pub fn build_microvm_for_boot(
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(
         vcpus,
-        Arc::new(
-            seccomp_filters
-                .get("vcpu")
-                .ok_or_else(|| MissingSeccompFilters("vcpu".to_string()))?
-                .clone(),
-        ),
+        seccomp_filters
+            .get("vcpu")
+            .ok_or_else(|| MissingSeccompFilters("vcpu".to_string()))?
+            .clone(),
     )
     .map_err(Internal)?;
 
@@ -452,12 +450,10 @@ pub fn build_microvm_from_snapshot(
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(
         vcpus,
-        Arc::new(
-            seccomp_filters
-                .get("vcpu")
-                .ok_or_else(|| MissingSeccompFilters("vcpu".to_string()))?
-                .clone(),
-        ),
+        seccomp_filters
+            .get("vcpu")
+            .ok_or_else(|| MissingSeccompFilters("vcpu".to_string()))?
+            .clone(),
     )
     .map_err(Internal)?;
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -389,7 +389,7 @@ pub fn snapshot_state_sanity_check(
 /// Loads a Microvm snapshot producing a 'paused' Microvm.
 pub fn restore_from_snapshot(
     event_manager: &mut EventManager,
-    seccomp_filters: &mut BpfThreadMap,
+    seccomp_filters: &BpfThreadMap,
     params: &LoadSnapshotParams,
     version_map: VersionMap,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, LoadSnapshotError> {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -208,7 +208,7 @@ pub type ActionResult = result::Result<VmmData, VmmActionError>;
 
 /// Enables pre-boot setup and instantiation of a Firecracker VMM.
 pub struct PrebootApiController<'a> {
-    seccomp_filters: &'a mut BpfThreadMap,
+    seccomp_filters: &'a BpfThreadMap,
     instance_info: InstanceInfo,
     vm_resources: &'a mut VmResources,
     event_manager: &'a mut EventManager,
@@ -221,7 +221,7 @@ pub struct PrebootApiController<'a> {
 impl<'a> PrebootApiController<'a> {
     /// Constructor for the PrebootApiController.
     pub fn new(
-        seccomp_filters: &'a mut BpfThreadMap,
+        seccomp_filters: &'a BpfThreadMap,
         instance_info: InstanceInfo,
         vm_resources: &'a mut VmResources,
         event_manager: &'a mut EventManager,
@@ -242,7 +242,7 @@ impl<'a> PrebootApiController<'a> {
     ///
     /// Returns a populated `VmResources` object and a running `Vmm` object.
     pub fn build_microvm_from_requests<F, G>(
-        seccomp_filters: &mut BpfThreadMap,
+        seccomp_filters: &BpfThreadMap,
         event_manager: &mut EventManager,
         instance_info: InstanceInfo,
         recv_req: F,
@@ -387,7 +387,7 @@ impl<'a> PrebootApiController<'a> {
         build_microvm_for_boot(
             &self.vm_resources,
             &mut self.event_manager,
-            &mut self.seccomp_filters,
+            self.seccomp_filters,
         )
         .map(|vmm| {
             self.built_vmm = Some(vmm);
@@ -409,7 +409,7 @@ impl<'a> PrebootApiController<'a> {
 
         let result = restore_from_snapshot(
             &mut self.event_manager,
-            &mut self.seccomp_filters,
+            self.seccomp_filters,
             load_params,
             VERSION_MAP.clone(),
         )
@@ -908,7 +908,7 @@ mod tests {
     pub fn build_microvm_for_boot(
         _: &VmResources,
         _: &mut EventManager,
-        _: &mut BpfThreadMap,
+        _: &BpfThreadMap,
     ) -> Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
         Ok(Arc::new(Mutex::new(MockVmm::default())))
     }
@@ -927,7 +927,7 @@ mod tests {
     // instead of our mocks.
     pub fn restore_from_snapshot(
         _: &mut EventManager,
-        _: &mut BpfThreadMap,
+        _: &BpfThreadMap,
         _: &LoadSnapshotParams,
         _: versionize::VersionMap,
     ) -> Result<Arc<Mutex<Vmm>>, LoadSnapshotError> {
@@ -937,7 +937,7 @@ mod tests {
     fn default_preboot<'a>(
         vm_resources: &'a mut VmResources,
         event_manager: &'a mut EventManager,
-        seccomp_filters: &'a mut BpfThreadMap,
+        seccomp_filters: &'a BpfThreadMap,
     ) -> PrebootApiController<'a> {
         let instance_info = InstanceInfo {
             id: String::new(),
@@ -954,8 +954,8 @@ mod tests {
     {
         let mut vm_resources = MockVmRes::default();
         let mut evmgr = EventManager::new().unwrap();
-        let mut seccomp_filters = BpfThreadMap::new();
-        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &mut seccomp_filters);
+        let seccomp_filters = BpfThreadMap::new();
+        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &seccomp_filters);
         let res = preboot.handle_preboot_request(request);
         check_success(res, &vm_resources);
     }
@@ -965,8 +965,8 @@ mod tests {
         let mut vm_resources = MockVmRes::default();
         vm_resources.force_errors = true;
         let mut evmgr = EventManager::new().unwrap();
-        let mut seccomp_filters = BpfThreadMap::new();
-        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &mut seccomp_filters);
+        let seccomp_filters = BpfThreadMap::new();
+        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &seccomp_filters);
         let err = preboot.handle_preboot_request(request).unwrap_err();
         assert_eq!(err, expected_err);
     }
@@ -1152,8 +1152,8 @@ mod tests {
     fn test_preboot_load_snapshot() {
         let mut vm_resources = MockVmRes::default();
         let mut evmgr = EventManager::new().unwrap();
-        let mut seccomp_filters = BpfThreadMap::new();
-        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &mut seccomp_filters);
+        let seccomp_filters = BpfThreadMap::new();
+        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &seccomp_filters);
 
         // Without resume.
         let req = VmmAction::LoadSnapshot(LoadSnapshotParams {
@@ -1271,7 +1271,7 @@ mod tests {
         };
 
         let (_vm_res, _vmm) = PrebootApiController::build_microvm_from_requests(
-            &mut BpfThreadMap::new(),
+            &BpfThreadMap::new(),
             &mut EventManager::new().unwrap(),
             InstanceInfo {
                 id: String::new(),
@@ -1560,8 +1560,8 @@ mod tests {
     fn verify_load_snap_disallowed_after_boot_resources(res: VmmAction, res_name: &str) {
         let mut vm_resources = MockVmRes::default();
         let mut evmgr = EventManager::new().unwrap();
-        let mut seccomp_filters = BpfThreadMap::new();
-        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &mut seccomp_filters);
+        let seccomp_filters = BpfThreadMap::new();
+        let mut preboot = default_preboot(&mut vm_resources, &mut evmgr, &seccomp_filters);
 
         preboot.handle_preboot_request(res).unwrap();
 

--- a/src/vmm/src/seccomp_filters/mod.rs
+++ b/src/vmm/src/seccomp_filters/mod.rs
@@ -5,6 +5,7 @@ use seccompiler::{deserialize_binary, BpfThreadMap, DeserializationError, Instal
 use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, Read};
+use std::sync::Arc;
 
 const THREAD_CATEGORIES: [&str; 3] = ["vmm", "api", "vcpu"];
 
@@ -122,9 +123,9 @@ fn get_default_filters(basic: bool) -> Result<BpfThreadMap, FilterError> {
 /// Retrieve empty seccomp filters.
 fn get_empty_filters() -> BpfThreadMap {
     let mut map = BpfThreadMap::new();
-    map.insert("vmm".to_string(), vec![]);
-    map.insert("api".to_string(), vec![]);
-    map.insert("vcpu".to_string(), vec![]);
+    map.insert("vmm".to_string(), Arc::new(vec![]));
+    map.insert("api".to_string(), Arc::new(vec![]));
+    map.insert("vcpu".to_string(), Arc::new(vec![]));
     map
 }
 
@@ -199,18 +200,18 @@ mod tests {
     fn test_filter_thread_categories() {
         // correct categories
         let mut map = BpfThreadMap::new();
-        map.insert("vcpu".to_string(), vec![]);
-        map.insert("vmm".to_string(), vec![]);
-        map.insert("api".to_string(), vec![]);
+        map.insert("vcpu".to_string(), Arc::new(vec![]));
+        map.insert("vmm".to_string(), Arc::new(vec![]));
+        map.insert("api".to_string(), Arc::new(vec![]));
 
         assert_eq!(filter_thread_categories(map).unwrap().len(), 3);
 
         // invalid categories
         let mut map = BpfThreadMap::new();
-        map.insert("vcpu".to_string(), vec![]);
-        map.insert("vmm".to_string(), vec![]);
-        map.insert("thread1".to_string(), vec![]);
-        map.insert("thread2".to_string(), vec![]);
+        map.insert("vcpu".to_string(), Arc::new(vec![]));
+        map.insert("vmm".to_string(), Arc::new(vec![]));
+        map.insert("thread1".to_string(), Arc::new(vec![]));
+        map.insert("thread2".to_string(), Arc::new(vec![]));
 
         match filter_thread_categories(map).unwrap_err() {
             FilterError::ThreadCategories(err) => {
@@ -221,8 +222,8 @@ mod tests {
 
         // missing category
         let mut map = BpfThreadMap::new();
-        map.insert("vcpu".to_string(), vec![]);
-        map.insert("vmm".to_string(), vec![]);
+        map.insert("vcpu".to_string(), Arc::new(vec![]));
+        map.insert("vmm".to_string(), Arc::new(vec![]));
 
         match filter_thread_categories(map).unwrap_err() {
             FilterError::MissingThreadCategory(name) => assert_eq!(name, "api"),

--- a/src/vmm/src/utilities/test_utils/mod.rs
+++ b/src/vmm/src/utilities/test_utils/mod.rs
@@ -19,7 +19,7 @@ const VMM_ERR_EXIT: i32 = 42;
 
 pub fn create_vmm(_kernel_image: Option<&str>, is_diff: bool) -> (Arc<Mutex<Vmm>>, EventManager) {
     let mut event_manager = EventManager::new().unwrap();
-    let mut empty_seccomp_filters = get_filters(SeccompConfig::None).unwrap();
+    let empty_seccomp_filters = get_filters(SeccompConfig::None).unwrap();
 
     let boot_source_cfg = MockBootSourceConfig::new().with_default_boot_args();
     #[cfg(target_arch = "aarch64")]
@@ -39,7 +39,7 @@ pub fn create_vmm(_kernel_image: Option<&str>, is_diff: bool) -> (Arc<Mutex<Vmm>
     };
 
     (
-        build_microvm_for_boot(&resources, &mut event_manager, &mut empty_seccomp_filters).unwrap(),
+        build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filters).unwrap(),
         event_manager,
     )
 }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -915,7 +915,7 @@ mod tests {
 
         let mut seccomp_filters = get_filters(SeccompConfig::None).unwrap();
         let vcpu_handle = vcpu
-            .start_threaded(Arc::new(seccomp_filters.remove("vcpu").unwrap()))
+            .start_threaded(seccomp_filters.remove("vcpu").unwrap())
             .expect("failed to start vcpu");
 
         (vcpu_handle, vcpu_exit_evt)

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.85, "AMD": 84.15, "ARM": 83.0}
+COVERAGE_DICT = {"Intel": 84.85, "AMD": 84.15, "ARM": 83.13}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

See comment: https://github.com/firecracker-microvm/firecracker/pull/2557#discussion_r631847141

Previously, the InstanceStart request, was using a mutable
reference of the seccomp filter collection, removing the
entries for each thread category, after they were launched.

If a recoverable error occured, that did not bring down
the process, because the BPF map was mutated, a subsequent
InstanceStart would fail because the filters would have
already been freed.

## Description of Changes

This commit fixes this, by changing the mutable reference
on the PrebootAPIController to be a regular reference,
kept valid for the entire lifetime of the preboot controller
(until the instance is started).

The vmm and vcpu filters are no longer removed from the
filter map, until the entire map is freed.

This way, a subsequent call would not fail.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
