### PR TITLE
seccompiler: remove rule-level actions and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@
   statistics update immediately after processing the request.
 - Deprecated the `--seccomp-level parameter`. It will be removed  in a future
   release. Using it logs a runtime warning.
-- Experimental gnu libc builds no longer use a default seccomp filter.
+- Experimental gnu libc builds use empty default seccomp filters, allowing all
+  system calls.
 
 ### Fixed
 

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -29,8 +29,8 @@ Example usage:
     --input-file "x86_64_musl.json" # File path of the JSON input.
     --output-file "bpf_x86_64_musl" # Optional path of the output file.
                                     # [default: "seccomp_binary_filter.out"]
-    --basic # Optional, creates basic filters, discarding rule-level actions
-            # and any parameter checks. Not recommended.
+    --basic # Optional, creates basic filters, discarding any parameter checks.
+            # (Not recommended).
 ```
 
 ### Seccompiler library
@@ -120,7 +120,6 @@ Here is the structure of the object:
 ```
 {
     "syscall": "accept4", // mandatory, the syscall name
-    "action": "allow", // optional, overrides the filter_action if present
     "comment": "Used by vsock & api thread", // optional, for adding meaningful comments
     "args": [...] // optional, vector of and-bound conditions for the parameters
 }
@@ -134,8 +133,8 @@ In order to allow a syscall with multiple alternatives for the same parameters,
 you can write multiple syscall rule objects at the filter-level, each with its
 own rules.
 
-Note that, when passing the `--basic` flag to seccompiler, all `action` and
-`args` fields of the `SeccompRule`s are ignored.
+Note that, when passing the `--basic` flag to seccompiler, all `args` fields
+of the `SeccompRule`s are ignored.
 
 A **condition object** is made up of the following mandatory properties:
 

--- a/src/seccompiler/src/seccompiler.rs
+++ b/src/seccompiler/src/seccompiler.rs
@@ -243,16 +243,13 @@ mod tests {
                 "filter_action": "allow",
                 "filter": [
                     {
-                        "syscall": "open",
-                        "action": "log"
+                        "syscall": "open"
                     },
                     {
-                        "syscall": "close",
-                        "action": "trap"
+                        "syscall": "close"
                     },
                     {
-                        "syscall": "stat",
-                        "action": "trap"
+                        "syscall": "stat"
                     },
                     {
                         "syscall": "futex",
@@ -273,7 +270,6 @@ mod tests {
                     },
                     {
                         "syscall": "futex",
-                        "action": "log",
                         "args": [
                             {
                                 "arg_index": 3,
@@ -706,12 +702,11 @@ mod tests {
                     SeccompAction::Errno(12),
                     SeccompAction::Allow,
                     vec![
-                        SyscallRule::new("open".to_string(), Some(SeccompAction::Log), None),
-                        SyscallRule::new("close".to_string(), Some(SeccompAction::Trap), None),
-                        SyscallRule::new("stat".to_string(), Some(SeccompAction::Trap), None),
+                        SyscallRule::new("open".to_string(), None),
+                        SyscallRule::new("close".to_string(), None),
+                        SyscallRule::new("stat".to_string(), None),
                         SyscallRule::new(
                             "futex".to_string(),
-                            None,
                             Some(vec![
                                 Cond::new(2, Dword, Le, 65).unwrap(),
                                 Cond::new(1, Qword, Ne, 80).unwrap(),
@@ -719,7 +714,6 @@ mod tests {
                         ),
                         SyscallRule::new(
                             "futex".to_string(),
-                            Some(SeccompAction::Log),
                             Some(vec![
                                 Cond::new(3, Qword, Gt, 65).unwrap(),
                                 Cond::new(1, Qword, Lt, 80).unwrap(),
@@ -727,12 +721,10 @@ mod tests {
                         ),
                         SyscallRule::new(
                             "futex".to_string(),
-                            None,
                             Some(vec![Cond::new(3, Qword, Ge, 65).unwrap()]),
                         ),
                         SyscallRule::new(
                             "ioctl".to_string(),
-                            None,
                             Some(vec![Cond::new(3, Dword, MaskedEq(100), 65).unwrap()]),
                         ),
                     ],
@@ -746,7 +738,6 @@ mod tests {
                     SeccompAction::Allow,
                     vec![SyscallRule::new(
                         "ioctl".to_string(),
-                        None,
                         Some(vec![Cond::new(3, Dword, Eq, 65).unwrap()]),
                     )],
                 ),

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -76,9 +76,7 @@ def test_allow_all(test_microvm_with_api):
 
     test_microvm.start()
 
-    # because Firecracker receives empty filters, the seccomp-level will
-    # remain 0
-    utils.assert_seccomp_level(test_microvm.jailer_clone_pid, "0")
+    utils.assert_seccomp_level(test_microvm.jailer_clone_pid, "2")
 
 
 def test_working_filter(test_microvm_with_api):

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -125,7 +125,8 @@ def test_advanced_seccomp(bin_seccomp_paths):
     Test seccompiler with `demo_jailer`.
 
     Test that the demo jailer (with advanced seccomp) allows the harmless demo
-    binary and denies the malicious demo binary.
+    binary, denies the malicious demo binary and that an empty allowlist
+    denies everything.
     """
     # pylint: disable=redefined-outer-name
     # pylint: disable=subprocess-run-check
@@ -200,6 +201,28 @@ def test_advanced_seccomp(bin_seccomp_paths):
     # The malicious binary also terminates gracefully, since the --basic option
     # disables all argument checks.
     assert outcome.returncode == 0
+
+    os.unlink(bpf_path)
+
+    # Run the mini jailer with an empty allowlist. It should trap on any
+    # syscall.
+    json_filter = """{
+        "main": {
+            "default_action": "trap",
+            "filter_action": "allow",
+            "filter": []
+        }
+    }"""
+
+    # Run seccompiler.
+    bpf_path = _run_seccompiler(json_filter)
+
+    outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path],
+                            no_shell=True,
+                            ignore_return_code=True)
+
+    # The demo binary should have received `SIGSYS`.
+    assert outcome.returncode == -31
 
     os.unlink(bpf_path)
 


### PR DESCRIPTION
# Reason for This PR

This commit fixes https://github.com/firecracker-microvm/firecracker/issues/2585, adds a check to deny filters that have the same on-match and default actions and removes support for rule-level actions.

See details on why we are removing rule-level actions below:

Until now, a filter consisted of a default action, a filter action and an array of rules.
Each of these rules can have an optional rule-level action, that, when it matches, overrides the filter-level action.
This can be useful sometimes, when debugging or for some advanced filters. For example, you could specifically kill the process when you get an exec() call, instead of trapping, which would be the filter-level action.

Firecracker does not use this option, and there are no real use cases I can think of, where this is neccessary.
Having thought of it some more, it can lead to some undefined results. Consider this filter:

```
{
    "vmm":
        "default_action": "trap",
        "filter_action": "allow",
        "filter": {
                "syscall": "futex",
                "comment": "Used for synchronization",
                "args": [
                    {
                        "arg_index": 1,
                        "arg_type": "dword",
                        "op": "eq",
                        "val": 128,
                        "comment": "FUTEX_WAIT_PRIVATE"
                    }
                ]
            },
            {
                "syscall": "futex",
                "comment": "Used for synchronization",
                "args": [
                    {
                        "arg_index": 1,
                        "arg_type": "dword",
                        "op": "eq",
                        "val": 129,
                        "comment": "FUTEX_WAKE_PRIVATE"
                    }
                ]
            }
            {
                "syscall": "futex",
                "comment": "Used for synchronization",
                "action": "kill",
                "args": [
                    {
                        "arg_index": 1,
                        "arg_type": "dword",
                        "op": "eq",
                        "val": 129,
                        "comment": "FUTEX_WAKE_PRIVATE"
                    }
                ]
            }
        }
    }
}
```

Note the `"action":"kill"` on the last rule.
For `FUTEX_WAKE_PRIVATE`, the result is undefined. Depending on how we compile the BPF and
the end order of the rules, this can either allow the syscall or kill the process.
This case would be difficult to validate, and for a use-case that Firecracker does not currently need.

Therefore, this PR removes it. It's a two way door. If, in the future, it turns out that we need it, we can build it.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
