### PR TITLE
[CI] Make handling functions and tap field pub

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -95,7 +95,7 @@ unsafe impl ByteValued for ConfigSpace {}
 pub struct Net {
     pub(crate) id: String,
 
-    pub(crate) tap: Tap,
+    pub tap: Tap,
 
     pub(crate) avail_features: u64,
     pub(crate) acked_features: u64,

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -36,7 +36,7 @@ impl<B> Vsock<B>
 where
     B: VsockBackend + 'static,
 {
-    pub(crate) fn handle_rxq_event(&mut self, evset: EventSet) -> bool {
+    pub fn handle_rxq_event(&mut self, evset: EventSet) -> bool {
         debug!("vsock: RX queue event");
 
         if evset != EventSet::IN {
@@ -56,7 +56,7 @@ where
         raise_irq
     }
 
-    pub(crate) fn handle_txq_event(&mut self, evset: EventSet) -> bool {
+    pub fn handle_txq_event(&mut self, evset: EventSet) -> bool {
         debug!("vsock: TX queue event");
 
         if evset != EventSet::IN {
@@ -82,7 +82,7 @@ where
         raise_irq
     }
 
-    fn handle_evq_event(&mut self, evset: EventSet) -> bool {
+    pub fn handle_evq_event(&mut self, evset: EventSet) -> bool {
         debug!("vsock: event queue event");
 
         if evset != EventSet::IN {
@@ -98,7 +98,7 @@ where
         false
     }
 
-    fn notify_backend(&mut self, evset: EventSet) -> bool {
+    pub fn notify_backend(&mut self, evset: EventSet) -> bool {
         debug!("vsock: backend event");
 
         self.backend.notify(evset);


### PR DESCRIPTION
Make event handling functions from vsock and tap field from net
pub so we can use them from fuzzer.

Signed-off-by: AlexandruCihodaru <cihodar@amazon.com>

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
