### PR TITLE
test seccomp-level deprecation warning

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -368,7 +368,7 @@ fn warn_deprecated_parameters(arguments: &Arguments) {
     // --seccomp-level is deprecated.
     if let Some(value) = arguments.single_value("seccomp-level") {
         warn!(
-            "You are using a deprecated parameter: --seccomp-level {}, that will be removed in a\
+            "You are using a deprecated parameter: --seccomp-level {}, that will be removed in a \
             future version.",
             value
         );

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -170,7 +170,7 @@ class Microvm:
             # Needed to avoid false positives in case kill() is called again.
             self.expect_kill_by_signal = True
             utils.run_cmd(
-                'screen -XS {} kill || true'.format(self._session_name))
+                'kill -9 {} || true'.format(self.screen_pid))
 
         if self._memory_monitor and self._memory_monitor.is_alive():
             self._memory_monitor.signal_stop()

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -5,6 +5,7 @@
 import os
 import tempfile
 import platform
+import time
 import pytest
 
 from host_tools.cargo_build import run_seccompiler
@@ -258,9 +259,12 @@ KERNEL_LEVEL = {"default": "2", "0": "0", "1": "2", "2": "2"}
 def test_seccomp_level(test_microvm_with_api, level):
     """Test Firecracker --seccomp-level value."""
     test_microvm = test_microvm_with_api
+    test_microvm.jailer.daemonize = False
+
     if level != "default":
         test_microvm.jailer.extra_args.update({"seccomp-level": level})
-    test_microvm.spawn()
+
+    test_microvm.spawn(create_logger=False)
 
     test_microvm.basic_config()
 
@@ -268,3 +272,14 @@ def test_seccomp_level(test_microvm_with_api, level):
 
     utils.assert_seccomp_level(
         test_microvm.jailer_clone_pid, KERNEL_LEVEL[level])
+
+    test_microvm.kill()
+
+    # For seccomp-level, check that we output the deprecation warnings.
+    if level != "default":
+        time.sleep(0.5)
+        with open(test_microvm.screen_log, 'r') as file:
+            log_data = file.read()
+            assert "You are using a deprecated parameter: --seccomp-level " \
+                f"{level}, that will be removed in a future version." \
+                in log_data


### PR DESCRIPTION
# Reason for This PR

We didn't have a test that checked the runtime warning logged for using `--seccomp-level`.

## Description of Changes

Add a check that verifies the existence of the warning

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
