### PR TITLE
Fix balloon statistics being broken after a snapshot restore event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
   flushed to their backing mediums as part of the CreateSnapshot operation.
 - Fixed the SSBD mitigation not being enabled on `aarch64` with the provided
   `prod-host-setup.md`.
+- Fixed the balloon statistics not working after a snapshot restore event.
 
 ## [0.24.0]
 

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -501,6 +501,10 @@ impl Balloon {
     pub(crate) fn stats_enabled(&self) -> bool {
         self.stats_polling_interval_s > 0
     }
+
+    pub(crate) fn set_stats_desc_index(&mut self, stats_desc_index: Option<u16>) {
+        self.stats_desc_index = stats_desc_index;
+    }
 }
 
 impl VirtioDevice for Balloon {

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -140,8 +140,11 @@ impl Persist<'_> for Balloon {
         if state.virtio_state.activated {
             balloon.device_state = DeviceState::Activated(constructor_args.mem);
 
-            // Restart timer if needed.
             if balloon.stats_enabled() {
+                // Restore the stats descriptor.
+                balloon.set_stats_desc_index(state.stats_desc_index);
+
+                // Restart timer if needed.
                 let timer_state = TimerState::Periodic {
                     current: Duration::from_secs(state.stats_polling_interval_s as u64),
                     interval: Duration::from_secs(state.stats_polling_interval_s as u64),

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -651,6 +651,9 @@ def _test_balloon_snapshot(context):
     # Get the firecracker from snapshot pid, and open an ssh connection.
     firecracker_pid = microvm.jailer_clone_pid
 
+    # Get the stats right after we take a snapshot.
+    stats_after_snap = microvm.balloon.get_stats().json()
+
     # Check memory usage.
     third_reading = get_stable_rss_mem_by_pid(firecracker_pid)
 
@@ -671,6 +674,17 @@ def _test_balloon_snapshot(context):
     # There should be a reduction in RSS, but it's inconsistent.
     # We only test that the reduction happens.
     assert fourth_reading > fifth_reading
+
+    # Get the stats after we take a snapshot and dirty some memory,
+    # then reclaim it.
+    latest_stats = microvm.balloon.get_stats().json()
+
+    # Ensure the stats are still working after restore and show
+    # that the balloon inflated.
+    assert (
+        stats_after_snap['available_memory'] >
+        latest_stats['available_memory']
+    )
 
     microvm.kill()
 


### PR DESCRIPTION
# Reason for This PR

When testing for another issue, I resumed a snapshot with a balloon device in Firecracker v0.25. After resuming, the following log message is printed every `stats_polling_interval_s` seconds:

```
2021-05-26T16:04:35.049659990 [anonymous-instance:main:ERROR:src/devices/src/virtio/balloon/device.rs:426] Failed to update balloon stats, missing descriptor.
```

After digging into this some more, I found the root cause.

For context, the way balloon statistics work is the following:
- The guest driver is always putting a descriptor with the latest stats on the stats queue, in the available ring.
- The host sees the statistics and, when it wants new ones, it places the descriptor in the used ring.
- The guest driver immediately sends a new descriptor in the available ring.

We save the descriptor head in a special field in the balloon device (`stats_desc_index`). When the stats timer expires and we want new stats, we take the descriptor and place it in the used ring, signaling the driver that we did so.

The problem is that when saving the device state, while we do save the descriptor, we do not configure the restored device to use it. This makes the interaction broken because the descriptor is essentially lost, and the driver will not send a new one until we place this one on the used ring.

## Description of Changes

Fixed the issue described above by actually restoring `stats_desc_index` in `Balloon::restore`.
Also added a negative test for this issue in the integration tests.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
