### PR TITLE
[v0.23] Allow syscalls used by Rust panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed seccomp blocking syscalls necessary for Rust panics.
+
 ## [0.23.4]
 
 ### Changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,12 +319,19 @@ def bin_seccomp_paths(test_session_root_path):
             'demo_malicious'
         )
     )
+    demo_panic = os.path.normpath(
+        os.path.join(
+            release_binaries_path,
+            'demo_panic'
+        )
+    )
 
     yield {
         'demo_basic_jailer': demo_basic_jailer,
         'demo_advanced_jailer': demo_advanced_jailer,
         'demo_harmless': demo_harmless,
-        'demo_malicious': demo_malicious
+        'demo_malicious': demo_malicious,
+        'demo_panic': demo_panic
     }
 
 

--- a/tests/framework/decorators.py
+++ b/tests/framework/decorators.py
@@ -14,7 +14,7 @@ def timed_request(method):
 
         def __init__(self, duration, method, resource, payload):
             """Compose the error message from the API call components."""
-            super(ApiTimeoutException, self).__init__(
+            super().__init__(
                 'API call exceeded maximum duration: {:.2f} ms.\n'
                 'Call: {} {} {}'.format(duration, method, resource, payload)
             )

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -16,7 +16,7 @@ class Session(requests_unixsocket.Session):
 
     def __init__(self):
         """Create a Session object and set the is_good_response callback."""
-        super(Session, self).__init__()
+        super().__init__()
 
         def is_good_response(response: int):
             """Return `True` for all HTTP 2xx response codes."""
@@ -49,24 +49,24 @@ class Session(requests_unixsocket.Session):
         """Wrap the GET call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).get(url, **kwargs)
+        return super().get(url, **kwargs)
 
     @decorators.timed_request
     def patch(self, url, data=None, **kwargs):
         """Wrap the PATCH call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).patch(url, data=data, **kwargs)
+        return super().patch(url, data=data, **kwargs)
 
     @decorators.timed_request
     def put(self, url, data=None, **kwargs):
         """Wrap the PUT call with duration limit."""
         # pylint: disable=method-hidden
         # The `untime` method overrides this, and pylint disapproves.
-        return super(Session, self).put(url, data=data, **kwargs)
+        return super().put(url, data=data, **kwargs)
 
     def untime(self):
         """Restore the HTTP methods to their un-timed selves."""
-        self.get = super(Session, self).get
-        self.patch = super(Session, self).patch
-        self.put = super(Session, self).put
+        self.get = super().get
+        self.patch = super().patch
+        self.put = super().put

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -25,7 +25,7 @@ class StoppableThread(threading.Thread):
 
     def __init__(self, *args, **kwargs):
         """Set up a Stoppable thread."""
-        super(StoppableThread, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._should_stop = False
 
     def stop(self):

--- a/tests/host_tools/cpu_load.py
+++ b/tests/host_tools/cpu_load.py
@@ -18,7 +18,7 @@ class CpuLoadExceededException(Exception):
 
     def __init__(self, cpu_load_samples, threshold):
         """Compose the error message containing the cpu load details."""
-        super(CpuLoadExceededException, self).__init__(
+        super().__init__(
             'Cpu load samples {} exceeded maximum threshold {}.\n'
             .format(cpu_load_samples, threshold)
         )

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -13,7 +13,7 @@ class MemoryUsageExceededException(Exception):
 
     def __init__(self, usage, threshold):
         """Compose the error message containing the memory consumption."""
-        super(MemoryUsageExceededException, self).__init__(
+        super().__init__(
             'Memory usage ({} KiB) exceeded maximum threshold ({} KiB).\n'
             .format(usage, threshold)
         )

--- a/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/demo_panic.rs
@@ -1,0 +1,9 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+fn main() {
+    unsafe {
+        // Simulate a Firecracker panic by aborting.
+        // The Firecracker build is configured with panic = "abort".
+        unsafe { libc::abort() };
+    }
+}

--- a/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
+++ b/tests/integration_tests/security/demo_seccomp/src/bin/seccomp_rules/mod.rs
@@ -1,21 +1,23 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use seccomp::{allow_syscall, SyscallRuleSet};
+use seccomp::{allow_syscall, allow_syscall_if, SyscallRuleSet};
 
 /// Returns a list of rules that allow syscalls required for running a rust program.
 pub fn rust_required_rules() -> Vec<SyscallRuleSet> {
     vec![
-        allow_syscall(libc::SYS_sigaltstack),
-        allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_exit_group),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_rt_sigaction),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_tkill),
     ]
 }
 
 /// Returns a list of rules that allow syscalls required for executing another program.
 pub fn jailer_required_rules() -> Vec<SyscallRuleSet> {
     vec![
-        allow_syscall(libc::SYS_rt_sigprocmask),
-        allow_syscall(libc::SYS_rt_sigaction),
         allow_syscall(libc::SYS_execve),
         allow_syscall(libc::SYS_mmap),
         #[cfg(target_arch = "x86_64")]

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -78,6 +78,30 @@ def test_advanced_seccomp_malicious(bin_seccomp_paths):
     assert outcome.returncode == -31
 
 
+def test_advanced_seccomp_panic(bin_seccomp_paths):
+    """
+    Test `demo_panic`.
+
+    Test that the advanced demo jailer allows the panic demo binary.
+    """
+    # pylint: disable=redefined-outer-name
+    # pylint: disable=subprocess-run-check
+    # The fixture pattern causes a pylint false positive for that rule.
+
+    demo_advanced_jailer = bin_seccomp_paths['demo_advanced_jailer']
+    demo_panic = bin_seccomp_paths['demo_panic']
+
+    assert os.path.exists(demo_advanced_jailer)
+    assert os.path.exists(demo_panic)
+
+    outcome = utils.run_cmd([demo_advanced_jailer, demo_panic],
+                            no_shell=True,
+                            ignore_return_code=True)
+
+    # The demo harmless binary should have terminated gracefully.
+    assert outcome.returncode == -6
+
+
 def test_seccomp_applies_to_all_threads(test_microvm_with_api):
     """Test all Firecracker threads get default seccomp level 2."""
     test_microvm = test_microvm_with_api

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v17"
+DEVCTR_IMAGE="public.ecr.aws/firecracker/fcuvm:v23"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
# Reason for This PR

Whenever a panic happens, libc::abort is called. This function uses syscalls that are not allowed by the current seccomp filters.

## Description of Changes

Allowed these syscalls in order to allow the panics to finish cleanly.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
