### PR TITLE
Rename seccompiler binary, deprecate --basic parameter and add extra thread name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   version of a snapshot state file provided as argument.
 - Added `--no-seccomp` parameter for disabling the default seccomp filters.
 - Added `--seccomp-filter` parameter for supplying user-provided, custom filters.
-- Added the `seccompiler` binary that is used to compile JSON seccomp filters
+- Added the `seccompiler-bin` binary that is used to compile JSON seccomp filters
   into serialized BPF for Firecracker consumption.
 - Snapshotting support for GICv2 enabled guests.
 - Added `devtool install` to deploy built binaries in `/usr/local/bin` or a

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -20,8 +20,8 @@ Firecracker uses JSON files for expressing the filter rules and relies on the
 ## Default filters (recommended)
 
 At build time, the default target-specific JSON file is compiled into the
-serialized binary file, using seccompiler, and gets embedded in the Firecracker
-binary.
+serialized binary file, using seccompiler-bin, and gets embedded in the
+Firecracker binary.
 
 This process is performed automatically, when building the executable.
 
@@ -51,7 +51,7 @@ with fully customisable alternatives, leveraging the same JSON/seccompiler
 tooling, at startup time.
 
 Via Firecracker's optional `--seccomp-filter` parameter, one can supply
-the path to a custom filter file compiled with seccompiler.
+the path to a custom filter file compiled with seccompiler-bin.
 
 Potential use cases:
 

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -2,28 +2,28 @@
 
 ## Overview
 
-Seccompiler is a tool that compiles seccomp filters expressed as JSON files
+Seccompiler-bin is a tool that compiles seccomp filters expressed as JSON files
 into serialized, binary BPF code that is directly consumed by Firecracker,
 at build or launch time.
 
-Seccompiler defines a custom [JSON file structure](#json-file-format), detailed
-further below, that the filters must adhere to.
+Seccompiler-bin uses a custom [JSON file structure](#json-file-format),
+detailed further below, that the filters must adhere to.
 
-Besides the compiler binary, seccompiler also exports a small library
-interface, with a couple of helper functions, for deserializing and installing
-the binary filters.
+Besides the seccompiler-bin executable, seccompiler also exports a library
+interface, with helper functions for deserializing and installing the binary
+filters.
 
 ## Usage
 
-### Seccompiler binary
+### Seccompiler-bin
 
-To view the seccompiler command line arguments, pass the `--help` parameter to
-the executable.
+To view the seccompiler-bin command line arguments, pass the `--help` parameter
+to the executable.
 
 Example usage:
 
 ```bash
-./seccompiler
+./seccompiler-bin
     --target-arch "x86_64"  # The CPU arch where the BPF program will run.
                             # Supported architectures: x86_64, aarch64.
     --input-file "x86_64_musl.json" # File path of the JSON input.
@@ -45,12 +45,12 @@ workspace. The code is located at `firecracker/src/seccompiler/src`.
 
 ## Supported platforms
 
-Seccompiler is supported on the
+Seccompiler-bin is supported on the
 [same platforms as Firecracker](../README.md#supported-platforms).
 
 ## Release policy
 
-Seccompiler follows Firecracker's [release policy](RELEASE_POLICY.md) and
+Seccompiler-bin follows Firecracker's [release policy](RELEASE_POLICY.md) and
 version (it's released at the same time, with the same version number and
 adheres to the same support window).
 
@@ -133,7 +133,7 @@ In order to allow a syscall with multiple alternatives for the same parameters,
 you can write multiple syscall rule objects at the filter-level, each with its
 own rules.
 
-Note that, when passing the `--basic` flag to seccompiler, all `args` fields
+Note that, when passing the `--basic` flag to seccompiler-bin, all `args` fields
 of the `SeccompRule`s are ignored.
 
 A **condition object** is made up of the following mandatory properties:

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -30,7 +30,7 @@ Example usage:
     --output-file "bpf_x86_64_musl" # Optional path of the output file.
                                     # [default: "seccomp_binary_filter.out"]
     --basic # Optional, creates basic filters, discarding any parameter checks.
-            # (Not recommended).
+            # (Deprecated).
 ```
 
 ### Seccompiler library
@@ -133,8 +133,8 @@ In order to allow a syscall with multiple alternatives for the same parameters,
 you can write multiple syscall rule objects at the filter-level, each with its
 own rules.
 
-Note that, when passing the `--basic` flag to seccompiler-bin, all `args` fields
-of the `SeccompRule`s are ignored.
+Note that, when passing the deprecated `--basic` flag to seccompiler-bin, all
+`args` fields of the `SeccompRule`s are ignored.
 
 A **condition object** is made up of the following mandatory properties:
 

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://firecracker-microvm.github.io/"
 license = "Apache-2.0"
 
 [[bin]]
-name = "seccompiler"
-path = "src/seccompiler.rs"
+name = "seccompiler-bin"
+path = "src/seccompiler_bin.rs"
 
 [dependencies]
 utils = { path = "../utils" }

--- a/src/seccompiler/src/common.rs
+++ b/src/seccompiler/src/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module that defines common data structures used by both the library crate
-//! and the seccompiler binary.
+//! and seccompiler-bin.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module defining the logic for compiling the deserialized filter objects into the IR.
-//! Used by the seccompiler binary.
+//! Used by seccompiler-bin.
 //!
 //! Via the `Compiler::compile_blob()` method, it also drives the entire JSON -> BLOB
 //! transformation process.

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 
 //! The library crate that defines common helper functions that are generally used in
-//! conjunction with the seccompiler binary.
+//! conjunction with seccompiler-bin.
 
 mod common;
 

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -120,7 +120,7 @@ fn build_arg_parser() -> ArgParser<'static> {
         .arg(
             Argument::new("basic")
                 .takes_value(false)
-                .help("Transforms the filters into basic filters. Drops all argument checks \
+                .help("Deprecated! Transforms the filters into basic filters. Drops all argument checks \
                 and rule-level actions. Not recommended."),
         )
 }
@@ -141,12 +141,20 @@ fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments> {
         return Err(Error::MissingInputFile);
     }
 
+    let is_basic = arguments.flag_present("basic");
+    if is_basic {
+        println!(
+            "Warning! You are using a deprecated parameter: --basic, that will be removed in a \
+            future version.\n"
+        );
+    }
+
     Ok(Arguments {
         target_arch,
         input_file: input_file.unwrap().to_owned(),
         // Safe to unwrap because it has a default value
         output_file: arguments.single_value("output-file").unwrap().to_owned(),
-        is_basic: arguments.flag_present("basic"),
+        is_basic,
     })
 }
 
@@ -178,7 +186,7 @@ fn main() {
     let mut arg_parser = build_arg_parser();
 
     if let Err(err) = arg_parser.parse_from_cmdline() {
-        println!(
+        eprintln!(
             "Arguments parsing error: {} \n\n\
              For more information try --help.",
             err

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -187,12 +187,12 @@ fn main() {
     }
 
     if arg_parser.arguments().flag_present("help") {
-        println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
+        println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
         println!("{}", arg_parser.formatted_help());
         return;
     }
     if arg_parser.arguments().flag_present("version") {
-        println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
+        println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
         return;
     }
 
@@ -405,7 +405,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler",
+                    "seccompiler-bin",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -431,7 +431,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler",
+                    "seccompiler-bin",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -460,7 +460,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler"]
+                vec!["seccompiler-bin"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -472,7 +472,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler", "--input-file", "foo.txt"]
+                vec!["seccompiler-bin", "--input-file", "foo.txt"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -484,7 +484,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler", "--target-arch", "x86_64"]
+                vec!["seccompiler-bin", "--target-arch", "x86_64"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -497,7 +497,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler",
+                    "seccompiler-bin",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -518,7 +518,7 @@ mod tests {
         assert!(arguments
             .parse(
                 vec![
-                    "seccompiler",
+                    "seccompiler-bin",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Seccompiler is a program that compiles multi-threaded seccomp-bpf filters expressed as JSON
+//! seccompiler-bin is a program that compiles multi-threaded seccomp-bpf filters expressed as JSON
 //! into raw BPF programs, serializing them and outputting them to a file.
 //!
 //! Used in conjunction with the provided library crate, one can deserialize the binary filters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,7 +310,7 @@ def bin_seccomp_paths(test_fc_session_root_path):
 
     They currently consist of:
 
-    * a jailer that receives a seccompiler generated filter;
+    * a jailer that receives filter generated using seccompiler-bin;
     * a jailed binary that follows the seccomp rules;
     * a jailed binary that breaks the seccomp rules.
     """

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -101,11 +101,13 @@ def get_rustflags():
     return rustflags
 
 
-def run_seccompiler(bpf_path, json_path=defs.SECCOMP_JSON_DIR, basic=False):
+def run_seccompiler_bin(bpf_path,
+                        json_path=defs.SECCOMP_JSON_DIR,
+                        basic=False):
     """
-    Run seccompiler.
+    Run seccompiler-bin.
 
-    :param bpf_path: path to the seccompiler output file
+    :param bpf_path: path to the output file
     :param json_path: optional path to json file
     """
     cargo_target = '{}-unknown-linux-musl'.format(platform.machine())

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -8,7 +8,7 @@ import time
 import platform
 
 import host_tools.logging as log_tools
-from host_tools.cargo_build import run_seccompiler
+from host_tools.cargo_build import run_seccompiler_bin
 
 MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2900}
 """ The maximum acceptable startup time in CPU us. """
@@ -75,7 +75,7 @@ def _test_startup_time(microvm):
 def _custom_filter_setup(test_microvm):
     bpf_path = os.path.join(test_microvm.path, 'bpf.out')
 
-    run_seccompiler(bpf_path)
+    run_seccompiler_bin(bpf_path)
 
     test_microvm.create_jailed_resource(bpf_path)
     test_microvm.jailer.extra_args.update({"seccomp-filter": 'bpf.out'})

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -13,7 +13,7 @@ import requests
 import framework.utils as utils
 import host_tools.logging as log_tools
 
-from host_tools.cargo_build import run_seccompiler
+from host_tools.cargo_build import run_seccompiler_bin
 
 
 def _custom_filter_setup(test_microvm, json_filter):
@@ -23,7 +23,7 @@ def _custom_filter_setup(test_microvm, json_filter):
 
     bpf_path = os.path.join(test_microvm.path, 'bpf.out')
 
-    run_seccompiler(bpf_path=bpf_path, json_path=json_temp.name)
+    run_seccompiler_bin(bpf_path=bpf_path, json_path=json_temp.name)
 
     os.unlink(json_temp.name)
     test_microvm.create_jailed_resource(bpf_path)

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -8,7 +8,7 @@ import platform
 import time
 import pytest
 
-from host_tools.cargo_build import run_seccompiler
+from host_tools.cargo_build import run_seccompiler_bin
 import framework.utils as utils
 
 
@@ -70,15 +70,15 @@ def _get_basic_syscall_list():
     return json
 
 
-def _run_seccompiler(json_data, basic=False):
+def _run_seccompiler_bin(json_data, basic=False):
     json_temp = tempfile.NamedTemporaryFile(delete=False)
     json_temp.write(json_data.encode('utf-8'))
     json_temp.flush()
 
     bpf_temp = tempfile.NamedTemporaryFile(delete=False)
 
-    run_seccompiler(bpf_path=bpf_temp.name,
-                    json_path=json_temp.name, basic=basic)
+    run_seccompiler_bin(bpf_path=bpf_temp.name,
+                        json_path=json_temp.name, basic=basic)
 
     os.unlink(json_temp.name)
     return bpf_temp.name
@@ -106,8 +106,8 @@ def test_seccomp_ls(bin_seccomp_paths):
         }}
     }}""".format(_get_basic_syscall_list())
 
-    # Run seccompiler.
-    bpf_path = _run_seccompiler(json_filter)
+    # Run seccompiler-bin.
+    bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer.
     outcome = utils.run_cmd([demo_jailer, ls_command_path, bpf_path],
@@ -123,7 +123,7 @@ def test_seccomp_ls(bin_seccomp_paths):
 
 def test_advanced_seccomp(bin_seccomp_paths):
     """
-    Test seccompiler with `demo_jailer`.
+    Test seccompiler-bin with `demo_jailer`.
 
     Test that the demo jailer (with advanced seccomp) allows the harmless demo
     binary, denies the malicious demo binary and that an empty allowlist
@@ -170,8 +170,8 @@ def test_advanced_seccomp(bin_seccomp_paths):
         }}
     }}""".format(_get_basic_syscall_list())
 
-    # Run seccompiler.
-    bpf_path = _run_seccompiler(json_filter)
+    # Run seccompiler-bin.
+    bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer for harmless binary.
     outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path],
@@ -191,8 +191,8 @@ def test_advanced_seccomp(bin_seccomp_paths):
 
     os.unlink(bpf_path)
 
-    # Run seccompiler with `--basic` flag.
-    bpf_path = _run_seccompiler(json_filter, basic=True)
+    # Run seccompiler-bin with `--basic` flag.
+    bpf_path = _run_seccompiler_bin(json_filter, basic=True)
 
     # Run the mini jailer for malicious binary.
     outcome = utils.run_cmd([demo_jailer, demo_malicious, bpf_path],
@@ -215,8 +215,8 @@ def test_advanced_seccomp(bin_seccomp_paths):
         }
     }"""
 
-    # Run seccompiler.
-    bpf_path = _run_seccompiler(json_filter)
+    # Run seccompiler-bin.
+    bpf_path = _run_seccompiler_bin(json_filter)
 
     outcome = utils.run_cmd([demo_jailer, demo_harmless, bpf_path],
                             no_shell=True,

--- a/tools/devtool
+++ b/tools/devtool
@@ -299,7 +299,7 @@ ensure_release_binaries_exist() {
     profile=$2
     firecracker_bin_path="$CARGO_TARGET_DIR/$target/$profile/firecracker"
     jailer_bin_path="$CARGO_TARGET_DIR/$target/$profile/jailer"
-    seccompiler_bin_path="$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler"
+    seccompiler_bin_path="$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin"
 
     # Both binaries must exist for the stripping to be successful.
     [ -f "$firecracker_bin_path" ] && [ -f "$jailer_bin_path" ] && [ -f "$seccompiler_bin_path" ] || \
@@ -700,13 +700,13 @@ cmd_build() {
     # We don't need any special privileges for the build phase, so we run the
     # container as the current user/group.
 
-    # Build seccompiler.
+    # Build seccompiler-bin.
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
         ${extra_args} \
         -- \
-        cargo build -p seccompiler --bin seccompiler \
+        cargo build -p seccompiler --bin seccompiler-bin \
             --target-dir "$CTR_CARGO_SECCOMPILER_TARGET_DIR" \
             "${cargo_args[@]}"
     ret=$?
@@ -750,7 +750,7 @@ cmd_build() {
         # messages.
         say "Build successful."
         say "Firecracker and Jailer binaries placed under $cargo_bin_dir"
-        say "Seccompiler binary placed under $seccompiler_bin_dir"
+        say "Seccompiler-bin binary placed under $seccompiler_bin_dir"
     }
 
     return $ret
@@ -804,13 +804,13 @@ cmd_strip() {
       strip $strip_flags\
         "$CTR_CARGO_TARGET_DIR/$target/$profile/firecracker" \
         "$CTR_CARGO_TARGET_DIR/$target/$profile/jailer" \
-        "$CTR_CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler"
+        "$CTR_CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin"
     ret=$?
 
     [ $ret -eq 0 ] && {
         say "Stripping was successful."
         say "Stripped Firecracker and Jailer binaries placed under $CARGO_TARGET_DIR/$target/$profile."
-        say "Stripped seccompiler binary placed under $CARGO_SECCOMPILER_TARGET_DIR/$target/$profile."
+        say "Stripped seccompiler-bin binary placed under $CARGO_SECCOMPILER_TARGET_DIR/$target/$profile."
     }
 
     return $ret
@@ -1429,7 +1429,7 @@ cmd_install() {
     install -m 755 "$CARGO_TARGET_DIR/$target/$profile/jailer" "$install_path"
 
     say "Installing seccomp in $install_path"
-    install -m 755 "$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler" "$install_path"
+    install -m 755 "$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin" "$install_path"
 }
 
 main() {


### PR DESCRIPTION
# Reason for This PR

1. Considering the proposal of upstreaming the seccompiler library to rust-vmm,
the seccompiler binary used by Firecracker will need a slightly different name, so that
it doesn't clash with the library name.

2. Also, since the only use of the `--basic` flag of seccompiler-bin is to support Firecracker's `--seccomp-level 1`, which is deprecated, we are also deprecating the `--basic` flag.

3. Duplicated thread names in the JSON filter were allowed, due to the fact that the JSON spec doesn't forbid this. For the seccomp use case, however, it can result in undefined behaviour.

## Description of Changes

- rename the seccompiler binary to seccompiler-bin
- deprecate the seccompiler-bin `--basic` flag. It now displays a runtime warning when used.
- add a custom deserializer for the Json file that errors if there are duplicate thread keys in the file. also added a regression test.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
