### PR TITLE
[devtool] fix build_devctr

### DIFF
--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -7,12 +7,14 @@ FROM ubuntu:18.04
 ARG RUST_TOOLCHAIN="1.52.1"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
-ARG TMP_POERTY_DIR=/tmp/poetry
+ARG TMP_POETRY_DIR=/tmp/poetry
 ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
 ARG DEBIAN_FRONTEND=noninteractive
+# By default we don't provide a poetry.lock file
+ARG POETRY_LOCK_PATH="/dev/null/*"
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -73,9 +75,9 @@ RUN mkdir "$TMP_BUILD_DIR" \
     && rm -rf "$TMP_BUILD_DIR"
 
 RUN python3 -m pip install poetry
-RUN mkdir "$TMP_POERTY_DIR"
-COPY tools/devctr/pyproject.toml "$TMP_POERTY_DIR/pyproject.toml"
-RUN cd "$TMP_POERTY_DIR" \
+RUN mkdir "$TMP_POETRY_DIR"
+COPY tools/devctr/pyproject.toml $POETRY_LOCK_PATH "$TMP_POETRY_DIR/"
+RUN cd "$TMP_POETRY_DIR" \
     &&  poetry config virtualenvs.create false \
     &&  poetry install --no-dev --no-interaction
 

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -7,12 +7,14 @@ FROM ubuntu:18.04
 ARG RUST_TOOLCHAIN="1.52.1"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
-ARG TMP_POERTY_DIR=/tmp/poetry
+ARG TMP_POETRY_DIR=/tmp/poetry
 ARG FIRECRACKER_SRC_DIR="/firecracker"
 ARG FIRECRACKER_BUILD_DIR="$FIRECRACKER_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_registry"
 ARG CARGO_GIT_REGISTRY_DIR="$FIRECRACKER_BUILD_DIR/cargo_git_registry"
 ARG DEBIAN_FRONTEND=noninteractive
+# By default we don't provide a poetry.lock file
+ARG POETRY_LOCK_PATH="/dev/null/*"
 
 ENV CARGO_HOME=/usr/local/rust
 ENV RUSTUP_HOME=/usr/local/rust
@@ -61,9 +63,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install poetry
-RUN mkdir "$TMP_POERTY_DIR"
-COPY tools/devctr/pyproject.toml "$TMP_POERTY_DIR/pyproject.toml"
-RUN cd "$TMP_POERTY_DIR" \
+RUN mkdir "$TMP_POETRY_DIR"
+COPY tools/devctr/pyproject.toml $POETRY_LOCK_PATH "$TMP_POETRY_DIR/"
+RUN cd "$TMP_POETRY_DIR" \
     &&  poetry config virtualenvs.create false \
     &&  poetry install --no-dev --no-interaction
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -321,6 +321,7 @@ cmd_build_devctr() {
     arch=$(uname -m)
     docker_file_name="Dockerfile.$arch"
     should_update_python_packages=true
+    build_args=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -328,6 +329,7 @@ cmd_build_devctr() {
             "-n"|"--no-python-package-update")
                 shift
                 should_update_python_packages=false
+                build_args="--build-arg POETRY_LOCK_PATH=tools/devctr/poetry.lock"
                 ;;
             "--")               { shift; break;     } ;;
             *)
@@ -337,7 +339,7 @@ cmd_build_devctr() {
         shift
     done
 
-    docker build -t "$DEVCTR_IMAGE_NO_TAG" -f "$FC_DEVCTR_DIR/$docker_file_name" .
+    docker build -t "$DEVCTR_IMAGE_NO_TAG" -f "$FC_DEVCTR_DIR/$docker_file_name" $build_args .
 
     if [ "$should_update_python_packages" = true ]; then
         update_python_package_version


### PR DESCRIPTION
# Reason for This PR

fixes `build_devctr --no-python-package-update`

## Description of Changes

Copy poetry.lock to the docker image when executing
tools/devtool build_devctr --no-python-package-update
in order to make sure that the python packages won't be updated.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
