### PR TITLE
seccomp: remove timerfd_create from allow-list

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -238,26 +238,6 @@
                 ]
             },
             {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting and metrics",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for rate limiting and metrics",
                 "args": [

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -238,26 +238,6 @@
                 ]
             },
             {
-                "syscall": "timerfd_create",
-                "comment": "Needed for rate limiting and metrics",
-                "args": [
-                    {
-                        "arg_index": 0,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 1,
-                        "comment": "libc::CLOCK_MONOTONIC"
-                    },
-                    {
-                        "arg_index": 1,
-                        "arg_type": "dword",
-                        "op": "eq",
-                        "val": 526336,
-                        "comment": "libc::TFD_CLOEXEC | libc::TFD_NONBLOCK"
-                    }
-                ]
-            },
-            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for rate limiting and metrics",
                 "args": [


### PR DESCRIPTION
# Reason for This PR

Fixes #962 

## Description of Changes

`TimerFd`s are used by rate-limiters, metrics, and balloon device.

Since #1494, #1735 and #1736, all of them are created before boot, thus before seccomp filters are applied.

This means we don't need `timerfd_create` syscall on our allow-list, and can be removed to tighten it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] ~Any required documentation changes (code and docs) are included in this PR.~
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
