### PR TITLE
seccomp: allow timezone-specific syscalls on all threads

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -156,6 +156,19 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "arg_index": 3,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the vsock UDS",
                 "args": [
@@ -475,7 +488,14 @@
                 "syscall": "write"
             },
             {
+                "syscall": "openat"
+            },
+            {
                 "syscall": "close"
+            },
+            {
+                "syscall": "fstat",
+                "comment": "Used for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "brk",
@@ -520,6 +540,19 @@
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "arg_index": 3,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -156,6 +156,19 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "arg_index": 3,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the vsock UDS",
                 "args": [
@@ -487,7 +500,14 @@
                 "syscall": "write"
             },
             {
+                "syscall": "open"
+            },
+            {
                 "syscall": "close"
+            },
+            {
+                "syscall": "fstat",
+                "comment": "Used for reading the local timezone from /etc/localtime"
             },
             {
                 "syscall": "brk",
@@ -532,6 +552,19 @@
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used for reading the timezone in LocalTime::now()",
+                "args": [
+                    {
+                        "arg_index": 3,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 1,
+                        "comment": "libc::MAP_SHARED"
                     }
                 ]
             },


### PR DESCRIPTION
# Reason for This PR

With musl, `open`, `fstat` and `mmap` are used to read the
local timezone from `/etc/localtime`.
Depending on when the logger functions are first called,
they happen on different thread categories.

In the CI tests, they were always called on the API thread, but
when running with different configurations, this may not happen.

## Description of Changes

Added the above syscalls to the allowlist, for all thread
categories.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
