### PR TITLE
fix libfdt linking when compiled using -fstack-protector

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,14 +2,5 @@
 target = "x86_64-unknown-linux-musl"
 target-dir = "build/cargo_target"
 
-[target.'cfg(any(target_arch="arm", target_arch="aarch64"))']
-# On aarch64 musl depends on some libgcc functions (i.e `__addtf3` and other `*tf3` functions) for logic that uses
-# long double. Such functions are not builtin in the rust compiler, so we need to get them from libgcc.
-# No need for the `crt_static` flag as rustc appends it by default.
-rustflags = [
-	"-C", "link-arg=-lgcc",
-	"-C", "link-arg=-lfdt",
-]
-
 [net]
 git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "libfdt-bindings",
  "logger",
  "utils",
  "versionize",
@@ -450,6 +451,13 @@ name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+
+[[package]]
+name = "libfdt-bindings"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "log"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -18,3 +18,6 @@ utils = { path = "../utils" }
 
 [dev-dependencies]
 device_tree = ">=1.1.0"
+
+[target.'cfg(target_arch="aarch64")'.dependencies]
+libfdt-bindings = { path = "../libfdt-bindings" }

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -5,12 +5,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use libc::{c_char, c_int, c_void};
+use libc::{c_int, c_void};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString, NulError};
 use std::fmt::Debug;
 use std::ptr::null;
 use std::{io, result};
+
+use libfdt_bindings::*;
 
 use super::super::DeviceType;
 use super::super::InitrdConfig;
@@ -44,21 +46,6 @@ const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
 // From https://elixir.bootlin.com/linux/v4.9.62/source/include/dt-bindings/interrupt-controller/irq.h#L17
 const IRQ_TYPE_EDGE_RISING: u32 = 1;
 const IRQ_TYPE_LEVEL_HI: u32 = 4;
-
-// This links to libfdt which handles the creation of the binary blob
-// flattened device tree (fdt) that is passed to the kernel and indicates
-// the hardware configuration of the machine.
-extern "C" {
-    fn fdt_create(buf: *mut c_void, bufsize: c_int) -> c_int;
-    fn fdt_finish_reservemap(fdt: *mut c_void) -> c_int;
-    fn fdt_begin_node(fdt: *mut c_void, name: *const c_char) -> c_int;
-    fn fdt_property(fdt: *mut c_void, name: *const c_char, val: *const c_void, len: c_int)
-        -> c_int;
-    fn fdt_end_node(fdt: *mut c_void) -> c_int;
-    fn fdt_open_into(fdt: *const c_void, buf: *mut c_void, bufsize: c_int) -> c_int;
-    fn fdt_finish(fdt: *const c_void) -> c_int;
-    fn fdt_pack(fdt: *mut c_void) -> c_int;
-}
 
 /// Trait for devices to be added to the Flattened Device Tree.
 pub trait DeviceInfoForFDT {

--- a/src/libfdt-bindings/Cargo.toml
+++ b/src/libfdt-bindings/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "libfdt-bindings"
+version = "0.1.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2018"
+
+[target.'cfg(target_arch="aarch64")'.dependencies]
+libc = ">=0.2.39"

--- a/src/libfdt-bindings/Cargo.toml
+++ b/src/libfdt-bindings/Cargo.toml
@@ -3,6 +3,7 @@ name = "libfdt-bindings"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
+build = "build.rs"
 
 [target.'cfg(target_arch="aarch64")'.dependencies]
 libc = ">=0.2.39"

--- a/src/libfdt-bindings/build.rs
+++ b/src/libfdt-bindings/build.rs
@@ -1,0 +1,47 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+/// Get the ld linker search paths
+///
+/// Cargo overwrites LD_LIBRARY_PATH with rust specific paths. But we need the default system
+/// paths in order to find libfdt. So we query `ld` in order to get them.
+fn get_ld_search_dirs() -> Vec<String> {
+    // We need to extract from `ld --verbose` all the search paths.
+    // For example `ld --verbose | grep SEARCH_DIR | tr -s ' ;' '\n'` returns the following:
+    // ```
+    // SEARCH_DIR("=/usr/local/lib/aarch64-linux-gnu")
+    // SEARCH_DIR("=/lib/aarch64-linux-gnu")
+    // SEARCH_DIR("=/usr/lib/aarch64-linux-gnu")
+    // SEARCH_DIR("=/usr/local/lib")
+    // SEARCH_DIR("=/lib")
+    // SEARCH_DIR("=/usr/lib")
+    // SEARCH_DIR("=/usr/aarch64-linux-gnu/lib")
+    // ```
+    let cmd = r#"
+        ld --verbose | grep -oP '(?<=SEARCH_DIR\(\"=)[^"]+(?=\"\);)'
+    "#;
+
+    Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                return Some(output.stdout);
+            }
+            None
+        })
+        .and_then(|stdout_bytes| String::from_utf8(stdout_bytes).ok())
+        .map_or(vec![], |stdout| {
+            stdout.lines().map(|item| item.to_string()).collect()
+        })
+}
+
+fn main() {
+    for ld_search_dir in get_ld_search_dirs() {
+        println!("cargo:rustc-link-search=native={}", ld_search_dir);
+    }
+}

--- a/src/libfdt-bindings/src/lib.rs
+++ b/src/libfdt-bindings/src/lib.rs
@@ -8,6 +8,7 @@ use libc::{c_char, c_int, c_void};
 // flattened device tree (fdt) that is passed to the kernel and indicates
 // the hardware configuration of the machine.
 #[cfg(target_arch = "aarch64")]
+#[link(name = "fdt", kind = "static")]
 extern "C" {
     pub fn fdt_create(buf: *mut c_void, bufsize: c_int) -> c_int;
     pub fn fdt_finish_reservemap(fdt: *mut c_void) -> c_int;

--- a/src/libfdt-bindings/src/lib.rs
+++ b/src/libfdt-bindings/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(target_arch = "aarch64")]
+use libc::{c_char, c_int, c_void};
+
+// This links to libfdt which handles the creation of the binary blob
+// flattened device tree (fdt) that is passed to the kernel and indicates
+// the hardware configuration of the machine.
+#[cfg(target_arch = "aarch64")]
+extern "C" {
+    pub fn fdt_create(buf: *mut c_void, bufsize: c_int) -> c_int;
+    pub fn fdt_finish_reservemap(fdt: *mut c_void) -> c_int;
+    pub fn fdt_begin_node(fdt: *mut c_void, name: *const c_char) -> c_int;
+    pub fn fdt_property(
+        fdt: *mut c_void,
+        name: *const c_char,
+        val: *const c_void,
+        len: c_int,
+    ) -> c_int;
+    pub fn fdt_end_node(fdt: *mut c_void) -> c_int;
+    pub fn fdt_open_into(fdt: *const c_void, buf: *mut c_void, bufsize: c_int) -> c_int;
+    pub fn fdt_finish(fdt: *const c_void) -> c_int;
+    pub fn fdt_pack(fdt: *mut c_void) -> c_int;
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.52, "ARM": 83.36}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.52, "ARM": 83.46}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -10,7 +10,7 @@ import platform
 import host_tools.logging as log_tools
 from host_tools.cargo_build import run_seccompiler
 
-MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 3200}
+MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2900}
 """ The maximum acceptable startup time in CPU us. """
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -38,6 +38,7 @@ RUN apt-get update \
         libbfd-dev \
         libcurl4-openssl-dev \
         libdw-dev \
+        libfdt-dev \
         libiberty-dev \
         libssl-dev \
         lsof \
@@ -59,20 +60,6 @@ RUN apt-get update \
         wheel \
     && python3 -m pip install --upgrade pip \ 
     && rm -rf /var/lib/apt/lists/*
-
-# We need to build libfdt-dev using -fno-stack-protector
-# See https://github.com/rust-lang/rust/issues/79791
-RUN mkdir "$TMP_BUILD_DIR" \
-    && sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list \
-    && apt update \
-    && apt -y install build-essential fakeroot dpkg-dev \
-    && apt source libfdt-dev \
-    && apt -y build-dep libfdt-dev \
-    && cd device-tree-compiler-1.4.5 \
-    && echo "CFLAGS += -fno-stack-protector" >> libfdt/Makefile.libfdt \
-    && dpkg-buildpackage -uc -us -b \
-    && dpkg -i ../libfdt1_1.4.5-3_arm64.deb ../libfdt-dev_1.4.5-3_arm64.deb \
-    && rm -rf "$TMP_BUILD_DIR"
 
 RUN python3 -m pip install poetry
 RUN mkdir "$TMP_POETRY_DIR"

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v29"
+DEVCTR_IMAGE_TAG="v30"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
# Reason for This PR

fix libfdt linking when compiled using `-fstack-protector`

## Description of Changes

As part of #2579 we pushed a commit that involved compiling libfdt using `-fno-stack-protector` in order to workaround https://github.com/rust-lang/rust/issues/79791 .

This is a cleaner fix that enables us to compile firecracker using rust toolchain 1.52.1 even when libfdt is compiled using `-fstack-protector`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
