### PR TITLE
cargo-bitbake support

### DIFF
--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.24.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"
+description = "Firecracker enables you to deploy workloads in lightweight virtual machines, called microVMs, which provide enhanced security and workload isolation over traditional VMs, while enabling the speed and resource efficiency of containers."
+homepage = "https://firecracker-microvm.github.io/"
+license = "Apache-2.0"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.24.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"
+description = "Process for starting Firecracker in production scenarios; applies a cgroup/namespace isolation barrier and then drops privileges."
+homepage = "https://firecracker-microvm.github.io/"
+license = "Apache-2.0"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -3,6 +3,9 @@ name = "seccompiler"
 version = "0.24.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
+description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."
+homepage = "https://firecracker-microvm.github.io/"
+license = "Apache-2.0"
 
 [[bin]]
 name = "seccompiler"


### PR DESCRIPTION
# Reason for This PR

Adds support for [cargo-bitbake](https://github.com/meta-rust/cargo-bitbake), which enables easier maintenance for firecracker recipes going into [meta-aws](https://github.com/aws/meta-aws/pull/128).

## Description of Changes

Adds meta data needed by cargo-bitbake, so manual changes are not required prior to running cargo-bitbake.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
