### PR TITLE
Implement MMDSv2 functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   Firecracker version.
 - Added `--metadata` paramater to enable MMDS content to be supplied from a file
   allowing the MMDS to be used when using `--no-api` to disable the API server.
+- Added support for custom headers to MMDS requests. Accepted headers are:
+  `X-metadata-token`, which accepts a string value that provides a session
+  token for MMDS requests; and `X-metadata-token-ttl-seconds`, which
+  specifies the lifetime of the session token in seconds.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@
 ### Changed
 
 - Deprecated `vsock_id` body field in `PUT`s on `/vsock`.
-- Enhanced `/mmds/config` endpoint to contain optional `mmds_version` parameter
-  that specifies the MMDS version used. Default is `V1`.
+- Added `version` field inside the body of `PUT` requests towards
+  `/mmds/config` to configure MMDS version. Accepted values are: `V1` and `V2`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@
   `X-metadata-token` header when MMDSv2 is configured.
 - Allow `PUT` requests to MMDSv2 in order to generate a session token
   to be used for future `GET` requests.
+- Added `GET` request for `/mmds/config` that provides the MMDS configuration.
 
 ### Changed
 
 - Deprecated `vsock_id` body field in `PUT`s on `/vsock`.
+- Enhanced `/mmds/config` endpoint to contain optional `mmds_version` parameter
+  that specifies the MMDS version used. Default is `V1`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   `X-metadata-token`, which accepts a string value that provides a session
   token for MMDS requests; and `X-metadata-token-ttl-seconds`, which
   specifies the lifetime of the session token in seconds.
+- `GET` requests to MMDS require a session token to be provided through
+  `X-metadata-token` header when MMDSv2 is configured.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
   `X-metadata-token` header when MMDSv2 is configured.
 - Allow `PUT` requests to MMDSv2 in order to generate a session token
   to be used for future `GET` requests.
-- Added `GET` request for `/mmds/config` that provides the MMDS configuration.
-
+- Added `GET` request on `/mmds/config` that provides the MMDS configuration:
+  ip address and MMDS version. Default value for MMDS version is `V1`.
 ### Changed
 
 - Deprecated `vsock_id` body field in `PUT`s on `/vsock`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   specifies the lifetime of the session token in seconds.
 - `GET` requests to MMDS require a session token to be provided through
   `X-metadata-token` header when MMDSv2 is configured.
+- Allow `PUT` requests to MMDSv2 in order to generate a session token
+  to be used for future `GET` requests.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "api_server"
 version = "0.1.0"
 dependencies = [
@@ -56,6 +91,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -112,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +170,15 @@ dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -240,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "device_tree"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +399,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -400,9 +488,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.100"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "linux-loader"
@@ -463,10 +551,14 @@ dependencies = [
 name = "mmds"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
+ "base64",
+ "bincode",
  "dumbo",
  "lazy_static",
  "logger",
  "micro_http",
+ "serde",
  "serde_json",
  "snapshot",
  "utils",
@@ -504,6 +596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -775,6 +885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "utils"
 version = "0.1.0"
 dependencies = [
@@ -835,6 +967,12 @@ dependencies = [
  "serde_json",
  "vmm-sys-util",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "versionize"

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -334,8 +334,10 @@ impl ApiServer {
         match mmds_response {
             Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
             Err(e) => match e {
-                data_store::Error::NotFound => unreachable!(),
-                data_store::Error::UnsupportedValueType => unreachable!(),
+                data_store::Error::NotFound
+                | data_store::Error::UnsupportedValueType
+                | data_store::Error::AlreadyAtRequestedVersion(_)
+                | data_store::Error::TokenAuthority(_) => unreachable!(),
                 data_store::Error::NotInitialized => ApiServer::json_response(
                     StatusCode::BadRequest,
                     ApiServer::json_fault_message(e.to_string()),

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -160,6 +160,9 @@ impl ParsedRequest {
                 VmmData::MachineConfiguration(vm_config) => {
                     Self::success_response_with_data(vm_config)
                 }
+                VmmData::MmdsConfiguration(mmds_config) => {
+                    Self::success_response_with_data(mmds_config)
+                }
                 VmmData::BalloonConfig(balloon_config) => {
                     Self::success_response_with_data(balloon_config)
                 }
@@ -572,6 +575,9 @@ pub(crate) mod tests {
                     http_response(&serde_json::to_string(cfg).unwrap(), 200)
                 }
                 VmmData::MachineConfiguration(cfg) => {
+                    http_response(&serde_json::to_string(cfg).unwrap(), 200)
+                }
+                VmmData::MmdsConfiguration(cfg) => {
                     http_response(&serde_json::to_string(cfg).unwrap(), 200)
                 }
                 VmmData::InstanceInformation(info) => {

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -430,7 +430,7 @@ paths:
     put:
       summary: Set MMDS configuration. Pre-boot only.
       description:
-        Creates MMDS configuration to be used by the MMDS network stack.
+        Creates MMDS configuration to be used by the MMDS network stack and backend.
       parameters:
         - name: body
           in: body
@@ -445,6 +445,19 @@ paths:
           description: MMDS configuration cannot be updated due to bad input.
           schema:
             $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+    get:
+      summary: Get MMDS configuration.
+      description:
+        Fetches MMDS configuration used by the MMDS network stack and backend.
+      responses:
+        200:
+          description: The MMDS configuration.
+          schema:
+            $ref: "#/definitions/MmdsConfig"
         default:
           description: Internal server error
           schema:
@@ -960,6 +973,13 @@ definitions:
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
         default: "169.254.169.254"
         description: A valid IPv4 link-local address.
+      mmds_version:
+        description: Enumeration indicating the MMDS version configured.
+        type: string
+        enum:
+          - V1
+          - V2
+        default: V1
 
   NetworkInterface:
     type: object

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -172,7 +172,7 @@ impl Endpoint {
             // If we got here, then we still have some response bytes to send (which are
             // stored in self.response_buf).
 
-            // It seems we just recevied the last ACK we were waiting for, so the entire
+            // It seems we just received the last ACK we were waiting for, so the entire
             // response has been successfully received. Set the new response_seq and clear
             // the response_buf.
             self.response_seq = self.connection.highest_ack_received();

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -209,7 +209,7 @@ impl Endpoint {
                         response.write_all(&mut self.response_buf).unwrap();
 
                         // Sanity check because the current logic operates under this assumption.
-                        assert!(self.response_buf.len() < u32::max_value() as usize);
+                        assert!(self.response_buf.len() < u32::MAX as usize);
 
                         // We have to remove the bytes up to end from receive_buf, by shifting the
                         // others to the beginning of the buffer, and updating receive_buf_left.

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -196,14 +196,14 @@ impl TcpIPv4Handler {
         self.max_connections
     }
 
-    /// Returns the max pending resetes of this TCP handler.
+    /// Returns the max pending resets of this TCP handler.
     pub fn max_pending_resets(&self) -> usize {
         self.max_pending_resets
     }
 
     /// Contains logic for handling incoming segments.
     ///
-    /// Any changes to the state if the handler are communicated through an `Ok(RecvEvent)`.
+    /// Any changes to the state of the handler are communicated through an `Ok(RecvEvent)`.
     pub fn receive_packet<T: NetworkBytes>(
         &mut self,
         packet: &IPv4Packet<T>,

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -36,6 +36,12 @@ const DEV_NET_TUN_WITH_NUL: &[u8] = b"/dev/net/tun\0";
 const DEV_NET_TUN_MAJOR: u32 = 10;
 const DEV_NET_TUN_MINOR: u32 = 200;
 
+// Random number generator device minor/major numbers are taken from
+// https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+const DEV_URANDOM_WITH_NUL: &[u8] = b"/dev/urandom\0";
+const DEV_URANDOM_MAJOR: u32 = 1;
+const DEV_URANDOM_MINOR: u32 = 9;
+
 const DEV_NULL_WITH_NUL: &[u8] = b"/dev/null\0";
 
 // Relevant folders inside the jail that we create or/and for which we change ownership.
@@ -565,6 +571,18 @@ impl Env {
         self.mknod_and_own_dev(DEV_NET_TUN_WITH_NUL, DEV_NET_TUN_MAJOR, DEV_NET_TUN_MINOR)?;
         // Do the same for /dev/kvm with (major, minor) = (10, 232).
         self.mknod_and_own_dev(DEV_KVM_WITH_NUL, DEV_KVM_MAJOR, DEV_KVM_MINOR)?;
+        // And for /dev/urandom with (major, minor) = (1, 9).
+        // If the device is not accessible on the host, output a warning to inform user that MMDS
+        // version 2 will not be available to use.
+        let _ = self
+            .mknod_and_own_dev(DEV_URANDOM_WITH_NUL, DEV_URANDOM_MAJOR, DEV_URANDOM_MINOR)
+            .map_err(|err| {
+                println!(
+                    "Warning! Could not create /dev/urandom device inside jailer: {}.",
+                    err
+                );
+                println!("Configuring MMDS version to V2 would not be possible.");
+            });
 
         // Daemonize before exec, if so required (when the dev_null variable != None).
         if let Some(fd) = dev_null {

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -6,7 +6,11 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+aes-gcm = "0.9.4"
+base64 = "0.13.0"
+bincode = "1.2.1"
 lazy_static = ">=1.1.0"
+serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -11,6 +11,14 @@ pub struct Mmds {
     data_store: Value,
     is_initialized: bool,
     data_store_limit: usize,
+    version: MmdsVersion,
+}
+
+/// MMDS version.
+#[derive(Clone, Copy)]
+pub enum MmdsVersion {
+    V1,
+    V2,
 }
 
 /// MMDS possible outputs.
@@ -21,22 +29,22 @@ pub enum OutputFormat {
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    DataStoreLimitExceeded,
     NotFound,
     NotInitialized,
     UnsupportedValueType,
-    DataStoreLimitExceeded,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
             Error::NotFound => write!(f, "The MMDS resource does not exist."),
             Error::NotInitialized => write!(f, "The MMDS data store is not initialized."),
             Error::UnsupportedValueType => write!(
                 f,
                 "Cannot retrieve value. The value has an unsupported type."
             ),
-            Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
         }
     }
 }
@@ -47,6 +55,7 @@ impl Default for Mmds {
             data_store: Value::default(),
             is_initialized: false,
             data_store_limit: MAX_DATA_STORE_SIZE,
+            version: MmdsVersion::V1,
         }
     }
 }
@@ -61,6 +70,16 @@ impl Mmds {
         } else {
             Err(Error::NotInitialized)
         }
+    }
+
+    /// Set the MMDS version.
+    pub fn set_version(&mut self, version: MmdsVersion) {
+        self.version = version;
+    }
+
+    /// Return the MMDS version.
+    pub fn version(&self) -> MmdsVersion {
+        self.version
     }
 
     pub fn set_data_store_limit(&mut self, data_store_limit: usize) {

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -1,24 +1,36 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::token::{Error as TokenError, TokenAuthority};
 use crate::MAX_DATA_STORE_SIZE;
 use serde_json::{to_vec, Value};
 use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// The Mmds is the Microvm Metadata Service represented as an untyped json.
 #[derive(Clone)]
 pub struct Mmds {
     data_store: Value,
+    // None when MMDS V1 is configured, Some for MMDS V2.
+    token_authority: Option<TokenAuthority>,
     is_initialized: bool,
     data_store_limit: usize,
-    version: MmdsVersion,
 }
 
 /// MMDS version.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MmdsVersion {
     V1,
     V2,
+}
+
+impl Display for MmdsVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            MmdsVersion::V1 => write!(f, "V1"),
+            MmdsVersion::V2 => write!(f, "V2"),
+        }
+    }
 }
 
 /// MMDS possible outputs.
@@ -27,20 +39,26 @@ pub enum OutputFormat {
     Imds,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
+    AlreadyAtRequestedVersion(MmdsVersion),
     DataStoreLimitExceeded,
     NotFound,
     NotInitialized,
+    TokenAuthority(TokenError),
     UnsupportedValueType,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match &*self {
+            Error::AlreadyAtRequestedVersion(ver) => {
+                write!(f, "MMDS is already using requested version {}", ver)
+            }
             Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
             Error::NotFound => write!(f, "The MMDS resource does not exist."),
             Error::NotInitialized => write!(f, "The MMDS data store is not initialized."),
+            Error::TokenAuthority(err) => write!(f, "Token Authority error: {}", err),
             Error::UnsupportedValueType => write!(
                 f,
                 "Cannot retrieve value. The value has an unsupported type."
@@ -53,9 +71,9 @@ impl Default for Mmds {
     fn default() -> Self {
         Mmds {
             data_store: Value::default(),
+            token_authority: None,
             is_initialized: false,
             data_store_limit: MAX_DATA_STORE_SIZE,
-            version: MmdsVersion::V1,
         }
     }
 }
@@ -72,14 +90,52 @@ impl Mmds {
         }
     }
 
-    /// Set the MMDS version.
-    pub fn set_version(&mut self, version: MmdsVersion) {
-        self.version = version;
+    /// Checks if the provided token has not expired.
+    pub fn is_valid_token(&self, token: &str) -> Result<bool, TokenError> {
+        match &self.token_authority {
+            None => Err(TokenError::NotInitialized),
+            Some(ta) => Ok(ta.is_valid(token)),
+        }
     }
 
-    /// Return the MMDS version.
+    /// Set the MMDS version.
+    pub fn set_version(&mut self, version: MmdsVersion) -> Result<(), Error> {
+        match version {
+            MmdsVersion::V1 => self.set_mmds_v1(),
+            MmdsVersion::V2 => self.set_mmds_v2(),
+        }
+    }
+
+    /// Sets MMDS version back to V1 by removing the token authority entity.
+    fn set_mmds_v1(&mut self) -> Result<(), Error> {
+        match self.token_authority {
+            None => Err(Error::AlreadyAtRequestedVersion(MmdsVersion::V1)),
+            Some(_) => {
+                self.token_authority = None;
+                Ok(())
+            }
+        }
+    }
+
+    /// Sets MMDS version to V2 by creating the token authority entity.
+    fn set_mmds_v2(&mut self) -> Result<(), Error> {
+        match self.token_authority {
+            None => {
+                let token_authority = TokenAuthority::new().map_err(Error::TokenAuthority)?;
+                self.token_authority = Some(token_authority);
+                Ok(())
+            }
+            Some(_) => Err(Error::AlreadyAtRequestedVersion(MmdsVersion::V2)),
+        }
+    }
+
+    /// Return the MMDS version by checking the token authority field.
     pub fn version(&self) -> MmdsVersion {
-        self.version
+        if self.token_authority.is_none() {
+            MmdsVersion::V1
+        } else {
+            MmdsVersion::V2
+        }
     }
 
     pub fn set_data_store_limit(&mut self, data_store_limit: usize) {
@@ -260,12 +316,16 @@ mod tests {
 
         // Test invalid path.
         assert_eq!(
-            mmds.get_value("/invalid_path".to_string(), OutputFormat::Json),
-            Err(Error::NotFound)
+            mmds.get_value("/invalid_path".to_string(), OutputFormat::Json)
+                .unwrap_err()
+                .to_string(),
+            Error::NotFound.to_string()
         );
         assert_eq!(
-            mmds.get_value("/invalid_path".to_string(), OutputFormat::Imds),
-            Err(Error::NotFound)
+            mmds.get_value("/invalid_path".to_string(), OutputFormat::Imds)
+                .unwrap_err()
+                .to_string(),
+            Error::NotFound.to_string()
         );
 
         // Retrieve an object.
@@ -296,8 +356,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/age".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
 
         // Test path ends with /; Value is a dictionary.
@@ -316,8 +377,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/phones/".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
 
         // Test path does NOT end with /; Value is a dictionary.
@@ -329,8 +391,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/phones".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
 
         // Retrieve the first element of an array.
@@ -354,8 +417,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/member".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
 
         // Retrieve a float.
@@ -367,8 +431,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/shares_percentage".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
 
         // Retrieve a negative integer.
@@ -380,8 +445,9 @@ mod tests {
         assert_eq!(
             mmds.get_value("/balance".to_string(), OutputFormat::Imds)
                 .err()
-                .unwrap(),
-            Error::UnsupportedValueType
+                .unwrap()
+                .to_string(),
+            Error::UnsupportedValueType.to_string()
         );
     }
 
@@ -439,8 +505,8 @@ mod tests {
         let data = "{\"new_key2\" : \"smth\"}";
         let data_store: Value = serde_json::from_str(&data).unwrap();
         assert_eq!(
-            mmds.patch_data(data_store).unwrap_err(),
-            Error::DataStoreLimitExceeded
+            mmds.patch_data(data_store).unwrap_err().to_string(),
+            Error::DataStoreLimitExceeded.to_string()
         );
         assert!(!mmds.get_data_str().contains("smth"));
 

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -3,6 +3,7 @@
 
 use crate::token::{Error as TokenError, TokenAuthority};
 use crate::MAX_DATA_STORE_SIZE;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_vec, Value};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -18,10 +19,16 @@ pub struct Mmds {
 }
 
 /// MMDS version.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum MmdsVersion {
     V1,
     V2,
+}
+
+impl Default for MmdsVersion {
+    fn default() -> MmdsVersion {
+        MmdsVersion::V1
+    }
 }
 
 impl Display for MmdsVersion {

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -98,6 +98,17 @@ impl Mmds {
         }
     }
 
+    /// Generate a new Mmds V2 token and add it to the store.
+    pub fn generate_token(&mut self, ttl_seconds: u32) -> Result<String, TokenError> {
+        match &self.token_authority {
+            None => Err(TokenError::NotInitialized),
+            Some(ta) => match ta.generate_token_secret(ttl_seconds) {
+                Ok(token) => Ok(token),
+                Err(err) => Err(err),
+            },
+        }
+    }
+
     /// Set the MMDS version.
     pub fn set_version(&mut self, version: MmdsVersion) -> Result<(), Error> {
         match version {

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -4,9 +4,12 @@
 pub mod data_store;
 pub mod ns;
 pub mod persist;
+pub mod token_headers;
 
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
+
+use token_headers::TokenHeaders;
 
 use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
 use lazy_static::lazy_static;
@@ -96,6 +99,17 @@ fn convert_to_response(request: Request) -> Response {
         response.allow_method(Method::Get);
         return response;
     }
+
+    let _token_headers = match TokenHeaders::try_from(request.headers.custom_entries()) {
+        Ok(token_headers) => token_headers,
+        Err(err) => {
+            return build_response(
+                request.http_version(),
+                StatusCode::BadRequest,
+                Body::new(err.to_string()),
+            )
+        }
+    };
 
     // The data store expects a strict json path, so we need to
     // sanitize the URI.
@@ -217,6 +231,30 @@ mod tests {
         let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
         expected_response.set_body(Body::new("Invalid URI.".to_string()));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
+        // Test invalid value for custom header.
+        let request_bytes = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
+                                    Accept: application/json\r\n
+                                    X-metadata-token-ttl-seconds: application/json\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        expected_response.set_body(Body::new(
+            "Invalid header. Reason: Invalid value. \
+            Key:X-metadata-token-ttl-seconds; Value:application/json"
+                .to_string(),
+        ));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
+        // Test valid values for custom headers.
+        let request_bytes = b"GET http://169.254.169.254/name/first HTTP/1.0\r\n\
+                                    X-metadata-token: application/json\r\n
+                                    X-metadata-token-ttl-seconds: 100\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
+        expected_response.set_body(Body::new("John"));
         let actual_response = convert_to_response(request);
         assert_eq!(actual_response, expected_response);
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod data_store;
 pub mod ns;
 pub mod persist;
+mod token;
 pub mod token_headers;
 
 use serde_json::{Map, Value};

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -13,8 +13,11 @@ use std::sync::{Arc, Mutex};
 use crate::data_store::{Error as MmdsError, Mmds, MmdsVersion, OutputFormat};
 use crate::token::PATH_TO_TOKEN;
 
+use crate::token_headers::REJECTED_HEADER;
 use lazy_static::lazy_static;
-use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
+use micro_http::{
+    Body, HttpHeaderError, MediaType, Method, Request, RequestError, Response, StatusCode, Version,
+};
 use token_headers::TokenHeaders;
 
 pub const MAX_DATA_STORE_SIZE: usize = 51200;
@@ -231,6 +234,23 @@ fn respond_to_put_request(request: Request, token_headers: TokenHeaders) -> Resp
     // Sanitize the URI into a strict json path.
     let json_pointer = sanitize_uri(uri.to_string());
 
+    // Reject `PUT` requests that contain `X-Forwarded-For` header.
+    if request
+        .headers
+        .custom_entries()
+        .contains_key(REJECTED_HEADER)
+    {
+        let error_msg = RequestError::HeaderError(HttpHeaderError::UnsupportedName(
+            REJECTED_HEADER.to_string(),
+        ))
+        .to_string();
+        return build_response(
+            request.http_version(),
+            StatusCode::BadRequest,
+            Body::new(error_msg),
+        );
+    }
+
     // Only accept PUT requests towards TOKEN_PATH.
     if json_pointer != PATH_TO_TOKEN {
         let error_msg = format!("Resource not found: {}.", uri);
@@ -432,6 +452,17 @@ mod tests {
         assert_eq!(actual_response, expected_response);
 
         // Test PUT requests.
+        // Unsupported `X-Forwarded-For` header present.
+        let request_bytes = b"PUT http://169.254.169.254/latest/api/token HTTP/1.0\r\n\
+                                    X-Forwarded-For: 203.0.113.195\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        expected_response.set_body(Body::new(
+            "Invalid header. Reason: Unsupported header name. Key: X-Forwarded-For".to_string(),
+        ));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
         // Test invalid path.
         let request_bytes = b"PUT http://169.254.169.254/token HTTP/1.0\r\n\
                                     X-metadata-token-ttl-seconds: 60\r\n\r\n";

--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -39,6 +39,8 @@ pub enum Error {
     ExpiryExtraction,
     /// Time to live value for token is invalid.
     InvalidTtlValue(u32),
+    /// Token authority not initialized.
+    NotInitialized,
     /// Failed to create token authority entity.
     TokenAuthorityCreation(io::Error),
     /// Failed to generate token.
@@ -55,6 +57,7 @@ impl fmt::Display for Error {
                 Please provide a value between {} and {}.",
                 value, MIN_TOKEN_TTL_SECONDS, MAX_TOKEN_TTL_SECONDS,
             ),
+            Error::NotInitialized => write!(f, "Token Authority not initialized."),
             Error::TokenAuthorityCreation(err) => {
                 write!(f, "Failed to create token authority: {}.", err)
             }
@@ -477,6 +480,11 @@ mod tests {
                 Please provide a value between {} and {}.",
                 MIN_TOKEN_TTL_SECONDS, MAX_TOKEN_TTL_SECONDS
             )
+        );
+
+        assert_eq!(
+            Error::NotInitialized.to_string(),
+            "Token Authority not initialized."
         );
 
         assert_eq!(

--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -1,10 +1,6 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Temporarily disable unused warnings.
-// TODO: remove these once the Token integration is completed.
-#![allow(dead_code)]
-
 use aes_gcm::aead::{Aead, NewAead};
 use aes_gcm::{AeadInPlace, Aes256Gcm, Key, Nonce};
 use serde::{Deserialize, Serialize};

--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -1,0 +1,495 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Temporarily disable unused warnings.
+// TODO: remove these once the Token integration is completed.
+#![allow(dead_code)]
+
+use aes_gcm::aead::{Aead, NewAead};
+use aes_gcm::{AeadInPlace, Aes256Gcm, Key, Nonce};
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::Read;
+use std::ops::Add;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{fmt, io};
+
+/// Length of the key used for encryption.
+pub const KEY_LEN: usize = 32;
+/// Length of encryption payload.
+pub const PAYLOAD_LEN: usize = std::mem::size_of::<u64>();
+/// Length of encryption tag.
+pub const TAG_LEN: usize = 16;
+/// Length of initialization vector.
+pub const IV_LEN: usize = 12;
+/// Path to token.
+pub const PATH_TO_TOKEN: &str = "/latest/api/token";
+/// Minimum lifetime of token.
+pub const MIN_TOKEN_TTL_SECONDS: u32 = 1;
+/// Maximum lifetime of token.
+pub const MAX_TOKEN_TTL_SECONDS: u32 = 21600;
+/// Randomness pool file path.
+const RANDOMNESS_POOL: &str = "/dev/urandom";
+
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to extract expiry from token sequence.
+    ExpiryExtraction,
+    /// Time to live value for token is invalid.
+    InvalidTtlValue(u32),
+    /// Failed to create token authority entity.
+    TokenAuthorityCreation(io::Error),
+    /// Failed to generate token.
+    TokenGeneration,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &*self {
+            Error::ExpiryExtraction => write!(f, "Failed to extract expiry value from token."),
+            Error::InvalidTtlValue(value) => write!(
+                f,
+                "Invalid time to live value provided for token: {}. \
+                Please provide a value between {} and {}.",
+                value, MIN_TOKEN_TTL_SECONDS, MAX_TOKEN_TTL_SECONDS,
+            ),
+            Error::TokenAuthorityCreation(err) => {
+                write!(f, "Failed to create token authority: {}.", err)
+            }
+            Error::TokenGeneration => write!(f, "Failed to generate token."),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TokenAuthority {
+    cipher: aes_gcm::Aes256Gcm,
+}
+
+impl TokenAuthority {
+    /// Create a new token authority entity.
+    pub fn new() -> Result<TokenAuthority, Error> {
+        // Randomly generate a 256-bit key to be used for encryption/decryption purposes.
+        let mut key = [0u8; KEY_LEN];
+        read_into_buf_from_entropy_pool(&mut key).map_err(Error::TokenAuthorityCreation)?;
+
+        // Create cipher entity to handle encryption/decryption.
+        let cipher = Aes256Gcm::new(Key::from_slice(&key));
+
+        Ok(TokenAuthority { cipher })
+    }
+
+    /// Generate encoded token string using the token time to live provided.
+    pub fn generate_token_secret(&self, ttl_seconds: u32) -> Result<String, Error> {
+        // Create token structure containing the encrypted expiry value.
+        let token_struct = self.create_token_struct(ttl_seconds)?;
+        // Encode struct into base64 in order to obtain token string.
+        TokenAuthority::base64_encode_token_struct(&token_struct)
+    }
+
+    /// Create a new Token structure to encrypt.
+    fn create_token_struct(&self, ttl_seconds: u32) -> Result<Token, Error> {
+        // Validate token time to live against bounds.
+        if !TokenAuthority::check_ttl(ttl_seconds) {
+            return Err(Error::InvalidTtlValue(ttl_seconds));
+        }
+
+        // Generate 12-byte random nonce.
+        let mut iv = [0u8; IV_LEN];
+        read_into_buf_from_entropy_pool(&mut iv).map_err(|_| Error::TokenGeneration)?;
+
+        // Compute expiration time from ttl.
+        let expiry = TokenAuthority::compute_expiry(ttl_seconds);
+        // Encrypt expiry using the nonce.
+        let (payload, tag) = self.encrypt_expiry(expiry, iv.as_ref())?;
+
+        Ok(Token::new(iv, payload, tag))
+    }
+
+    /// Encrypt expiry using AES-GCM block cipher and return payload and tag obtained.
+    fn encrypt_expiry(
+        &self,
+        expiry: u64,
+        iv: &[u8],
+    ) -> Result<([u8; PAYLOAD_LEN], [u8; TAG_LEN]), Error> {
+        // Create Nonce object from initialization vector.
+        let nonce = Nonce::from_slice(iv);
+        // Convert expiry u64 value into bytes.
+        let mut expiry_as_bytes: Vec<u8> =
+            bincode::serialize(&expiry).map_err(|_| Error::TokenGeneration)?;
+
+        let tag = self
+            .cipher
+            .encrypt_in_place_detached(nonce, b"", &mut expiry_as_bytes)
+            .map_err(|_| Error::TokenGeneration)?;
+
+        // Payload must be of size `PAYLOAD_LEN`.
+        let payload: [u8; PAYLOAD_LEN] = expiry_as_bytes
+            .try_into()
+            .map_err(|_| Error::TokenGeneration)?;
+        // Tag must be of size `TAG_LEN`.
+        let tag_bytes: [u8; TAG_LEN] = tag
+            .as_slice()
+            .try_into()
+            .map_err(|_| Error::TokenGeneration)?;
+
+        Ok((payload, tag_bytes))
+    }
+
+    /// Encode token structure into a string using base64 encoding.
+    fn base64_encode_token_struct(token: &Token) -> Result<String, Error> {
+        let token_bytes: Vec<u8> = bincode::serialize(token).map_err(|_| Error::TokenGeneration)?;
+        let mut encoded_token = Vec::new();
+        // Ensure vector has enough space for base64 encoding.
+        encoded_token.resize(get_size_of_base64_encoding(token_bytes.len()), 0);
+        // Encode token structure bytes into base64.
+        let size = base64::encode_config_slice(token_bytes, base64::STANDARD, &mut encoded_token);
+        encoded_token.resize(size, 0);
+
+        // Convert base64 bytes to String.
+        // Safe to unwrap because `encoded_token` represents a base64 encoding.
+        Ok(String::from_utf8(encoded_token).unwrap())
+    }
+
+    /// Attempts to decrypt expiry value within token sequence. Returns false if expiry
+    /// cannot be decrypted. If decryption succeeds, returns true if token has not expired
+    /// (i.e. current time is greater than expiry) and false otherwise.
+    pub fn is_valid(&self, token: &str) -> bool {
+        let mut ciphertext = Vec::new();
+
+        // Decode token struct from base64.
+        let token_struct = match TokenAuthority::base64_decode_token_struct(token) {
+            Ok(token_struct) => token_struct,
+            Err(_) => return false,
+        };
+
+        // Validate constant fields inside decoded token structure.
+        if !token_struct.sanity_check() {
+            return false;
+        }
+
+        // Construct ciphertext from payload and tag within token structure.
+        ciphertext.extend_from_slice(&token_struct.payload);
+        ciphertext.extend_from_slice(&token_struct.tag);
+
+        // Decrypt ttl using AES-GCM block cipher.
+        let expiry = match self.decrypt_expiry(&ciphertext, &token_struct.iv) {
+            Ok(expiry) => expiry,
+            Err(_) => return false,
+        };
+
+        // Get current time.
+        let time_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time is before UNIX_EPOCH.");
+        let time_now_as_seconds = time_now.as_secs();
+
+        expiry > time_now_as_seconds
+    }
+
+    /// Decrypt ciphertext composed of payload and tag to obtain the expiry value.
+    fn decrypt_expiry(&self, ciphertext: &[u8], iv: &[u8]) -> Result<u64, Error> {
+        // Create Nonce object from initialization vector.
+        let nonce = Nonce::from_slice(iv);
+        // Decrypt expiry as vector of bytes from ciphertext.
+        let expiry_as_bytes = self
+            .cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| Error::ExpiryExtraction)?;
+        // Get expiry value in seconds from bytes.
+        let expiry: u64 =
+            bincode::deserialize(&expiry_as_bytes).map_err(|_| Error::ExpiryExtraction)?;
+
+        Ok(expiry)
+    }
+
+    /// Decode token structure from base64 string.
+    fn base64_decode_token_struct(encoded_token: &str) -> Result<Token, Error> {
+        let mut token_bytes = vec![0; encoded_token.len()];
+        let size = base64::decode_config_slice(
+            encoded_token.as_bytes(),
+            base64::STANDARD,
+            &mut token_bytes,
+        )
+        .map_err(|_| Error::ExpiryExtraction)?;
+        // Resize to actual length because base64 encodings require more space.
+        token_bytes.resize(size, 0);
+
+        let token: Token =
+            bincode::deserialize(&token_bytes).map_err(|_| Error::ExpiryExtraction)?;
+        Ok(token)
+    }
+
+    /// Validate the token time to live against bounds.
+    fn check_ttl(ttl_seconds: u32) -> bool {
+        (MIN_TOKEN_TTL_SECONDS..=MAX_TOKEN_TTL_SECONDS).contains(&ttl_seconds)
+    }
+
+    /// Compute expiry time in seconds by adding the time to live provided
+    /// to the current time measured in seconds.
+    fn compute_expiry(ttl_seconds: u32) -> u64 {
+        // Get time elapsed since UNIX_EPOCH.
+        let now_as_duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time is before UNIX_EPOCH.");
+        // Convert elapsed time into seconds.
+        let ttl_duration = Duration::from_secs(u64::from(ttl_seconds));
+
+        // Compute expiry by adding ttl value to current time in seconds.
+        // This addition is safe because ttl is verified beforehand and
+        // can never be more than 6h.
+        let expiry_duration = now_as_duration.add(ttl_duration);
+
+        expiry_duration.as_secs()
+    }
+}
+
+/// Structure for token information.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct Token {
+    version: u16,
+    payload_size: u16,
+    // Nonce or Initialization Vector.
+    iv: [u8; IV_LEN],
+    // Encrypted expire time.
+    payload: [u8; PAYLOAD_LEN],
+    // Tag returned after encryption.
+    tag: [u8; TAG_LEN],
+}
+
+impl Token {
+    /// Create a new token struct.
+    fn new(iv: [u8; IV_LEN], payload: [u8; PAYLOAD_LEN], tag: [u8; TAG_LEN]) -> Self {
+        Token {
+            version: 1,
+            payload_size: PAYLOAD_LEN as u16,
+            iv,
+            payload,
+            tag,
+        }
+    }
+
+    /// Validate constant fields inside the token structure.
+    fn sanity_check(&self) -> bool {
+        self.version == 1 && self.payload_size == PAYLOAD_LEN as u16
+    }
+}
+
+// Base64 encodings require more space than the number of bytes to encode.
+// This ensures enough space for encoding and padding.
+fn get_size_of_base64_encoding(bytes_size: usize) -> usize {
+    bytes_size * 4 / 3 + 4
+}
+
+fn read_into_buf_from_entropy_pool(buf: &mut [u8]) -> Result<(), io::Error> {
+    let mut random_file = File::open(Path::new(RANDOMNESS_POOL))?;
+    random_file.read_exact(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_read_into_buf_from_entropy_pool() {
+        let mut buf = [0u8; 12];
+        read_into_buf_from_entropy_pool(&mut buf).unwrap();
+        assert_ne!(buf, [0u8; 12]);
+    }
+
+    #[test]
+    fn test_token_struct_validate() {
+        let mut token = Token::new([0u8; IV_LEN], [0u8; PAYLOAD_LEN], [0u8; TAG_LEN]);
+        assert!(token.sanity_check());
+
+        // Test invalid version.
+        {
+            token.version = 2;
+            assert!(!token.sanity_check());
+        }
+
+        // Test invalid payload size.
+        {
+            token.payload_size = 0;
+            assert!(!token.sanity_check());
+        }
+    }
+
+    #[test]
+    fn test_check_tll() {
+        // Test invalid time to live values.
+        assert!(!TokenAuthority::check_ttl(MIN_TOKEN_TTL_SECONDS - 1));
+        assert!(!TokenAuthority::check_ttl(MAX_TOKEN_TTL_SECONDS + 1));
+
+        // Test time to live value within bounds.
+        assert!(TokenAuthority::check_ttl(MIN_TOKEN_TTL_SECONDS));
+        assert!(TokenAuthority::check_ttl(MAX_TOKEN_TTL_SECONDS / 2));
+        assert!(TokenAuthority::check_ttl(MAX_TOKEN_TTL_SECONDS));
+    }
+
+    #[test]
+    fn test_create_token_struct() {
+        let token_authority = TokenAuthority::new().unwrap();
+
+        // Test invalid time to live value.
+        assert_eq!(
+            token_authority
+                .create_token_struct(0)
+                .unwrap_err()
+                .to_string(),
+            format!(
+                "Invalid time to live value provided for token: 0. \
+                Please provide a value between {} and {}.",
+                MIN_TOKEN_TTL_SECONDS, MAX_TOKEN_TTL_SECONDS
+            )
+        );
+
+        // Test valid time to live value.
+        let token_struct = token_authority.create_token_struct(1).unwrap();
+        assert_eq!(token_struct.version, 1);
+        assert_eq!(token_struct.iv.len(), IV_LEN);
+        assert_eq!(token_struct.payload_size, PAYLOAD_LEN as u16);
+        assert_eq!(token_struct.payload.len(), PAYLOAD_LEN);
+        assert_eq!(token_struct.tag.len(), TAG_LEN);
+    }
+
+    #[test]
+    fn test_compute_expiry() {
+        let time_now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let expiry = TokenAuthority::compute_expiry(1);
+        assert_eq!(expiry - time_now.as_secs(), 1);
+
+        let time_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let expiry = TokenAuthority::compute_expiry(0);
+        assert_eq!(expiry, time_now);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt() {
+        let token_authority = TokenAuthority::new().unwrap();
+        let mut iv = [0u8; IV_LEN];
+        read_into_buf_from_entropy_pool(&mut iv).unwrap();
+        let expiry = TokenAuthority::compute_expiry(10);
+
+        // Test valid ciphertext.
+        let (payload, mut tag) = token_authority.encrypt_expiry(expiry, &iv).unwrap();
+        let mut ciphertext = vec![];
+        ciphertext.extend_from_slice(&payload);
+        ciphertext.extend_from_slice(&tag);
+        let decrypted_expiry = token_authority
+            .decrypt_expiry(&ciphertext, iv.as_mut())
+            .unwrap();
+        assert_eq!(expiry, decrypted_expiry);
+
+        // Test ciphertext with corrupted payload.
+        ciphertext[0] += 1;
+        assert!(token_authority
+            .decrypt_expiry(&ciphertext, iv.as_mut())
+            .is_err());
+
+        // Test ciphertext with corrupted tag.
+        tag[0] += 1;
+        let mut ciphertext = vec![];
+        ciphertext.extend_from_slice(&payload);
+        ciphertext.extend_from_slice(&tag);
+        assert!(token_authority
+            .decrypt_expiry(&ciphertext, iv.as_mut())
+            .is_err());
+    }
+
+    #[test]
+    fn test_encode_decode() {
+        let token_struct = Token::new([0u8; IV_LEN], [0u8; PAYLOAD_LEN], [0u8; TAG_LEN]);
+        let mut token = TokenAuthority::base64_encode_token_struct(&token_struct).unwrap();
+        let decoded_token_struct = TokenAuthority::base64_decode_token_struct(&token).unwrap();
+        assert_eq!(token_struct, decoded_token_struct);
+
+        // Decode invalid base64 bytes sequence.
+        token.push('x');
+        assert!(TokenAuthority::base64_decode_token_struct(&token).is_err());
+    }
+
+    #[test]
+    fn test_token_authority() {
+        let token_authority = TokenAuthority::new().unwrap();
+
+        // Test time to live value too small.
+        assert_eq!(
+            token_authority
+                .generate_token_secret(MIN_TOKEN_TTL_SECONDS - 1)
+                .unwrap_err()
+                .to_string(),
+            format!(
+                "Invalid time to live value provided for token: {}. \
+                Please provide a value between {} and {}.",
+                MIN_TOKEN_TTL_SECONDS - 1,
+                MIN_TOKEN_TTL_SECONDS,
+                MAX_TOKEN_TTL_SECONDS
+            )
+        );
+
+        // Test time to live value too big.
+        assert_eq!(
+            token_authority
+                .generate_token_secret(MAX_TOKEN_TTL_SECONDS + 1)
+                .unwrap_err()
+                .to_string(),
+            format!(
+                "Invalid time to live value provided for token: {}. \
+                Please provide a value between {} and {}.",
+                MAX_TOKEN_TTL_SECONDS + 1,
+                MIN_TOKEN_TTL_SECONDS,
+                MAX_TOKEN_TTL_SECONDS
+            )
+        );
+
+        // Generate token with lifespan of 60 seconds.
+        let token0 = token_authority.generate_token_secret(60).unwrap();
+        assert!(token_authority.is_valid(&token0));
+
+        // Generate token with lifespan of one second.
+        let token1 = token_authority.generate_token_secret(1).unwrap();
+        assert!(token_authority.is_valid(&token1));
+        // Wait for `token1` to expire.
+        sleep(Duration::new(1, 0));
+        assert!(!token_authority.is_valid(&token1));
+        // The first token should still be valid.
+        assert!(token_authority.is_valid(&token0));
+    }
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            Error::ExpiryExtraction.to_string(),
+            "Failed to extract expiry value from token."
+        );
+
+        assert_eq!(
+            Error::InvalidTtlValue(0).to_string(),
+            format!(
+                "Invalid time to live value provided for token: 0. \
+                Please provide a value between {} and {}.",
+                MIN_TOKEN_TTL_SECONDS, MAX_TOKEN_TTL_SECONDS
+            )
+        );
+
+        assert_eq!(
+            Error::TokenAuthorityCreation(io::Error::from_raw_os_error(0)).to_string(),
+            format!(
+                "Failed to create token authority: {}.",
+                io::Error::from_raw_os_error(0)
+            )
+        );
+
+        assert_eq!(
+            Error::TokenGeneration.to_string(),
+            "Failed to generate token."
+        );
+    }
+}

--- a/src/mmds/src/token_headers.rs
+++ b/src/mmds/src/token_headers.rs
@@ -7,6 +7,9 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::result::Result;
 
+/// Header rejected by MMDSv2.
+pub const REJECTED_HEADER: &str = "X-Forwarded-For";
+
 /// Wrapper over supported HTTP Custom Header types.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum TokenHeader {

--- a/src/mmds/src/token_headers.rs
+++ b/src/mmds/src/token_headers.rs
@@ -1,0 +1,141 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use micro_http::{HttpHeaderError, RequestError};
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::result::Result;
+
+/// Wrapper over supported HTTP Custom Header types.
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum TokenHeader {
+    /// Header `X-metadata-token`
+    XMetadataToken,
+    /// Header `X-metadata-token-ttl-seconds`
+    XMetadataTokenTtlSeconds,
+}
+
+impl Display for TokenHeader {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match *self {
+            TokenHeader::XMetadataToken => write!(f, "X-metadata-token"),
+            TokenHeader::XMetadataTokenTtlSeconds => {
+                write!(f, "X-metadata-token-ttl-seconds")
+            }
+        }
+    }
+}
+
+/// Wrapper over the list of token headers associated with a Request.
+#[derive(Debug, PartialEq)]
+pub struct TokenHeaders {
+    /// The `X-metadata-token` header might be used by HTTP clients to specify a token in order
+    /// to authenticate to the session. This is used for guest requests to MMDS only.
+    x_metadata_token: Option<String>,
+    /// The `X-metadata-token-ttl-seconds` header might be used by HTTP clients to specify
+    /// the expiry time of a token. This is used for PUT requests issued by the guest to MMDS only.
+    x_metadata_token_ttl_seconds: Option<u32>,
+}
+
+impl Default for TokenHeaders {
+    /// Token headers are not present in the request by default.
+    fn default() -> Self {
+        Self {
+            x_metadata_token: None,
+            x_metadata_token_ttl_seconds: None,
+        }
+    }
+}
+
+impl TokenHeaders {
+    /// Return `TokenHeaders` from headers map.
+    pub fn try_from(map: &HashMap<String, String>) -> Result<TokenHeaders, RequestError> {
+        let mut headers = Self::default();
+
+        if let Some(token) = map.get(&*TokenHeader::XMetadataToken.to_string()) {
+            headers.x_metadata_token = Some(token.to_string());
+        }
+
+        if let Some(value) = map.get(&*TokenHeader::XMetadataTokenTtlSeconds.to_string()) {
+            match value.parse::<u32>() {
+                Ok(seconds) => {
+                    headers.x_metadata_token_ttl_seconds = Some(seconds);
+                }
+                Err(_) => {
+                    return Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                        TokenHeader::XMetadataTokenTtlSeconds.to_string(),
+                        value.to_string(),
+                    )));
+                }
+            }
+        }
+
+        Ok(headers)
+    }
+
+    /// Returns the `XMetadataToken` token.
+    pub fn x_metadata_token(&self) -> Option<&String> {
+        self.x_metadata_token.as_ref()
+    }
+
+    /// Returns the `XMetadataTokenTtlSeconds` token.
+    pub fn x_metadata_token_ttl_seconds(&self) -> Option<u32> {
+        self.x_metadata_token_ttl_seconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        let headers = TokenHeaders::default();
+        assert_eq!(headers.x_metadata_token(), None);
+        assert_eq!(headers.x_metadata_token_ttl_seconds(), None);
+    }
+
+    #[test]
+    fn test_try_from_headers() {
+        // Empty token header map.
+        let map: HashMap<String, String> = HashMap::default();
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers, TokenHeaders::default());
+
+        // Unrecognised headers.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert("Some-Header".to_string(), "10".to_string());
+        map.insert("Another-Header".to_string(), "value".to_string());
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers, TokenHeaders::default());
+
+        // Valid headers.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert("Some-Header".to_string(), "10".to_string());
+        map.insert("X-metadata-token-ttl-seconds".to_string(), "60".to_string());
+        map.insert("X-metadata-token".to_string(), "foo".to_string());
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers.x_metadata_token_ttl_seconds().unwrap(), 60);
+        assert_eq!(*headers.x_metadata_token().unwrap(), "foo".to_string());
+
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert("X-metadata-token".to_string(), "".to_string());
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(*headers.x_metadata_token().unwrap(), "".to_string());
+
+        // Invalid value.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert(
+            "X-metadata-token-ttl-seconds".to_string(),
+            "-60".to_string(),
+        );
+        assert_eq!(
+            TokenHeaders::try_from(&map).unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                "X-metadata-token-ttl-seconds".to_string(),
+                "-60".to_string()
+            ))
+        );
+    }
+}

--- a/src/mmds/src/token_headers.rs
+++ b/src/mmds/src/token_headers.rs
@@ -83,6 +83,16 @@ impl TokenHeaders {
     pub fn x_metadata_token_ttl_seconds(&self) -> Option<u32> {
         self.x_metadata_token_ttl_seconds
     }
+
+    /// Sets the `XMetadataToken` token.
+    pub fn set_x_metadata_token(&mut self, token: String) {
+        self.x_metadata_token = Some(token)
+    }
+
+    /// Sets the `XMetadataTokenTtlSeconds` token.
+    pub fn set_x_metadata_token_ttl_seconds(&mut self, ttl: u32) {
+        self.x_metadata_token_ttl_seconds = Some(ttl);
+    }
 }
 
 #[cfg(test)]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -240,6 +240,11 @@ impl VmResources {
         self.boot_config.as_ref()
     }
 
+    /// Gets the MMDS configuration.
+    pub fn mmds_config(&self) -> MmdsConfig {
+        self.mmds_config.unwrap_or_default()
+    }
+
     /// Sets a balloon device to be attached when the VM starts.
     pub fn set_balloon_device(
         &mut self,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -717,7 +717,8 @@ mod tests {
                         "ht_enabled": false
                     }},
                     "mmds-config": {{
-                        "ipv4_address": "169.254.170.2"
+                        "ipv4_address": "169.254.170.2",
+                        "version": "V1"
                     }}
             }}"#,
             kernel_file.as_path().to_str().unwrap(),

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -339,7 +339,7 @@ impl From<&VmResources> for VmmConfig {
             logger: None,
             machine_config: Some(resources.vm_config.clone()),
             metrics: None,
-            mmds_config: resources.mmds_config.clone(),
+            mmds_config: resources.mmds_config,
             net_devices: resources.net_builder.configs(),
             vsock_device: resources.vsock.config(),
         }
@@ -717,8 +717,7 @@ mod tests {
                         "ht_enabled": false
                     }},
                     "mmds-config": {{
-                        "ipv4_address": "169.254.170.2",
-                        "version": "V1"
+                        "ipv4_address": "169.254.170.2"
                     }}
             }}"#,
             kernel_file.as_path().to_str().unwrap(),

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -707,6 +707,7 @@ mod tests {
     use devices::virtio::VsockError;
     use seccompiler::BpfThreadMap;
 
+    use mmds::data_store::MmdsVersion;
     use std::path::PathBuf;
 
     impl PartialEq for VmmActionError {
@@ -1202,13 +1203,19 @@ mod tests {
 
     #[test]
     fn test_preboot_set_mmds_config() {
-        let req = VmmAction::SetMmdsConfiguration(MmdsConfig { ipv4_address: None });
+        let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
+            ipv4_address: None,
+            version: MmdsVersion::default(),
+        });
         check_preboot_request(req, |result, vm_res| {
             assert_eq!(result, Ok(VmmData::Empty));
             assert!(vm_res.mmds_set)
         });
 
-        let req = VmmAction::SetMmdsConfiguration(MmdsConfig { ipv4_address: None });
+        let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
+            ipv4_address: None,
+            version: MmdsVersion::default(),
+        });
         check_preboot_request_err(
             req,
             VmmActionError::MmdsConfig(MmdsConfigError::InvalidIpv4Addr),
@@ -1603,7 +1610,10 @@ mod tests {
             VmmActionError::OperationNotSupportedPostBoot,
         );
         check_runtime_request_err(
-            VmmAction::SetMmdsConfiguration(MmdsConfig { ipv4_address: None }),
+            VmmAction::SetMmdsConfiguration(MmdsConfig {
+                ipv4_address: None,
+                version: MmdsVersion::default(),
+            }),
             VmmActionError::OperationNotSupportedPostBoot,
         );
         check_runtime_request_err(
@@ -1685,7 +1695,10 @@ mod tests {
         let req = VmmAction::SetVmConfiguration(VmConfig::default());
         verify_load_snap_disallowed_after_boot_resources(req, "SetVmConfiguration");
 
-        let req = VmmAction::SetMmdsConfiguration(MmdsConfig { ipv4_address: None });
+        let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
+            ipv4_address: None,
+            version: MmdsVersion::default(),
+        });
         verify_load_snap_disallowed_after_boot_resources(req, "SetMmdsConfiguration");
     }
 }

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter, Result};
 use std::net::Ipv4Addr;
 
 /// Keeps the MMDS configuration.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MmdsConfig {
     /// MMDS IPv4 configured address.

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter, Result};
 use std::net::Ipv4Addr;
 
 /// Keeps the MMDS configuration.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MmdsConfig {
     /// MMDS IPv4 configured address.

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use mmds::data_store::MmdsVersion;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result};
 use std::net::Ipv4Addr;
@@ -11,6 +12,9 @@ use std::net::Ipv4Addr;
 pub struct MmdsConfig {
     /// MMDS IPv4 configured address.
     pub ipv4_address: Option<Ipv4Addr>,
+    /// MMDS version configured.
+    #[serde(default = "MmdsVersion::default")]
+    pub version: MmdsVersion,
 }
 
 impl MmdsConfig {
@@ -18,6 +22,12 @@ impl MmdsConfig {
     /// Otherwise returns None.
     pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
         self.ipv4_address
+    }
+
+    /// Returns the MMDS version. If no version was configured,
+    /// it returns default: V1.
+    pub fn version(&self) -> MmdsVersion {
+        self.version
     }
 }
 


### PR DESCRIPTION
# Reason for This PR

This PR implements MMDSv2 functionality, based on EC2's IMDSv2. IMDSv2 uses session-oriented requests. With session-oriented requests, the guest creates a session token that defines the session duration, which can be a minimum of one second and a maximum of six hours. During the specified duration, user can use the same session token for subsequent requests. After the specified duration expires, guest must create a new session token to use for future requests.

Workflow example:
- Guest creates a new session token via the PUT request, specifying the lifetime of the token.
- Guest uses the provided token for when issuing requests to fetch MMDS metadata items.

Fixes #2675.

## Description of Changes

- Store custom header lines inside a dedicated HashMap in Micro Http. Changes are tracked in [this PR](https://github.com/firecracker-microvm/micro-http/pull/22).
- Add custom headers parsing to mmds crate for IMDS specific headers: `X-aws-ec2-metadata-token-ttl-seconds` and `X-aws-ec2-metadata-token`. Names are consistent to the EC2 ones [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html). 
`X-aws-ec2-metadata-token` - used to provide session token
`X-aws-ec2-metadata-token-ttl-seconds` - used when fetching the session token to provide token lifetime in seconds
- Added logic to generate a random sequence of characters to be used as a session token and keep track of expiration time.
- Added  `PUT /mmds/version` API to configure MMDS version. Default is `MMDSv1` for compatibility reasons and can be configured from the host's side to `MMDSv2` if needed. 
- Added  `GET /mmds/version` API to fetch current IMDS version configured.
- Allowed PUT requests to MMDS to create session token when `MMDSv2` version is configured.
- Improved GET requests to MMDS to accept session token when `MMDSv2` version is configured.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
