### PR TITLE
Change serial_fd log from error to warn

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -464,11 +464,11 @@ impl MutEventSubscriber for Serial {
                 let serial_fd = self.serial_input_fd();
                 if serial_fd != -1 {
                     if let Err(e) = ops.add(Events::new(&serial_fd, EventSet::IN)) {
-                        error!("Failed to register serial input fd: {}", e);
+                        warn!("Failed to register serial input fd: {}", e);
                     }
                 }
                 if let Err(e) = ops.add(Events::new(buf_ready_evt, EventSet::IN)) {
-                    error!("Failed to register serial buffer ready event: {}", e);
+                    warn!("Failed to register serial buffer ready event: {}", e);
                 }
             }
         }


### PR DESCRIPTION
# Reason for This PR

This PR comes as an extension to solving issue #2651 and fixing `firecracker-go-sdk` builds failing. While we added an extra condition in Firecracker that would prevent the error from appearing, it seems the fc-go-sdk builds still fail.

## Description of Changes

The changes this PR brings are simple: changing an `error` log to a `warn` log. 

As we can observe [here](https://buildkite.com/firecracker-microvm/firecracker-go-sdk/builds/1875#533262e1-59ec-4e14-8ca1-b192698bc77b), fc-go-sdk builds are failing due to 
>"Running Firecracker v0.26-wip-13-g9e3c10fc\n2021-07-26T00:06:50.836452579 [UserSuppliedVMID:main:ERROR] 
> Failed to register serial input fd: event_manager: failed to manage epoll file descriptor\n" does not contain ":WARN]"

which means that the error keeps appearing and causes builds failure.

I have tracked back through the failures to the last successful Buildkite run. It is in 3 June, which is the date where we migrated the Serial device from using `polly` to `rust-vmm/event-manager`. The commit is [here](https://github.com/firecracker-microvm/firecracker/commit/85db06b8520663f73340cff300676c07ae8263c9). As we can observe, before migration we wouldn't log anything and in case something was not right, we returned an empty array. Else, a 2 element array of consisting of EpollEvents would be returned. After migration, we started logging `errors` should an event fail to create. Same as before, an error in this phase does not stop FC execution, it's role is only information. 

As logging a message should something go wrong is useful and an error at this step does not provoke a Firecracker termination, we should change the log level from `error` to `warn`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
