### PR TITLE
filter out cpuid leaves returned by KVM_GET_SUPPORTED_CPUID

### DIFF
--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod leaf_0x0 {
+    pub const LEAF_NUM: u32 = 0x0;
+}
+
 // Basic CPUID Information
 pub mod leaf_0x1 {
     pub const LEAF_NUM: u32 = 0x1;
@@ -67,6 +71,14 @@ pub mod leaf_0x1 {
     }
 }
 
+pub mod leaf_0x2 {
+    pub const LEAF_NUM: u32 = 0x2;
+}
+
+pub mod leaf_0x3 {
+    pub const LEAF_NUM: u32 = 0x3;
+}
+
 pub mod leaf_cache_parameters {
     pub mod eax {
         use crate::bit_helper::BitRange;
@@ -88,6 +100,10 @@ pub mod leaf_0x4 {
 
         pub const MAX_CORES_PER_PACKAGE_BITRANGE: BitRange = bit_range!(31, 26);
     }
+}
+
+pub mod leaf_0x5 {
+    pub const LEAF_NUM: u32 = 0x5;
 }
 
 // Thermal and Power Management Leaf
@@ -195,6 +211,14 @@ pub mod leaf_0x7 {
     }
 }
 
+pub mod leaf_0x8 {
+    pub const LEAF_NUM: u32 = 0x8;
+}
+
+pub mod leaf_0x9 {
+    pub const LEAF_NUM: u32 = 0x9;
+}
+
 pub mod leaf_0xa {
     pub const LEAF_NUM: u32 = 0xa;
 }
@@ -228,6 +252,10 @@ pub mod leaf_0xb {
         pub const LEVEL_TYPE_BITRANGE: BitRange = bit_range!(15, 8);
         pub const LEVEL_NUMBER_BITRANGE: BitRange = bit_range!(7, 0);
     }
+}
+
+pub mod leaf_0xc {
+    pub const LEAF_NUM: u32 = 0xc;
 }
 
 // Processor Extended State Enumeration Sub-leaves
@@ -277,6 +305,30 @@ pub mod leaf_0x80000001 {
     }
 }
 
+pub mod leaf_0x80000002 {
+    pub const LEAF_NUM: u32 = 0x8000_0002;
+}
+
+pub mod leaf_0x80000003 {
+    pub const LEAF_NUM: u32 = 0x8000_0003;
+}
+
+pub mod leaf_0x80000004 {
+    pub const LEAF_NUM: u32 = 0x8000_0004;
+}
+
+pub mod leaf_0x80000005 {
+    pub const LEAF_NUM: u32 = 0x8000_0005;
+}
+
+pub mod leaf_0x80000006 {
+    pub const LEAF_NUM: u32 = 0x8000_0006;
+}
+
+pub mod leaf_0x80000007 {
+    pub const LEAF_NUM: u32 = 0x8000_0007;
+}
+
 pub mod leaf_0x80000008 {
     pub const LEAF_NUM: u32 = 0x8000_0008;
 
@@ -292,6 +344,18 @@ pub mod leaf_0x80000008 {
         // The number of threads in the package - 1
         pub const NUM_THREADS_BITRANGE: BitRange = bit_range!(7, 0);
     }
+}
+
+pub mod leaf_0x8000000a {
+    pub const LEAF_NUM: u32 = 0x8000_000a;
+}
+
+pub mod leaf_0x80000019 {
+    pub const LEAF_NUM: u32 = 0x8000_0019;
+}
+
+pub mod leaf_0x8000001b {
+    pub const LEAF_NUM: u32 = 0x8000_001b;
 }
 
 // Extended Cache Topology Leaf

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -129,13 +129,12 @@ pub fn update_extended_apic_id_entry(
 pub struct AmdCpuidTransformer {}
 
 impl CpuidTransformer for AmdCpuidTransformer {
-    fn process_cpuid(&self, cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
+    fn preprocess_cpuid(&self, cpuid: &mut CpuId, _vm_spec: &VmSpec) -> Result<(), Error> {
         // Some versions of kernel may return the 0xB leaf for AMD even if this is an
         // Intel-specific leaf. Remove it.
         cpuid.retain(|entry| entry.function != leaf_0xb::LEAF_NUM);
         use_host_cpuid_function(cpuid, leaf_0x8000001e::LEAF_NUM, false)?;
-        use_host_cpuid_function(cpuid, leaf_0x8000001d::LEAF_NUM, true)?;
-        self.process_entries(cpuid, vm_spec)
+        use_host_cpuid_function(cpuid, leaf_0x8000001d::LEAF_NUM, true)
     }
 
     fn entry_transformer_fn(&self, entry: &mut kvm_cpuid_entry2) -> Option<EntryTransformerFn> {
@@ -158,7 +157,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_process_cpuid() {
+    fn test_preprocess_cpuid() {
         let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
         let mut cpuid = CpuId::new(0).unwrap();
         let entry = kvm_cpuid_entry2 {

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -118,6 +118,36 @@ fn update_extended_topology_entry(
 pub struct IntelCpuidTransformer {}
 
 impl CpuidTransformer for IntelCpuidTransformer {
+    fn valid_leaves_filter(&self) -> Option<&'static [u32]> {
+        Some(&[
+            // Standard functions
+            leaf_0x0::LEAF_NUM,
+            leaf_0x1::LEAF_NUM,
+            leaf_0x2::LEAF_NUM,
+            leaf_0x3::LEAF_NUM,
+            leaf_0x4::LEAF_NUM,
+            leaf_0x5::LEAF_NUM,
+            leaf_0x6::LEAF_NUM,
+            leaf_0x7::LEAF_NUM,
+            leaf_0x8::LEAF_NUM,
+            leaf_0x9::LEAF_NUM,
+            leaf_0xa::LEAF_NUM,
+            leaf_0xb::LEAF_NUM,
+            leaf_0xc::LEAF_NUM,
+            leaf_0xd::LEAF_NUM,
+            // Extended Functions
+            leaf_0x80000000::LEAF_NUM,
+            leaf_0x80000001::LEAF_NUM,
+            leaf_0x80000002::LEAF_NUM,
+            leaf_0x80000003::LEAF_NUM,
+            leaf_0x80000004::LEAF_NUM,
+            leaf_0x80000005::LEAF_NUM,
+            leaf_0x80000006::LEAF_NUM,
+            leaf_0x80000007::LEAF_NUM,
+            leaf_0x80000008::LEAF_NUM,
+        ])
+    }
+
     fn entry_transformer_fn(&self, entry: &mut kvm_cpuid_entry2) -> Option<EntryTransformerFn> {
         match entry.function {
             leaf_0x1::LEAF_NUM => Some(common::update_feature_info_entry),

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -71,9 +71,14 @@ pub type EntryTransformerFn =
 
 /// Generic trait that provides methods for transforming the cpuid
 pub trait CpuidTransformer {
+    /// Hook that is called by `process_cpuid` before executing the main logic.
+    fn preprocess_cpuid(&self, _cpuid: &mut CpuId, _vm_spec: &VmSpec) -> Result<(), Error> {
+        Ok(())
+    }
+
     /// Trait main function. It processes the cpuid and makes the desired transformations.
-    /// The default logic can be overwritten if needed. For example see `AmdCpuidTransformer`.
     fn process_cpuid(&self, cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
+        self.preprocess_cpuid(cpuid, vm_spec)?;
         self.process_entries(cpuid, vm_spec)
     }
 


### PR DESCRIPTION
# Reason for This PR

filter out cpuid leaves returned by KVM_GET_SUPPORTED_CPUID

## Description of Changes

in case of a bug KVM_GET_SUPPORTED_CPUID may return leaves that don't make sense. We create a list of allowed cpuid leaves for each vendor and filter the cpuid returned by KVM_GET_SUPPORTED_CPUID

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
