### PR TITLE
Updated snapshot docs with ARM kernel parameter induced latency

### DIFF
--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -46,6 +46,19 @@ for consuming and storing this data safely. We suggest using any upper-bounded
 forms of storage, such as fixed-size or ring buffers, programs like `journald`
 or `logrotate`, or redirecting to a named pipe.
 
+### Logging and performance
+
+We recommend adding `quiet loglevel=1` to the host kernel command line to limit
+the number of messages written to the serial console. This is because some host
+configurations can have an effect on Firecracker's performance as the process
+will generate host kernel logs during normal operations.
+
+The most recent example of this was the addition of `console=ttyAMA0` host
+kernel command line argument on one of our testing setups. This enabled console
+logging, which degraded the snapshot restore time from 3ms to 8.5ms on
+`aarch64`. In this case, creating the tap device for snapshot restore
+generated host kernel logs, which were very slow to write.
+
 ## Jailer Configuration
 
 Using Jailer in a production Firecracker deployment is highly recommended,


### PR DESCRIPTION
# Reason for This PR
Running with the host kernel command line parameter `console=AMA0` on `aarch64` was degrading the snapshot restore latency from 3ms to 8.5ms.

## Description of Changes

Added an entry in the snapshot performance known issues to highlight this behavior.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
