### PR TITLE
use `--mount type=tmpfs` instead of mount ramdisk of the host

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -816,21 +816,6 @@ cmd_strip() {
     return $ret
 }
 
-mount_ramdisk() {
-    say "Using ramdisk ..."
-    local ramdisk_size="$1"
-    umount_ramdisk
-    mkdir -p ${DEFAULT_RAMDISK_PATH} && \
-    mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
-    mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
-    mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
-}
-
-umount_ramdisk() {
-    umount ${DEFAULT_RAMDISK_PATH} &>/dev/null
-    rmdir ${DEFAULT_RAMDISK_PATH} &>/dev/null
-}
-
 # `$0 test` - run integration tests
 # Please see `$0 help` for more information.
 #
@@ -871,8 +856,7 @@ cmd_test() {
     say "Starting test run ..."
 
     if [[ $ramdisk = true ]]; then
-        mount_ramdisk ${ramdisk_size}
-        ramdisk_args="--volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
+        ramdisk_args="--mount type=tmpfs,destination=${DEFAULT_RAMDISK_PATH},tmpfs-size=${ramdisk_size}"
     fi
 
     # Testing (running Firecracker via the jailer) needs root access,
@@ -893,10 +877,6 @@ cmd_test() {
 
     ret=$?
 
-
-    if [[ $ramdisk = true ]]; then
-        umount_ramdisk
-    fi
 
     # Running as root would have created some root-owned files under the build
     # dir. Let's fix that.
@@ -936,8 +916,7 @@ cmd_shell() {
     ensure_build_dir
 
     if [[ $ramdisk = true ]]; then
-        mount_ramdisk ${ramdisk_size}
-        ramdisk_args="--volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
+        ramdisk_args="--mount type=tmpfs,destination=${DEFAULT_RAMDISK_PATH},tmpfs-size=${ramdisk_size}"
     fi
 
     if [[ $privileged = true ]]; then
@@ -981,10 +960,6 @@ cmd_shell() {
             -- \
             bash --norc
         ret=$?
-    fi
-
-    if [[ $ramdisk = true ]]; then
-        umount_ramdisk
     fi
 
     return $ret


### PR DESCRIPTION
# Reason for This PR

Close #2612 

The test suite fail to create a tmpfs when the user doesn't have appropriate permissions. As mentioned in #2612, docker has a feature of mounting tmpfs, so it doesn't have to create a tmpfs outside the container and mount it.
This replace the `mount_ramdisk` function to the docker option of mouting tmpfs, so it no longer needs a permission to do `mkdir`.

This is my first PR of this repository, so if you notice any mistakes, please let me know.

## Description of Changes

This PR removes mount_ramdisk function and adds `--mount type=tmpfs` option to the docker args.
The document of mounting tmpfs is below.
https://docs.docker.com/storage/tmpfs/

There is two options to mount tmpfs;
- `--mount type=tmpfs`
- `--tmpfs`

I used `--mount type=tmpfs` because `--tmpfs` doesn't allow us to use any other configuration such as `tmpfs-size`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
