### PR TITLE
[v0.24] Allow syscalls used by Rust panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed seccomp blocking syscalls necessary for Rust panics.
+
 ## [0.24.4]
 
 ### Fixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,12 +327,19 @@ def bin_seccomp_paths(test_session_root_path):
             'demo_malicious'
         )
     )
+    demo_panic = os.path.normpath(
+        os.path.join(
+            release_binaries_path,
+            'demo_panic'
+        )
+    )
 
     yield {
         'demo_basic_jailer': demo_basic_jailer,
         'demo_advanced_jailer': demo_advanced_jailer,
         'demo_harmless': demo_harmless,
-        'demo_malicious': demo_malicious
+        'demo_malicious': demo_malicious,
+        'demo_panic': demo_panic
     }
 
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 85.1, "AMD": 84.37, "ARM": 83.16}
+COVERAGE_DICT = {"Intel": 85.15, "AMD": 84.37, "ARM": 83.07}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
@@ -1,0 +1,9 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+fn main() {
+    unsafe {
+        // Simulate a Firecracker panic by aborting.
+        // The Firecracker build is configured with panic = "abort".
+        unsafe { libc::abort() };
+    }
+}

--- a/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
@@ -1,21 +1,23 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use seccomp::{allow_syscall, SyscallRuleSet};
+use seccomp::{allow_syscall, allow_syscall_if, SyscallRuleSet};
 
 /// Returns a list of rules that allow syscalls required for running a rust program.
 pub fn rust_required_rules() -> Vec<SyscallRuleSet> {
     vec![
-        allow_syscall(libc::SYS_sigaltstack),
-        allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_exit_group),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_rt_sigaction),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_tkill),
     ]
 }
 
 /// Returns a list of rules that allow syscalls required for executing another program.
 pub fn jailer_required_rules() -> Vec<SyscallRuleSet> {
     vec![
-        allow_syscall(libc::SYS_rt_sigprocmask),
-        allow_syscall(libc::SYS_rt_sigaction),
         allow_syscall(libc::SYS_execve),
         allow_syscall(libc::SYS_mmap),
         allow_syscall(libc::SYS_mprotect),

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -78,6 +78,30 @@ def test_advanced_seccomp_malicious(bin_seccomp_paths):
     assert outcome.returncode == -31
 
 
+def test_advanced_seccomp_panic(bin_seccomp_paths):
+    """
+    Test `demo_panic`.
+
+    Test that the advanced demo jailer allows the panic demo binary.
+    """
+    # pylint: disable=redefined-outer-name
+    # pylint: disable=subprocess-run-check
+    # The fixture pattern causes a pylint false positive for that rule.
+
+    demo_advanced_jailer = bin_seccomp_paths['demo_advanced_jailer']
+    demo_panic = bin_seccomp_paths['demo_panic']
+
+    assert os.path.exists(demo_advanced_jailer)
+    assert os.path.exists(demo_panic)
+
+    outcome = utils.run_cmd([demo_advanced_jailer, demo_panic],
+                            no_shell=True,
+                            ignore_return_code=True)
+
+    # The demo harmless binary should have terminated gracefully.
+    assert outcome.returncode == -6
+
+
 def test_seccomp_applies_to_all_threads(test_microvm_with_api):
     """Test all Firecracker threads get default seccomp level 2."""
     test_microvm = test_microvm_with_api


### PR DESCRIPTION
# Reason for This PR

Whenever a panic happens, libc::abort is called. This function uses syscalls that are not allowed by the current seccomp filters.

## Description of Changes

Allowed these syscalls in order to allow the panics to finish cleanly.

Tested manually that the new filters allow for clean panics. The panic uses the same syscalls as in v0.25, as they are `libc::abort` dependent and not Firecracker implementation dependent, so the test on `main` branch should be sufficient to prove the validity of the new list in v0.24. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
