### PR TITLE
Adjust balloon tests for newer x86 kernel image

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -254,7 +254,7 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon
-    response = test_microvm.balloon.patch(amount_mib=172)
+    response = test_microvm.balloon.patch(amount_mib=180)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)
@@ -295,7 +295,7 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
     ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Inflate the balloon.
-    response = test_microvm.balloon.patch(amount_mib=172)
+    response = test_microvm.balloon.patch(amount_mib=180)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     # This call will internally wait for rss to become stable.
     _ = get_stable_rss_mem_by_pid(firecracker_pid)


### PR DESCRIPTION
The `deflate_on_oom` balloon tests are creating a 256MiB VM, inflating the balloon to 172MiB and then trying to allocate 32MiB of memory using the `fillmem` helper program. Depending on the `deflate_on_oom` balloon setting, the allocation should either succeed thanks to the balloon deflation making room for it, or fail by getting the helper program killed through the OOM killer.

On Intel x86_64 with the old kernel, the 172MiB inflation leaves the VM with about 29MiB of available memory, which is less than the amount the helper program wants to allocate, thus triggering the desired behavior.

A later version of the 4.14 kernel makes the VM lighter by about 4MiB, which means that, after the 172MiB inflation, the VM will have about 33MiB of available memory, which is slightly more than the amount the helper program is trying to allocate, making the allocation succeed and not trigger the balloon behavior we want to test.

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

This PR adjusts the inflate amount to 180MiB so that we can update the kernel image to the later version. This adjustment should also work with the current kernel image.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
