### PR TITLE
Backport and Release Firecracker v0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Changed Docker images repository from DockerHub to Amazon ECR.
 
+### Fixed
+
+- Snapshot related host files (vm-state, memory, block backing files) are now
+  flushed to their backing mediums as part of the CreateSnapshot operation.
+
 ## [0.23.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.23.4]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Snapshot related host files (vm-state, memory, block backing files) are now
   flushed to their backing mediums as part of the CreateSnapshot operation.
+- Fixed race between vcpu initialization and emulation thread which could
+  potentially lead to segmentation faults.
 
 ## [0.23.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Changed Docker images repository from DockerHub to Amazon ECR.
+
 ## [0.23.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   flushed to their backing mediums as part of the CreateSnapshot operation.
 - Fixed race between vcpu initialization and emulation thread which could
   potentially lead to segmentation faults.
+- Fixed the SSBD mitigation not being enabled on `aarch64` with the provided
+  `prod-host-setup.md`, by force-enabling it.
 
 ## [0.23.3]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "api_server 0.1.0",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jailer"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -5,15 +5,13 @@
 Firecracker uses a [Docker container](https://www.docker.com/) to standardize
 the build process. This also fixes the build tools and dependencies to specific
 versions. Every once in a while, something needs to be updated. To do this, a
-new container image needs to be built locally, then published to the Docker
+new container image needs to be built locally, then published to the [AWS ECR](https://aws.amazon.com/ecr/)
 registry. The Firecracker CI suite must also be updated to use the new image.
 
 ## Prerequisites
 
-1. A Docker account. You must create this by yourself on
-   [Docker hub](https://hub.docker.com/).
 1. Access to the
-   [`fcuvm` Docker organization](https://cloud.docker.com/u/fcuvm/).
+   [`fcuvm` ECR repository](https://gallery.ecr.aws/firecracker/fcuvm).
 1. The `docker` package installed locally. You should already have this if
    you've ever built Firecracker from source.
 1. Access to both an `x86_64` and `aarch64` machines to build the container
@@ -23,11 +21,11 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 
 ### `x86_64`
 
-1. Login to the Docker organization in a shell. Use your username and password
-(not `fcuvm`).
+1. Login to the Docker organization in a shell. Make sure that your account has
+   access to the repository:
 
     ```bash
-    docker login
+    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
     ```
 
 1. Navigate to the Firecracker directory. Verify that you have the latest
@@ -35,8 +33,8 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Make your necessary changes, if any, to the
@@ -48,35 +46,35 @@ registry. The Firecracker CI suite must also be updated to use the new image.
 1. Build a new container image with the updated Dockerfile.
 
    ```bash
-    docker build -t fcuvm/dev -f tools/devctr/Dockerfile.x86_64 .
+    docker build -t fcuvm -f tools/devctr/Dockerfile.x86_64 .
     ```
 
 1. Verify that the new image exists.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        2 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Tag the new image with the next available version and the architecture
    you're on.
 
     ```bash
-    docker tag 402b87586d11 fcuvm/dev:v15_x86_64
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_x86_64
 
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v15_x86_64          402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 9bbc159ad600        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v27_x86_64          1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 1. Push the image.
 
     ```bash
-    docker push fcuvm/dev:v15_x86_64
+    docker push public.ecr.aws/firecracker/fcuvm:v27_x86_64
     ```
 
 ### `aarch64`
@@ -90,45 +88,43 @@ Then:
 5. Build a new container image with the updated Dockerfile.
 
     ```bash
-    docker build -t fcuvm/dev -f tools/devctr/Dockerfile.aarch64  .
+    docker build -t fcuvm -f tools/devctr/Dockerfile.aarch64  .
     ```
 
 5. Verify that the new image exists.
 
     ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 c8581789ead3        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        2 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 5. Tag the new image with the next available version and the architecture
    you're on.
 
     ```bash
-    docker tag 402b87586d11 fcuvm/dev:v15_aarch64
-    ```
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_aarch64
 
-    ```bash
     docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    fcuvm/dev           latest              402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v15_aarch64         402b87586d11        5 minutes ago       2.31GB
-    fcuvm/dev           v14                 c8581789ead3        2 months ago        2.31GB
+    REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
+    fcuvm                              latest              1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v27_aarch64         1f9852368efb        5 minutes ago       2.36GB
+    public.ecr.aws/firecracker/fcuvm   v26                 8d00deb17f7a        2 weeks ago         2.41GB
     ```
 
 5. Push the image.
 
     ```bash
-    docker push fcuvm/dev:v15_aarch64
+    docker push public.ecr.aws/firecracker/fcuvm:v27_aarch64
     ```
 
 5. Create a manifest to point the latest container version to each specialized
    image, per architecture.
 
     ```bash
-    docker manifest create fcuvm/dev:v15 fcuvm/dev:v15_x86_64 fcuvm/dev:v15_aarch64
-    docker manifest push fcuvm/dev:v15
+    docker manifest create public.ecr.aws/firecracker/fcuvm/dev:v27 public.ecr.aws/firecracker/fcuvm/dev:v27_x86_64 public.ecr.aws/firecracker/fcuvm/dev:v27_aarch64
+    docker manifest push public.ecr.aws/firecracker/fcuvm/dev:v27
     ```
 
 5. Update the image tag in the
@@ -136,7 +132,7 @@ Then:
    Commit and push the change.
 
     ```bash
-    sed -i 's%DEVCTR_IMAGE="fcuvm/dev:v14"%DEVCTR_IMAGE="fcuvm/dev:v15"%' tools/devtool
+    sed -i 's%DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v26"%DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v27"%' tools/devtool
     ```
 
 ## Troubleshooting
@@ -167,15 +163,15 @@ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 
 tools/devtool shell
-[Firecracker devtool] About to pull docker image fcuvm/dev:v15
+[Firecracker devtool] About to pull docker image public.ecr.aws/firecracker/fcuvm/dev:v15
 [Firecracker devtool] Continue?
 ```
 
-### I don't have access to the Docker registry
+### I don't have access to the AWS ECR registry
 
 ```bash
-docker push fcuvm/dev:v15
-The push refers to repository [docker.io/fcuvm/dev]
+docker push public.ecr.aws/firecracker/fcuvm:v27
+The push refers to repository [public.ecr.aws/firecracker/fcuvm]
 e2b5ee0c4e6b: Preparing
 0fbb5fd5f156: Preparing
 ...
@@ -184,12 +180,11 @@ denied: requested access to the resource is denied
 ```
 
 Only a Firecracker maintainer can update the container image. If you are one,
-ask a member of the team to add you to the `fcuvm` organization and retry.
+ask a member of the team to add you to the AWS ECR repository and retry.
 
 ### I pushed the wrong tag
 
-Tags can be deleted from the
-[Docker's repository WebUI](https://cloud.docker.com/u/fcuvm/repository/registry-1.docker.io/fcuvm/dev/tags).
+Tags can be deleted from the [AWS ECR interface](https://aws.amazon.com/ecr/).
 
 Also, pushing the same tag twice will overwrite the initial content.
 

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -139,13 +139,23 @@ See more details [here](https://www.kernel.org/doc/html/latest/admin-guide/hw-vu
 This will mitigate variants of Spectre side-channel issues such as
 Speculative Store Bypass and SpectreNG.
 
-It can be enabled by adding the following Linux kernel boot parameter:
+On x86_64 systems, it can be enabled by adding the following Linux kernel boot
+parameter:
 
 ```
 spec_store_bypass_disable=seccomp
 ```
 
 which will apply SSB if seccomp is enabled by Firecracker.
+
+On aarch64 systems, it is enabled by Firecracker
+[using the `prctl` interface][1]. However, this is only availabe on host
+kernels Linux >=4.17 and also Amazon Linux 4.14. Alternatively, a global
+mitigation can be enabled by adding the following Linux kernel boot parameter:
+
+```console
+ssbd=force-on
+```
 
 Verification can be done by running:
 
@@ -235,3 +245,5 @@ The fix was integrated in the mainline kernel and in 4.19.103, 5.4.19, 5.5.3
 stable kernel releases. Please follow [kernel.org](https://www.kernel.org/) and
 once the fix is available in your stable release please update the host kernel. 
 If you are not using a vanilla kernel, please check with Linux distro provider.
+
+[1]: https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/prctl.h#L212

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.23.3
+  version: 0.23.4
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -63,6 +63,10 @@ impl DiskProperties {
         })
     }
 
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
     pub fn file_mut(&mut self) -> &mut File {
         &mut self.file
     }

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -3,10 +3,11 @@
 
 //! Defines the structures needed for saving/restoring block devices.
 
-use std::io;
+use std::io::{self, Write};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
+use logger::error;
 use rate_limiter::{persist::RateLimiterState, RateLimiter};
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
@@ -39,6 +40,14 @@ impl Persist<'_> for Block {
     type Error = io::Error;
 
     fn save(&self) -> Self::State {
+        if let Err(e) = self.disk.file().flush() {
+            error!("Failed to flush block data on serialization. Error: {}", e);
+        }
+        // Sync data out to backing file on host.
+        if let Err(e) = self.disk.file().sync_all() {
+            error!("Failed to sync block data on serialization. Error: {}", e);
+        }
+        // Save device state.
         BlockState {
             id: self.id.clone(),
             partuuid: self.partuuid.clone(),

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -29,6 +29,38 @@ const DEFAULT_API_SOCK_PATH: &str = "/run/firecracker.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 const FIRECRACKER_VERSION: &str = env!("FIRECRACKER_VERSION");
 
+#[cfg(target_arch = "aarch64")]
+/// Enable SSBD mitigation through `prctl`.
+pub fn enable_ssbd_mitigation() {
+    // Parameters for `prctl`
+    // TODO: generate bindings for these from the kernel sources.
+    // https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/prctl.h#L212
+    const PR_SET_SPECULATION_CTRL: i32 = 53;
+    const PR_SPEC_STORE_BYPASS: u64 = 0;
+    const PR_SPEC_FORCE_DISABLE: u64 = 1u64 << 3;
+
+    let ret = unsafe {
+        libc::prctl(
+            PR_SET_SPECULATION_CTRL,
+            PR_SPEC_STORE_BYPASS,
+            PR_SPEC_FORCE_DISABLE,
+            0,
+            0,
+        )
+    };
+
+    if ret < 0 {
+        let last_error = std::io::Error::last_os_error().raw_os_error().unwrap();
+        error!(
+            "Could not enable SSBD mitigation through prctl, error {}",
+            last_error
+        );
+        if last_error == libc::EINVAL {
+            error!("The host does not support SSBD mitigation through prctl.");
+        }
+    }
+}
+
 fn main() {
     LOGGER
         .configure(Some(DEFAULT_INSTANCE_ID.to_string()))
@@ -38,6 +70,8 @@ fn main() {
         error!("Failed to register signal handlers: {}", e);
         process::exit(i32::from(vmm::FC_EXIT_CODE_GENERIC_ERROR));
     }
+    #[cfg(target_arch = "aarch64")]
+    enable_ssbd_mitigation();
 
     // We need this so that we can reset terminal to canonical mode if panic occurs.
     let stdin = io::stdin();

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/vmm/src/default_syscalls/filters.rs
+++ b/src/vmm/src/default_syscalls/filters.rs
@@ -56,6 +56,7 @@ pub fn default_filter() -> Result<SeccompFilter, Error> {
                     )?],
                 ],
             ),
+            allow_syscall(libc::SYS_fsync),
             #[cfg(target_env = "gnu")]
             allow_syscall(libc::SYS_getpid),
             allow_syscall(libc::SYS_getrandom),

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -222,10 +222,6 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
             mem_full_path = os.path.join(snaps_dir, mem_file_name)
             vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
 
-        # Disable API timeout as the APIs for snapshot related procedures
-        # take longer.
-        self._microvm.api_session.untime()
-
         snaps_dir_name = os.path.basename(snaps_dir)
         self._microvm.pause_to_snapshot(
             mem_file_path=os.path.join('/', snaps_dir_name, mem_file_name),

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -56,17 +56,21 @@ class MicrovmBuilder:
               ssh_key: Artifact,
               config: Artifact,
               enable_diff_snapshots=False,
-              cpu_template=None):
+              cpu_template=None,
+              use_ramdisk=False):
         """Build a fresh microvm."""
         vm = init_microvm(self.root_path, self.bin_cloner_path,
                           self._fc_binary, self._jailer_binary)
 
+        # Start firecracker.
+        vm.spawn(use_ramdisk=use_ramdisk)
+
         # Link the microvm to kernel, rootfs, ssh_key artifacts.
         vm.kernel_file = kernel.local_path()
         vm.rootfs_file = disks[0].local_path()
-
-        # Start firecracker.
-        vm.spawn()
+        # copy rootfs to ramdisk if needed
+        jailed_rootfs_path = vm.copy_to_jail_ramfs(vm.rootfs_file) if \
+            use_ramdisk else vm.create_jailed_resource(vm.rootfs_file)
 
         # Download ssh key into the microvm root.
         ssh_key.download(self.root_path)
@@ -91,7 +95,21 @@ class MicrovmBuilder:
         with open(config.local_path()) as microvm_config_file:
             microvm_config = json.load(microvm_config_file)
 
-        response = vm.basic_config(boot_args='console=ttyS0 reboot=k panic=1')
+        response = vm.basic_config(
+            add_root_device=False,
+            boot_args='console=ttyS0 reboot=k panic=1'
+        )
+
+        # Add the root file system with rw permissions.
+        response = vm.drive.put(
+            drive_id='rootfs',
+            path_on_host=jailed_rootfs_path,
+            is_root_device=True,
+            is_read_only=False
+        )
+        assert vm.api_session \
+            .is_status_no_content(response.status_code), \
+            response.text
 
         # Apply the microvm artifact configuration and template.
         response = vm.machine_cfg.put(
@@ -171,30 +189,54 @@ class SnapshotBuilder:  # pylint: disable=too-few-public-methods
                disks,
                ssh_key: Artifact,
                snapshot_type: SnapshotType = SnapshotType.FULL,
-               target_version: str = None):
+               target_version: str = None,
+               use_ramdisk=False):
         """Create a Snapshot object from a microvm and artifacts."""
+        mem_file_name = "vm.mem"
+        snapshot_name = "vm.vmstate"
+
+        if use_ramdisk:
+            snaps_dir = self._microvm.jailer.chroot_ramfs_path()
+            mem_full_path = os.path.join(snaps_dir, mem_file_name)
+            vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
+
+            memsize = self._microvm.machine_cfg.configuration['mem_size_mib']
+            # Pre-allocate ram for memfile to eliminate allocation variability.
+            utils.run_cmd('dd if=/dev/zero of={} bs=1M count={}'.format(
+                mem_full_path, memsize
+            ))
+            cmd = 'chown {}:{} {}'.format(
+                self._microvm.jailer.uid,
+                self._microvm.jailer.gid,
+                mem_full_path
+            )
+            utils.run_cmd(cmd)
+        else:
+            chroot_path = self._microvm.jailer.chroot_path()
+            snaps_dir = os.path.join(chroot_path, "snapshot")
+            Path(snaps_dir).mkdir(parents=True, exist_ok=True)
+            cmd = 'chown {}:{} {}'.format(self._microvm.jailer.uid,
+                                          self._microvm.jailer.gid,
+                                          snaps_dir)
+            utils.run_cmd(cmd)
+            mem_full_path = os.path.join(snaps_dir, mem_file_name)
+            vmstate_full_path = os.path.join(snaps_dir, snapshot_name)
+
         # Disable API timeout as the APIs for snapshot related procedures
         # take longer.
         self._microvm.api_session.untime()
-        chroot_path = self._microvm.jailer.chroot_path()
-        snapshot_dir = os.path.join(chroot_path, "snapshot")
-        Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
-        cmd = 'chown {}:{} {}'.format(self._microvm.jailer.uid,
-                                      self._microvm.jailer.gid,
-                                      snapshot_dir)
-        utils.run_cmd(cmd)
+
+        snaps_dir_name = os.path.basename(snaps_dir)
         self._microvm.pause_to_snapshot(
-            mem_file_path="/snapshot/vm.mem",
-            snapshot_path="/snapshot/vm.vmstate",
+            mem_file_path=os.path.join('/', snaps_dir_name, mem_file_name),
+            snapshot_path=os.path.join('/', snaps_dir_name, snapshot_name),
             diff=snapshot_type == SnapshotType.DIFF,
             version=target_version)
 
         # Create a copy of the ssh_key artifact.
         ssh_key_copy = ssh_key.copy()
-        mem_path = os.path.join(snapshot_dir, "vm.mem")
-        vmstate_path = os.path.join(snapshot_dir, "vm.vmstate")
-        return Snapshot(mem=mem_path,
-                        vmstate=vmstate_path,
+        return Snapshot(mem=mem_full_path,
+                        vmstate=vmstate_full_path,
                         # TODO: To support more disks we need to figure out a
                         # simple and flexible way to store snapshot artifacts
                         # in S3. This should be done in a PR where we add tests

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -65,6 +65,8 @@ class JailerContext:
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
+        self.ramfs_subdir_name = 'ramfs'
+        self._ramfs_path = None
 
     def __del__(self):
         """Cleanup this jailer context."""
@@ -134,6 +136,10 @@ class JailerContext:
         """Return the MicroVM chroot path."""
         return os.path.join(self.chroot_base_with_id(), 'root')
 
+    def chroot_ramfs_path(self):
+        """Return the MicroVM chroot ramfs subfolder path."""
+        return os.path.join(self.chroot_path(), self.ramfs_subdir_name)
+
     def jailed_path(self, file_path, create=False, create_jail=False):
         """Create a hard link or block special device owned by uid:gid.
 
@@ -179,19 +185,39 @@ class JailerContext:
             return 'ip netns exec {} '.format(self.netns)
         return ''
 
-    def setup(self):
+    def setup(self, use_ramdisk=False):
         """Set up this jailer context."""
         os.makedirs(
             self.chroot_base if self.chroot_base is not None
             else DEFAULT_CHROOT_PATH,
             exist_ok=True
         )
+
+        if use_ramdisk:
+            self._ramfs_path = self.chroot_ramfs_path()
+            os.makedirs(self._ramfs_path, exist_ok=True)
+            ramdisk_name = 'ramfs-{}'.format(self.jailer_id)
+            utils.run_cmd(
+                'mount -t ramfs -o size=1M {} {}'.format(
+                    ramdisk_name, self._ramfs_path
+                )
+            )
+            cmd = 'chown {}:{} {}'.format(
+                self.uid, self.gid, self._ramfs_path
+            )
+            utils.run_cmd(cmd)
+
         if self.netns:
             utils.run_cmd('ip netns add {}'.format(self.netns))
 
     def cleanup(self):
         """Clean up this jailer context."""
         # pylint: disable=subprocess-run-check
+        if self._ramfs_path:
+            utils.run_cmd(
+                'umount {}'.format(self._ramfs_path), ignore_return_code=True
+            )
+
         if self.jailer_id:
             shutil.rmtree(self.chroot_base_with_id(), ignore_errors=True)
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -684,6 +684,7 @@ class Microvm:
         response = self.vm.patch(state='Paused')
         assert self.api_session.is_status_no_content(response.status_code)
 
+        self.api_session.untime()
         response = self.snapshot_create.put(mem_file_path=mem_file_path,
                                             snapshot_path=snapshot_path,
                                             diff=diff,

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import select
+import shutil
 import time
 
 from retry import retry
@@ -296,6 +297,22 @@ class Microvm:
         )
         self._cpu_load_monitor.start()
 
+    def copy_to_jail_ramfs(self, src):
+        """Copy a file to a jail ramfs."""
+        filename = os.path.basename(src)
+        dest_path = os.path.join(self.jailer.chroot_ramfs_path(), filename)
+        jailed_path = os.path.join(
+            '/', self.jailer.ramfs_subdir_name, filename
+        )
+        shutil.copy(src, dest_path)
+        cmd = 'chown {}:{} {}'.format(
+            self.jailer.uid,
+            self.jailer.gid,
+            dest_path
+        )
+        utils.run_cmd(cmd)
+        return jailed_path
+
     def create_jailed_resource(self, path, create_jail=False):
         """Create a hard link to some resource inside this microvm."""
         return self.jailer.jailed_path(path, create=True,
@@ -349,10 +366,11 @@ class Microvm:
             self._api_session
         )
 
-    def spawn(self, create_logger=True, log_file='log_fifo', log_level='Info'):
+    def spawn(self, create_logger=True,
+              log_file='log_fifo', log_level='Info', use_ramdisk=False):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
-        self._jailer.setup()
+        self._jailer.setup(use_ramdisk=use_ramdisk)
         self._api_socket = self._jailer.api_socket_path()
         self._api_session = Session()
 

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -235,6 +235,7 @@ class SnapshotCreate():
 
     def put(self, **args):
         """Create a snapshot of the microvm."""
+        self._api_session.untime()
         datax = self.create_json(**args)
         return self._api_session.put(
             "{}".format(self._snapshot_cfg_url),

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -343,19 +343,26 @@ class MachineConfigure():
 
         self._machine_cfg_url = api_url + self.MACHINE_CFG_RESOURCE
         self._api_session = api_session
+        self._datax = {}
+
+    @property
+    def configuration(self):
+        """Return machine config dictionary."""
+        return self._datax
 
     def put(self, **args):
         """Specify the details of the machine configuration."""
-        datax = self.create_json(**args)
+        self._datax = self.create_json(**args)
 
         return self._api_session.put(
             "{}".format(self._machine_cfg_url),
-            json=datax
+            json=self._datax
         )
 
     def patch(self, **args):
         """Update the details of the machine configuration."""
         datax = self.create_json(**args)
+        self._datax.update(datax)
 
         return self._api_session.patch(
             "{}".format(self._machine_cfg_url),

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -71,7 +71,8 @@ kernel {}, disk {} """.format(snapshot_type,
                               disks=[rw_disk],
                               ssh_key=ssh_key,
                               config=context.microvm,
-                              enable_diff_snapshots=enable_diff_snapshots)
+                              enable_diff_snapshots=enable_diff_snapshots,
+                              use_ramdisk=True)
 
         # Configure metrics system.
         metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
@@ -88,7 +89,8 @@ kernel {}, disk {} """.format(snapshot_type,
         snapshot_builder = SnapshotBuilder(vm)
         snapshot_builder.create([rw_disk],
                                 ssh_key,
-                                snapshot_type)
+                                snapshot_type,
+                                use_ramdisk=True)
         metrics = vm.flush_metrics(metrics_fifo)
 
         if snapshot_type == SnapshotType.FULL:

--- a/tests/integration_tests/security/test_ssbd_mitigation.py
+++ b/tests/integration_tests/security/test_ssbd_mitigation.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests Speculative Store Bypass mitigations in jailer/Firecracker."""
+
+from framework.utils import run_cmd
+
+
+def test_ssbd_mitigation(test_microvm_with_initrd):
+    """Test that SSBD mitigation is enabled."""
+    vm = test_microvm_with_initrd
+    vm.jailer.daemonize = False
+    vm.spawn()
+    vm.memory_monitor = None
+
+    vm.basic_config(
+        add_root_device=False,
+        vcpu_count=1,
+        boot_args='console=ttyS0 reboot=k panic=1 pci=off',
+        use_initrd=True
+    )
+
+    vm.start()
+
+    cmd = 'ps -T --no-headers -p {} | awk \'{{print $2}}\''.format(
+        vm.jailer_clone_pid
+    )
+    process = run_cmd(cmd)
+    threads_out_lines = process.stdout.splitlines()
+    for tid in threads_out_lines:
+        # Verify each thread's status
+        cmd = 'cat /proc/{}/status | grep Speculation_Store_Bypass'.format(tid)
+        _, output, _ = run_cmd(cmd)
+        assert "thread force mitigated" in output or \
+            "globally mitigated" in output

--- a/tests/integration_tests/style/test_rust.py
+++ b/tests/integration_tests/style/test_rust.py
@@ -5,7 +5,7 @@
 import os
 import framework.utils as utils
 
-AMAZON_COPYRIGHT_YEARS = (2018, 2019, 2020)
+AMAZON_COPYRIGHT_YEARS = (2018, 2019, 2020, 2021)
 AMAZON_COPYRIGHT = (
     "Copyright {} Amazon.com, Inc. or its affiliates. All Rights Reserved."
 )
@@ -52,21 +52,21 @@ def _validate_license(filename):
             copy = file.readline()
             local_license = file.readline()
             has_amazon_copyright = (
-                    _has_amazon_copyright(copy) and
-                    AMAZON_LICENSE in local_license
+                _has_amazon_copyright(copy) and
+                AMAZON_LICENSE in local_license
             )
             has_chromium_copyright = (
-                    CHROMIUM_COPYRIGHT in copy and
-                    CHROMIUM_LICENSE in local_license
+                CHROMIUM_COPYRIGHT in copy and
+                CHROMIUM_LICENSE in local_license
             )
             has_tuntap_copyright = (
-                    TUNTAP_COPYRIGHT in copy and
-                    TUNTAP_LICENSE in local_license
+                TUNTAP_COPYRIGHT in copy and
+                TUNTAP_LICENSE in local_license
             )
             return (
-                    has_amazon_copyright or
-                    has_chromium_copyright or
-                    has_tuntap_copyright
+                has_amazon_copyright or
+                has_chromium_copyright or
+                has_tuntap_copyright
             )
     return True
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -756,7 +756,7 @@ cmd_fmt() {
 }
 
 
-# Prepare a Firecracker release by updating the version, crate dependencies
+# Prepare a Firecracker release by updating the version, changelog
 # and credits.
 # Example: `devtool release 0.42.0`
 #
@@ -798,14 +798,15 @@ cmd_prepare_release() {
         rm -f "${file}="
     done
 
-    # Update crate dependencies.
-    say "Updating crate dependencies..."
+    # Run `cargo check` to update firecracker and jailer versions in 
+    # `Cargo.lock`.
+    say "Updating lockfile..."
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
         -- \
-        cargo update
-    ok_or_die "cargo update failed."
+        cargo check
+    ok_or_die "cargo check failed."
 
     # Update credits.
     say "Updating credits..."

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="fcuvm/dev:v17"
+DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v17"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"

--- a/tools/devtool
+++ b/tools/devtool
@@ -189,6 +189,38 @@ ensure_docker() {
         "https://docs.docker.com/install/linux/linux-postinstall/"
 }
 
+# Run a command and retry multiple times if it fails. Once it stops
+# failing return to normal execution. If there are "retry count"
+# failures, set the last error code.
+# $1 - command
+# $2 - retry count
+# $3 - sleep interval between retries
+retry_cmd() {
+    command=$1
+    retry_cnt=$2
+    sleep_int=$3
+
+    {
+        $command
+    } || {
+        # Save error code
+        err_code=$?
+
+        # Command failed, substract one from retry_cnt
+        retry_cnt=$((retry_cnt - 1))
+
+        # If retry_cnt is larger than 0, sleep and call again
+        if [ "$retry_cnt" -gt 0 ]; then
+            echo "$command failed, retrying..."
+            sleep "$sleep_int"
+            retry_cmd "$command" "$retry_cnt" "$sleep_int"
+        fi
+
+        # Set what error code docker returned
+        $(exit "$err_code")
+    }
+}
+
 # Attempt to download our Docker image. Exit if that fails.
 # Upon returning from this call, the caller can be certain our Docker image is
 # available on this system.
@@ -204,7 +236,9 @@ ensure_devctr() {
         say "About to pull docker image $DEVCTR_IMAGE"
         get_user_confirmation || die "Aborted."
 
-        docker pull "${DEVCTR_IMAGE}"
+        # Run docker pull 5 times in case it fails - sleep 3 seconds
+        # between attempts
+        retry_cmd "docker pull $DEVCTR_IMAGE" 5 3
 
         ok_or_die "Error pulling docker image. Aborting."
     }


### PR DESCRIPTION
# Reason for This PR

Backport fixes to v0.23 and release v0.23.4

## Description of Changes

- Changed Docker images repository from DockerHub to Amazon ECR.
- Snapshot related host files (vm-state, memory, block backing files) are now
  flushed to their backing mediums as part of the CreateSnapshot operation.
- Fixed race between vcpu initialization and emulation thread which could
  potentially lead to segmentation faults.
- Fixed the SSBD mitigation not being enabled on `aarch64` with the provided
  `prod-host-setup.md`, by force-enabling it.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
