### PR TITLE
Add snapshot compatibility checks for snapshot create/restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74058b16912c6723db02d4ca3ec919b73cd41512ccd3b6202cf91ae8d6c9dce5"
+checksum = "f2924454e22895c738e43331ae310459c74a11ded9c97dc250129ee10d2f9ca2"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -921,6 +921,30 @@
                         "comment": "KVM_SET_XCRS"
                     }
                 ]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [
+                    {
+                        "arg_index": 1,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 44706,
+                        "comment": "KVM_SET_TSC_KHZ"
+                    }
+                ]
+            },
+            {
+                "syscall": "ioctl",
+                "args": [
+                    {
+                        "arg_index": 1,
+                        "arg_type": "dword",
+                        "op": "eq",
+                        "val": 44707,
+                        "comment": "KVM_GET_TSC_KHZ"
+                    }
+                ]
             }
         ]
     }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.8.0"
+kvm-ioctls = ">=0.9.0"
 libc = ">=0.2.39"
 vm-memory = { path = "../vm-memory" }
 versionize = ">=0.1.6"

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.8.0"
+kvm-ioctls = ">=0.9.0"
 
 utils = { path = "../utils"}

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::bit_helper::BitHelper;
 use crate::cpu_leaf::*;
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::CpuId;
@@ -91,6 +92,70 @@ pub fn get_vendor_id_from_cpuid(cpuid: &CpuId) -> Result<[u8; 12], Error> {
     Err(Error::NotSupported)
 }
 
+/// Validates that the provided CPUID belongs to a CPU of the same
+/// model as the host's.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn is_same_model(cpuid: &CpuId) -> bool {
+    // Try to get the vendor IDs from the host and the CPUID struct.
+    if let (Ok(host_vendor_id), Ok(cpuid_vendor_id)) =
+        (get_vendor_id_from_host(), get_vendor_id_from_cpuid(cpuid))
+    {
+        // If the vendor IDs aren't the same, the CPUs are not identical.
+        if host_vendor_id != cpuid_vendor_id {
+            return false;
+        }
+    } else {
+        // This only fails when CPUID is not supported, in which case
+        // we can't tell if the CPUs are identical.
+        return false;
+    }
+
+    // Try to get the feature information leaf from the host CPUID.
+    let host_feature_info_leaf = get_cpuid(leaf_0x1::LEAF_NUM, 0);
+
+    // The relevant information for this comparison is in the EAX register.
+    let host_feature_info_leaf_eax = match host_feature_info_leaf {
+        Ok(leaf) => leaf.eax,
+        Err(_) => {
+            // If this fails, we can't tell if the CPUs are identical.
+            return false;
+        }
+    };
+
+    // Search for the entry for leaf0x1.
+    let feature_info_leaf = cpuid
+        .as_slice()
+        .iter()
+        .find(|entry| entry.function == leaf_0x1::LEAF_NUM);
+
+    // The relevant information is in EAX.
+    let feature_info_leaf_eax = match feature_info_leaf {
+        Some(leaf) => leaf.eax,
+        None => {
+            // Fail fast if we can't retrieve the relevant
+            // information from CPUID.
+            return false;
+        }
+    };
+
+    // Validate that all of these properties are the same.
+    for elem in &[
+        leaf_0x1::eax::EXTENDED_FAMILY_ID_BITRANGE,
+        leaf_0x1::eax::EXTENDED_PROCESSOR_MODEL_BITRANGE,
+        leaf_0x1::eax::PROCESSOR_FAMILY_BITRANGE,
+        leaf_0x1::eax::PROCESSOR_MODEL_BITRANGE,
+        leaf_0x1::eax::STEPPING_BITRANGE,
+    ] {
+        if feature_info_leaf_eax.read_bits_in_range(elem)
+            != host_feature_info_leaf_eax.read_bits_in_range(elem)
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
 #[cfg(test)]
 pub mod tests {
     use crate::common::*;
@@ -146,5 +211,43 @@ pub mod tests {
         let vendor_id = get_vendor_id_from_host();
         assert!(vendor_id.is_ok());
         matches!(&vendor_id.ok().unwrap(), VENDOR_ID_INTEL | VENDOR_ID_AMD);
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn test_is_same_model() {
+        let mut curr_cpuid = CpuId::new(2).unwrap();
+
+        // Add the vendor ID leaf.
+        let vendor = get_cpuid(0x0, 0).unwrap();
+        curr_cpuid.as_mut_slice()[0].function = 0x0;
+        curr_cpuid.as_mut_slice()[0].index = 0;
+        curr_cpuid.as_mut_slice()[0].ebx = vendor.ebx;
+        curr_cpuid.as_mut_slice()[0].ecx = vendor.ecx;
+        curr_cpuid.as_mut_slice()[0].edx = vendor.edx;
+
+        // Add the feature info leaf.
+        let feature_info = get_cpuid(0x1, 0).unwrap();
+        curr_cpuid.as_mut_slice()[1].function = 0x1;
+        curr_cpuid.as_mut_slice()[1].index = 0;
+        curr_cpuid.as_mut_slice()[1].eax = feature_info.eax;
+
+        assert!(is_same_model(&curr_cpuid));
+
+        let mut diff_vendor_cpuid = curr_cpuid.clone();
+        for mut entry in diff_vendor_cpuid.as_mut_slice() {
+            if entry.function == 0x0 && entry.index == 0 {
+                entry.ebx = 0xFFFF_FFFF;
+            }
+        }
+        assert!(!is_same_model(&diff_vendor_cpuid));
+
+        let mut diff_feature_cpuid = curr_cpuid;
+        for mut entry in diff_feature_cpuid.as_mut_slice() {
+            if entry.function == 0x1 && entry.index == 0 {
+                entry.eax ^= 0x1;
+            }
+        }
+        assert!(!is_same_model(&diff_feature_cpuid));
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -19,7 +19,7 @@ arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
 kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.8.0"
+kvm-ioctls = ">=0.9.0"
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }
 rate_limiter = { path = "../rate_limiter" }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -66,6 +66,8 @@ pub struct MicrovmState {
 /// Errors related to saving and restoring Microvm state.
 #[derive(Debug)]
 pub enum MicrovmStateError {
+    /// Compatibility checks failed.
+    IncompatibleState(String),
     /// Provided MicroVM state is invalid.
     InvalidInput,
     /// Operation not allowed.
@@ -90,6 +92,7 @@ impl Display for MicrovmStateError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::MicrovmStateError::*;
         match self {
+            IncompatibleState(msg) => write!(f, "Compatibility checks failed: {}", msg),
             InvalidInput => write!(f, "Provided MicroVM state is invalid."),
             NotAllowed(msg) => write!(f, "Operation not allowed: {}", msg),
             RestoreDevices(err) => write!(f, "Cannot restore devices. Error: {:?}", err),

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -6,6 +6,8 @@
 use std::collections::HashMap;
 
 use crate::device_manager::persist::DeviceStates;
+#[cfg(target_arch = "x86_64")]
+use crate::vstate::vcpu::VcpuState;
 use devices::virtio::block::persist::BlockState;
 
 use lazy_static::lazy_static;
@@ -16,9 +18,17 @@ lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
     /// Static instance used for handling microVM state versions.
     pub static ref VERSION_MAP: VersionMap = {
+        // v0.23 - all structs and root version are set to 1.
         let mut version_map = VersionMap::new();
+
+        // v0.24 state change mappings.
         version_map.new_version().set_type_version(DeviceStates::type_id(), 2);
+
+        // v0.25 state change mappings.
         version_map.new_version().set_type_version(BlockState::type_id(), 2);
+        #[cfg(target_arch = "x86_64")]
+        version_map.set_type_version(VcpuState::type_id(), 2);
+
         version_map
     };
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.10, "AMD": 84.52, "ARM": 83.26}
+COVERAGE_DICT = {"Intel": 84.93, "AMD": 84.36, "ARM": 83.26}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

VMs restored from a snapshot might have the TSC frequency misaligned with the original, which could lead to problems further down the line. We took this as an opportunity to add snapshot compatibility checks, which start with adding the original TSC in the state file and scaling it for resumed VMs.

## Description of Changes

Added compatibility checks for snapshot create/restore, starting with TSC scaling.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
