### PR TITLE
add negative tests for mem_size in machine config

### DIFF
--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -4,14 +4,18 @@
 
 import os
 import platform
+import resource
 import time
 
 import pytest
 
 from framework.builder import MicrovmBuilder
+import framework.utils_cpuid as utils
 import host_tools.drive as drive_tools
 import host_tools.logging as log_tools
 import host_tools.network as net_tools
+
+MEM_LIMIT = 1000000000
 
 
 def test_api_happy_start(test_microvm_with_api):
@@ -223,12 +227,6 @@ def test_api_put_machine_config(test_microvm_with_api):
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
 
-    # Test invalid mem_size_mib < 0.
-    response = test_microvm.machine_cfg.put(
-        mem_size_mib='-2'
-    )
-    assert test_microvm.api_session.is_status_bad_request(response.status_code)
-
     # Test invalid type for ht_enabled flag.
     response = test_microvm.machine_cfg.put(
         ht_enabled='random_string'
@@ -258,6 +256,68 @@ def test_api_put_machine_config(test_microvm_with_api):
             response.status_code
         )
         assert "CPU templates are not supported on aarch64" in response.text
+
+    # Test invalid mem_size_mib < 0.
+    response = test_microvm.machine_cfg.put(
+        mem_size_mib='-2'
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+    # Test invalid mem_size_mib > usize::MAX.
+    bad_size = 1 << 64
+    response = test_microvm.machine_cfg.put(
+        mem_size_mib=bad_size
+    )
+    fail_msg = "error occurred when deserializing the json body of a " \
+               "request: invalid type"
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert fail_msg in response.text
+
+    # Test mem_size_mib of valid type, but too large.
+    test_microvm.basic_config()
+    firecracker_pid = int(test_microvm.jailer_clone_pid)
+    resource.prlimit(
+        firecracker_pid,
+        resource.RLIMIT_AS,
+        (MEM_LIMIT, resource.RLIM_INFINITY)
+    )
+
+    bad_size = (1 << 64) - 1
+    response = test_microvm.machine_cfg.patch(
+        mem_size_mib=bad_size
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    response = test_microvm.actions.put(action_type='InstanceStart')
+    fail_msg = "Invalid Memory Configuration: MmapRegion(Mmap(Os { code: " \
+               "12, kind: Other, message: Out of memory }))"
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert fail_msg in response.text
+
+    # Test invalid mem_size_mib = 0.
+    response = test_microvm.machine_cfg.patch(
+        mem_size_mib=0
+    )
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert "The memory size (MiB) is invalid." in response.text
+
+    # Test valid mem_size_mib.
+    response = test_microvm.machine_cfg.patch(
+        mem_size_mib=256
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    response = test_microvm.actions.put(action_type='InstanceStart')
+    if utils.get_cpu_vendor() != utils.CpuVendor.INTEL:
+        # We shouldn't be able to apply Intel templates on AMD hosts
+        fail_msg = "Internal error while starting microVM: Error configuring" \
+                   " the vcpu for boot: Cpuid error: InvalidVendor"
+        assert test_microvm.api_session.is_status_bad_request(
+            response.status_code)
+        assert fail_msg in response.text
+    else:
+        assert test_microvm.api_session.is_status_no_content(
+            response.status_code)
 
 
 def test_api_put_update_post_boot(test_microvm_with_api):


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Enhance negative testing for machine config's `mem_size_mib` field.

## Description of Changes

Added test cases to cover:
- mem_size_mib > usize::MAX
- mem_size_mib too large
- mem_size_mib = 0


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] ~Any required documentation changes (code and docs) are included in this PR.~
- [X] ~Any newly added `unsafe` code is properly documented.~
- [X] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [X] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [X] ~All added/changed functionality is tested.~
