### PR TITLE
docs: Add note about TAP IP in networking setup

### DIFF
--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -28,6 +28,9 @@ sudo iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 sudo iptables -A FORWARD -i tap0 -o eth0 -j ACCEPT
 ```
 
+*Note:* The IP of the TAP device should be chosen such that it's not in the same
+subnet as the IP address of the host.
+
 *Advanced:* If you are running multiple Firecracker MicroVMs in parallel, or
 have something else on your system using `tap0` then you need to create a `tap`
 for each one, with a unique name.


### PR DESCRIPTION
Signed-off-by: Bartosz Zbytniewski <bartosz.zbytniewski.dev@gmail.com>

# Reason for This PR

It addresses https://github.com/firecracker-microvm/firecracker/issues/2620

## Description of Changes

This PR adds small note about TAP device IP address during networking setup.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~~Any newly added `unsafe` code is properly documented.~~ - N/A
- [ ] ~~Any API changes are reflected in `firecracker/swagger.yaml`.~~ - N/A
- [ ] ~~Any user-facing changes are mentioned in `CHANGELOG.md`.~~ - N/A
- [ ] ~~All added/changed functionality is tested.~~ - N/A
