### PR TITLE
Tap snapshot/restore integration test

### DIFF
--- a/docs/snapshotting/network-for-clones.md
+++ b/docs/snapshotting/network-for-clones.md
@@ -142,6 +142,18 @@ sudo ip route add 192.168.0.3 via 10.0.0.2
 
 **Full connectivity to/from the clone should be present at this point.**
 
+To make sure the guest also adjusts to the new environment, you can explicitly
+clear the ARP/neighbour table in the guest:
+
+```bash
+ip -family inet neigh flush any
+ip -family inet6 neigh flush any
+```
+
+ Otherwise, packets originating from the guest might be using old Link Layer
+ Address for up to arp cache timeout seconds. After said timeout period,
+ connectivity will work both ways even without an explicit flush.
+
 ## Scalability evaluation
 
 We ran synthetic tests to determine the impact of the addtional iptables


### PR DESCRIPTION
# Reason for This PR
If there was a connection before snapshot, we will also save the address
resolution information. If we delete the tap device and recreate it the
information will not be valid anymore because the tap device will have a new
mac address. The interval of time when packets are lost is due to ARP broadcast
packet being sent to all the hosts on the network requesting the physical 
hardware address for the host.

## Description of Changes
-> Added documentation update to drop arp tables before initiating a new connection
after restore if the tap device has been deleted.
-> Add integration test to check that we do not lose any packets after restore.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
