### PR TITLE
Fix SSBD mitigation for aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   to use "MiB" instead.
 - Snapshot related host files (vm-state, memory, block backing files) are now
   flushed to their backing mediums as part of the CreateSnapshot operation.
+- Fixed the SSBD mitigation not being enabled on `aarch64` with the provided
+  `prod-host-setup.md`.
 
 ## [0.24.0]
 

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -220,13 +220,23 @@ See more details [here](https://www.kernel.org/doc/html/latest/admin-guide/hw-vu
 This will mitigate variants of Spectre side-channel issues such as
 Speculative Store Bypass and SpectreNG.
 
-It can be enabled by adding the following Linux kernel boot parameter:
+On x86_64 systems, it can be enabled by adding the following Linux kernel boot
+parameter:
 
 ```console
 spec_store_bypass_disable=seccomp
 ```
 
 which will apply SSB if seccomp is enabled by Firecracker.
+
+On aarch64 systems, it is enabled by Firecracker
+[using the `prctl` interface][3]. However, this is only availabe on host
+kernels Linux >=4.17 and also Amazon Linux 4.14. Alternatively, a global
+mitigation can be enabled by adding the following Linux kernel boot parameter:
+
+```console
+ssbd=force-on
+```
 
 Verification can be done by running:
 
@@ -329,3 +339,4 @@ to trap and control this in the hypervisor.
 
 [1]: https://elixir.free-electrons.com/linux/v4.14.203/source/virt/kvm/arm/hyp/timer-sr.c#L63
 [2]: https://lists.cs.columbia.edu/pipermail/kvmarm/2017-January/023323.html
+[3]: https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/prctl.h#L212

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.36, "AMD": 84.79, "ARM": 83.62}
+COVERAGE_DICT = {"Intel": 85.36, "AMD": 84.79, "ARM": 83.52}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/security/test_ssbd_mitigation.py
+++ b/tests/integration_tests/security/test_ssbd_mitigation.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests Speculative Store Bypass mitigations in jailer/Firecracker."""
+
+from framework.utils import run_cmd
+
+
+def test_ssbd_mitigation(test_microvm_with_initrd):
+    """Test that SSBD mitigation is enabled."""
+    vm = test_microvm_with_initrd
+    vm.jailer.daemonize = False
+    vm.spawn()
+    vm.memory_monitor = None
+
+    vm.basic_config(
+        add_root_device=False,
+        vcpu_count=1,
+        boot_args='console=ttyS0 reboot=k panic=1 pci=off',
+        use_initrd=True
+    )
+
+    vm.start()
+
+    cmd = 'ps -T --no-headers -p {} | awk \'{{print $2}}\''.format(
+        vm.jailer_clone_pid
+    )
+    process = run_cmd(cmd)
+    threads_out_lines = process.stdout.splitlines()
+    for tid in threads_out_lines:
+        # Verify each thread's status
+        cmd = 'cat /proc/{}/status | grep Speculation_Store_Bypass'.format(tid)
+        _, output, _ = run_cmd(cmd)
+        assert "thread force mitigated" in output or \
+            "globally mitigated" in output


### PR DESCRIPTION
# Reason for This PR

In our guide, we recommend enabling the SSBD mitiagtion through the kernel command line with `spec_store_bypass_disable=seccomp`. However, this only works for x86_64.

## Description of Changes

Added the fix in the jailer through the `prctl` interface. Updated the guide with the addition of the mitigation in the jailer through `prctl` and the alternative through the `ssbd=force-on` kernel command line parameter.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
