### PR TITLE
Block device fixes and simplifications

### DIFF
--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -119,9 +119,9 @@ pub mod tests {
         {
             mem.write_obj::<u32>(VIRTIO_BLK_T_OUT, request_type_addr)
                 .unwrap();
-            // Make data read only, 8 bytes in len, and set the actual value to be written.
+            // Make data read only, 512 bytes in len, and set the actual value to be written.
             vq.dtable[1].flags.set(VIRTQ_DESC_F_NEXT);
-            vq.dtable[1].len.set(8);
+            vq.dtable[1].len.set(512);
             mem.write_obj::<u64>(123_456_789, data_addr).unwrap();
 
             // Trigger the queue event.

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -30,6 +30,8 @@ pub enum Error {
     GetFileMetadata(std::io::Error),
     /// Guest gave us bad memory addresses.
     GuestMemory(GuestMemoryError),
+    /// The data length is invalid.
+    InvalidDataLength,
     /// The requested operation would cause a seek beyond disk end.
     InvalidOffset,
     /// Guest gave us a read only descriptor that protocol says to write to.

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -49,14 +49,16 @@ impl Status {
         }
     }
 
-    pub fn virtio_blk_status(&self) -> u32 {
-        match self {
+    pub fn virtio_blk_status(&self) -> u8 {
+        let virtio_blk_status = match self {
             Status::Ok(_) => VIRTIO_BLK_S_OK,
             Status::Err(status) => match status {
                 ErrStatus::IoErr(_) => VIRTIO_BLK_S_IOERR,
                 ErrStatus::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,
             },
-        }
+        };
+
+        virtio_blk_status as u8
     }
 
     pub fn num_used_bytes(&self) -> u32 {
@@ -367,7 +369,7 @@ mod tests {
     fn test_status() {
         {
             let status = Status::from_result(Ok(10));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_OK);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_OK as u8);
             assert_eq!(status.num_used_bytes(), 11);
         }
 
@@ -375,7 +377,7 @@ mod tests {
             let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
                 Error::InvalidOffset,
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
 
@@ -383,7 +385,7 @@ mod tests {
             let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Flush(
                 io::Error::from_raw_os_error(42),
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
 
@@ -392,7 +394,7 @@ mod tests {
                 0,
                 GuestMemoryError::InvalidBackendAddress,
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
 
@@ -404,7 +406,7 @@ mod tests {
                     completed: 20,
                 },
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 11);
         }
 
@@ -412,7 +414,7 @@ mod tests {
             let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Seek(
                 io::Error::from_raw_os_error(42),
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
 
@@ -420,13 +422,13 @@ mod tests {
             let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Write(
                 GuestMemoryError::InvalidBackendAddress,
             ))));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
 
         {
             let status = Status::from_result(Err(ErrStatus::Unsupported(0)));
-            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_UNSUPP);
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_UNSUPP as u8);
             assert_eq!(status.num_used_bytes(), 1);
         }
     }

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -18,27 +18,60 @@ use super::device::{CacheType, DiskProperties};
 use super::{Error, SECTOR_SHIFT, SECTOR_SIZE};
 
 #[derive(Debug)]
-pub enum ExecuteError {
+pub enum IoErrStatus {
     BadRequest(Error),
     Flush(io::Error),
-    Read(GuestMemoryError),
+    // Read(num_used_bytes, GuestMemoryError)
+    Read(u32, GuestMemoryError),
     Seek(io::Error),
     SyncAll(io::Error),
     Write(GuestMemoryError),
+}
+
+#[derive(Debug)]
+pub enum ErrStatus {
+    IoErr(IoErrStatus),
     Unsupported(u32),
 }
 
-impl ExecuteError {
-    pub fn status(&self) -> u32 {
-        match *self {
-            ExecuteError::BadRequest(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Flush(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Read(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Seek(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::SyncAll(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Write(_) => VIRTIO_BLK_S_IOERR,
-            ExecuteError::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,
+#[derive(Debug)]
+pub enum Status {
+    // Ok(num_used_bytes)
+    Ok(u32),
+    Err(ErrStatus),
+}
+
+impl Status {
+    pub fn from_result(result: result::Result<u32, ErrStatus>) -> Status {
+        match result {
+            Ok(status) => Status::Ok(status),
+            Err(status) => Status::Err(status),
         }
+    }
+
+    pub fn virtio_blk_status(&self) -> u32 {
+        match self {
+            Status::Ok(_) => VIRTIO_BLK_S_OK,
+            Status::Err(status) => match status {
+                ErrStatus::IoErr(_) => VIRTIO_BLK_S_IOERR,
+                ErrStatus::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,
+            },
+        }
+    }
+
+    pub fn num_used_bytes(&self) -> u32 {
+        let num_used_bytes = match self {
+            Status::Ok(num_used_bytes) => *num_used_bytes,
+            Status::Err(status) => match status {
+                ErrStatus::IoErr(io_err) => match io_err {
+                    IoErrStatus::Read(num_used_bytes, _) => *num_used_bytes,
+                    _ => 0,
+                },
+                ErrStatus::Unsupported(_) => 0,
+            },
+        };
+        // account for the status byte
+        num_used_bytes + 1
     }
 }
 
@@ -178,23 +211,29 @@ impl Request {
         Ok(req)
     }
 
-    fn execute_seek(&self, disk: &mut DiskProperties) -> result::Result<(), ExecuteError> {
+    fn execute_seek(&self, disk: &mut DiskProperties) -> result::Result<(), ErrStatus> {
         // TODO: perform this logic at request parsing level in the future.
         // Check that the data length is a multiple of 512 as specified in the virtio standard.
         if u64::from(self.data_len) % SECTOR_SIZE != 0 {
-            return Err(ExecuteError::BadRequest(Error::InvalidDataLength));
+            return Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
+                Error::InvalidDataLength,
+            )));
         }
         let top_sector = self
             .sector
             .checked_add(u64::from(self.data_len) >> SECTOR_SHIFT)
-            .ok_or(ExecuteError::BadRequest(Error::InvalidOffset))?;
+            .ok_or(ErrStatus::IoErr(IoErrStatus::BadRequest(
+                Error::InvalidOffset,
+            )))?;
         if top_sector > disk.nsectors() {
-            return Err(ExecuteError::BadRequest(Error::InvalidOffset));
+            return Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
+                Error::InvalidOffset,
+            )));
         }
 
         disk.file_mut()
             .seek(SeekFrom::Start(self.sector << SECTOR_SHIFT))
-            .map_err(ExecuteError::Seek)?;
+            .map_err(|e| ErrStatus::IoErr(IoErrStatus::Seek(e)))?;
 
         Ok(())
     }
@@ -203,7 +242,7 @@ impl Request {
         &self,
         disk: &mut DiskProperties,
         mem: &GuestMemoryMmap,
-    ) -> result::Result<u32, ExecuteError> {
+    ) -> result::Result<u32, ErrStatus> {
         let cache_type = disk.cache_type();
 
         match self.request_type {
@@ -216,10 +255,13 @@ impl Request {
                         self.data_len
                     })
                     .map_err(|e| {
+                        let mut num_used_bytes = self.data_len;
                         if let GuestMemoryError::PartialBuffer { completed, .. } = e {
                             METRICS.block.read_bytes.add(completed);
+                            // It's safe to cast to u32 since completed < data_len.
+                            num_used_bytes = completed as u32;
                         }
-                        ExecuteError::Read(e)
+                        ErrStatus::IoErr(IoErrStatus::Read(num_used_bytes, e))
                     })
             }
             RequestType::Out => {
@@ -234,16 +276,20 @@ impl Request {
                         if let GuestMemoryError::PartialBuffer { completed, .. } = e {
                             METRICS.block.write_bytes.add(completed);
                         }
-                        ExecuteError::Write(e)
+                        ErrStatus::IoErr(IoErrStatus::Write(e))
                     })
             }
             RequestType::Flush => {
                 match cache_type {
                     CacheType::Writeback => {
                         // flush() first to force any cached data out.
-                        disk.file_mut().flush().map_err(ExecuteError::Flush)?;
+                        disk.file_mut()
+                            .flush()
+                            .map_err(|e| ErrStatus::IoErr(IoErrStatus::Flush(e)))?;
                         // Sync data out to physical media on host.
-                        disk.file_mut().sync_all().map_err(ExecuteError::SyncAll)?;
+                        disk.file_mut()
+                            .sync_all()
+                            .map_err(|e| ErrStatus::IoErr(IoErrStatus::SyncAll(e)))?;
                         METRICS.block.flush_count.inc();
                     }
                     CacheType::Unsafe => {
@@ -255,13 +301,15 @@ impl Request {
             RequestType::GetDeviceID => {
                 let disk_id = disk.image_id();
                 if (self.data_len as usize) < disk_id.len() {
-                    return Err(ExecuteError::BadRequest(Error::InvalidOffset));
+                    return Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
+                        Error::InvalidOffset,
+                    )));
                 }
                 mem.write_slice(disk_id, self.data_addr)
                     .map(|_| VIRTIO_BLK_ID_BYTES)
-                    .map_err(ExecuteError::Write)
+                    .map_err(|e| ErrStatus::IoErr(IoErrStatus::Write(e)))
             }
-            RequestType::Unsupported(t) => Err(ExecuteError::Unsupported(t)),
+            RequestType::Unsupported(op) => Err(ErrStatus::Unsupported(op)),
         }
     }
 }
@@ -316,28 +364,71 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_error_status() {
-        assert_eq!(
-            ExecuteError::BadRequest(Error::InvalidOffset).status(),
-            VIRTIO_BLK_S_IOERR
-        );
-        assert_eq!(
-            ExecuteError::Flush(io::Error::from_raw_os_error(42)).status(),
-            VIRTIO_BLK_S_IOERR
-        );
-        assert_eq!(
-            ExecuteError::Read(GuestMemoryError::InvalidBackendAddress).status(),
-            VIRTIO_BLK_S_IOERR
-        );
-        assert_eq!(
-            ExecuteError::Seek(io::Error::from_raw_os_error(42)).status(),
-            VIRTIO_BLK_S_IOERR
-        );
-        assert_eq!(
-            ExecuteError::Write(GuestMemoryError::InvalidBackendAddress).status(),
-            VIRTIO_BLK_S_IOERR
-        );
-        assert_eq!(ExecuteError::Unsupported(42).status(), VIRTIO_BLK_S_UNSUPP);
+    fn test_status() {
+        {
+            let status = Status::from_result(Ok(10));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_OK);
+            assert_eq!(status.num_used_bytes(), 11);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
+                Error::InvalidOffset,
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Flush(
+                io::Error::from_raw_os_error(42),
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Read(
+                0,
+                GuestMemoryError::InvalidBackendAddress,
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Read(
+                10,
+                GuestMemoryError::PartialBuffer {
+                    expected: 10,
+                    completed: 20,
+                },
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 11);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Seek(
+                io::Error::from_raw_os_error(42),
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::IoErr(IoErrStatus::Write(
+                GuestMemoryError::InvalidBackendAddress,
+            ))));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_IOERR);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
+
+        {
+            let status = Status::from_result(Err(ErrStatus::Unsupported(0)));
+            assert_eq!(status.virtio_blk_status(), VIRTIO_BLK_S_UNSUPP);
+            assert_eq!(status.num_used_bytes(), 1);
+        }
     }
 
     #[test]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.82, "AMD": 84.22, "ARM": 83.14}
+COVERAGE_DICT = {"Intel": 84.76, "AMD": 84.22, "ARM": 83.07}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Block device fixes and simplifications

## Description of Changes

Block device fixes and simplifications:
- fix the write_bytes metric
- fix the size of the block request status
- simplify the request status logic

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
