### PR TITLE
Allow syscalls used by Rust panic

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -67,6 +67,10 @@
                 "comment": "Used by vsock to retrieve data from the socket"
             },
             {
+                "syscall": "rt_sigprocmask",
+                "comment": "rt_sigprocmask is used by libc::abort during a panic to block and unblock signals"
+            },
+            {
                 "syscall": "rt_sigreturn",
                 "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
             },
@@ -199,6 +203,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the vsock UDS",
                 "args": [
@@ -221,6 +238,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },
@@ -491,6 +521,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the unix domain socket",
                 "args": [
@@ -513,6 +556,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },
@@ -661,6 +717,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for updating the balloon statistics interval",
                 "args": [
@@ -669,6 +738,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -67,6 +67,10 @@
                 "comment": "Used by vsock to retrieve data from the socket"
             },
             {
+                "syscall": "rt_sigprocmask",
+                "comment": "rt_sigprocmask is used by libc::abort during a panic to block and unblock signals"
+            },
+            {
                 "syscall": "rt_sigreturn",
                 "comment": "rt_sigreturn is needed in case a fault does occur, so that the signal handler can return. Otherwise we get stuck in a fault loop."
             },
@@ -199,6 +203,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the vsock UDS",
                 "args": [
@@ -221,6 +238,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },
@@ -503,6 +533,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "socket",
                 "comment": "Called to open the unix domain socket",
                 "args": [
@@ -525,6 +568,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },
@@ -673,6 +729,19 @@
                 ]
             },
             {
+                "syscall": "rt_sigaction",
+                "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
+                "args": [
+                    {
+                        "index": 0,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
+                    }
+                ]
+            },
+            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for updating the balloon statistics interval",
                 "args": [
@@ -681,6 +750,19 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 0
+                    }
+                ]
+            },
+            {
+                "syscall": "tkill",
+                "comment": "tkill is used by libc::abort during a panic to raise SIGABRT",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 6,
+                        "comment": "SIGABRT"
                     }
                 ]
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,11 +351,18 @@ def bin_seccomp_paths(test_fc_session_root_path):
             'demo_malicious'
         )
     )
+    demo_panic = os.path.normpath(
+        os.path.join(
+            release_binaries_path,
+            'demo_panic'
+        )
+    )
 
     yield {
         'demo_jailer': demo_jailer,
         'demo_harmless': demo_harmless,
-        'demo_malicious': demo_malicious
+        'demo_malicious': demo_malicious,
+        'demo_panic': demo_panic
     }
 
 

--- a/tests/integration_tests/security/demo_seccomp/Cargo.toml
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.toml
@@ -10,3 +10,9 @@ libc = ">=0.2.39"
 seccompiler = { path = "../../../../src/seccompiler" }
 
 [workspace]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::env::args;
+use std::fs::File;
+
+use seccompiler::{apply_filter, deserialize_binary};
+
+fn main() {
+    let args: Vec<String> = args().collect();
+    let bpf_path = &args[1];
+    let filter_thread = &args[2];
+
+    let filter_file = File::open(bpf_path).unwrap();
+    let map = deserialize_binary(&filter_file, None).unwrap();
+    apply_filter(map.get(filter_thread).unwrap()).unwrap();
+    panic!("Expected panic.");
+}


### PR DESCRIPTION
# Reason for This PR

Whenever a panic happens, libc::abort is called. This function uses syscalls that are not allowed by the current seccomp filters.

## Description of Changes

Allowed these syscalls in order to allow the panics to finish cleanly.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
