### PR TITLE
Fix snapshot files being created when snapshot operation failed

### DIFF
--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -172,6 +172,11 @@ impl VmResources {
         self.vm_config().track_dirty_pages
     }
 
+    /// Configures the dirty page tracking functionality of the microVM.
+    pub fn set_track_dirty_pages(&mut self, dirty_page_tracking: bool) {
+        self.vm_config.track_dirty_pages = dirty_page_tracking;
+    }
+
     /// Returns the VmConfig.
     pub fn vm_config(&self) -> &VmConfig {
         &self.vm_config

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.10, "AMD": 84.52, "ARM": 83.35}
+COVERAGE_DICT = {"Intel": 85.10, "AMD": 84.52, "ARM": 83.26}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -570,5 +570,10 @@ def test_negative_snapshot_create(bin_cloner_path):
     response = vm.snapshot.create(mem_file_path='memfile',
                                   snapshot_path='statefile',
                                   diff=True)
-    assert "Cannot get dirty bitmap" in response.text
+    msg = "Diff snapshots are not allowed on uVMs with dirty page" \
+          " tracking disabled"
+    assert msg in response.text
+    assert not os.path.exists('statefile')
+    assert not os.path.exists('memfile')
+
     vm.kill()


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Creating diff snapshot fails when the target microVM's config has `enable_diff_snapshots` off.  Even if the operation fails, snapshot files are still created.

## Description of Changes

Added a check at the beginning of the snapshotting operation. If `diff` snapshot is requested and `enable_diff_snapshots` is disabled in the machine configuration, a `NotSupported(Diff snapshots are not allowed on uVMs with dirty page tracking disabled.)` error is displayed.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] ~Any required documentation changes (code and docs) are included in this PR.~
- [X] ~Any newly added `unsafe` code is properly documented.~
- [X] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [X] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [X] All added/changed functionality is tested.
