### PR TITLE
test report: fetch description from docstring

### DIFF
--- a/tests/framework/report.py
+++ b/tests/framework/report.py
@@ -90,7 +90,7 @@ class Report(mpsing.MultiprocessSingleton):
         "name": ReportItem("", False, None),
 
         # What the test does
-        "description": ReportItem("", False, None),
+        "description": ReportItem("", True, None),
 
         # If the test passed, failed or was skipped
         "outcome": ReportItem("", False, None),


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

`description` item needs to enable `from_docstring` in order to be populated when parsing the test's docstring.

## Description of Changes

Enabled `from_docstring` in the "description" `ReportItem`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] ~Any required documentation changes (code and docs) are included in this PR.~
- [X] ~Any newly added `unsafe` code is properly documented.~
- [X] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [X] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [X] ~All added/changed functionality is tested.~
