### PR TITLE
fix reports being generated over multiple PIDs

### DIFF
--- a/tests/framework/report.py
+++ b/tests/framework/report.py
@@ -227,24 +227,17 @@ class Report(mpsing.MultiprocessSingleton):
         for item in items:
             self._collected_items[item.nodeid] = Report.TestItem(item)
 
-    def catch_return(self, item):
+    @mpsing.ipcmethod
+    def set_return(self, nodeid, rval):
         """
-        Wrap around a pytest test function.
+        Set return value for a given test.
 
-        We do this because we want to somehow catch the return value of
-        functions to set expected test criteria and actual criteria.
+        This function is called over IPC and needs picklable
+        objects as params.
         """
-        # Save the original function
-        original_function = item.obj
+        self._collected_items[nodeid].set_return(rval)
 
-        def func_wrapper(*args, **kwargs):
-            # Set the return value of this test item as the return value
-            # of the function
-            self._collected_items[item.nodeid].set_return(
-                original_function(*args, **kwargs))
-
-        item.obj = func_wrapper
-
+    @mpsing.ipcmethod
     def finish_test_item(self, report):
         """Mark a test as finished and update the report."""
         self._collected_items[report.nodeid].finish(report)


### PR DESCRIPTION
Since the scheduler launches multiple processes to run tests, the test
report functionality was always reporting the last batch of tests.

This commit adds IPC communication for the report class so that all tests
are properly reported.

Signed-off-by: Gabriel Ionescu <gbi@amazon.com>

Thanks to @alindima for signalling this :+1: 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
