### PR TITLE
seccompiler: rename arg_index&arg_type, add KillProcess action and allow madvise on all threads

### DIFF
--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -138,8 +138,8 @@ Note that, when passing the deprecated `--basic` flag to seccompiler-bin, all
 
 A **condition object** is made up of the following mandatory properties:
 
-- `arg_index` (0-based index of the syscall argument we want to check)
-- `arg_type` (`dword` or `qword`, which specifies the argument size - 4 or 8
+- `index` (0-based index of the syscall argument we want to check)
+- `type` (`dword` or `qword`, which specifies the argument size - 4 or 8
     bytes respectively)
 - `op`, which is one of `eq, ge, gt, ge, lt, masked_eq, ne` (the operator used
     for comparing the parameter to `val`)
@@ -155,8 +155,8 @@ value, much like when using named parameters, like so:
     "syscall": "accept4",
     "args": [
         {
-            "arg_index": 3,
-            "arg_type": "dword",
+            "index": 3,
+            "type": "dword",
             "op": "eq",
             "val": 1,
             "comment": "libc::AF_UNIX"

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -79,8 +79,8 @@
                 "comment": "Called to accept vsock connections",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
@@ -92,15 +92,15 @@
                 "comment": "Used by snapshotting, drive patching and rescanning",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2,
                         "comment": "FCNTL_F_SETFD"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
@@ -112,8 +112,8 @@
                 "comment": "Used for synchronization (during thread teardown when joining multiple vcpu threads at once)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -125,8 +125,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -138,8 +138,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -151,8 +151,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -164,8 +164,8 @@
                 "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
@@ -177,8 +177,8 @@
                 "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 50,
                         "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
@@ -190,8 +190,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -203,22 +203,22 @@
                 "comment": "Called to open the vsock UDS",
                 "args": [
                     {
-                        "arg_index": 0,
-                        "arg_type": "dword",
+                        "index": 0,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::AF_UNIX"
                     },
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524289,
                         "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -229,8 +229,8 @@
                 "comment": "Used to kick vcpus",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 35,
                         "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
@@ -242,8 +242,8 @@
                 "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -254,8 +254,8 @@
                 "comment": "Used to make vsock UDS nonblocking",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
@@ -267,8 +267,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21523,
                         "comment": "TIOCGWINSZ"
@@ -280,8 +280,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21505,
                         "comment": "TCGETS"
@@ -293,8 +293,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21506,
                         "comment": "TCSETS"
@@ -305,8 +305,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074835010,
                         "comment": "KVM_GET_DIRTY_LOG"
@@ -317,8 +317,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1075359457,
                         "comment": "KVM_SET_DEVICE_ATTR"
@@ -329,8 +329,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1075359458,
                         "comment": "KVM_GET_DEVICE_ATTR"
@@ -404,8 +404,8 @@
                 "comment": "Called to accept socket connections",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
@@ -417,8 +417,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -430,8 +430,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -443,8 +443,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -456,8 +456,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -469,8 +469,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -482,22 +482,22 @@
                 "comment": "Called to open the unix domain socket",
                 "args": [
                     {
-                        "arg_index": 0,
-                        "arg_type": "dword",
+                        "index": 0,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::AF_UNIX"
                     },
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524289,
                         "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -508,8 +508,8 @@
                 "comment": "Used to make api socket nonblocking",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
@@ -574,8 +574,8 @@
                 "comment": "Used for synchronization (during thread teardown when joining multiple vcpu threads at once)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -587,8 +587,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -600,8 +600,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -613,8 +613,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -626,8 +626,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -639,8 +639,8 @@
                 "comment": "Needed for updating the balloon statistics interval",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -650,8 +650,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 44672,
                         "comment": "KVM_RUN"
@@ -662,8 +662,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2147790488,
                         "comment": "KVM_GET_MP_STATE"
@@ -674,8 +674,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074048665,
                         "comment": "KVM_SET_MP_STATE"
@@ -686,8 +686,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2151722655,
                         "comment": "KVM_GET_VCPU_EVENTS"
@@ -698,8 +698,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1077980832,
                         "comment": "KVM_SET_VCPU_EVENTS"
@@ -710,8 +710,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074835115,
                         "comment": "KVM_GET_ONE_REG"
@@ -722,8 +722,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074835116,
                         "comment": "KVM_SET_ONE_REG"
@@ -734,8 +734,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 3221794480,
                         "comment": "KVM_GET_REG_LIST"

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -161,7 +161,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Used by the VirtIO balloon device",
+                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads",
                 "args": [
                     {
                         "index": 2,
@@ -465,6 +465,19 @@
                 ]
             },
             {
+                "syscall": "madvise",
+                "comment": "Triggered by musl for some customer workloads",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4,
+                        "comment": "libc::MADV_DONTNEED"
+                    }
+                ]
+            },
+            {
                 "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
@@ -618,6 +631,19 @@
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "madvise",
+                "comment": "Triggered by musl for some customer workloads",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4,
+                        "comment": "libc::MADV_DONTNEED"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -79,8 +79,8 @@
                 "comment": "Called to accept vsock connections",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
@@ -92,15 +92,15 @@
                 "comment": "Used by snapshotting, drive patching and rescanning",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2,
                         "comment": "FCNTL_F_SETFD"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FCNTL_FD_CLOEXEC"
@@ -112,8 +112,8 @@
                 "comment": "Used for synchronization (during thread teardown when joining multiple vcpu threads at once)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -125,8 +125,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -138,8 +138,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -151,8 +151,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -164,8 +164,8 @@
                 "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 4,
                         "comment": "libc::MADV_DONTNEED"
@@ -177,8 +177,8 @@
                 "comment": "Used by the VirtIO balloon device",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 50,
                         "comment": "libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
@@ -190,8 +190,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -203,22 +203,22 @@
                 "comment": "Called to open the vsock UDS",
                 "args": [
                     {
-                        "arg_index": 0,
-                        "arg_type": "dword",
+                        "index": 0,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::AF_UNIX"
                     },
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524289,
                         "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -229,8 +229,8 @@
                 "comment": "Used to kick vcpus",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 35,
                         "comment": "sigrtmin() + vcpu::VCPU_RTSIG_OFFSET"
@@ -242,8 +242,8 @@
                 "comment": "Needed for rate limiting and metrics",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -254,8 +254,8 @@
                 "comment": "Used to make vsock UDS nonblocking",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
@@ -267,8 +267,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21523,
                         "comment": "TIOCGWINSZ"
@@ -280,8 +280,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21505,
                         "comment": "TCGETS"
@@ -293,8 +293,8 @@
                 "comment": "Triggered on shutdown, to restore the initial terminal settings, only when Firecracker was launched from a shell.",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21506,
                         "comment": "TCSETS"
@@ -305,8 +305,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074835010,
                         "comment": "KVM_GET_DIRTY_LOG"
@@ -317,8 +317,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 3255348834,
                         "comment": "KVM_GET_IRQCHIP"
@@ -329,8 +329,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2150674044,
                         "comment": "KVM_GET_CLOCK"
@@ -341,8 +341,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2154868383,
                         "comment": "KVM_GET_PIT2"
@@ -416,8 +416,8 @@
                 "comment": "Called to accept socket connections",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524288,
                         "comment": "libc::SOCK_CLOEXEC"
@@ -429,8 +429,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -442,8 +442,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -455,8 +455,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -468,8 +468,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -481,8 +481,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -494,22 +494,22 @@
                 "comment": "Called to open the unix domain socket",
                 "args": [
                     {
-                        "arg_index": 0,
-                        "arg_type": "dword",
+                        "index": 0,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::AF_UNIX"
                     },
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 524289,
                         "comment": "libc::SOCK_STREAM | libc::SOCK_CLOEXEC"
                     },
                     {
-                        "arg_index": 2,
-                        "arg_type": "dword",
+                        "index": 2,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -520,8 +520,8 @@
                 "comment": "Used to make api socket nonblocking",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 21537,
                         "comment": "FIONBIO"
@@ -586,8 +586,8 @@
                 "comment": "Used for synchronization (during thread teardown when joining multiple vcpu threads at once)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0,
                         "comment": "FUTEX_WAIT"
@@ -599,8 +599,8 @@
                 "comment": "Used for synchronization (during thread teardown)",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "FUTEX_WAKE"
@@ -612,8 +612,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 128,
                         "comment": "FUTEX_WAIT_PRIVATE"
@@ -625,8 +625,8 @@
                 "comment": "Used for synchronization",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
@@ -638,8 +638,8 @@
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
-                        "arg_index": 3,
-                        "arg_type": "dword",
+                        "index": 3,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
@@ -651,8 +651,8 @@
                 "comment": "Needed for updating the balloon statistics interval",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 0
                     }
@@ -662,8 +662,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 44672,
                         "comment": "KVM_RUN"
@@ -674,8 +674,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2147790488,
                         "comment": "KVM_GET_MP_STATE"
@@ -686,8 +686,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074048665,
                         "comment": "KVM_SET_MP_STATE"
@@ -698,8 +698,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2151722655,
                         "comment": "KVM_GET_VCPU_EVENTS"
@@ -710,8 +710,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1077980832,
                         "comment": "KVM_SET_VCPU_EVENTS"
@@ -722,8 +722,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2214637198,
                         "comment": "KVM_GET_LAPIC"
@@ -734,8 +734,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2167975555,
                         "comment": "KVM_GET_SREGS"
@@ -746,8 +746,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074310800,
                         "comment": "KVM_SET_CPUID2"
@@ -758,8 +758,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1140895375,
                         "comment": "KVM_SET_LAPIC"
@@ -770,8 +770,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1074310793,
                         "comment": "KVM_SET_MSRS"
@@ -782,8 +782,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1083223682,
                         "comment": "KVM_SET_REGS"
@@ -794,8 +794,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1094233732,
                         "comment": "KVM_SET_SREGS"
@@ -806,8 +806,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2154868383,
                         "comment": "KVM_GET_PIT2"
@@ -818,8 +818,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2156965505,
                         "comment": "KVM_GET_REGS"
@@ -830,8 +830,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 3221794440,
                         "comment": "KVM_GET_MSRS"
@@ -842,8 +842,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 3221794449,
                         "comment": "KVM_GET_CPUID2"
@@ -854,8 +854,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2155916961,
                         "comment": "KVM_GET_DEBUGREGS"
@@ -866,8 +866,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1082175138,
                         "comment": "KVM_SET_DEBUGREGS"
@@ -878,8 +878,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2415963812,
                         "comment": "KVM_GET_XSAVE"
@@ -890,8 +890,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1342221989,
                         "comment": "KVM_SET_XSAVE"
@@ -902,8 +902,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 2173218470,
                         "comment": "KVM_GET_XCRS"
@@ -914,8 +914,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 1099476647,
                         "comment": "KVM_SET_XCRS"
@@ -926,8 +926,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 44706,
                         "comment": "KVM_SET_TSC_KHZ"
@@ -938,8 +938,8 @@
                 "syscall": "ioctl",
                 "args": [
                     {
-                        "arg_index": 1,
-                        "arg_type": "dword",
+                        "index": 1,
+                        "type": "dword",
                         "op": "eq",
                         "val": 44707,
                         "comment": "KVM_GET_TSC_KHZ"

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -161,7 +161,7 @@
             },
             {
                 "syscall": "madvise",
-                "comment": "Used by the VirtIO balloon device",
+                "comment": "Used by the VirtIO balloon device and by musl for some customer workloads",
                 "args": [
                     {
                         "index": 2,
@@ -477,6 +477,19 @@
                 ]
             },
             {
+                "syscall": "madvise",
+                "comment": "Triggered by musl for some customer workloads",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4,
+                        "comment": "libc::MADV_DONTNEED"
+                    }
+                ]
+            },
+            {
                 "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
@@ -630,6 +643,19 @@
                         "op": "eq",
                         "val": 129,
                         "comment": "FUTEX_WAKE_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "madvise",
+                "comment": "Triggered by musl for some customer workloads",
+                "args": [
+                    {
+                        "index": 2,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 4,
+                        "comment": "libc::MADV_DONTNEED"
                     }
                 ]
             },

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -225,10 +225,10 @@ pub(crate) enum SeccompCmpArgLen {
 #[serde(deny_unknown_fields)]
 pub(crate) struct SeccompCondition {
     /// Index of the argument that is to be compared.
-    #[serde(rename = "arg_index")]
+    #[serde(rename = "index")]
     arg_number: u8,
     /// Length of the argument value that is to be compared.
-    #[serde(rename = "arg_type")]
+    #[serde(rename = "type")]
     arg_len: SeccompCmpArgLen,
     /// Comparison to perform.
     #[serde(rename = "op")]

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -263,14 +263,14 @@ mod tests {
                         "syscall": "futex",
                         "args": [
                             {
-                                "arg_index": 2,
-                                "arg_type": "dword",
+                                "index": 2,
+                                "type": "dword",
                                 "op": "le",
                                 "val": 65
                             },
                             {
-                                "arg_index": 1,
-                                "arg_type": "qword",
+                                "index": 1,
+                                "type": "qword",
                                 "op": "ne",
                                 "val": 80
                             }
@@ -280,14 +280,14 @@ mod tests {
                         "syscall": "futex",
                         "args": [
                             {
-                                "arg_index": 3,
-                                "arg_type": "qword",
+                                "index": 3,
+                                "type": "qword",
                                 "op": "gt",
                                 "val": 65
                             },
                             {
-                                "arg_index": 1,
-                                "arg_type": "qword",
+                                "index": 1,
+                                "type": "qword",
                                 "op": "lt",
                                 "val": 80
                             }
@@ -297,8 +297,8 @@ mod tests {
                         "syscall": "futex",
                         "args": [
                             {
-                                "arg_index": 3,
-                                "arg_type": "qword",
+                                "index": 3,
+                                "type": "qword",
                                 "op": "ge",
                                 "val": 65
                             }
@@ -308,8 +308,8 @@ mod tests {
                         "syscall": "ioctl",
                         "args": [
                             {
-                                "arg_index": 3,
-                                "arg_type": "dword",
+                                "index": 3,
+                                "type": "dword",
                                 "op": {
                                     "masked_eq": 100
                                 },
@@ -327,8 +327,8 @@ mod tests {
                         "syscall": "ioctl",
                         "args": [
                             {
-                                "arg_index": 3,
-                                "arg_type": "dword",
+                                "index": 3,
+                                "type": "dword",
                                 "op": "eq",
                                 "val": 65
                             }
@@ -615,8 +615,8 @@ mod tests {
                             "syscall": "ioctl",
                             "args": [
                                 {
-                                    "arg_index": 3,
-                                    "arg_type": "qword",
+                                    "index": 3,
+                                    "type": "qword",
                                     "op": "eq",
                                     "val": 18446744073709551616
                                 }
@@ -641,8 +641,8 @@ mod tests {
                             "syscall": "ioctl",
                             "args": [
                                 {
-                                    "arg_index": 3,
-                                    "arg_type": "qword",
+                                    "index": 3,
+                                    "type": "qword",
                                     "op": "eq",
                                     "val": -1846
                                 }
@@ -667,8 +667,8 @@ mod tests {
                             "syscall": "ioctl",
                             "args": [
                                 {
-                                    "arg_index": 3,
-                                    "arg_type": "qword",
+                                    "index": 3,
+                                    "type": "qword",
                                     "op": "eq",
                                     "val": 1846.4
                                 }

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -87,7 +87,7 @@ def test_working_filter(test_microvm_with_api):
     _custom_filter_setup(test_microvm, """{
         "Vmm": {
             "default_action": "allow",
-            "filter_action": "kill",
+            "filter_action": "kill_process",
             "filter": [
                 {
                     "syscall": "clone"
@@ -99,7 +99,7 @@ def test_working_filter(test_microvm_with_api):
         },
         "Api": {
             "default_action": "allow",
-            "filter_action": "kill",
+            "filter_action": "kill_process",
             "filter": [
                 {
                     "syscall": "clone"
@@ -111,7 +111,7 @@ def test_working_filter(test_microvm_with_api):
         },
         "Vcpu": {
             "default_action": "allow",
-            "filter_action": "kill",
+            "filter_action": "kill_process",
             "filter": [
                 {
                     "syscall": "clone"

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -151,15 +151,15 @@ def test_advanced_seccomp(bin_seccomp_paths):
                     "syscall": "write",
                     "args": [
                         {{
-                            "arg_index": 0,
-                            "arg_type": "dword",
+                            "index": 0,
+                            "type": "dword",
                             "op": "eq",
                             "val": 1,
                             "comment": "stdout fd"
                         }},
                         {{
-                            "arg_index": 2,
-                            "arg_type": "qword",
+                            "index": 2,
+                            "type": "qword",
                             "op": "eq",
                             "val": 14,
                             "comment": "nr of bytes"


### PR DESCRIPTION
# Reason for This PR

- `arg_index` and `arg_type` redundantly include the `arg_*` in the name.
- the `kill` seccomp action was renamed in the kernel to kill_thread and a separate kill_process action was added.
- the `madvise(DONT_NEED)` is also triggered by some customer workloads but we don't know on which thread.

More details in the commit messages.

## Description of Changes

- renamed `arg_index` and `arg_type` to `index` and `type`
- rename kill actions to match the kernel
- allow madvise(DONT_NEED) on all thread categories, for safety.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
