### PR TITLE
Use the evset passed as a parameter instead of the one from connection

### DIFF
--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -273,7 +273,7 @@ impl VsockEpollListener for VsockMuxer {
     /// Get the epoll events to be polled upstream.
     ///
     /// Since the polled FD is a nested epoll FD, we're only interested in EPOLLIN events (i.e.
-    /// some event occured on one of the FDs registered under our epoll FD).
+    /// some event occurred on one of the FDs registered under our epoll FD).
     fn get_polled_evset(&self) -> EventSet {
         EventSet::IN
     }
@@ -327,30 +327,29 @@ impl VsockMuxer {
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
         };
 
-        // Listen on the host initiated socket, for incomming connections.
+        // Listen on the host initiated socket, for incoming connections.
         muxer.add_listener(muxer.host_sock.as_raw_fd(), EpollListener::HostSock)?;
         Ok(muxer)
     }
 
     /// Handle/dispatch an epoll event to its listener.
-    fn handle_event(&mut self, fd: RawFd, evset: EventSet) {
+    fn handle_event(&mut self, fd: RawFd, event_set: EventSet) {
         debug!(
             "vsock: muxer processing event: fd={}, evset={:?}",
-            fd, evset
+            fd, event_set
         );
 
         match self.listener_map.get_mut(&fd) {
             // This event needs to be forwarded to a `MuxerConnection` that is listening for
             // it.
-            Some(EpollListener::Connection { key, evset }) => {
+            Some(EpollListener::Connection { key, evset: _ }) => {
                 let key_copy = *key;
-                let evset_copy = *evset;
                 // The handling of this event will most probably mutate the state of the
-                // receiving conection. We'll need to check for new pending RX, event set
+                // receiving connection. We'll need to check for new pending RX, event set
                 // mutation, and all that, so we're wrapping the event delivery inside those
                 // checks.
                 self.apply_conn_mutation(key_copy, |conn| {
-                    conn.notify(evset_copy);
+                    conn.notify(event_set);
                 });
             }
 
@@ -412,7 +411,10 @@ impl VsockMuxer {
             }
 
             _ => {
-                info!("vsock: unexpected event: fd={:?}, evset={:?}", fd, evset);
+                info!(
+                    "vsock: unexpected event: fd={:?}, evset={:?}",
+                    fd, event_set
+                );
                 METRICS.vsock.muxer_event_fails.inc();
             }
         }


### PR DESCRIPTION
# Reason for This PR

Aims to close #2539

## Description of Changes

Renamed name-clashing variables to fix the bug and avoid the confusion in the future.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
