### PR TITLE
Check for serial_input_fd validity

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -461,8 +461,11 @@ impl MutEventSubscriber for Serial {
     fn init(&mut self, ops: &mut EventOps) {
         if self.input.is_some() {
             if let Some(buf_ready_evt) = self.buffer_ready_evt.as_ref() {
-                if let Err(e) = ops.add(Events::new(&self.serial_input_fd(), EventSet::IN)) {
-                    error!("Failed to register serial input fd: {}", e);
+                let serial_fd = self.serial_input_fd();
+                if serial_fd != -1 {
+                    if let Err(e) = ops.add(Events::new(&serial_fd, EventSet::IN)) {
+                        error!("Failed to register serial input fd: {}", e);
+                    }
                 }
                 if let Err(e) = ops.add(Events::new(buf_ready_evt, EventSet::IN)) {
                     error!("Failed to register serial buffer ready event: {}", e);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.84, "AMD": 84.22, "ARM": 83.05}
+COVERAGE_DICT = {"Intel": 84.84, "AMD": 84.22, "ARM": 83.16}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fixes #2651 

## Description of Changes

This PR adds an extra check for the serial_input_fd before passing it to the event_manager register function. In this way, an error that should arise from the event_manager that the FD is invalid can be avoided.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
