### PR TITLE
Jailer limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   connections on the guest.
 - Added `GET` request on `/vm/config` that provides full microVM configuration
   as a JSON HTTP response.
+- Added `--resource-limit` flag to jailer to limit resources such as: number of
+  file descriptors allowed at a time (with a default value of 2048) and maximum
+  size of files created by the process.
 
 ### Changed
 

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -3,6 +3,7 @@
 mod cgroup;
 mod chroot;
 mod env;
+mod resource_limits;
 
 use std::ffi::{CString, NulError, OsString};
 use std::fmt;
@@ -59,6 +60,7 @@ pub enum Error {
     RmOldRootDir(io::Error),
     SetCurrentDir(io::Error),
     SetNetNs(io::Error),
+    Setrlimit(String),
     SetSid(io::Error),
     Uid(String),
     UmountOldRoot(io::Error),
@@ -192,6 +194,7 @@ impl fmt::Display for Error {
             RmOldRootDir(ref err) => write!(f, "Failed to remove old jail root directory: {}", err),
             SetCurrentDir(ref err) => write!(f, "Failed to change current directory: {}", err),
             SetNetNs(ref err) => write!(f, "Failed to join network namespace: netns: {}", err),
+            Setrlimit(ref err) => write!(f, "Failed to set limit for resource: {}", err),
             SetSid(ref err) => write!(f, "Failed to daemonize: setsid: {}", err),
             Uid(ref uid) => write!(f, "Invalid uid: {}", uid),
             UmountOldRoot(ref err) => write!(f, "Failed to unmount the old jail root: {}", err),
@@ -653,6 +656,10 @@ mod tests {
         assert_eq!(
             format!("{}", Error::SetNetNs(io::Error::from_raw_os_error(42))),
             "Failed to join network namespace: netns: No message of desired type (os error 42)",
+        );
+        assert_eq!(
+            format!("{}", Error::Setrlimit("foobar".to_string())),
+            "Failed to set limit for resource: foobar",
         );
         assert_eq!(
             format!("{}", Error::SetSid(io::Error::from_raw_os_error(42))),

--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -1,0 +1,145 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused)]
+use super::{Error, Result};
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use utils::syscall::SyscallReturnCode;
+
+// Default limit for the maximum number of file descriptors open at a time.
+const NO_FILE: u64 = 2048;
+
+#[derive(Clone, Copy)]
+pub enum Resource {
+    // Size of created files.
+    RlimitFsize,
+    // Number of open file descriptors.
+    RlimitNoFile,
+}
+
+impl From<Resource> for u32 {
+    fn from(resource: Resource) -> u32 {
+        match resource {
+            Resource::RlimitFsize => libc::RLIMIT_FSIZE as u32,
+            Resource::RlimitNoFile => libc::RLIMIT_NOFILE as u32,
+        }
+    }
+}
+
+impl Display for Resource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Resource::RlimitFsize => write!(f, "size of file"),
+            Resource::RlimitNoFile => write!(f, "number of file descriptors"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ResourceLimits {
+    file_size: Option<u64>,
+    no_file: u64,
+}
+
+impl Default for ResourceLimits {
+    fn default() -> Self {
+        ResourceLimits {
+            file_size: None,
+            no_file: NO_FILE,
+        }
+    }
+}
+
+impl ResourceLimits {
+    pub fn install(self) -> Result<()> {
+        if let Some(file_size) = self.file_size {
+            // Set file size limit.
+            ResourceLimits::set_limit(Resource::RlimitFsize, file_size)?;
+        }
+        // Set limit on number of file descriptors.
+        ResourceLimits::set_limit(Resource::RlimitNoFile, self.no_file)?;
+
+        Ok(())
+    }
+
+    fn set_limit(resource: Resource, target: libc::rlim_t) -> Result<()> {
+        let rlim: libc::rlimit = libc::rlimit {
+            rlim_cur: target,
+            rlim_max: target,
+        };
+
+        SyscallReturnCode(unsafe { libc::setrlimit(u32::from(resource) as _, &rlim) })
+            .into_empty_result()
+            .map_err(|_| Error::Setrlimit(resource.to_string()))
+    }
+
+    pub fn set_file_size(&mut self, file_size: u64) {
+        self.file_size = Some(file_size);
+    }
+
+    pub fn set_no_file(&mut self, no_file: u64) {
+        self.no_file = no_file;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_resource() {
+        assert_eq!(u32::from(Resource::RlimitFsize), libc::RLIMIT_FSIZE as _);
+        assert_eq!(u32::from(Resource::RlimitNoFile), libc::RLIMIT_NOFILE as _);
+    }
+
+    #[test]
+    fn test_display_resource() {
+        assert_eq!(
+            Resource::RlimitFsize.to_string(),
+            "size of file".to_string()
+        );
+        assert_eq!(
+            Resource::RlimitNoFile.to_string(),
+            "number of file descriptors".to_string()
+        );
+    }
+
+    #[test]
+    fn test_default_resource_limits() {
+        let mut rlimits = ResourceLimits::default();
+        assert!(rlimits.file_size.is_none());
+        assert_eq!(rlimits.no_file, NO_FILE);
+
+        rlimits.set_file_size(1);
+        assert_eq!(rlimits.file_size.unwrap(), 1);
+        rlimits.set_no_file(1);
+        assert_eq!(rlimits.no_file, 1);
+    }
+
+    #[test]
+    fn test_set_resource_limits() {
+        let resource = Resource::RlimitNoFile;
+        let new_limit = NO_FILE - 1;
+        // Get current file size limit.
+        let mut rlim: libc::rlimit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        unsafe { libc::getrlimit(u32::from(resource) as _, &mut rlim) };
+        assert_ne!(rlim.rlim_cur, new_limit);
+        assert_ne!(rlim.rlim_max, new_limit);
+
+        // Set new file size limit.
+        ResourceLimits::set_limit(resource, new_limit).unwrap();
+
+        // Verify new limit.
+        let mut rlim: libc::rlimit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        unsafe { libc::getrlimit(u32::from(resource) as _, &mut rlim) };
+        assert_eq!(rlim.rlim_cur, new_limit);
+        assert_eq!(rlim.rlim_max, new_limit);
+    }
+}

--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused)]
 use super::{Error, Result};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -9,6 +8,10 @@ use utils::syscall::SyscallReturnCode;
 
 // Default limit for the maximum number of file descriptors open at a time.
 const NO_FILE: u64 = 2048;
+// File size resource argument name.
+pub(crate) const FSIZE_ARG: &str = "fsize";
+// Number of files resource argument name.
+pub(crate) const NO_FILE_ARG: &str = "no-file";
 
 #[derive(Clone, Copy)]
 pub enum Resource {

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -36,6 +36,7 @@ class JailerContext:
     extra_args = None
     api_socket_name = None
     cgroups = None
+    resource_limits = None
 
     def __init__(
             self,
@@ -49,6 +50,7 @@ class JailerContext:
             daemonize=True,
             new_pid_ns=False,
             cgroups=None,
+            resource_limits=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -69,6 +71,7 @@ class JailerContext:
         self.extra_args = extra_args
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
+        self.resource_limits = resource_limits
         self.ramfs_subdir_name = 'ramfs'
         self._ramfs_path = None
 
@@ -113,7 +116,10 @@ class JailerContext:
         if self.cgroups is not None:
             for cgroup in self.cgroups:
                 jailer_param_list.extend(['--cgroup', str(cgroup)])
-        # applying neccessory extra args if needed
+        if self.resource_limits is not None:
+            for limit in self.resource_limits:
+                jailer_param_list.extend(['--resource-limit', str(limit)])
+        # applying necessary extra args if needed
         if len(self.extra_args) > 0:
             jailer_param_list.append('--')
             for key, value in self.extra_args.items():

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -1,10 +1,18 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests that verify the jailer's behavior."""
+import http.client as http_client
 import os
+import resource
 import stat
 import subprocess
+import time
 
+import psutil
+import requests
+import urllib3
+
+from framework.builder import SnapshotBuilder
 from framework.defs import FC_BINARY_NAME
 from framework.jailer import JailerContext
 import host_tools.cargo_build as build_tools
@@ -19,6 +27,15 @@ FILE_STATS = stat.S_IFREG | REG_PERMS
 SOCK_STATS = stat.S_IFSOCK | REG_PERMS
 # These are the stats of the devices created by tha jailer.
 CHAR_STATS = stat.S_IFCHR | stat.S_IRUSR | stat.S_IWUSR
+# Limit on file size in bytes.
+FSIZE = 2097151
+# Limit on number of file descriptors.
+NOFILE = 1024
+# Resource limits to be set by the jailer.
+RESOURCE_LIMITS = [
+    'no-file={}'.format(NOFILE),
+    'fsize={}'.format(FSIZE),
+]
 
 
 def check_stats(filepath, stats, uid, gid):
@@ -130,6 +147,19 @@ def get_cpus(node):
     return open(node_cpus_path, 'r').readline().strip()
 
 
+def check_limits(pid, no_file, fsize):
+    """Verify resource limits against expected values."""
+    # Fetch firecracker process limits for number of open fds
+    (soft, hard) = resource.prlimit(pid, resource.RLIMIT_NOFILE)
+    assert soft == no_file
+    assert hard == no_file
+
+    # Fetch firecracker process limits for maximum file size
+    (soft, hard) = resource.prlimit(pid, resource.RLIMIT_FSIZE)
+    assert soft == fsize
+    assert hard == fsize
+
+
 def test_cgroups(test_microvm_with_initrd):
     """Test the cgroups are correctly set by the jailer."""
     test_microvm = test_microvm_with_initrd
@@ -196,6 +226,115 @@ def test_args_cgroups(test_microvm_with_initrd):
         sys_cgroup,
         test_microvm.jailer.jailer_id
     )
+
+
+def test_args_default_resource_limits(test_microvm_with_initrd):
+    """Test the resource limits are correctly set by the jailer."""
+    test_microvm = test_microvm_with_initrd
+
+    test_microvm.spawn()
+
+    # Get firecracker's PID
+    pid = int(test_microvm.jailer_clone_pid)
+    assert pid != 0
+
+    # Fetch firecracker process limits for number of open fds
+    (soft, hard) = resource.prlimit(pid, resource.RLIMIT_NOFILE)
+    # Check that the default limit was set.
+    assert soft == 2048
+    assert hard == 2048
+
+    # Fetch firecracker process limits for number of open fds
+    (soft, hard) = resource.prlimit(pid, resource.RLIMIT_FSIZE)
+    # Check that no limit was set
+    assert soft == -1
+    assert hard == -1
+
+
+def test_args_resource_limits(test_microvm_with_initrd):
+    """Test the resource limits are correctly set by the jailer."""
+    test_microvm = test_microvm_with_initrd
+    test_microvm.jailer.resource_limits = RESOURCE_LIMITS
+
+    test_microvm.spawn()
+
+    # Get firecracker's PID
+    pid = int(test_microvm.jailer_clone_pid)
+    assert pid != 0
+
+    # Check limit values were correctly set.
+    check_limits(pid, NOFILE, FSIZE)
+
+
+def test_negative_file_size_limit(test_microvm_with_ssh):
+    """Test creating snapshot file fails when size exceeds `fsize` limit."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.jailer.resource_limits = ['fsize=1024']
+
+    test_microvm.spawn()
+    test_microvm.basic_config()
+    test_microvm.start()
+
+    snapshot_builder = SnapshotBuilder(test_microvm)
+    # Create directory and files for saving snapshot state and memory.
+    _snapshot_dir = snapshot_builder.create_snapshot_dir()
+
+    # Pause microVM for snapshot.
+    response = test_microvm.vm.patch(state='Paused')
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Attempt to create a snapshot.
+    try:
+        test_microvm.snapshot.create(
+            mem_file_path="/snapshot/vm.mem",
+            snapshot_path="/snapshot/vm.vmstate",
+        )
+    except (
+            http_client.RemoteDisconnected,
+            urllib3.exceptions.ProtocolError,
+            requests.exceptions.ConnectionError
+    ) as _error:
+        test_microvm.expect_kill_by_signal = True
+        # Check the microVM received signal `SIGXFSZ` (25),
+        # which corresponds to exceeding file size limit.
+        msg = 'Shutting down VM after intercepting signal 25, code 0'
+        test_microvm.check_log_message(msg)
+        time.sleep(1)
+        # Check that the process was terminated.
+        assert not psutil.pid_exists(test_microvm.jailer_clone_pid)
+    else:
+        assert False, "Negative test failed"
+
+
+def test_negative_no_file_limit(test_microvm_with_ssh):
+    """Test microVM is killed when exceeding `no-file` limit."""
+    test_microvm = test_microvm_with_ssh
+    test_microvm.jailer.resource_limits = ['no-file=3']
+
+    # pylint: disable=W0703
+    try:
+        test_microvm.spawn()
+    except Exception as error:
+        assert "No file descriptors available (os error 24)" in str(error)
+        assert test_microvm.jailer_clone_pid is None
+    else:
+        assert False, "Negative test failed"
+
+
+def test_new_pid_ns_resource_limits(test_microvm_with_ssh):
+    """Test that Firecracker process inherits jailer resource limits."""
+    test_microvm = test_microvm_with_ssh
+
+    test_microvm.jailer.daemonize = False
+    test_microvm.jailer.new_pid_ns = True
+    test_microvm.jailer.resource_limits = RESOURCE_LIMITS
+
+    test_microvm.spawn()
+
+    # Get Firecracker's PID.
+    fc_pid = test_microvm.pid_in_new_ns
+    # Check limit values were correctly set.
+    check_limits(fc_pid, NOFILE, FSIZE)
 
 
 def test_new_pid_namespace(test_microvm_with_ssh):


### PR DESCRIPTION
# Reason for This PR

Defense in depth

## Description of Changes

Focused on two approaches:

- Provide jailer with default limits on the active resources without compromising legit user scenarios by placing aggressive constraints. The `--resource-limits` argument was added to the command line arguments accepted by jailer. This accepts a format similar to `--cgroup`, so that limits on resources ca be provided in the following format: `<resource=value>`. For example:
`--resource-limits fsize=1048575`
This argument can be used  multiple times to add multiple resource limits. Current available resource values are:
  - `fsize`: The maximum size in bytes for files created by the process.
  - `no-file`: Specifies a value one greater than the maximum file descriptor number that can be opened by this process.
 
- Update the documentation with recommended means for preventing resource exhaustion attacks. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] ~Any newly added `unsafe` code is properly documented.~
- [X] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
