### PR TITLE
rate-limiter: increase limiter precision

### DIFF
--- a/src/rate_limiter/src/persist.rs
+++ b/src/rate_limiter/src/persist.rs
@@ -109,7 +109,7 @@ mod tests {
         assert!(tb.partial_eq(&restored_tb));
 
         // Check that TokenBucket restores correctly after replenishing tokens.
-        tb.replenish(100);
+        tb.force_replenish(100);
         let restored_tb = TokenBucket::restore((), &tb.save()).unwrap();
         assert!(tb.partial_eq(&restored_tb));
 


### PR DESCRIPTION
# Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/2176

The firecracker rate-limiter implementation leans more on efficiency at the expense of accuracy. Even so, the accuracy can be improved without performance penalties.

## Description of Changes

Firecracker rate-limiter is a passive implementation driven by the consumer. Each time `X` tokens go through it, the rate-limiter:
 1. calculates how much time has passed since last operation
 2. replenishes its budget based on elapsed time above
 3. attempts to allow `X` if it fits the budget

Because we don't want to incur the cost of floating point operations the operation in `step 2` is a non-floating point division which loses precision:
```rust
  // At each 'time_delta' nanoseconds the bucket should refill with:
  refill_amount = (time_delta * size) / (refill_time_ms * 1_000_000)
```

The smaller `time_delta * size` and the more of these operations we do, the higher our precision loss.

We can't control `size` since it's user-provided input, but we can slightly change our implementation to optimize on the other two dimensions: we want bigger `time_delta`s and fewer division operations.

These are complementary and can be achieved by doing bucket replenish operations only when needed (budget is low/empty) instead of every time the limiter sees traffic.

This small change results in increased precision (it should be cheaper too since we're doing fewer operations).

## Testing

Set up block rate limiter:
```json
"rate_limiter": {
  "ops": {
    "size": 3000,
    "one_time_burst": 0,
    "refill_time": 1000
  }
}
```

And tested _ops rate-limiting_ using `fio`:

```
fio -rw=randwrite -ioengine=libaio -bs=4k -size=1G -numjobs=1 -runtime=1000 -group_reporting -filename=iotest -name=Rand_Write_Testing -direct=1 -iodepth=128
```

### Before

```
iops        : min=  1980, max=13142, avg=2794.51
```

### After

```
iops        : min= 2518, max=12576, avg=2989.88
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
