### PR TITLE
Abort test when failing to mount ramdisk

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -822,6 +822,7 @@ mount_ramdisk() {
     umount_ramdisk
     mkdir -p ${DEFAULT_RAMDISK_PATH} && \
     mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
+    ok_or_die "Failed to mount ramdisk to ${DEFAULT_RAMDISK_PATH}. Check the permission."
     mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
     mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
 }

--- a/tools/devtool
+++ b/tools/devtool
@@ -828,6 +828,15 @@ mount_ramdisk() {
 }
 
 umount_ramdisk() {
+    if [ ! -e "${DEFAULT_RAMDISK_PATH}" ]; then
+        return 0
+    fi
+    if [ ! -d "${DEFAULT_RAMDISK_PATH}" ]; then
+        die "${DEFAULT_RAMDISK_PATH} is not a directory."
+    fi
+    if [ ! -w "${DEFAULT_RAMDISK_PATH}" ]; then
+        die "Failed to unmount ${DEFAULT_RAMDISK_PATH}. Check the permission."
+    fi
     umount ${DEFAULT_RAMDISK_PATH} &>/dev/null
     rmdir ${DEFAULT_RAMDISK_PATH} &>/dev/null
 }


### PR DESCRIPTION
# Reason for This PR

When you don't have a proper permission to mount ramdisk, the test suite won't issue a fatal error as mentioned in #2612. 
This PR adds check the status code of creating and mounting ramdisk so that test will die if you fail to mount it.

Before this PR, I tried to use docker `--mount type=tmpfs` option instead of adding the status check, but it had some performance regression (See #2655 ).

Close #2612 

## Description of Changes

It checks the status code of this command
```bash
    mkdir -p ${DEFAULT_RAMDISK_PATH} && \
    mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
```

In order to check the status code I used `ok_or_die` command.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
