### PR TITLE
[v0.24] Allow syscalls used by Rust panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed seccomp blocking syscalls necessary for Rust panics.
+
 ## [0.24.4]
 
 ### Fixed

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.1, "AMD": 84.37, "ARM": 83.16}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.37, "ARM": 83.16}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Whenever a panic happens, `libc::abort` is called. This function uses syscalls that are not allowed by the current seccomp filters.

## Description of Changes

Allowed these syscalls in order to allow the panics to finish cleanly.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
