### PR TITLE
Add snapshot restore performance tests for scalable configurations

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -480,6 +480,11 @@ class Snapshot:
         merge_memory_bitmaps(base.mem, self.mem)
         self._mem = base.mem
 
+    def cleanup(self):
+        """Delete the backing files from disk."""
+        os.remove(self._mem)
+        os.remove(self._vmstate)
+
     @property
     def mem(self):
         """Return the mem file path."""

--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -7,6 +7,8 @@ of the cartesian product of all artifact sets.
 """
 
 import os
+import sys
+import traceback
 from framework.artifacts import ARTIFACTS_LOCAL_ROOT
 from framework.utils import ExceptionAggregator
 
@@ -115,8 +117,10 @@ class TestMatrix:
         if len(self._sets) == len(cartesian_product):
             try:
                 self._run_test_fn(cartesian_product, test_fn)
-            except Exception as err:  # pylint: disable=W0703
-                self._failure_aggregator.add_row(err)
+            except Exception as _err:  # pylint: disable=W0703
+                self._failure_aggregator.add_row(
+                    "".join(traceback.format_exception(*sys.exc_info()))
+                )
             return
 
         current_set = self._sets[self._set_index]

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -657,11 +657,15 @@ class Microvm:
             is_read_only=False,
             partuuid=None,
             cache_type=None,
+            use_ramdisk=False,
     ):
         """Add a block device."""
         response = self.drive.put(
             drive_id=drive_id,
-            path_on_host=self.create_jailed_resource(file_path),
+            path_on_host=(
+                self.copy_to_jail_ramfs(file_path) if
+                use_ramdisk else self.create_jailed_resource(file_path)
+            ),
             is_root_device=root_device,
             is_read_only=is_read_only,
             partuuid=partuuid,

--- a/tests/framework/stats/function.py
+++ b/tests/framework/stats/function.py
@@ -163,8 +163,9 @@ class Percentile(Function, ABC):
         length = len(result)
         result.sort()
         idx = length * self.k / 100
-        if idx is not int(idx):
-            return (result[int(idx)] + result[(int(idx) + 1)]) / 2
+        if not idx.is_integer():
+            return (result[int(idx)] + result[min((int(idx) + 1),
+                    length - 1)]) / 2
 
         return result[int(idx)]
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -11,6 +11,7 @@ import subprocess
 import threading
 import typing
 import time
+
 from collections import namedtuple, defaultdict
 import psutil
 from retry import retry
@@ -287,7 +288,7 @@ class ExceptionAggregator(Exception):
 
     def __str__(self):
         """Return custom as string implementation."""
-        return "\n".join(self.failures)
+        return "\n\n".join(self.failures)
 
 
 def search_output_from_cmd(cmd: str,

--- a/tests/integration_tests/performance/configs/snap_restore_test_config.json
+++ b/tests/integration_tests/performance/configs/snap_restore_test_config.json
@@ -1,0 +1,537 @@
+{
+  "measurements": {
+    "restore_latency": {
+      "unit": "ms",
+      "statistics": [
+        {
+          "name": "P50",
+          "function": "Percentile50",
+          "criteria": "EqualWith"
+        },
+        {
+          "name": "P90",
+          "function": "Percentile90",
+          "criteria": "EqualWith"
+        }
+      ]
+    }
+  },
+  "hosts": {
+    "instances": {
+      "m5d.metal": {
+        "baselines": {
+          "restore_latency": {
+            "vmlinux-4.14.bin": {
+              "ubuntu-18.04.ext4": {
+                "1vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 37
+                  }
+                },
+                "2vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 68
+                  }
+                },
+                "3vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 32
+                  }
+                },
+                "4vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 34
+                  }
+                },
+                "5vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 14
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 44
+                  }
+                },
+                "6vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 89
+                  }
+                },
+                "7vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 20
+                  }
+                },
+                "8vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 11
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 34
+                  }
+                },
+                "9vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 14
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 30
+                  }
+                },
+                "10vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 32
+                  }
+                },
+                "1vcpu_256mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 7
+                  }
+                },
+                "1vcpu_512mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 31
+                  }
+                },
+                "1vcpu_1024mb": {
+                  "P50": {
+                    "target": 7,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 16
+                  }
+                },
+                "1vcpu_2048mb": {
+                  "P50": {
+                    "target": 9,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 10,
+                    "delta_percentage": 25
+                  }
+                },
+                "1vcpu_4096mb": {
+                  "P50": {
+                    "target": 13,
+                    "delta_percentage": 7
+                  },
+                  "P90": {
+                    "target": 14,
+                    "delta_percentage": 16
+                  }
+                },
+                "1vcpu_8192mb": {
+                  "P50": {
+                    "target": 22,
+                    "delta_percentage": 18
+                  },
+                  "P90": {
+                    "target": 22,
+                    "delta_percentage": 14
+                  }
+                },
+                "1vcpu_16384mb": {
+                  "P50": {
+                    "target": 37,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 38,
+                    "delta_percentage": 10
+                  }
+                },
+                "1vcpu_32768mb": {
+                  "P50": {
+                    "target": 68,
+                    "delta_percentage": 5
+                  },
+                  "P90": {
+                    "target": 70,
+                    "delta_percentage": 8
+                  }
+                },
+                "2net_dev": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 7
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 42
+                  }
+                },
+                "3net_dev": {
+                  "P50": {
+                    "target": 7,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 8,
+                    "delta_percentage": 30
+                  }
+                },
+                "4net_dev": {
+                  "P50": {
+                    "target": 8,
+                    "delta_percentage": 10
+                  },
+                  "P90": {
+                    "target": 9,
+                    "delta_percentage": 21
+                  }
+                },
+                "2block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 11
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 29
+                  }
+                },
+                "3block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 13
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 27
+                  }
+                },
+                "4block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 12
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 34
+                  }
+                },
+                "all_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 12
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 39
+                  }
+                }
+              }
+            },
+            "vmlinux-4.9.bin": {
+              "ubuntu-18.04.ext4": {
+                "1vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 39
+                  }
+                },
+                "2vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 43
+                  }
+                },
+                "3vcpu_128mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 11
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 41
+                  }
+                },
+                "4vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 10
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 27
+                  }
+                },
+                "5vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 6
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 43
+                  }
+                },
+                "6vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 10
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 23
+                  }
+                },
+                "7vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 11
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 7
+                  }
+                },
+                "8vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 13
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 31
+                  }
+                },
+                "9vcpu_128mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 11
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 28
+                  }
+                },
+                "10vcpu_128mb": {
+                  "P50": {
+                    "target": 7,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 8,
+                    "delta_percentage": 32
+                  }
+                },
+                "1vcpu_256mb": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 10
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 35
+                  }
+                },
+                "1vcpu_512mb": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 38
+                  }
+                },
+                "1vcpu_1024mb": {
+                  "P50": {
+                    "target": 7,
+                    "delta_percentage": 7
+                  },
+                  "P90": {
+                    "target": 8,
+                    "delta_percentage": 30
+                  }
+                },
+                "1vcpu_2048mb": {
+                  "P50": {
+                    "target": 9,
+                    "delta_percentage": 6
+                  },
+                  "P90": {
+                    "target": 9,
+                    "delta_percentage": 22
+                  }
+                },
+                "1vcpu_4096mb": {
+                  "P50": {
+                    "target": 13,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 14,
+                    "delta_percentage": 17
+                  }
+                },
+                "1vcpu_8192mb": {
+                  "P50": {
+                    "target": 21,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 23,
+                    "delta_percentage": 14
+                  }
+                },
+                "1vcpu_16384mb": {
+                  "P50": {
+                    "target": 36,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 39,
+                    "delta_percentage": 15
+                  }
+                },
+                "1vcpu_32768mb": {
+                  "P50": {
+                    "target": 69,
+                    "delta_percentage": 12
+                  },
+                  "P90": {
+                    "target": 79,
+                    "delta_percentage": 29
+                  }
+                },
+                "2net_dev": {
+                  "P50": {
+                    "target": 6,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 7,
+                    "delta_percentage": 11
+                  }
+                },
+                "3net_dev": {
+                  "P50": {
+                    "target": 7,
+                    "delta_percentage": 10
+                  },
+                  "P90": {
+                    "target": 9,
+                    "delta_percentage": 31
+                  }
+                },
+                "4net_dev": {
+                  "P50": {
+                    "target": 8,
+                    "delta_percentage": 9
+                  },
+                  "P90": {
+                    "target": 9,
+                    "delta_percentage": 36
+                  }
+                },
+                "2block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 13
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 47
+                  }
+                },
+                "3block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 34
+                  }
+                },
+                "4block_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 7
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 42
+                  }
+                },
+                "all_dev": {
+                  "P50": {
+                    "target": 5,
+                    "delta_percentage": 8
+                  },
+                  "P90": {
+                    "target": 6,
+                    "delta_percentage": 50
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -1,0 +1,360 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Performance benchmark for snapshot restore."""
+import json
+import logging
+import tempfile
+import pytest
+
+from conftest import _test_images_s3_bucket
+from framework.artifacts import ArtifactCollection, ArtifactSet, NetIfaceConfig
+from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.matrix import TestContext, TestMatrix
+from framework.stats import core
+from framework.stats.baseline import Provider as BaselineProvider
+from framework.stats.metadata import DictProvider as DictMetadataProvider
+from framework.utils import DictQuery
+from framework.utils_cpuid import get_cpu_model_name
+import host_tools.drive as drive_tools
+import host_tools.network as net_tools  # pylint: disable=import-error
+import framework.stats as st
+from integration_tests.performance.configs import defs
+from integration_tests.performance.utils import handle_failure, \
+    dump_test_result
+
+DEBUG = False
+TEST_ID = "snapshot_restore_performance"
+BASE_VCPU_COUNT = 1
+BASE_MEM_SIZE_MIB = 128
+BASE_NET_COUNT = 1
+BASE_BLOCK_COUNT = 1
+USEC_IN_MSEC = 1000
+
+# Measurements tags.
+RESTORE_LATENCY = "restore_latency"
+CONFIG = json.load(open(defs.CFG_LOCATION /
+                        "snap_restore_test_config.json"))
+
+# Define 4 net device configurations.
+net_ifaces = [NetIfaceConfig(),
+              NetIfaceConfig(host_ip="192.168.1.1",
+                             guest_ip="192.168.1.2",
+                             tap_name="tap1",
+                             dev_name="eth1"),
+              NetIfaceConfig(host_ip="192.168.2.1",
+                             guest_ip="192.168.2.2",
+                             tap_name="tap2",
+                             dev_name="eth2"),
+              NetIfaceConfig(host_ip="192.168.3.1",
+                             guest_ip="192.168.3.2",
+                             tap_name="tap3",
+                             dev_name="eth3")]
+
+# We are using this as a global variable in order to only
+# have to call the constructor and destructor once.
+# pylint: disable=C0103
+scratch_drives = []
+
+
+# pylint: disable=R0903
+class SnapRestoreBaselinesProvider(BaselineProvider):
+    """Baselines provider for snapshot restore latency."""
+
+    def __init__(self, env_id):
+        """Snapshot baseline provider initialization."""
+        baselines = CONFIG["hosts"]["instances"]["m5d.metal"]
+        super().__init__(DictQuery(baselines))
+        self._tag = "baselines/{}/" + env_id + "/{}"
+
+    def get(self, ms_name: str, st_name: str) -> dict:
+        """Return the baseline value corresponding to the key."""
+        key = self._tag.format(ms_name, st_name)
+        baseline = self._baselines.get(key)
+        if baseline:
+            target = baseline.get("target")
+            delta_percentage = baseline.get("delta_percentage")
+            return {
+                "target": target,
+                "delta": delta_percentage * target / 100,
+            }
+        return None
+
+
+def construct_scratch_drives():
+    """Create an array of scratch disks."""
+    scratchdisks = ["vdb", "vdc", "vdd", "vde"]
+    disk_files = [
+        drive_tools.FilesystemFile(tempfile.mktemp(), size=64)
+        for _ in scratchdisks
+    ]
+    return zip(scratchdisks, disk_files)
+
+
+def default_lambda_consumer(env_id):
+    """Create a default lambda consumer for the snapshot restore test."""
+    return st.consumer.LambdaConsumer(
+        metadata_provider=DictMetadataProvider(
+            CONFIG["measurements"],
+            SnapRestoreBaselinesProvider(env_id)
+        ),
+        func=consume_output,
+        func_kwargs={})
+
+
+def get_snap_restore_latency(
+        context,
+        vcpus,
+        mem_size,
+        nets=1,
+        blocks=1,
+        all_devices=False,
+        iterations=10):
+    """Restore snapshots with various configs to measure latency."""
+    vm_builder = context.custom['builder']
+
+    # Create a rw copy artifact.
+    rw_disk = context.disk.copy()
+    # Get ssh key from read-only artifact.
+    ssh_key = context.disk.ssh_key()
+
+    ifaces = None
+    if nets > 1:
+        ifaces = net_ifaces[:nets]
+
+    # Create a fresh microvm from artifacts.
+    vm_instance = vm_builder.build(
+        kernel=context.kernel,
+        disks=[rw_disk],
+        ssh_key=ssh_key,
+        config=context.microvm,
+        net_ifaces=ifaces,
+        use_ramdisk=True)
+    basevm = vm_instance.vm
+    response = basevm.machine_cfg.put(
+        vcpu_count=vcpus,
+        mem_size_mib=mem_size,
+        ht_enabled=False
+    )
+    assert basevm.api_session.is_status_no_content(response.status_code)
+
+    extra_disk_paths = []
+    if blocks > 1:
+        for (name, diskfile) in list(scratch_drives)[:(blocks - 1)]:
+            basevm.add_drive(name, diskfile.path, use_ramdisk=True)
+            extra_disk_paths.append(diskfile.path)
+        assert len(extra_disk_paths) > 0
+
+    if all_devices:
+        response = basevm.balloon.put(
+            amount_mib=0,
+            deflate_on_oom=True,
+            stats_polling_interval_s=1
+        )
+        assert basevm.api_session.is_status_no_content(response.status_code)
+
+        response = basevm.vsock.put(
+            vsock_id="vsock0",
+            guest_cid=3,
+            uds_path="/v.sock"
+        )
+        assert basevm.api_session.is_status_no_content(response.status_code)
+
+    basevm.start()
+
+    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+
+    # Create a snapshot builder from a microvm.
+    snapshot_builder = SnapshotBuilder(basevm)
+    full_snapshot = snapshot_builder.create(
+        [rw_disk.local_path()] + extra_disk_paths,
+        ssh_key,
+        SnapshotType.FULL,
+        net_ifaces=ifaces
+    )
+
+    basevm.kill()
+    values = []
+    for _ in range(iterations):
+        microvm, metrics_fifo = vm_builder.build_from_snapshot(
+            full_snapshot,
+            resume=True,
+            use_ramdisk=True
+        )
+        # Attempt to connect to resumed microvm.
+        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+        # Check if guest still runs commands.
+        exit_code, _, _ = ssh_connection.execute_command("dmesg")
+        assert exit_code == 0
+
+        value = 0
+        # Parse all metric data points in search of load_snapshot time.
+        metrics = microvm.get_all_metrics(metrics_fifo)
+        for data_point in metrics:
+            metrics = json.loads(data_point)
+            cur_value = metrics['latencies_us']['load_snapshot']
+            if cur_value > 0:
+                value = cur_value / USEC_IN_MSEC
+                break
+        values.append(value)
+        microvm.kill()
+
+    full_snapshot.cleanup()
+    result = dict()
+    result[RESTORE_LATENCY] = values
+    return result
+
+
+def consume_output(cons, result):
+    """Consumer function."""
+    restore_latency = result[RESTORE_LATENCY]
+    for value in restore_latency:
+        cons.consume_data(RESTORE_LATENCY, value)
+
+
+@pytest.mark.nonci
+@pytest.mark.timeout(300 * 1000)  # 1.40 hours
+def test_snap_restore_performance(bin_cloner_path, results_file_dumper):
+    """Test the performance of snapshot restore."""
+    logger = logging.getLogger(TEST_ID)
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_1024mb"))
+    kernel_artifacts = ArtifactSet(artifacts.kernels())
+    disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
+
+    # Create a test context and add builder, logger, network.
+    test_context = TestContext()
+    test_context.custom = {
+        'builder': MicrovmBuilder(bin_cloner_path),
+        'logger': logger,
+        'name': TEST_ID,
+        'results_file_dumper': results_file_dumper
+    }
+
+    test_matrix = TestMatrix(context=test_context,
+                             artifact_sets=[
+                                 microvm_artifacts,
+                                 kernel_artifacts,
+                                 disk_artifacts
+                             ])
+    test_matrix.run_test(snapshot_workload)
+
+
+def snapshot_scaling_vcpus(context, st_core, vcpu_count=10):
+    """Restore snapshots with variable vcpu count."""
+    for i in range(vcpu_count):
+        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+             f"{BASE_VCPU_COUNT + i}vcpu_{BASE_MEM_SIZE_MIB}mb"
+
+        st_prod = st.producer.LambdaProducer(
+            func=get_snap_restore_latency,
+            func_kwargs={
+                "context": context,
+                "vcpus": BASE_VCPU_COUNT + i,
+                "mem_size": BASE_MEM_SIZE_MIB
+            }
+        )
+        st_cons = default_lambda_consumer(env_id)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+
+
+def snapshot_scaling_mem(context, st_core, mem_exponent=9):
+    """Restore snapshots with variable memory size."""
+    for i in range(1, mem_exponent):
+        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+             f"{BASE_VCPU_COUNT}vcpu_{BASE_MEM_SIZE_MIB * (2 ** i)}mb"
+
+        st_prod = st.producer.LambdaProducer(
+            func=get_snap_restore_latency,
+            func_kwargs={
+                "context": context,
+                "vcpus": BASE_VCPU_COUNT,
+                "mem_size": BASE_MEM_SIZE_MIB * (2 ** i)
+            }
+        )
+        st_cons = default_lambda_consumer(env_id)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+
+
+def snapshot_scaling_net(context, st_core, net_count=4):
+    """Restore snapshots with variable net device count."""
+    for i in range(1, net_count):
+        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+             f"{BASE_NET_COUNT + i}net_dev"
+
+        st_prod = st.producer.LambdaProducer(
+            func=get_snap_restore_latency,
+            func_kwargs={
+                "context": context,
+                "vcpus": BASE_VCPU_COUNT,
+                "mem_size": BASE_MEM_SIZE_MIB,
+                "nets": BASE_NET_COUNT + i
+            }
+        )
+        st_cons = default_lambda_consumer(env_id)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+
+
+def snapshot_scaling_block(context, st_core, block_count=4):
+    """Restore snapshots with variable block device count."""
+    # pylint: disable=W0603
+    global scratch_drives
+    scratch_drives = construct_scratch_drives()
+
+    for i in range(1, block_count):
+        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+             f"{BASE_BLOCK_COUNT + i}block_dev"
+
+        st_prod = st.producer.LambdaProducer(
+            func=get_snap_restore_latency,
+            func_kwargs={
+                "context": context,
+                "vcpus": BASE_VCPU_COUNT,
+                "mem_size": BASE_MEM_SIZE_MIB,
+                "blocks": BASE_BLOCK_COUNT + i
+            }
+        )
+        st_cons = default_lambda_consumer(env_id)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+
+
+def snapshot_all_devices(context, st_core):
+    """Restore snapshots with one of each devices."""
+    env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+        f"all_dev"
+
+    st_prod = st.producer.LambdaProducer(
+        func=get_snap_restore_latency,
+        func_kwargs={
+            "context": context,
+            "vcpus": BASE_VCPU_COUNT,
+            "mem_size": BASE_MEM_SIZE_MIB,
+            "all_devices": True
+        }
+    )
+    st_cons = default_lambda_consumer(env_id)
+    st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+
+
+def snapshot_workload(context):
+    """Test all VM configurations for snapshot restore."""
+    file_dumper = context.custom["results_file_dumper"]
+
+    st_core = core.Core(
+        name=TEST_ID,
+        iterations=1,
+        custom={"cpu_model_name": get_cpu_model_name()}
+    )
+
+    snapshot_scaling_vcpus(context, st_core, vcpu_count=10)
+    snapshot_scaling_mem(context, st_core, mem_exponent=9)
+    snapshot_scaling_net(context, st_core)
+    snapshot_scaling_block(context, st_core)
+    snapshot_all_devices(context, st_core)
+
+    # Gather results and verify pass criteria.
+    try:
+        result = st_core.run_exercise()
+    except core.CoreException as err:
+        handle_failure(file_dumper, err)
+
+    dump_test_result(file_dumper, result)

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -11,17 +11,20 @@ from typing import List
 from providers.types import FileDataProvider
 from providers.iperf3 import Iperf3DataParser
 from providers.block import BlockDataParser
+from providers.snapshot_restore import SnapshotRestoreDataParser
 
 OUTPUT_FILENAMES = {
     'vsock_throughput': 'test_vsock_throughput',
     'network_tcp_throughput': 'test_network_tcp_throughput',
-    'block_performance': 'test_block_performance'
+    'block_performance': 'test_block_performance',
+    'snapshot_restore_performance': 'test_snap_restore_performance'
 }
 
 DATA_PARSERS = {
     'vsock_throughput': Iperf3DataParser,
     'network_tcp_throughput': Iperf3DataParser,
-    'block_performance': BlockDataParser
+    'block_performance': BlockDataParser,
+    'snapshot_restore_performance': SnapshotRestoreDataParser,
 }
 
 
@@ -67,7 +70,8 @@ def main():
                         action="store",
                         choices=['vsock_throughput',
                                  'network_tcp_throughput',
-                                 'block_performance'],
+                                 'block_performance',
+                                 'snapshot_restore_performance'],
                         required=True)
     args = parser.parse_args()
 

--- a/tools/parse_baselines/providers/snapshot_restore.py
+++ b/tools/parse_baselines/providers/snapshot_restore.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Implement the DataParser for snapshot restore performance tests."""
+
+import statistics
+import math
+from collections import Iterator
+from typing import List
+from providers.types import DataParser
+
+# We add a small extra percentage margin, to account for small variations
+# that were not caught while gathering baselines. This provides
+# slightly better reliability, while not affecting regression
+# detection.
+DELTA_EXTRA_MARGIN = 4
+
+
+# pylint: disable=R0903
+class SnapshotRestoreDataParser(DataParser):
+    """Parse the data provided by the snapshot restore performance tests."""
+
+    # pylint: disable=W0102
+    def __init__(self, data_provider: Iterator):
+        """Initialize the data parser."""
+        super().__init__(data_provider, [
+            "restore_latency/P50",
+            "restore_latency/P90",
+        ])
+
+    # pylint: disable=R0201
+    def calculate_baseline(self, data: List[float]) -> dict:
+        """Return the target and delta values, given a list of data points."""
+        avg = statistics.mean(data)
+        stddev = statistics.stdev(data)
+        return {
+            'target': math.ceil(round(avg, 2)),
+            'delta_percentage':
+                math.ceil(3 * stddev/avg * 100) + DELTA_EXTRA_MARGIN
+        }


### PR DESCRIPTION
# Reason for This PR

The current snapshot restore tests are not enough to understand the impact on the restore latency of various variables in the VM configuration.

## Description of Changes

Added snapshot restore tests which measure the restore latency of VMs with variable configurations. The tests are scaling VCPU count, memory size, net device count and block device count, each individually over a base configuration of 1 VCPU 128MiB. We also test a configuration with the vsock and balloon devices enabled.

The tests are built on top of the existing performance test framework and come with a set of baselines, detailed in a config JSON file.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
