### PR TITLE
devtool: add distclean command

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -595,6 +595,8 @@ cmd_help() {
     echo "        Outputs a rust file for each supported arch: src/seccompiler/src/syscall_table/{arch}.rs"
     echo "        Supported architectures: x86_64 and aarch64."
     echo ""
+    echo "    distclean"
+    echo "        Clean up the build tree and remove the docker container."
 }
 
 # `$0 build` - build Firecracker
@@ -735,6 +737,24 @@ cmd_build() {
     }
 
     return $ret
+}
+
+cmd_distclean() {
+    # List of folders to remove.
+    dirs=("build" "test_results")
+
+    for dir in "${dirs[@]}"; do
+        if [ -d "$dir" ]; then
+            say "Removing $dir"
+            rm -rf "$dir"
+        fi
+    done
+
+    # Remove devctr if it exists
+    if [ $(docker images -q "$DEVCTR_IMAGE" | wc -l) -eq "1" ]; then
+        say "Removing $DEVCTR_IMAGE"
+        docker rmi -f "$DEVCTR_IMAGE"
+    fi
 }
 
 cmd_strip() {
@@ -1293,9 +1313,9 @@ cmd_generate_syscall_tables() {
                 chmod +x+w "$KERNEL_DIR"
             } || \
             die "Error: wrong permissions for $KERNEL_DIR. Should be +x+w"
-    
+
     cd "$KERNEL_DIR"
-    
+
     say "Fetching linux kernel..."
 
     # Get sha256 checksum.


### PR DESCRIPTION
Add the 'distclean' command to clean up build files, test results and
the docker container.

The purpose of this command is to remove everything built or pulled
during the build process.

Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
