### PR TITLE
[virtio] code deduplication and simplifications

### DIFF
--- a/src/devices/src/bus.rs
+++ b/src/devices/src/bus.rs
@@ -10,7 +10,6 @@
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::collections::btree_map::BTreeMap;
 use std::fmt;
-use std::io;
 use std::result;
 use std::sync::{Arc, Mutex};
 
@@ -26,10 +25,6 @@ pub trait BusDevice: AsAny + Send {
     fn read(&mut self, offset: u64, data: &mut [u8]) {}
     /// Writes at `offset` into this device
     fn write(&mut self, offset: u64, data: &[u8]) {}
-    /// Triggers the `irq_mask` interrupt on this device
-    fn interrupt(&self, irq_mask: u32) -> io::Result<()> {
-        Ok(())
-    }
 }
 
 #[derive(Debug)]

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -33,8 +33,8 @@ pub(crate) fn report_balloon_event_fail(err: virtio::balloon::Error) {
 pub enum Error {
     /// Failed to read from the TAP device.
     FailedReadTap,
-    /// Failed to signal the virtio used queue.
-    FailedSignalingUsedQueue(io::Error),
+    /// Failed to signal irq.
+    FailedSignalingIrq(io::Error),
     /// IO error.
     IoError(io::Error),
     /// Device received malformed payload.

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::cmp;
 use std::io::Write;
 use std::result::Result;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,15 +18,13 @@ use ::vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 
 use super::*;
 use super::{
-    super::{
-        ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BALLOON, VIRTIO_MMIO_INT_VRING,
-    },
+    super::{ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BALLOON},
     utils::{compact_page_frame_numbers, remove_range},
     BALLOON_DEV_ID,
 };
 
-use crate::report_balloon_event_fail;
 use crate::virtio::balloon::Error as BalloonError;
+use crate::virtio::{IrqTrigger, IrqType};
 
 const SIZE_OF_U32: usize = std::mem::size_of::<u32>();
 const SIZE_OF_STAT: usize = std::mem::size_of::<BalloonStat>();
@@ -134,10 +132,9 @@ pub struct Balloon {
 
     // Transport related fields.
     pub(crate) queues: Vec<Queue>,
-    pub(crate) interrupt_status: Arc<AtomicUsize>,
-    pub(crate) interrupt_evt: EventFd,
     pub(crate) queue_evts: [EventFd; NUM_QUEUES],
     pub(crate) device_state: DeviceState,
+    pub(crate) irq_trigger: IrqTrigger,
 
     // Implementation specific fields.
     pub(crate) restored: bool,
@@ -192,10 +189,9 @@ impl Balloon {
                 num_pages: mib_to_pages(amount_mib)?,
                 actual_pages: 0,
             },
-            interrupt_status: Arc::new(AtomicUsize::new(0)),
-            interrupt_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(BalloonError::EventFd)?,
             queue_evts,
             queues,
+            irq_trigger: IrqTrigger::new().map_err(BalloonError::EventFd)?,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(BalloonError::EventFd)?,
             restored,
@@ -317,8 +313,7 @@ impl Balloon {
         }
 
         if needs_interrupt {
-            self.signal_used_queue()
-                .unwrap_or_else(report_balloon_event_fail);
+            self.signal_used_queue()?;
         }
 
         Ok(())
@@ -385,14 +380,10 @@ impl Balloon {
     }
 
     pub(crate) fn signal_used_queue(&self) -> Result<(), BalloonError> {
-        self.interrupt_status
-            .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
-
-        self.interrupt_evt.write(1).map_err(|e| {
-            error!("Failed to signal used queue: {:?}", e);
-            BalloonError::FailedSignalingUsedQueue(e)
-        })?;
-        Ok(())
+        self.irq_trigger.trigger_irq(IrqType::Vring).map_err(|e| {
+            METRICS.balloon.event_fails.inc();
+            BalloonError::InterruptError(e)
+        })
     }
 
     /// Process device virtio queue(s).
@@ -425,7 +416,9 @@ impl Balloon {
     pub fn update_size(&mut self, amount_mib: u32) -> Result<(), BalloonError> {
         if self.is_activated() {
             self.config_space.num_pages = mib_to_pages(amount_mib)?;
-            Ok(())
+            self.irq_trigger
+                .trigger_irq(IrqType::Config)
+                .map_err(BalloonError::InterruptError)
         } else {
             Err(BalloonError::DeviceNotActive)
         }
@@ -519,11 +512,11 @@ impl VirtioDevice for Balloon {
     }
 
     fn interrupt_evt(&self) -> &EventFd {
-        &self.interrupt_evt
+        &self.irq_trigger.irq_evt
     }
 
     fn interrupt_status(&self) -> Arc<AtomicUsize> {
-        self.interrupt_status.clone()
+        self.irq_trigger.irq_status.clone()
     }
 
     fn avail_features(&self) -> u64 {
@@ -593,12 +586,12 @@ pub(crate) mod tests {
 
     use super::super::CONFIG_SPACE_SIZE;
     use super::*;
-    use crate::check_metric_after_block;
     use crate::virtio::balloon::test_utils::{
         check_request_completion, invoke_handler_for_queue_event, set_request,
     };
     use crate::virtio::test_utils::{default_mem, VirtQueue};
     use crate::virtio::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use crate::{check_metric_after_block, report_balloon_event_fail};
     use vm_memory::GuestAddress;
 
     impl Balloon {
@@ -987,7 +980,7 @@ pub(crate) mod tests {
                 assert!(balloon.stats_desc_index.is_some());
                 assert!(balloon.process_stats_timer_event().is_ok());
                 assert!(balloon.stats_desc_index.is_none());
-                assert_eq!(balloon.interrupt_evt().read().unwrap(), 1);
+                assert!(balloon.irq_trigger.has_pending_irq(IrqType::Vring));
             });
         }
     }

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -4,6 +4,7 @@
 pub mod device;
 pub mod event_handler;
 pub mod persist;
+#[cfg(test)]
 pub mod test_utils;
 mod utils;
 
@@ -63,8 +64,6 @@ pub enum Error {
     DeviceNotActive,
     /// EventFd error.
     EventFd(std::io::Error),
-    /// Failed to signal the virtio used queue.
-    FailedSignalingUsedQueue(std::io::Error),
     /// Guest gave us bad memory addresses.
     GuestMemory(GuestMemoryError),
     /// Received error while sending an interrupt.

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -128,7 +128,8 @@ impl Persist<'_> for Balloon {
             .virtio_state
             .build_queues_checked(&constructor_args.mem, TYPE_BALLOON, num_queues, QUEUE_SIZE)
             .map_err(|_| Self::Error::QueueRestoreError)?;
-        balloon.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        balloon.irq_trigger.irq_status =
+            Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
         balloon.avail_features = state.virtio_state.avail_features;
         balloon.acked_features = state.virtio_state.acked_features;
         balloon.latest_stats = state.latest_stats.create_stats();

--- a/src/devices/src/virtio/balloon/test_utils.rs
+++ b/src/devices/src/virtio/balloon/test_utils.rs
@@ -4,7 +4,9 @@
 use std::u32;
 
 use crate::virtio::test_utils::VirtQueue;
-use crate::virtio::{balloon::NUM_QUEUES, Balloon, DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX};
+use crate::virtio::{
+    balloon::NUM_QUEUES, Balloon, IrqType, DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX,
+};
 
 pub fn invoke_handler_for_queue_event(b: &mut Balloon, queue_index: usize) {
     assert!(queue_index < NUM_QUEUES);
@@ -18,7 +20,7 @@ pub fn invoke_handler_for_queue_event(b: &mut Balloon, queue_index: usize) {
         _ => unreachable!(),
     };
     // Validate the queue operation finished successfully.
-    assert_eq!(b.interrupt_evt.read().unwrap(), 1);
+    assert!(b.irq_trigger.has_pending_irq(IrqType::Vring));
 }
 
 pub fn set_request(queue: &VirtQueue, idx: usize, addr: u64, len: u32, flags: u16) {

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -275,11 +275,9 @@ impl Block {
     }
 
     pub fn process_queue(&mut self, queue_index: usize) -> bool {
-        let mem = match self.device_state {
-            DeviceState::Activated(ref mem) => mem,
-            // This should never happen, it's been already validated in the event handler.
-            DeviceState::Inactive => unreachable!(),
-        };
+        // This is safe since we checked in the event handler that the device is activated.
+        let mem = self.device_state.mem().unwrap();
+
         let queue = &mut self.queues[queue_index];
         let mut used_any = false;
         while let Some(head) = queue.pop(mem) {
@@ -488,10 +486,7 @@ impl VirtioDevice for Block {
     }
 
     fn is_activated(&self) -> bool {
-        match self.device_state {
-            DeviceState::Inactive => false,
-            DeviceState::Activated(_) => true,
-        }
+        self.device_state.is_activated()
     }
 
     fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -359,7 +359,7 @@ impl Block {
         self.interrupt_evt.write(1).map_err(|e| {
             error!("Failed to signal used queue: {:?}", e);
             METRICS.block.event_fails.inc();
-            DeviceError::FailedSignalingUsedQueue(e)
+            DeviceError::FailedSignalingIrq(e)
         })?;
         Ok(())
     }

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -95,6 +95,7 @@ pub mod tests {
     use crate::virtio::block::test_utils::{default_block, set_queue};
     use crate::virtio::queue::tests::*;
     use crate::virtio::test_utils::{default_mem, initialize_virtqueue, VirtQueue};
+    use crate::virtio::IrqType;
     use event_manager::{EventManager, SubscriberOps};
     use virtio_gen::virtio_blk::*;
     use vm_memory::{Bytes, GuestAddress};
@@ -144,7 +145,11 @@ pub mod tests {
             .run_with_timeout(100)
             .expect("Metrics event timeout or error.");
         // Validate the queue operation finished successfully.
-        assert_eq!(block.lock().unwrap().interrupt_evt().read().unwrap(), 1);
+        assert!(block
+            .lock()
+            .unwrap()
+            .irq_trigger
+            .has_pending_irq(IrqType::Vring));
 
         assert_eq!(vq.used.idx.get(), 1);
         assert_eq!(vq.used.ring[0].get().id, 0);

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -5,6 +5,7 @@ pub mod device;
 pub mod event_handler;
 pub mod persist;
 pub mod request;
+#[cfg(test)]
 pub mod test_utils;
 
 pub use self::device::{Block, CacheType};

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -129,7 +129,8 @@ impl Persist<'_> for Block {
             .virtio_state
             .build_queues_checked(&constructor_args.mem, TYPE_BLOCK, NUM_QUEUES, QUEUE_SIZE)
             .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-        block.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        block.irq_trigger.irq_status =
+            Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
         block.avail_features = state.virtio_state.avail_features;
         block.acked_features = state.virtio_state.acked_features;
 

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::virtio::{Block, CacheType, Queue};
+use crate::virtio::{Block, CacheType, IrqType, Queue};
 use rate_limiter::RateLimiter;
 use utils::tempfile::TempFile;
 
@@ -39,7 +39,7 @@ pub fn invoke_handler_for_queue_event(b: &mut Block) {
     // Handle event.
     b.process_queue_event();
     // Validate the queue operation finished successfully.
-    assert_eq!(b.interrupt_evt.read().unwrap(), 1);
+    assert!(b.irq_trigger.has_pending_irq(IrqType::Vring));
 }
 
 pub fn set_queue(blk: &mut Block, idx: usize, q: Queue) {

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -20,6 +20,24 @@ pub enum DeviceState {
     Activated(GuestMemoryMmap),
 }
 
+impl DeviceState {
+    /// Checks if the device is activated.
+    pub fn is_activated(&self) -> bool {
+        match self {
+            DeviceState::Inactive => false,
+            DeviceState::Activated(_) => true,
+        }
+    }
+
+    /// Gets the memory attached to the device if it is activated.
+    pub fn mem(&self) -> Option<&GuestMemoryMmap> {
+        match self {
+            DeviceState::Activated(ref mem) => Some(mem),
+            DeviceState::Inactive => None,
+        }
+    }
+}
+
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
 /// The lifecycle of a virtio device is to be moved to a virtio transport, which will then query the

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -19,6 +19,11 @@ use crate::bus::BusDevice;
 //TODO crosvm uses 0 here, but IIRC virtio specified some other vendor id that should be used
 const VENDOR_ID: u32 = 0;
 
+/// Interrupt flags (re: interrupt status & acknowledge registers).
+/// See linux/virtio_mmio.h.
+pub const VIRTIO_MMIO_INT_VRING: u32 = 0x01;
+pub const VIRTIO_MMIO_INT_CONFIG: u32 = 0x02;
+
 //required by the virtio mmio device register layout at offset 0 from base
 const MMIO_MAGIC_VALUE: u32 = 0x7472_6976;
 

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -319,16 +319,6 @@ impl BusDevice for MmioTransport {
             }
         }
     }
-
-    fn interrupt(&self, irq_mask: u32) -> std::io::Result<()> {
-        self.interrupt_status
-            .fetch_or(irq_mask as usize, Ordering::SeqCst);
-        // interrupt_evt() is safe to unwrap because the inner interrupt_evt is initialized in the
-        // constructor.
-        // write() is safe to unwrap because the inner syscall is tailored to be safe as well.
-        self.locked_device().interrupt_evt().write(1).unwrap();
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -51,11 +51,6 @@ pub const TYPE_NET: u32 = 1;
 pub const TYPE_BLOCK: u32 = 2;
 pub const TYPE_BALLOON: u32 = 5;
 
-/// Interrupt flags (re: interrupt status & acknowledge registers).
-/// See linux/virtio_mmio.h.
-pub const VIRTIO_MMIO_INT_VRING: u32 = 0x01;
-pub const VIRTIO_MMIO_INT_CONFIG: u32 = 0x02;
-
 /// Offset from the base MMIO address of a virtio device used by the guest to notify the device of
 /// queue events.
 pub const NOTIFY_REG_OFFSET: u32 = 0x50;

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -251,7 +251,7 @@ impl Net {
         self.interrupt_evt.write(1).map_err(|e| {
             error!("Failed to signal used queue: {:?}", e);
             METRICS.net.event_fails.inc();
-            DeviceError::FailedSignalingUsedQueue(e)
+            DeviceError::FailedSignalingIrq(e)
         })?;
 
         self.rx_deferred_irqs = false;

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -12,7 +12,7 @@ use crate::virtio::net::Error;
 use crate::virtio::net::Result;
 use crate::virtio::net::{MAX_BUFFER_SIZE, QUEUE_SIZE, QUEUE_SIZES, RX_INDEX, TX_INDEX};
 use crate::virtio::{
-    ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_NET, VIRTIO_MMIO_INT_VRING,
+    ActivateResult, DeviceState, IrqTrigger, IrqType, Queue, VirtioDevice, TYPE_NET,
 };
 use crate::{report_net_event_fail, Error as DeviceError};
 
@@ -26,7 +26,6 @@ use std::io;
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::{cmp, mem, result};
 use utils::eventfd::EventFd;
@@ -115,8 +114,7 @@ pub struct Net {
     tx_iovec: Vec<(GuestAddress, usize)>,
     tx_frame_buf: [u8; MAX_BUFFER_SIZE],
 
-    pub(crate) interrupt_status: Arc<AtomicUsize>,
-    pub(crate) interrupt_evt: EventFd,
+    pub(crate) irq_trigger: IrqTrigger,
 
     pub(crate) config_space: ConfigSpace,
     pub(crate) guest_mac: Option<MacAddr>,
@@ -195,8 +193,7 @@ impl Net {
             rx_frame_buf: [0u8; MAX_BUFFER_SIZE],
             tx_frame_buf: [0u8; MAX_BUFFER_SIZE],
             tx_iovec: Vec::with_capacity(QUEUE_SIZE as usize),
-            interrupt_status: Arc::new(AtomicUsize::new(0)),
-            interrupt_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?,
+            irq_trigger: IrqTrigger::new().map_err(Error::EventFd)?,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?,
             config_space,
@@ -246,10 +243,7 @@ impl Net {
     }
 
     fn signal_used_queue(&mut self) -> result::Result<(), DeviceError> {
-        self.interrupt_status
-            .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
-        self.interrupt_evt.write(1).map_err(|e| {
-            error!("Failed to signal used queue: {:?}", e);
+        self.irq_trigger.trigger_irq(IrqType::Vring).map_err(|e| {
             METRICS.net.event_fails.inc();
             DeviceError::FailedSignalingIrq(e)
         })?;
@@ -770,11 +764,11 @@ impl VirtioDevice for Net {
     }
 
     fn interrupt_evt(&self) -> &EventFd {
-        &self.interrupt_evt
+        &self.irq_trigger.irq_evt
     }
 
     fn interrupt_status(&self) -> Arc<AtomicUsize> {
-        self.interrupt_status.clone()
+        self.irq_trigger.irq_status.clone()
     }
 
     fn avail_features(&self) -> u64 {
@@ -845,20 +839,18 @@ pub mod tests {
         frame_bytes_from_buf, frame_bytes_from_buf_mut, init_vnet_hdr, vnet_hdr_len,
     };
     use std::net::Ipv4Addr;
-    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use std::{io, mem, thread};
 
     use crate::check_metric_after_block;
     use crate::virtio::net::test_utils::test::TestHelper;
     use crate::virtio::net::test_utils::{
-        check_used_queue_signal, default_net, if_index, inject_tap_tx_frame, set_mac, NetEvent,
-        NetQueue, ReadTapMock, TapTrafficSimulator,
+        default_net, if_index, inject_tap_tx_frame, set_mac, NetEvent, NetQueue, ReadTapMock,
+        TapTrafficSimulator,
     };
     use crate::virtio::net::QUEUE_SIZES;
     use crate::virtio::{
-        Net, VirtioDevice, MAX_BUFFER_SIZE, RX_INDEX, TX_INDEX, TYPE_NET, VIRTIO_MMIO_INT_VRING,
-        VIRTQ_DESC_F_WRITE,
+        Net, VirtioDevice, MAX_BUFFER_SIZE, RX_INDEX, TX_INDEX, TYPE_NET, VIRTQ_DESC_F_WRITE,
     };
     use dumbo::pdu::arp::{EthIPv4ArpFrame, ETH_IPV4_FRAME_LEN};
     use dumbo::pdu::ethernet::ETHERTYPE_ARP;
@@ -1112,7 +1104,7 @@ pub mod tests {
 
         // Check that the used queue has advanced.
         assert_eq!(th.rxq.used.idx.get(), 4);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         // Check that the invalid descriptor chains have been discarded
         th.rxq.check_used_elem(0, 0, 0);
         th.rxq.check_used_elem(1, 3, 0);
@@ -1154,7 +1146,7 @@ pub mod tests {
         assert!(!th.net().rx_deferred_frame);
         // Check that the used queue has advanced.
         assert_eq!(th.rxq.used.idx.get(), 1);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         // Check that the frame has been written successfully to the Rx descriptor chain.
         th.rxq.check_used_elem(0, 3, frame.len() as u32);
         th.rxq.dtable[3].check_data(&frame[..100]);
@@ -1193,7 +1185,7 @@ pub mod tests {
         assert!(!th.net().rx_deferred_frame);
         // Check that the used queue has advanced.
         assert_eq!(th.rxq.used.idx.get(), 2);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         // Check that the 1st frame was written successfully to the 1st Rx descriptor chain.
         th.rxq.check_used_elem(0, 0, frame_1.len() as u32);
         th.rxq.dtable[0].check_data(&frame_1);
@@ -1237,7 +1229,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(0, 0, 0);
         // Check that the frame was skipped.
         assert!(!tap_traffic_simulator.pop_rx_packet(&mut []));
@@ -1259,7 +1251,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(0, 0, 0);
         // Check that the frame was skipped.
         assert!(!tap_traffic_simulator.pop_rx_packet(&mut []));
@@ -1287,7 +1279,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(0, 0, 0);
         // Check that the frame was skipped.
         assert!(!tap_traffic_simulator.pop_rx_packet(&mut []));
@@ -1323,7 +1315,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 4);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(3, 4, 0);
         // Check that the valid frame was sent to the tap.
         let mut buf = vec![0; 1000];
@@ -1353,7 +1345,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 1);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(0, 3, 0);
         // Check that the frame was sent to the tap.
         let mut buf = vec![0; 1000];
@@ -1384,7 +1376,7 @@ pub mod tests {
 
         // Check that the used queue advanced.
         assert_eq!(th.txq.used.idx.get(), 2);
-        check_used_queue_signal(&th.net(), 1);
+        assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
         th.txq.check_used_elem(0, 0, 0);
         th.txq.check_used_elem(1, 3, 0);
         // Check that the first frame was sent to the tap.
@@ -1651,7 +1643,7 @@ pub mod tests {
                 assert_eq!(METRICS.net.rx_rate_limiter_throttled.count(), 1);
                 assert!(th.net().rx_deferred_frame);
                 // assert that no operation actually completed (limiter blocked it)
-                check_used_queue_signal(&th.net(), 1);
+                assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
                 // make sure the data is still queued for processing
                 assert_eq!(th.rxq.used.idx.get(), 0);
             }
@@ -1672,7 +1664,7 @@ pub mod tests {
                 // validate the rate_limiter is no longer blocked
                 assert!(!th.net().rx_rate_limiter.is_blocked());
                 // make sure the virtio queue operation completed this time
-                check_used_queue_signal(&th.net(), 1);
+                assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
                 // make sure the data queue advanced
                 assert_eq!(th.rxq.used.idx.get(), 1);
                 th.rxq.check_used_elem(0, 0, frame.len() as u32);
@@ -1760,14 +1752,14 @@ pub mod tests {
                 assert!(METRICS.net.rx_rate_limiter_throttled.count() >= 1);
                 assert!(th.net().rx_deferred_frame);
                 // assert that no operation actually completed (limiter blocked it)
-                check_used_queue_signal(&th.net(), 1);
+                assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
                 // make sure the data is still queued for processing
                 assert_eq!(th.rxq.used.idx.get(), 0);
 
                 // trigger the RX handler again, this time it should do the limiter fast path exit
                 th.simulate_event(NetEvent::Tap);
                 // assert that no operation actually completed, that the limiter blocked it
-                check_used_queue_signal(&th.net(), 0);
+                assert!(!&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
                 // make sure the data is still queued for processing
                 assert_eq!(th.rxq.used.idx.get(), 0);
             }
@@ -1781,7 +1773,7 @@ pub mod tests {
                 let frame = &th.net().mocks.read_tap.mock_frame();
                 th.simulate_event(NetEvent::RxRateLimiter);
                 // make sure the virtio queue operation completed this time
-                check_used_queue_signal(&th.net(), 1);
+                assert!(&th.net().irq_trigger.has_pending_irq(IrqType::Vring));
                 // make sure the data queue advanced
                 assert_eq!(th.rxq.used.idx.get(), 1);
                 th.rxq.check_used_elem(0, 0, frame.len() as u32);
@@ -1847,13 +1839,6 @@ pub mod tests {
         assert_eq!(net.queue_events().len(), QUEUE_SIZES.len());
 
         // Test interrupts.
-        let interrupt_status = net.interrupt_status();
-        interrupt_status.fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
-        assert_eq!(
-            interrupt_status.load(Ordering::SeqCst),
-            VIRTIO_MMIO_INT_VRING as usize
-        );
-
-        check_used_queue_signal(&net, 0);
+        assert!(!&net.irq_trigger.has_pending_irq(IrqType::Vring));
     }
 }

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -16,6 +16,7 @@ pub mod device;
 pub mod event_handler;
 pub mod persist;
 mod tap;
+#[cfg(test)]
 pub mod test_utils;
 
 pub use self::device::Net;

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -98,7 +98,8 @@ impl Persist<'_> for Net {
             .virtio_state
             .build_queues_checked(&constructor_args.mem, TYPE_NET, NUM_QUEUES, QUEUE_SIZE)
             .map_err(Error::VirtioState)?;
-        net.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        net.irq_trigger.irq_status =
+            Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
         net.avail_features = state.virtio_state.avail_features;
         net.acked_features = state.virtio_state.acked_features;
         net.config_space = ConfigSpace {

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -135,11 +135,8 @@ where
     /// otherwise.
     pub fn process_rx(&mut self) -> bool {
         debug!("vsock: process_rx()");
-        let mem = match self.device_state {
-            DeviceState::Activated(ref mem) => mem,
-            // This should never happen, it's been already validated in the event handler.
-            DeviceState::Inactive => unreachable!(),
-        };
+        // This is safe since we checked in the event handler that the device is activated.
+        let mem = self.device_state.mem().unwrap();
 
         let mut have_used = false;
 
@@ -186,11 +183,8 @@ where
     /// ring, and `false` otherwise.
     pub fn process_tx(&mut self) -> bool {
         debug!("vsock::process_tx()");
-        let mem = match self.device_state {
-            DeviceState::Activated(ref mem) => mem,
-            // This should never happen, it's been already validated in the event handler.
-            DeviceState::Inactive => unreachable!(),
-        };
+        // This is safe since we checked in the event handler that the device is activated.
+        let mem = self.device_state.mem().unwrap();
 
         let mut have_used = false;
 
@@ -229,11 +223,8 @@ where
     // connections and the guest_cid configuration field is fetched again. Existing listen sockets remain
     // but their CID is updated to reflect the current guest_cid.
     pub fn send_transport_reset_event(&mut self) -> result::Result<(), DeviceError> {
-        let mem = match self.device_state {
-            DeviceState::Activated(ref mem) => mem,
-            // This should never happen, it's been already validated in the caller function.
-            DeviceState::Inactive => unreachable!(),
-        };
+        // This is safe since we checked in the caller function that the device is activated.
+        let mem = self.device_state.mem().unwrap();
 
         let head = self.queues[EVQ_INDEX].pop(mem).ok_or_else(|| {
             METRICS.vsock.ev_queue_event_fails.inc();
@@ -347,10 +338,7 @@ where
     }
 
     fn is_activated(&self) -> bool {
-        match self.device_state {
-            DeviceState::Inactive => false,
-            DeviceState::Activated(_) => true,
-        }
+        self.device_state.is_activated()
     }
 }
 

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -126,7 +126,7 @@ where
             .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
         self.interrupt_evt.write(1).map_err(|e| {
             error!("Failed to signal used queue: {:?}", e);
-            DeviceError::FailedSignalingUsedQueue(e)
+            DeviceError::FailedSignalingIrq(e)
         })
     }
 

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -200,7 +200,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
 
     use super::super::*;
@@ -208,39 +207,8 @@ mod tests {
 
     use crate::virtio::vsock::packet::VSOCK_PKT_HDR_SIZE;
     use crate::virtio::vsock::test_utils::{EventHandlerContext, TestContext};
-    use crate::virtio::VIRTIO_MMIO_INT_VRING;
-    use crate::Error as DeviceError;
     use event_manager::{EventManager, SubscriberOps};
     use vm_memory::Bytes;
-
-    #[test]
-    fn test_irq() {
-        // Test case: successful IRQ signaling.
-        {
-            let test_ctx = TestContext::new();
-            let ctx = test_ctx.create_event_handler_context();
-
-            ctx.device.signal_used_queue().unwrap();
-            assert_eq!(
-                ctx.device.interrupt_status.load(Ordering::SeqCst),
-                VIRTIO_MMIO_INT_VRING as usize
-            );
-            assert_eq!(ctx.device.interrupt_evt.read().unwrap(), 1);
-        }
-
-        // Test case: error (a real stretch) - the event counter is full.
-        //
-        {
-            let test_ctx = TestContext::new();
-            let ctx = test_ctx.create_event_handler_context();
-
-            ctx.device.interrupt_evt.write(std::u64::MAX - 1).unwrap();
-            match ctx.device.signal_used_queue() {
-                Err(DeviceError::FailedSignalingIrq(_)) => (),
-                other => panic!("{:?}", other),
-            }
-        }
-    }
 
     #[test]
     fn test_txq_event() {

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -236,7 +236,7 @@ mod tests {
 
             ctx.device.interrupt_evt.write(std::u64::MAX - 1).unwrap();
             match ctx.device.signal_used_queue() {
-                Err(DeviceError::FailedSignalingUsedQueue(_)) => (),
+                Err(DeviceError::FailedSignalingIrq(_)) => (),
                 other => panic!("{:?}", other),
             }
         }

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -114,7 +114,8 @@ where
 
         vsock.acked_features = state.virtio_state.acked_features;
         vsock.avail_features = state.virtio_state.avail_features;
-        vsock.interrupt_status = Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
+        vsock.irq_trigger.irq_status =
+            Arc::new(AtomicUsize::new(state.virtio_state.interrupt_status));
         vsock.device_state = if state.virtio_state.activated {
             DeviceState::Activated(constructor_args.mem)
         } else {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -637,12 +637,9 @@ impl Vmm {
                     .downcast_mut::<Balloon>()
                     .unwrap()
                     .update_size(amount_mib)?;
-            }
 
-            let locked_dev = busdev.lock().expect("Poisoned lock");
-            locked_dev
-                .interrupt(devices::virtio::VIRTIO_MMIO_INT_CONFIG)
-                .map_err(BalloonError::InterruptError)
+                Ok(())
+            }
         } else {
             Err(BalloonError::DeviceNotFound)
         }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.84, "AMD": 84.22, "ARM": 83.16}
+COVERAGE_DICT = {"Intel": 85.02, "AMD": 84.45, "ARM": 83.31}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

[virtio] code deduplication and simplifications

## Description of Changes

We move some logic to `DeviceState` in order to decrease code duplication.

We introduce `IrqTrigger` as an incremental improvement over the old approach where each device  was implementing a `signal_used_queue(&mut self)` method. This has 2 advatages:
1. We define this logic in one place in order to avoid code duplication
2. We can trigger a guest irq without borrowing the entire device. This
   can lead to some code simplifications in the devices.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
