### PR TITLE
Add VM cleanup for tests using MicrovmBuilder

### DIFF
--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -27,7 +27,7 @@ class VmInstance:
         self._kernel = kernel
         self._disks = disks
         self._ssh_key = ssh_key
-        self._vm = vm
+        self.vm = vm
 
     @property
     def config(self):
@@ -49,10 +49,9 @@ class VmInstance:
         """Return ssh key artifact linked to the root block device."""
         return self._ssh_key
 
-    @property
-    def vm(self):
-        """Return the Microvm object instance."""
-        return self._vm
+    def __del__(self):
+        """Teardown the VM."""
+        self.vm.kill()
 
 
 class MicrovmBuilder:


### PR DESCRIPTION
# Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/2602

## Description of Changes

Explicitly calls `vm.kill()` on VmInstance destructor

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
