### PR TITLE
Fix docs of vcpu constructors

### DIFF
--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -68,7 +68,7 @@ impl KvmVcpu {
     ///
     /// # Arguments
     ///
-    /// * `id` - Represents the CPU number between [0, max vcpus).
+    /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
     pub fn new(index: u8, vm: &Vm) -> Result<Self> {
         let kvm_vcpu = vm.fd().create_vcpu(index.into()).map_err(Error::CreateFd)?;
@@ -90,7 +90,6 @@ impl KvmVcpu {
     ///
     /// # Arguments
     ///
-    /// * `vm_fd` - The kvm `VmFd` for this microvm.
     /// * `guest_mem` - The guest memory used by this microvm.
     /// * `kernel_load_addr` - Offset from `guest_mem` at which the kernel is loaded.
     pub fn configure(

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -206,9 +206,8 @@ impl Vcpu {
     ///
     /// # Arguments
     ///
-    /// * `id` - Represents the CPU number between [0, max vcpus).
-    /// * `vm_fd` - The kvm `VmFd` for the virtual machine this vcpu will get attached to.
-    /// * `msr_list` - The `MsrList` listing the supported MSRs for this vcpu.
+    /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
+    /// * `vm` - The vm to which this vcpu will get attached.
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
     pub fn new(index: u8, vm: &Vm, exit_evt: EventFd) -> Result<Self> {
         let (event_sender, event_receiver) = channel();

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -169,7 +169,7 @@ impl KvmVcpu {
     ///
     /// # Arguments
     ///
-    /// * `id` - Represents the CPU number between [0, max vcpus).
+    /// * `index` - Represents the 0-based CPU index between [0, max vcpus).
     /// * `vm` - The vm to which this vcpu will get attached.
     pub fn new(index: u8, vm: &Vm) -> Result<Self> {
         let kvm_vcpu = vm.fd().create_vcpu(index.into()).map_err(Error::VcpuFd)?;


### PR DESCRIPTION
# Reason for This PR

Making the docs up-to-date.

## Description of Changes

Updating & fixing the documentation of both `Vcpu::new()` and `KvmVcpu::new()` which seem to be outdated. Also, removed a legacy description of a `vm_fd` argument.

- [X] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes are reflected in `firecracker/swagger.yaml`.
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.
