### PR TITLE
add ramdisk to test_snapshot_resume_latency

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -176,7 +176,8 @@ kernel {}, disk {} """.format(snapshot_type,
                               disks=[rw_disk],
                               ssh_key=ssh_key,
                               config=context.microvm,
-                              enable_diff_snapshots=enable_diff_snapshots)
+                              enable_diff_snapshots=enable_diff_snapshots,
+                              use_ramdisk=True)
 
     basevm.start()
     ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
@@ -191,7 +192,8 @@ kernel {}, disk {} """.format(snapshot_type,
 
     snapshot = snapshot_builder.create([rw_disk.local_path()],
                                        ssh_key,
-                                       snapshot_type)
+                                       snapshot_type,
+                                       use_ramdisk=True)
 
     basevm.kill()
 
@@ -199,7 +201,8 @@ kernel {}, disk {} """.format(snapshot_type,
         microvm, metrics_fifo = vm_builder.build_from_snapshot(
             snapshot,
             True,
-            enable_diff_snapshots)
+            enable_diff_snapshots,
+            use_ramdisk=True)
 
         # Attempt to connect to resumed microvm.
         ssh_connection = net_tools.SSHConnection(microvm.ssh_config)


### PR DESCRIPTION
This aims to further stabilize the LoadSnapshot time
in the performance tests, by loading the snapshot from
a ramdisk.

Signed-off-by: alindima <alindima@amazon.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
