### PR TITLE
[RFC] [block] add support for notification suppression

### DIFF
--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -10,6 +10,7 @@ use std::io::{self, Seek, SeekFrom, Write};
 use std::result;
 
 use logger::{IncMetric, METRICS};
+use rate_limiter::{RateLimiter, TokenType};
 use virtio_gen::virtio_blk::*;
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
@@ -211,6 +212,26 @@ impl Request {
         req.status_addr = status_desc.addr;
 
         Ok(req)
+    }
+
+    pub(crate) fn rate_limit(&self, rate_limiter: &mut RateLimiter) -> bool {
+        // If limiter.consume() fails it means there is no more TokenType::Ops
+        // budget and rate limiting is in effect.
+        if !rate_limiter.consume(1, TokenType::Ops) {
+            return true;
+        }
+        // Exercise the rate limiter only if this request is of data transfer type.
+        if self.request_type == RequestType::In || self.request_type == RequestType::Out {
+            // If limiter.consume() fails it means there is no more TokenType::Bytes
+            // budget and rate limiting is in effect.
+            if !rate_limiter.consume(u64::from(self.data_len), TokenType::Bytes) {
+                // Revert the OPS consume().
+                rate_limiter.manual_replenish(1, TokenType::Ops);
+                return true;
+            }
+        }
+
+        false
     }
 
     fn execute_seek(&self, disk: &mut DiskProperties) -> result::Result<(), ErrStatus> {

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -37,6 +37,10 @@ pub trait VirtioDevice: AsAny + Send {
     /// - self.avail_features() & self.acked_features() = self.get_acked_features()
     fn set_acked_features(&mut self, acked_features: u64);
 
+    fn has_feature(&self, feature: u64) -> bool {
+        (self.acked_features() & 1 << feature) != 0
+    }
+
     /// The virtio device type.
     fn device_type(&self) -> u32;
 
@@ -114,5 +118,84 @@ pub trait VirtioDevice: AsAny + Send {
 impl std::fmt::Debug for dyn VirtioDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "VirtioDevice type {}", self.device_type())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    pub use super::*;
+
+    struct MockVirtioDevice {
+        acked_features: u64,
+    }
+
+    impl VirtioDevice for MockVirtioDevice {
+        fn avail_features(&self) -> u64 {
+            todo!()
+        }
+
+        fn acked_features(&self) -> u64 {
+            self.acked_features
+        }
+
+        fn set_acked_features(&mut self, _acked_features: u64) {
+            todo!()
+        }
+
+        fn device_type(&self) -> u32 {
+            todo!()
+        }
+
+        fn queues(&self) -> &[Queue] {
+            todo!()
+        }
+
+        fn queues_mut(&mut self) -> &mut [Queue] {
+            todo!()
+        }
+
+        fn queue_events(&self) -> &[EventFd] {
+            todo!()
+        }
+
+        fn interrupt_evt(&self) -> &EventFd {
+            todo!()
+        }
+
+        fn interrupt_status(&self) -> Arc<AtomicUsize> {
+            todo!()
+        }
+
+        fn read_config(&self, _offset: u64, _data: &mut [u8]) {
+            todo!()
+        }
+
+        fn write_config(&mut self, _offset: u64, _data: &[u8]) {
+            todo!()
+        }
+
+        fn activate(&mut self, _mem: GuestMemoryMmap) -> ActivateResult {
+            todo!()
+        }
+
+        fn is_activated(&self) -> bool {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn test_has_feature() {
+        let mut device = MockVirtioDevice { acked_features: 0 };
+
+        let mock_feature_1 = 1u64;
+        assert!(!device.has_feature(mock_feature_1));
+        device.acked_features = 1 << mock_feature_1;
+        assert!(device.has_feature(mock_feature_1));
+
+        let mock_feature_2 = 2u64;
+        assert!(!device.has_feature(mock_feature_2));
+        device.acked_features = (1 << mock_feature_1) | (1 << mock_feature_2);
+        assert!(device.has_feature(mock_feature_1));
+        assert!(device.has_feature(mock_feature_2));
     }
 }

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -43,6 +43,10 @@ pub struct QueueState {
 
     next_avail: Wrapping<u16>,
     next_used: Wrapping<u16>,
+
+    /// The number of added used buffers since last guest kick
+    #[version(start = 2)]
+    num_added: Wrapping<u16>,
 }
 
 impl Persist<'_> for Queue {
@@ -60,6 +64,7 @@ impl Persist<'_> for Queue {
             used_ring: self.used_ring.0,
             next_avail: self.next_avail,
             next_used: self.next_used,
+            num_added: self.num_added,
         }
     }
 
@@ -76,6 +81,7 @@ impl Persist<'_> for Queue {
             used_ring: GuestAddress::new(state.used_ring),
             next_avail: state.next_avail,
             next_used: state.next_used,
+            num_added: state.num_added,
         })
     }
 }
@@ -218,6 +224,7 @@ mod tests {
                 used_ring: 0,
                 next_avail: Wrapping(0),
                 next_used: Wrapping(0),
+                num_added: Wrapping(0),
             }
         }
     }


### PR DESCRIPTION
# Reason for This PR

#2635

## Description of Changes

### Important note

In the current RFC we try to batch requests and then send only 1 notification to the guest if needed. This is not fully compliant with the virtio standard which states that we should send a notification after processing each descriptor if `queue.needs_notification()` returns true: https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-400007 . But the current approach seems to work.

### Performance Results

**Test setup:** We run on a m5d.metal host with Ubuntu and kernel 5.5.19. We start a number of microVMs with 8vCPUs and 16GB of RAM running linux kernel v5.5.19 as a guest OS. Each microVMs is pinned to NUMA node 0. We mount a ramdisk. For each microVM we create an ext4 file on the ramdisk and we attach it to the microVM as /dev/vdb. We want to have the content of the drives in the page cache in order to asses the performance improvement brought by notification suppression. Otherwise we would be limited by the disk access speed. Inside the VM we run the following command:

```
fio --name=test --ioengine=libaio --rw=readwrite --randrepeat=1 --bs=4k --size=2G --numjobs=1 --iodepth=32 --runtime=30 --time_base=1 --end_fsync=1 --direct=1 --filename=/dev/vdb
```

Current implementation:
|description|IOPS|VMM thread CPU load|kworker threads CPU load|IOPS per CPU load|
|-|-|-|-|-|
|1 VMs|98.96|0.37|0.12|203.43||
|4 VMs|372.89|1.44|0.45|197.69||
|8 VMs|773.69|3.1|0.87|194.8||
|16 VMs|1400.15|6.6|2.03|162.33||
|32 VMs|2189.28|8.38|2.08|209.14||
|48 VMs|1377.53|7.0|1.96|153.83||

Notification suppression:
|description|IOPS|VMM thread CPU load|kworker threads CPU load|IOPS per CPU load|
|-|-|-|-|-|
|1 VMs|147.67|0.4|0.07|313.05||
|4 VMs|580.98|1.62|0.27|307.34||
|8 VMs|1163.95|3.42|0.55|292.82||
|16 VMs|2092.06|7.48|1.18|241.71||
|32 VMs|3587.84|10.45|1.13|309.81||
|48 VMs|1772.47|7.96|1.78|182.01||

If we look at the `IOPS per CPU load` metric, we observe an improvement of about 50% for the most cases when using notification suppression. There's a notable exception in the last case (48 VMs) where the performance improvement is only about 
20%. It would be worth investigating why this happens. If so, we'll do it in a different issue.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
