### PR TITLE
Fix GetInstanceInfo when config-file is used

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -27,7 +27,7 @@ use mmds::data_store::Mmds;
 use seccompiler::BpfProgramRef;
 use utils::eventfd::EventFd;
 use vmm::rpc_interface::{VmmAction, VmmActionError, VmmData};
-use vmm::vmm_config::instance_info::InstanceInfo;
+use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
 use vmm::vmm_config::snapshot::SnapshotType;
 
 use vmm::FC_EXIT_CODE_BAD_CONFIGURATION;
@@ -133,13 +133,6 @@ impl ApiServer {
     /// tmp_socket.remove().unwrap();
     /// let path_to_socket = tmp_socket.as_path().to_str().unwrap().to_owned();
     /// let api_thread_path_to_socket = path_to_socket.clone();
-    /// let instance_info = InstanceInfo {
-    ///     state: "Not started".to_string(),
-    ///     id: "test_serve_action_req".to_string(),
-    ///     vmm_version: "version 0.1.0".to_string(),
-    ///     app_name: "app name".to_string(),
-    /// };
-    ///
     /// let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
     /// let (api_request_sender, _from_api) = channel();
     /// let (to_api, vmm_response_receiver) = channel();
@@ -152,7 +145,7 @@ impl ApiServer {
     ///     .spawn(move || {
     ///         ApiServer::new(
     ///             mmds_info,
-    ///             instance_info,
+    ///             InstanceInfo::default(),
     ///             api_request_sender,
     ///             vmm_response_receiver,
     ///             to_vmm_fd,
@@ -290,9 +283,9 @@ impl ApiServer {
         };
 
         let vmm_new_state = match *vmm_action {
-            VmmAction::StartMicroVm => "Running".to_string(),
-            VmmAction::Pause => "Paused".to_string(),
-            VmmAction::Resume => "Running".to_string(),
+            VmmAction::StartMicroVm => VmState::Running,
+            VmmAction::Pause => VmState::Paused,
+            VmmAction::Resume => VmState::Running,
             _ => self.instance_info.state.clone(),
         };
         self.api_request_sender
@@ -445,13 +438,6 @@ mod tests {
 
     #[test]
     fn test_serve_vmm_action_request() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_serve_action_req".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (to_api, vmm_response_receiver) = channel();
@@ -459,7 +445,7 @@ mod tests {
 
         let mut api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -514,12 +500,6 @@ mod tests {
 
     #[test]
     fn test_get_instance_info() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_get_instance_info".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -527,7 +507,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -539,13 +519,6 @@ mod tests {
 
     #[test]
     fn test_get_mmds() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_get_mmds".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -553,7 +526,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -565,13 +538,6 @@ mod tests {
 
     #[test]
     fn test_put_mmds() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_put_mmds".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -579,7 +545,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -590,13 +556,6 @@ mod tests {
 
     #[test]
     fn test_patch_mmds() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_patch_mmds".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -604,7 +563,7 @@ mod tests {
 
         let api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -625,13 +584,6 @@ mod tests {
 
     #[test]
     fn test_handle_request() {
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_handle_request".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (to_api, vmm_response_receiver) = channel();
@@ -639,7 +591,7 @@ mod tests {
 
         let mut api_server = ApiServer::new(
             mmds_info,
-            instance_info,
+            InstanceInfo::default(),
             api_request_sender,
             vmm_response_receiver,
             to_vmm_fd,
@@ -729,13 +681,6 @@ mod tests {
         let path_to_socket = tmp_socket.as_path().to_str().unwrap().to_owned();
         let api_thread_path_to_socket = path_to_socket.clone();
 
-        let instance_info = InstanceInfo {
-            state: "Not started".to_string(),
-            id: "test_handle_request".to_string(),
-            vmm_version: "version 0.1.0".to_string(),
-            app_name: "app name".to_string(),
-        };
-
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (api_request_sender, _from_api) = channel();
         let (_to_api, vmm_response_receiver) = channel();
@@ -747,7 +692,7 @@ mod tests {
             .spawn(move || {
                 ApiServer::new(
                     mmds_info,
-                    instance_info,
+                    InstanceInfo::default(),
                     api_request_sender,
                     vmm_response_receiver,
                     to_vmm_fd,

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -27,7 +27,6 @@ use logger::{error, info};
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 
 pub(crate) enum ParsedRequest {
-    GetInstanceInfo,
     GetMMDS,
     PatchMMDS(Value),
     PutMMDS(Value),
@@ -273,7 +272,6 @@ pub(crate) mod tests {
                 (&ParsedRequest::Sync(ref sync_req), &ParsedRequest::Sync(ref other_sync_req)) => {
                     sync_req == other_sync_req
                 }
-                (&ParsedRequest::GetInstanceInfo, &ParsedRequest::GetInstanceInfo) => true,
                 (&ParsedRequest::GetMMDS, &ParsedRequest::GetMMDS) => true,
                 (&ParsedRequest::PutMMDS(ref val), &ParsedRequest::PutMMDS(ref other_val)) => {
                     val == other_val

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -117,6 +117,7 @@ impl ParsedRequest {
                     Self::success_response_with_data(balloon_config)
                 }
                 VmmData::BalloonStats(stats) => Self::success_response_with_data(stats),
+                VmmData::InstanceInformation(info) => Self::success_response_with_data(info),
             },
             Err(vmm_action_error) => {
                 error!(

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -3,10 +3,11 @@
 
 use crate::parsed_request::{Error, ParsedRequest};
 use logger::{IncMetric, METRICS};
+use vmm::rpc_interface::VmmAction;
 
 pub(crate) fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.instance_info_count.inc();
-    Ok(ParsedRequest::GetInstanceInfo)
+    Ok(ParsedRequest::new_sync(VmmAction::GetVmInstanceInfo))
 }
 
 #[cfg(test)]
@@ -16,7 +17,7 @@ mod tests {
     #[test]
     fn test_parse_get_instance_info_request() {
         match parse_get_instance_info() {
-            Ok(ParsedRequest::GetInstanceInfo) => {}
+            Ok(ParsedRequest::Sync(action)) if *action == VmmAction::GetVmInstanceInfo => {}
             _ => panic!("Test failed."),
         }
     }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -138,7 +138,6 @@ pub(crate) fn run_with_api(
 
     // MMDS only supported with API.
     let mmds_info = MMDS.clone();
-    let api_server_instance_info = instance_info.clone();
     let to_vmm_event_fd = api_event_fd
         .try_clone()
         .expect("Failed to clone API event FD");
@@ -151,15 +150,11 @@ pub(crate) fn run_with_api(
         .spawn(move || {
             mask_handled_signals().expect("Unable to install signal mask on API thread.");
 
-            match ApiServer::new(
-                mmds_info,
-                api_server_instance_info,
-                to_vmm,
-                from_vmm,
-                to_vmm_event_fd,
-            )
-            .bind_and_run(bind_path, process_time_reporter, &api_seccomp_filter)
-            {
+            match ApiServer::new(mmds_info, to_vmm, from_vmm, to_vmm_event_fd).bind_and_run(
+                bind_path,
+                process_time_reporter,
+                &api_seccomp_filter,
+            ) {
                 Ok(_) => (),
                 Err(api_server::Error::Io(inner)) => match inner.kind() {
                     std::io::ErrorKind::AddrInUse => panic!(

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -203,7 +203,7 @@ pub(crate) fn run_with_api(
             &seccomp_filters,
             &mut event_manager,
             json,
-            &instance_info,
+            instance_info,
             boot_timer_enabled,
         ),
         None => PrebootApiController::build_microvm_from_requests(

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -21,7 +21,7 @@ use vmm::resources::VmResources;
 use vmm::seccomp_filters::{get_filters, SeccompConfig};
 use vmm::signal_handler::{mask_handled_signals, SignalManager};
 use vmm::version_map::{FC_VERSION_TO_SNAP_VERSION, VERSION_MAP};
-use vmm::vmm_config::instance_info::InstanceInfo;
+use vmm::vmm_config::instance_info::{InstanceInfo, VmState};
 use vmm::vmm_config::logger::{init_logger, LoggerConfig, LoggerLevel};
 
 // The reason we place default API socket under /run is that API socket is a
@@ -202,7 +202,7 @@ fn main() {
 
     let instance_info = InstanceInfo {
         id: instance_id.clone(),
-        state: "Not started".to_string(),
+        state: VmState::NotStarted,
         vmm_version: FIRECRACKER_VERSION.to_string(),
         app_name: "Firecracker".to_string(),
     };

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -297,7 +297,7 @@ fn main() {
         run_without_api(
             &seccomp_filters,
             vmm_config_json,
-            &instance_info,
+            instance_info,
             boot_timer_enabled,
         );
     }
@@ -370,11 +370,11 @@ fn build_microvm_from_json(
     seccomp_filters: &BpfThreadMap,
     event_manager: &mut EventManager,
     config_json: String,
-    instance_info: &InstanceInfo,
+    instance_info: InstanceInfo,
     boot_timer_enabled: bool,
 ) -> (VmResources, Arc<Mutex<vmm::Vmm>>) {
     let mut vm_resources =
-        VmResources::from_json(&config_json, instance_info).unwrap_or_else(|err| {
+        VmResources::from_json(&config_json, &instance_info).unwrap_or_else(|err| {
             error!(
                 "Configuration for VMM from one single json failed: {:?}",
                 err
@@ -382,14 +382,19 @@ fn build_microvm_from_json(
             process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
         });
     vm_resources.boot_timer = boot_timer_enabled;
-    let vmm = vmm::builder::build_microvm_for_boot(&vm_resources, event_manager, seccomp_filters)
-        .unwrap_or_else(|err| {
-            error!(
-                "Building VMM configured from cmdline json failed: {:?}",
-                err
-            );
-            process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
-        });
+    let vmm = vmm::builder::build_microvm_for_boot(
+        &instance_info,
+        &vm_resources,
+        event_manager,
+        seccomp_filters,
+    )
+    .unwrap_or_else(|err| {
+        error!(
+            "Building VMM configured from cmdline json failed: {:?}",
+            err
+        );
+        process::exit(i32::from(vmm::FC_EXIT_CODE_BAD_CONFIGURATION));
+    });
     info!("Successfully started microvm that was configured from one single json");
 
     (vm_resources, vmm)
@@ -398,7 +403,7 @@ fn build_microvm_from_json(
 fn run_without_api(
     seccomp_filters: &BpfThreadMap,
     config_json: Option<String>,
-    instance_info: &InstanceInfo,
+    instance_info: InstanceInfo,
     bool_timer_enabled: bool,
 ) {
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -349,16 +349,10 @@ pub struct ApiServerMetrics {
 pub struct GetRequestsMetrics {
     /// Number of GETs for getting information on the instance.
     pub instance_info_count: SharedIncMetric,
-    /// Number of failures when obtaining information on the current instance.
-    pub instance_info_fails: SharedIncMetric,
     /// Number of GETs for getting status on attaching machine configuration.
     pub machine_cfg_count: SharedIncMetric,
-    /// Number of failures during GETs for getting information on the instance.
-    pub machine_cfg_fails: SharedIncMetric,
     /// Number of GETs for getting mmds.
     pub mmds_count: SharedIncMetric,
-    /// Number of failures during GETs for getting mmds.
-    pub mmds_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PUT API Requests for counting user triggered actions and/or failures.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -24,6 +24,7 @@ use crate::vstate::{
 };
 use crate::{device_manager, Error, Vmm, VmmEventsObserver};
 
+use crate::vmm_config::instance_info::InstanceInfo;
 use arch::InitrdConfig;
 use devices::legacy::Serial;
 use devices::virtio::{Balloon, Block, MmioTransport, Net, VirtioDevice, Vsock, VsockUnixBackend};
@@ -211,6 +212,7 @@ impl VmmEventsObserver for SerialStdin {
 
 #[cfg_attr(target_arch = "aarch64", allow(unused))]
 fn create_vmm_and_vcpus(
+    instance_info: &InstanceInfo,
     event_manager: &mut EventManager,
     guest_memory: GuestMemoryMmap,
     track_dirty_pages: bool,
@@ -271,6 +273,7 @@ fn create_vmm_and_vcpus(
 
     let vmm = Vmm {
         events_observer: Some(Box::new(SerialStdin::get())),
+        instance_info: instance_info.clone(),
         guest_memory,
         vcpus_handles: Vec::new(),
         exit_evt,
@@ -291,6 +294,7 @@ fn create_vmm_and_vcpus(
 /// An `Arc` reference of the built `Vmm` is also plugged in the `EventManager`, while another
 /// is returned.
 pub fn build_microvm_for_boot(
+    instance_info: &InstanceInfo,
     vm_resources: &super::resources::VmResources,
     event_manager: &mut EventManager,
     seccomp_filters: &BpfThreadMap,
@@ -317,6 +321,7 @@ pub fn build_microvm_for_boot(
     let request_ts = TimestampUs::default();
 
     let (mut vmm, mut vcpus) = create_vmm_and_vcpus(
+        instance_info,
         event_manager,
         guest_memory,
         track_dirty_pages,
@@ -400,6 +405,7 @@ pub fn build_microvm_for_boot(
 /// An `Arc` reference of the built `Vmm` is also plugged in the `EventManager`, while another
 /// is returned.
 pub fn build_microvm_from_snapshot(
+    instance_info: &InstanceInfo,
     event_manager: &mut EventManager,
     microvm_state: MicrovmState,
     guest_memory: GuestMemoryMmap,
@@ -413,6 +419,7 @@ pub fn build_microvm_from_snapshot(
 
     // Build Vmm.
     let (mut vmm, vcpus) = create_vmm_and_vcpus(
+        instance_info,
         event_manager,
         guest_memory.clone(),
         track_dirty_pages,
@@ -961,6 +968,7 @@ pub mod tests {
 
         Vmm {
             events_observer: Some(Box::new(SerialStdin::get())),
+            instance_info: InstanceInfo::default(),
             guest_memory,
             vcpus_handles: Vec::new(),
             exit_evt,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -248,6 +248,11 @@ pub struct Vmm {
 }
 
 impl Vmm {
+    /// Gets Vmm instance info.
+    pub fn instance_info(&self) -> InstanceInfo {
+        self.instance_info.clone()
+    }
+
     /// Gets the specified bus device.
     pub fn get_bus_device(
         &self,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -46,7 +46,7 @@ use crate::device_manager::legacy::PortIODeviceManager;
 use crate::device_manager::mmio::MMIODeviceManager;
 use crate::memory_snapshot::SnapshotMemory;
 use crate::persist::{MicrovmState, MicrovmStateError, VmInfo};
-use crate::vmm_config::instance_info::InstanceInfo;
+use crate::vmm_config::instance_info::{InstanceInfo, VmState};
 use crate::vstate::vcpu::VcpuState;
 use crate::vstate::{
     vcpu::{Vcpu, VcpuEvent, VcpuHandle, VcpuResponse},
@@ -284,7 +284,7 @@ impl Vmm {
                     .map_err(Error::VcpuHandle)?,
             );
         }
-        self.instance_info.state = "Paused".to_string();
+        self.instance_info.state = VmState::Paused;
 
         Ok(())
     }
@@ -311,7 +311,7 @@ impl Vmm {
         self.mmio_device_manager.kick_devices();
         self.broadcast_vcpu_event(VcpuEvent::Resume, VcpuResponse::Resumed)
             .map_err(|_| Error::VcpuResume)?;
-        self.instance_info.state = "Running".to_string();
+        self.instance_info.state = VmState::Running;
         Ok(())
     }
 
@@ -319,7 +319,7 @@ impl Vmm {
     pub fn pause_vm(&mut self) -> Result<()> {
         self.broadcast_vcpu_event(VcpuEvent::Pause, VcpuResponse::Paused)
             .map_err(|_| Error::VcpuPause)?;
-        self.instance_info.state = "Paused".to_string();
+        self.instance_info.state = VmState::Paused;
         Ok(())
     }
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -24,6 +24,7 @@ use crate::{Error as VmmError, Vmm};
 #[cfg(target_arch = "x86_64")]
 use cpuid::common::{get_vendor_id_from_cpuid, get_vendor_id_from_host};
 
+use crate::vmm_config::instance_info::InstanceInfo;
 #[cfg(target_arch = "aarch64")]
 use arch::regs::{get_manufacturer_id_from_host, get_manufacturer_id_from_state};
 use logger::{error, info};
@@ -391,6 +392,7 @@ pub fn snapshot_state_sanity_check(
 
 /// Loads a Microvm snapshot producing a 'paused' Microvm.
 pub fn restore_from_snapshot(
+    instance_info: &InstanceInfo,
     event_manager: &mut EventManager,
     seccomp_filters: &BpfThreadMap,
     params: &LoadSnapshotParams,
@@ -409,6 +411,7 @@ pub fn restore_from_snapshot(
         track_dirty_pages,
     )?;
     builder::build_microvm_from_snapshot(
+        instance_info,
         event_manager,
         microvm_state,
         guest_memory,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -460,13 +460,7 @@ mod tests {
     fn test_from_json() {
         let kernel_file = TempFile::new().unwrap();
         let rootfs_file = TempFile::new().unwrap();
-
-        let default_instance_info = InstanceInfo {
-            id: "".to_string(),
-            state: "Not started".to_string(),
-            vmm_version: "SOME_VERSION".to_string(),
-            app_name: "".to_string(),
-        };
+        let default_instance_info = InstanceInfo::default();
 
         // We will test different scenarios with invalid resources configuration and
         // check the expected errors. We include configuration for the kernel and rootfs

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -385,6 +385,7 @@ impl<'a> PrebootApiController<'a> {
     // will be replaced by a runtime controller.
     fn start_microvm(&mut self) -> ActionResult {
         build_microvm_for_boot(
+            &self.instance_info,
             &self.vm_resources,
             &mut self.event_manager,
             self.seccomp_filters,
@@ -408,6 +409,7 @@ impl<'a> PrebootApiController<'a> {
         }
 
         let result = restore_from_snapshot(
+            &self.instance_info,
             &mut self.event_manager,
             self.seccomp_filters,
             load_params,
@@ -906,6 +908,7 @@ mod tests {
     // Need to redefine this since the non-test one uses real VmResources
     // and real Vmm instead of our mocks.
     pub fn build_microvm_for_boot(
+        _: &InstanceInfo,
         _: &VmResources,
         _: &mut EventManager,
         _: &BpfThreadMap,
@@ -926,6 +929,7 @@ mod tests {
     // Need to redefine this since the non-test one uses real Vmm
     // instead of our mocks.
     pub fn restore_from_snapshot(
+        _: &InstanceInfo,
         _: &mut EventManager,
         _: &BpfThreadMap,
         _: &LoadSnapshotParams,

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -943,12 +943,7 @@ mod tests {
         event_manager: &'a mut EventManager,
         seccomp_filters: &'a BpfThreadMap,
     ) -> PrebootApiController<'a> {
-        let instance_info = InstanceInfo {
-            id: String::new(),
-            state: "Not started".to_string(),
-            vmm_version: String::new(),
-            app_name: String::new(),
-        };
+        let instance_info = InstanceInfo::default();
         PrebootApiController::new(seccomp_filters, instance_info, vm_resources, event_manager)
     }
 
@@ -1277,12 +1272,7 @@ mod tests {
         let (_vm_res, _vmm) = PrebootApiController::build_microvm_from_requests(
             &BpfThreadMap::new(),
             &mut EventManager::new().unwrap(),
-            InstanceInfo {
-                id: String::new(),
-                state: "Not started".to_string(),
-                vmm_version: String::new(),
-                app_name: String::new(),
-            },
+            InstanceInfo::default(),
             commands,
             expected_resp,
             false,

--- a/src/vmm/src/utilities/test_utils/mod.rs
+++ b/src/vmm/src/utilities/test_utils/mod.rs
@@ -12,6 +12,7 @@ use crate::resources::VmResources;
 use crate::seccomp_filters::{get_filters, SeccompConfig};
 use crate::utilities::mock_resources::{MockBootSourceConfig, MockVmConfig, MockVmResources};
 use crate::vmm_config::boot_source::BootSourceConfig;
+use crate::vmm_config::instance_info::InstanceInfo;
 use polly::event_manager::EventManager;
 use utils::terminal::Terminal;
 
@@ -39,7 +40,13 @@ pub fn create_vmm(_kernel_image: Option<&str>, is_diff: bool) -> (Arc<Mutex<Vmm>
     };
 
     (
-        build_microvm_for_boot(&resources, &mut event_manager, &empty_seccomp_filters).unwrap(),
+        build_microvm_for_boot(
+            &InstanceInfo::default(),
+            &resources,
+            &mut event_manager,
+            &empty_seccomp_filters,
+        )
+        .unwrap(),
         event_manager,
     )
 }

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -4,7 +4,7 @@ use serde::{ser, Serialize};
 use std::fmt::{self, Display, Formatter};
 
 /// Enumerates microVM runtime states.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VmState {
     /// Vm not started (yet)
     NotStarted,
@@ -40,7 +40,7 @@ impl ser::Serialize for VmState {
 }
 
 /// Serializable struct that contains general information about the microVM.
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct InstanceInfo {
     /// The ID of the microVM.
     pub id: String,

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 
 /// The strongly typed that contains general information about the microVM.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct InstanceInfo {
     /// The ID of the microVM.
     pub id: String,

--- a/src/vmm/src/vmm_config/instance_info.rs
+++ b/src/vmm/src/vmm_config/instance_info.rs
@@ -1,14 +1,51 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use serde::Serialize;
+use serde::{ser, Serialize};
+use std::fmt::{self, Display, Formatter};
 
-/// The strongly typed that contains general information about the microVM.
+/// Enumerates microVM runtime states.
+#[derive(Clone, Debug)]
+pub enum VmState {
+    /// Vm not started (yet)
+    NotStarted,
+    /// Vm is Paused
+    Paused,
+    /// Vm is running
+    Running,
+}
+
+impl Default for VmState {
+    fn default() -> VmState {
+        VmState::NotStarted
+    }
+}
+
+impl Display for VmState {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match *self {
+            VmState::NotStarted => write!(f, "Not started"),
+            VmState::Paused => write!(f, "Paused"),
+            VmState::Running => write!(f, "Running"),
+        }
+    }
+}
+
+impl ser::Serialize for VmState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+/// Serializable struct that contains general information about the microVM.
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct InstanceInfo {
     /// The ID of the microVM.
     pub id: String,
     /// Whether the microVM is not started/running/paused.
-    pub state: String,
+    pub state: VmState,
     /// The version of the VMM that runs the microVM.
     pub vmm_version: String,
     /// The name of the application that runs the microVM.

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -163,12 +163,7 @@ mod tests {
 
     #[test]
     fn test_init_logger() {
-        let default_instance_info = InstanceInfo {
-            id: "".to_string(),
-            state: "Not started".to_string(),
-            vmm_version: "some_version".to_string(),
-            app_name: "".to_string(),
-        };
+        let default_instance_info = InstanceInfo::default();
 
         // Error case: initializing logger with invalid pipe returns error.
         let desc = LoggerConfig {

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -23,6 +23,7 @@ use vmm::utilities::mock_resources::NOISY_KERNEL_IMAGE;
 #[cfg(target_arch = "x86_64")]
 use vmm::utilities::test_utils::dirty_tracking_vmm;
 use vmm::utilities::test_utils::{create_vmm, default_vmm, set_panic_hook, wait_vmm_child_process};
+use vmm::vmm_config::instance_info::InstanceInfo;
 
 #[test]
 fn test_setup_serial_device() {
@@ -46,8 +47,12 @@ fn test_build_microvm() {
         let mut event_manager = EventManager::new().unwrap();
         let mut empty_seccomp_filters = get_filters(SeccompConfig::None).unwrap();
 
-        let vmm_ret =
-            build_microvm_for_boot(&resources, &mut event_manager, &mut empty_seccomp_filters);
+        let vmm_ret = build_microvm_for_boot(
+            &InstanceInfo::default(),
+            &resources,
+            &mut event_manager,
+            &mut empty_seccomp_filters,
+        );
         assert_eq!(format!("{:?}", vmm_ret.err()), "Some(MissingKernelConfig)");
     }
 
@@ -326,6 +331,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
 
             // Build microVM from state.
             let vmm = build_microvm_from_snapshot(
+                &InstanceInfo::default(),
                 &mut event_manager,
                 microvm_state,
                 mem,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.85, "AMD": 84.15, "ARM": 83.13}
+COVERAGE_DICT = {"Intel": 84.85, "AMD": 84.15, "ARM": 83.15}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -52,6 +52,7 @@ def test_config_start_with_api(test_microvm_with_ssh, vm_config_file):
 
     response = test_microvm.machine_cfg.get()
     assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert test_microvm.state == "Running"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -452,12 +452,8 @@ def test_negative_postload_api(bin_cloner_path):
     fail_msg = "The requested operation is not supported after starting " \
         "the microVM"
 
-    try:
-        microvm.start()
-    except AssertionError as error:
-        assert fail_msg in str(error)
-    else:
-        assert False, "Negative test failed"
+    response = microvm.actions.put(action_type='InstanceStart')
+    assert fail_msg in response.text
 
     try:
         microvm.basic_config()


### PR DESCRIPTION
This PR is based on https://github.com/firecracker-microvm/firecracker/pull/2489 and some of the commits herein are co-authored by `Franck Séhédic <franck.sehedic@ledger.fr>`

# Reason for This PR

When configured through `--config-file` the ApiServer improperly reports the VmState as "Not started" even when it actually is "Running".
(Note: This breaks integration with kata-runtime which does use `--config-file` and expects a "Running" VmState to be reported by the ApiServer).

## Description of Changes

`InstanceInfo` contains Vmm-instance-related information. As such, it makes more sense to be tied to a `Vmm` instance.
Embedded `InstanceInfo` in `struct Vmm` and exposed it through RPC all the way to HTTP API.

All Vmm state changes are naturally handled by Vmm internal logic.
API server no longer tracks Vmm state based on HTTP API calls responses, it now simply delegates all InstanceInfo-related requests to the Vmm RPC interface.

Because state tracking is done internally by the Vmm, `--config-file` use-case now also reports good state.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
