### PR TITLE
Adjust balloon integration test for newer x86 rootfs

### DIFF
--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -411,7 +411,7 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
     time.sleep(5)
 
     # Now inflate the balloon.
-    response = test_microvm.balloon.patch(amount_mib=40)
+    response = test_microvm.balloon.patch(amount_mib=160)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # Check memory usage again.


### PR DESCRIPTION
# Reason for This PR

Using the new rootfs, the `test_size_reduction` balloon integration test failed due to an insufficient amount of memory reclaimed by inflating the balloon by 40 MiB on a 256 MiB VM.

## Description of Changes

This commit adjusts the inflate amount in the `test_size_reduction` balloon test to 160MiB so that we make sure the RSS drops below 100 MiB, making the assertions succeed.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
