### PR TITLE
[v0.24 backport] vmm: fix potential seg fault path on vcpu TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed race between vcpu initialization and emulation thread which could
+  potentially lead to segmentation faults.
+
 ## [0.24.3]
 
 ### Changed

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -38,6 +38,7 @@ use std::io;
 use std::os::unix::io::AsRawFd;
 use std::sync::mpsc::RecvTimeoutError;
 use std::sync::Mutex;
+use std::sync::{Arc, Barrier};
 use std::time::Duration;
 
 #[cfg(target_arch = "x86_64")]
@@ -261,6 +262,7 @@ impl Vmm {
         vcpu_seccomp_filter: BpfProgramRef,
     ) -> Result<()> {
         let vcpu_count = vcpus.len();
+        let barrier = Arc::new(Barrier::new(vcpu_count + 1));
 
         if let Some(observer) = self.events_observer.as_mut() {
             observer.on_vmm_boot().map_err(Error::VmmObserverInit)?;
@@ -277,10 +279,12 @@ impl Vmm {
                 .set_pio_bus(self.pio_device_manager.io_bus.clone());
 
             self.vcpus_handles.push(
-                vcpu.start_threaded(vcpu_seccomp_filter.to_vec())
+                vcpu.start_threaded(vcpu_seccomp_filter.to_vec(), barrier.clone())
                     .map_err(Error::VcpuHandle)?,
             );
         }
+        // Wait for vCPUs to initialize their TLS before moving forward.
+        barrier.wait();
 
         Ok(())
     }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -6,8 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use libc::{c_int, c_void, siginfo_t};
-#[cfg(not(test))]
-use std::sync::Barrier;
+use std::sync::{Arc, Barrier};
 use std::{
     cell::Cell,
     fmt::{Display, Formatter},
@@ -225,7 +224,11 @@ impl Vcpu {
 
     /// Moves the vcpu to its own thread and constructs a VcpuHandle.
     /// The handle can be used to control the remote vcpu.
-    pub fn start_threaded(mut self, seccomp_filter: BpfProgram) -> Result<VcpuHandle> {
+    pub fn start_threaded(
+        mut self,
+        seccomp_filter: BpfProgram,
+        barrier: Arc<Barrier>,
+    ) -> Result<VcpuHandle> {
         let event_sender = self.event_sender.take().expect("vCPU already started");
         let response_receiver = self.response_receiver.take().unwrap();
         let vcpu_thread = thread::Builder::new()
@@ -233,7 +236,8 @@ impl Vcpu {
             .spawn(move || {
                 self.init_thread_local_data()
                     .expect("Cannot cleanly initialize vcpu TLS.");
-
+                // Synchronization to make sure thread local data is initialized.
+                barrier.wait();
                 self.run(seccomp_filter);
             })
             .map_err(Error::VcpuSpawn)?;
@@ -616,12 +620,7 @@ pub enum VcpuEmulation {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        convert::TryInto,
-        fmt,
-        sync::{Arc, Barrier},
-        time::Duration,
-    };
+    use std::{convert::TryInto, fmt, time::Duration};
 
     use super::*;
     use crate::vstate::vm::{tests::setup_vm, Vm};
@@ -752,9 +751,12 @@ mod tests {
         }
 
         let seccomp_filter = seccomp::SeccompFilter::empty().try_into().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
         let vcpu_handle = vcpu
-            .start_threaded(seccomp_filter)
+            .start_threaded(seccomp_filter, barrier.clone())
             .expect("failed to start vcpu");
+        // Wait for vCPUs to initialize their TLS before moving forward.
+        barrier.wait();
 
         (vcpu_handle, vcpu_exit_evt)
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.1, "AMD": 84.37, "ARM": 83.06}
+COVERAGE_DICT = {"Intel": 85.1, "AMD": 84.37, "ARM": 83.22}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -54,8 +54,8 @@ CREATE_LATENCY_BASELINES = {
 # TODO: Update the table after fix. Target is < 5ms.
 LOAD_LATENCY_BASELINES = {
     'x86_64': {
-        '2vcpu_256mb.json': 8,
-        '2vcpu_512mb.json': 8,
+        '2vcpu_256mb.json': 9,
+        '2vcpu_512mb.json': 9,
     },
     'aarch64': {
         '2vcpu_256mb.json': 3,


### PR DESCRIPTION
# Reason for This PR

Currently the vcpus threads are started by the vmm which then moves forward and executes vcpu_resume which sends a signal to each vcpu thread.

The signal handler touches run_on_thread_local_vcpu in a way that is not thread and signal safe, so if there is a race between the main thread sending the signal and the vcpu threads initializing the local data in init_thread_local_data a SIGSEGV might happen because there is a risk for run_on_thread_local_vcpu to work with corrupted data.

## Description of Changes

The fix is for the Vmm thread to explicitly wait for vCPUs threads initialization after their creation, before moving forward.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
