### PR TITLE
[block] add support for notification suppression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "api_server",
  "event-manager",
@@ -381,7 +381,7 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jailer"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "libc",
  "regex",
@@ -1013,6 +1013,7 @@ dependencies = [
  "utils",
  "versionize",
  "versionize_derive",
+ "virtio_gen",
  "vm-memory 0.1.0",
  "vm-superio",
 ]

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -91,6 +91,10 @@ pub trait VirtioDevice: AsAny + Send {
     /// - self.avail_features() & self.acked_features() = self.get_acked_features()
     fn set_acked_features(&mut self, acked_features: u64);
 
+    fn has_feature(&self, feature: u64) -> bool {
+        (self.acked_features() & 1 << feature) != 0
+    }
+
     /// The virtio device type.
     fn device_type(&self) -> u32;
 
@@ -210,5 +214,79 @@ pub(crate) mod tests {
         irq_trigger.irq_evt.write(u64::MAX - 1).unwrap();
         assert!(irq_trigger.trigger_irq(IrqType::Config).is_err());
         assert!(irq_trigger.trigger_irq(IrqType::Vring).is_err());
+    }
+
+    struct MockVirtioDevice {
+        acked_features: u64,
+    }
+
+    impl VirtioDevice for MockVirtioDevice {
+        fn avail_features(&self) -> u64 {
+            todo!()
+        }
+
+        fn acked_features(&self) -> u64 {
+            self.acked_features
+        }
+
+        fn set_acked_features(&mut self, _acked_features: u64) {
+            todo!()
+        }
+
+        fn device_type(&self) -> u32 {
+            todo!()
+        }
+
+        fn queues(&self) -> &[Queue] {
+            todo!()
+        }
+
+        fn queues_mut(&mut self) -> &mut [Queue] {
+            todo!()
+        }
+
+        fn queue_events(&self) -> &[EventFd] {
+            todo!()
+        }
+
+        fn interrupt_evt(&self) -> &EventFd {
+            todo!()
+        }
+
+        fn interrupt_status(&self) -> Arc<AtomicUsize> {
+            todo!()
+        }
+
+        fn read_config(&self, _offset: u64, _data: &mut [u8]) {
+            todo!()
+        }
+
+        fn write_config(&mut self, _offset: u64, _data: &[u8]) {
+            todo!()
+        }
+
+        fn activate(&mut self, _mem: GuestMemoryMmap) -> ActivateResult {
+            todo!()
+        }
+
+        fn is_activated(&self) -> bool {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn test_has_feature() {
+        let mut device = MockVirtioDevice { acked_features: 0 };
+
+        let mock_feature_1 = 1u64;
+        assert!(!device.has_feature(mock_feature_1));
+        device.acked_features = 1 << mock_feature_1;
+        assert!(device.has_feature(mock_feature_1));
+
+        let mock_feature_2 = 2u64;
+        assert!(!device.has_feature(mock_feature_2));
+        device.acked_features = (1 << mock_feature_1) | (1 << mock_feature_2);
+        assert!(device.has_feature(mock_feature_1));
+        assert!(device.has_feature(mock_feature_2));
     }
 }

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -26,6 +26,7 @@ rate_limiter = { path = "../rate_limiter" }
 seccompiler = { path = "../seccompiler" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
+virtio_gen = { path = "../virtio_gen" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -21,7 +21,7 @@ use crate::memory_snapshot;
 use crate::memory_snapshot::{GuestMemoryState, SnapshotMemory};
 #[cfg(target_arch = "x86_64")]
 use crate::version_map::FC_V0_23_SNAP_VERSION;
-use crate::version_map::FC_VERSION_TO_SNAP_VERSION;
+use crate::version_map::{FC_V0_26_SNAP_VERSION, FC_VERSION_TO_SNAP_VERSION};
 use crate::{Error as VmmError, EventManager, Vmm};
 #[cfg(target_arch = "x86_64")]
 use cpuid::common::{get_vendor_id_from_cpuid, get_vendor_id_from_host};
@@ -34,6 +34,7 @@ use seccompiler::BpfThreadMap;
 use snapshot::Snapshot;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
+use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::GuestMemoryMmap;
 
 #[cfg(target_arch = "x86_64")]
@@ -111,6 +112,8 @@ impl Display for MicrovmStateError {
 pub enum CreateSnapshotError {
     /// Failed to get dirty bitmap.
     DirtyBitmap(VmmError),
+    /// The virtio devices uses a features that is incompatible with older versions of Firecracker.
+    IncompatibleVirtioFeature(&'static str),
     /// Invalid microVM version format
     InvalidVersionFormat,
     /// MicroVM version does not support snapshot.
@@ -135,6 +138,12 @@ impl Display for CreateSnapshotError {
         use self::CreateSnapshotError::*;
         match self {
             DirtyBitmap(err) => write!(f, "Cannot get dirty bitmap: {}", err),
+            IncompatibleVirtioFeature(feature) => write!(
+                f,
+                "The virtio devices use a features that is incompatible \
+                with older versions of Firecracker: {}",
+                feature
+            ),
             InvalidVersionFormat => write!(f, "Invalid microVM version format"),
             UnsupportedVersion => write!(
                 f,
@@ -299,7 +308,7 @@ fn snapshot_memory_to_file(
 pub fn get_snapshot_data_version(
     maybe_fc_version: &Option<String>,
     version_map: &VersionMap,
-    _vmm: &Vmm,
+    vmm: &Vmm,
 ) -> std::result::Result<u16, CreateSnapshotError> {
     let fc_version = match maybe_fc_version {
         None => return Ok(version_map.latest_version()),
@@ -312,7 +321,23 @@ pub fn get_snapshot_data_version(
 
     #[cfg(target_arch = "x86_64")]
     if data_version <= FC_V0_23_SNAP_VERSION {
-        validate_devices_number(_vmm.mmio_device_manager.used_irqs_count())?;
+        validate_devices_number(vmm.mmio_device_manager.used_irqs_count())?;
+    }
+
+    if data_version < FC_V0_26_SNAP_VERSION {
+        vmm.mmio_device_manager
+            .for_each_virtio_device(|_virtio_type, _id, _info, dev| {
+                if dev
+                    .lock()
+                    .expect("Poisoned lock")
+                    .has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX))
+                {
+                    return Err(CreateSnapshotError::IncompatibleVirtioFeature(
+                        "notification suppression",
+                    ));
+                }
+                Ok(())
+            })?;
     }
 
     Ok(data_version)

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -15,6 +15,16 @@ use lazy_static::lazy_static;
 use versionize::VersionMap;
 use versionize::Versionize;
 
+/// Snap version for Firecracker v0.23
+#[cfg(target_arch = "x86_64")]
+pub const FC_V0_23_SNAP_VERSION: u16 = 1;
+/// Snap version for Firecracker v0.24
+pub const FC_V0_24_SNAP_VERSION: u16 = 2;
+/// Snap version for Firecracker v0.25
+pub const FC_V0_25_SNAP_VERSION: u16 = 3;
+/// Snap version for Firecracker v0.26
+pub const FC_V0_26_SNAP_VERSION: u16 = 4;
+
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
     /// Static instance used for handling microVM state versions.
@@ -41,11 +51,11 @@ lazy_static! {
     pub static ref FC_VERSION_TO_SNAP_VERSION: HashMap<String, u16> = {
         let mut mapping = HashMap::new();
         #[cfg(not(target_arch = "aarch64"))]
-        mapping.insert(String::from("0.23.0"), 1);
+        mapping.insert(String::from("0.23.0"), FC_V0_23_SNAP_VERSION);
 
-        mapping.insert(String::from("0.24.0"), 2);
-        mapping.insert(String::from("0.25.0"), 3);
-        mapping.insert(String::from("0.26.0"), 4);
+        mapping.insert(String::from("0.24.0"), FC_V0_24_SNAP_VERSION);
+        mapping.insert(String::from("0.25.0"), FC_V0_25_SNAP_VERSION);
+        mapping.insert(String::from("0.26.0"), FC_V0_26_SNAP_VERSION);
 
         mapping
     };

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -9,6 +9,7 @@ use crate::device_manager::persist::DeviceStates;
 #[cfg(target_arch = "x86_64")]
 use crate::vstate::vcpu::VcpuState;
 use devices::virtio::block::persist::BlockState;
+use devices::virtio::QueueState;
 
 use lazy_static::lazy_static;
 use versionize::VersionMap;
@@ -29,6 +30,9 @@ lazy_static! {
         #[cfg(target_arch = "x86_64")]
         version_map.set_type_version(VcpuState::type_id(), 2);
 
+        // v0.26 state change mappings
+        version_map.new_version().set_type_version(QueueState::type_id(), 2);
+
         version_map
     };
 
@@ -41,6 +45,7 @@ lazy_static! {
 
         mapping.insert(String::from("0.24.0"), 2);
         mapping.insert(String::from("0.25.0"), 3);
+        mapping.insert(String::from("0.26.0"), 4);
 
         mapping
     };

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -381,7 +381,7 @@ class ArtifactCollection:
             keyword=keyword
         )
 
-    def firecrackers(self, keyword=None, older_than=None):
+    def firecrackers(self, keyword=None, min_version=None, max_version=None):
         """Return fc/jailer artifacts for the current arch."""
         firecrackers = self._fetch_artifacts(
             ArtifactCollection.ARTIFACTS_BINARIES,
@@ -391,19 +391,27 @@ class ArtifactCollection:
             keyword=keyword
         )
 
-        # Filter out binaries with versions newer than the `older_than` arg.
-        if older_than is not None:
+        # Filter out binaries with versions older than the `min_version` arg.
+        if min_version is not None:
             return list(filter(
-                lambda fc: compare_versions(fc.version, older_than) <= 0,
+                lambda fc: compare_versions(fc.version, min_version) >= 0,
+                firecrackers
+            ))
+
+        # Filter out binaries with versions newer than the `max_version` arg.
+        if max_version is not None:
+            return list(filter(
+                lambda fc: compare_versions(fc.version, max_version) <= 0,
                 firecrackers
             ))
 
         return firecrackers
 
-    def firecracker_versions(self, older_than=None):
+    def firecracker_versions(self, min_version=None, max_version=None):
         """Return fc/jailer artifacts' versions for the current arch."""
         return [fc.base_name()[1:]
-                for fc in self.firecrackers(older_than=older_than)]
+                for fc in self.firecrackers(min_version=min_version,
+                                            max_version=max_version)]
 
     def kernels(self, keyword=None):
         """Return kernel artifacts for the current arch."""

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -597,13 +597,9 @@ def compare_versions(first, second):
     first = list(map(int, first.split('.')))
     second = list(map(int, second.split('.')))
 
-    if first[0] == second[0]:
-        if first[1] == second[1]:
-            if first[2] == second[2]:
-                return 0
+    for i in range(3):
+        diff = first[i] - second[i]
+        if diff != 0:
+            return diff
 
-            return first[2] - second[2]
-
-        return first[1] - second[1]
-
-    return first[0] - second[0]
+    return 0

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2172072,
+        "FC_BINARY_SIZE_TARGET": 2181256,
         "JAILER_BINARY_SIZE_TARGET": 1439512,
-        "FC_BINARY_SIZE_LIMIT": 2280676,
+        "FC_BINARY_SIZE_LIMIT": 2185000,
         "JAILER_BINARY_SIZE_LIMIT": 1511488,
     },
     "aarch64": {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.88, "AMD": 84.32, "ARM": 83.05}
+COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.39, "ARM": 83.09}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -25,7 +25,7 @@ def test_describe_snapshot_all_versions(bin_cloner_path):
     # For each binary create a snapshot and verify the data version
     # of the snapshot state file.
     firecracker_artifacts = artifacts.firecrackers(
-        older_than=get_firecracker_version_from_toml())
+        max_version=get_firecracker_version_from_toml())
 
     for firecracker in firecracker_artifacts:
         firecracker.download()

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -107,6 +107,8 @@ def test_restore_old_version_all_devices(bin_cloner_path):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
+        # v0.26.0 breaks snapshot compatibility with older versions.
+        min_version="0.26.0",
         max_version=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()
@@ -117,8 +119,6 @@ def test_restore_old_version_all_devices(bin_cloner_path):
 
         # Old version from artifact.
         target_version = firecracker.base_name()[1:]
-        # v0.23 does not have a balloon device.
-        balloon = "0.23" not in target_version
 
         # Create a snapshot with current FC version targeting the old version.
         snapshot = create_snapshot_helper(builder,
@@ -126,7 +126,7 @@ def test_restore_old_version_all_devices(bin_cloner_path):
                                           target_version=target_version,
                                           drives=scratch_drives,
                                           ifaces=net_ifaces,
-                                          balloon=balloon,
+                                          balloon=True,
                                           diff_snapshots=True)
 
         logger.info("Restoring snapshot with Firecracker: %s",
@@ -139,8 +139,7 @@ def test_restore_old_version_all_devices(bin_cloner_path):
                                             diff_snapshots=False,
                                             fc_binary=firecracker.local_path(),
                                             jailer_binary=jailer.local_path())
-        validate_all_devices(logger, vm, net_ifaces, scratch_drives,
-                             balloon)
+        validate_all_devices(logger, vm, net_ifaces, scratch_drives, True)
         logger.debug("========== Firecracker restore snapshot log ==========")
         logger.debug(vm.log_data)
 

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -316,14 +316,14 @@ def create_snapshot_helper(builder, logger, target_version=None,
     vm.start()
 
     # Iterate and validate connectivity on all ifaces after boot.
-    for iface in net_ifaces:
+    for iface in ifaces:
         vm.ssh_config['hostname'] = iface.guest_ip
         ssh_connection = net_tools.SSHConnection(vm.ssh_config)
         exit_code, _, _ = ssh_connection.execute_command("sync")
         assert exit_code == 0
 
     # Mount scratch drives in guest.
-    for blk in scratch_drives:
+    for blk in test_drives:
         # Create mount point and mount each device.
         cmd = "mkdir -p /mnt/{blk} && mount /dev/{blk} /mnt/{blk}".format(
             blk=blk
@@ -349,7 +349,7 @@ def create_snapshot_helper(builder, logger, target_version=None,
                                        vm_instance.ssh_key,
                                        target_version=target_version,
                                        snapshot_type=snapshot_type,
-                                       net_ifaces=net_ifaces)
+                                       net_ifaces=ifaces)
     logger.debug("========== Firecracker create snapshot log ==========")
     logger.debug(vm.log_data)
     vm.kill()

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -52,7 +52,7 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
     # With each binary create a snapshot and try to restore in current
     # version.
     firecracker_artifacts = artifacts.firecrackers(
-        older_than=get_firecracker_version_from_toml())
+        max_version=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()
         jailer = firecracker.jailer()
@@ -107,7 +107,7 @@ def test_restore_old_version_all_devices(bin_cloner_path):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
-        older_than=get_firecracker_version_from_toml())
+        max_version=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()
         jailer = firecracker.jailer()

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -207,7 +207,7 @@ def _test_snapshot_create_latency(context):
                 .format(DEFAULT_TEST_IMAGES_S3_BUCKET))
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     firecracker_versions = artifacts.firecracker_versions(
-        older_than=get_firecracker_version_from_toml())
+        max_version=get_firecracker_version_from_toml())
     assert len(firecracker_versions) > 0
 
     # Test snapshot creation for every supported target version.
@@ -591,7 +591,7 @@ def test_older_snapshot_resume_latency(bin_cloner_path, results_file_dumper):
     # With each binary create a snapshot and try to restore in current
     # version.
     firecracker_artifacts = ArtifactSet(artifacts.firecrackers(
-        older_than=get_firecracker_version_from_toml()))
+        max_version=get_firecracker_version_from_toml()))
     assert len(firecracker_artifacts) > 0
 
     microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_512mb"))

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -207,6 +207,8 @@ def _test_snapshot_create_latency(context):
                 .format(DEFAULT_TEST_IMAGES_S3_BUCKET))
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     firecracker_versions = artifacts.firecracker_versions(
+        # v0.26.0 breaks snapshot compatibility with older versions.
+        min_version="0.26.0",
         max_version=get_firecracker_version_from_toml())
     assert len(firecracker_versions) > 0
 


### PR DESCRIPTION
# Reason for This PR

#2635 

## Description of Changes

### Performance Results

**Test setup:** We run on a m5d.metal host with Ubuntu and kernel 5.8.18. We start a number of microVMs with 8vCPUs and 16GB of RAM running linux kernel v5.8.18 as a guest OS. Each microVMs is pinned to NUMA node 1. We mount a ramdisk and we pin it to NUMA node 1 as well. For each microVM we create an ext4 file on the ramdisk and we attach it to the microVM as /dev/vdb. We want to have the content of the drives in the page cache in order to asses the performance improvement brought by notification suppression. Otherwise we would be limited by the disk access speed. Inside the VM we run the following command:

```
fio --name=test --ioengine=libaio --rw=readwrite --randrepeat=1 --bs=4k --size=500m --numjobs=1 --iodepth=32 --runtime=30 --time_base=1 --end_fsync=1 --direct=1 --filename=/dev/vdb
```

Current implementation:
|description|IOPS|VMM thread CPU load|kworker threads CPU load|IOPS per CPU load|
|-|-|-|-|-|
|1 VMs|104.86|0.36|0.13|213.5|
|4 VMs|439.28|1.51|0.52|216.34|
|8 VMs|849.83|3.1|1.07|203.47|
|16 VMs|1524.45|6.76|2.24|169.51|
|32 VMs|2202.07|8.32|2.19|209.51|
|64 VMs|1182.12|5.76|1.77|156.89|

Notification suppression:
|description|IOPS|VMM thread CPU load|kworker threads CPU load|IOPS per CPU load|increase in efficiency|
|-|-|-|-|-|-|
|1 VMs|160.72|0.42|0.09|315.65|47.85%|
|4 VMs|599.36|1.64|0.36|299.79|38.57%|
|8 VMs|1175.92|3.33|0.81|283.79|39.48%|
|16 VMs|1872.87|7.07|2.12|203.68|20.16%|
|32 VMs|2551.24|8.67|2.61|226.2|7.97%|
|64 VMs|1369.84|6.07|1.79|174.26|11.07%|


- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
