### PR TITLE
test_reports: document tests and make description and type required

### DIFF
--- a/tests/framework/matrix.py
+++ b/tests/framework/matrix.py
@@ -27,6 +27,16 @@ class TestContext:
         self._context[key] = value
 
     @property
+    def firecracker(self):
+        """Return the firecracker binary artifact."""
+        return self._context.get('firecracker', None)
+
+    @firecracker.setter
+    def firecracker(self, firecracker):
+        """Setter for firecracker binary artifact."""
+        self._context['firecracker'] = firecracker
+
+    @property
     def kernel(self):
         """Return the kernel artifact."""
         return self._context.get('kernel', None)

--- a/tests/framework/report.py
+++ b/tests/framework/report.py
@@ -101,7 +101,7 @@ class Report(mpsing.MultiprocessSingleton):
         # What kind of test we're running. We only accept a predefined list
         # of tests.
         "type": ReportItem("", True, ["build", "functional", "performance",
-                                      "security", "style"], True),
+                                      "security", "style", "negative"], True),
 
         # What we take into account to pass a test
         "criteria": ReportItem("", False, None, False),

--- a/tests/framework/report.py
+++ b/tests/framework/report.py
@@ -258,9 +258,9 @@ class Report(mpsing.MultiprocessSingleton):
     def finish_test_item(self, report):
         """Mark a test as finished and update the report."""
         self._collected_items[report.nodeid].finish(report)
-        self.write_report(self._collected_items)
+        self.write_report()
 
-    def write_report(self, report_items):
+    def write_report(self):
         """Write test report to disk."""
         # Sort tests alphabetically and serialize to json
         self._data_loc.mkdir(exist_ok=True, parents=True)
@@ -269,7 +269,8 @@ class Report(mpsing.MultiprocessSingleton):
         with open(self._data_loc / Report.FNAME_JSON, "w") as json_file:
             total_duration = 0
             test_items = []
-            for item in report_items.values():
+            for test_name in sorted(self._collected_items):
+                item = self._collected_items[test_name]
                 # Don't log items marked as not done. An item may be not done
                 # because of a series of reasons, such an item being removed
                 # from the test suite at runtime (e.g. lint tests only executed

--- a/tests/integration_tests/build/test_clippy.py
+++ b/tests/integration_tests/build/test_clippy.py
@@ -18,7 +18,11 @@ TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
     TARGETS
 )
 def test_rust_clippy(target):
-    """Fails if clippy generates any error, warnings are ignored."""
+    """
+    Test that clippy does not generate any errors/warnings.
+
+    @type: build
+    """
     utils.run_cmd(
         'cargo clippy --target {} --all --profile test'
         ' -- -D warnings'.format(target))

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -46,10 +46,12 @@ SECCOMPILER_BUILD_DIR = '../build/seccompiler'
 
 @pytest.mark.timeout(400)
 def test_coverage(test_fc_session_root_path, test_session_tmp_path):
-    """Test line coverage with kcov.
+    """Test line coverage for rust tests is within bounds.
 
     The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
     after a coverage run.
+
+    @type: build
     """
     proc_model = [item for item in COVERAGE_DICT if item in PROC_MODEL]
     assert len(proc_model) == 1, "Could not get processor model!"
@@ -126,3 +128,6 @@ def test_coverage(test_fc_session_root_path, test_session_tmp_path):
 
     assert coverage - coverage_target_pct <= COVERAGE_MAX_DELTA,\
         coverage_high_msg
+
+    return f"{coverage}%", \
+        f"{coverage_target_pct}% +/- {COVERAGE_MAX_DELTA * 100}%"

--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -18,7 +18,11 @@ TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
     TARGETS
 )
 def test_unittests(test_fc_session_root_path, target):
-    """Run unit and doc tests for all supported targets."""
+    """
+    Run unit and doc tests for all supported targets.
+
+    @type: build
+    """
     extra_args = "--release --target {} ".format(target)
 
     if "musl" in target and MACHINE == "x86_64":

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -13,14 +13,17 @@ import pytest
 
 import framework.utils_cpuid as utils
 import host_tools.drive as drive_tools
-import host_tools.logging as log_tools
 import host_tools.network as net_tools
 
 MEM_LIMIT = 1000000000
 
 
 def test_api_happy_start(test_microvm_with_api):
-    """Test a regular microvm API start sequence."""
+    """
+    Test that a regular microvm API config and boot sequence works.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -32,7 +35,13 @@ def test_api_happy_start(test_microvm_with_api):
 
 
 def test_api_put_update_pre_boot(test_microvm_with_api):
-    """Test that PUT updates are allowed before the microvm boots."""
+    """
+    Test that PUT updates are allowed before the microvm boots.
+
+    Tests updates on drives, boot source and machine config.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -151,7 +160,11 @@ def test_api_put_update_pre_boot(test_microvm_with_api):
 
 
 def test_net_api_put_update_pre_boot(test_microvm_with_api):
-    """Test PUT updates on network configurations before the microvm boots."""
+    """
+    Test PUT updates on network configurations before the microvm boots.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -217,8 +230,12 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
 
-def test_api_put_machine_config(test_microvm_with_api):
-    """Test /machine_config PUT scenarios that unit tests can't cover."""
+def test_api_machine_config(test_microvm_with_api):
+    """
+    Test /machine_config PUT/PATCH scenarios that unit tests can't cover.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -328,7 +345,11 @@ def test_api_put_machine_config(test_microvm_with_api):
 
 
 def test_api_put_update_post_boot(test_microvm_with_api):
-    """Test that PUT updates are rejected after the microvm boots."""
+    """
+    Test that PUT updates are rejected after the microvm boots.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -396,7 +417,11 @@ def test_api_put_update_post_boot(test_microvm_with_api):
 
 
 def test_rate_limiters_api_config(test_microvm_with_api):
-    """Test the Firecracker IO rate limiter API."""
+    """
+    Test the IO rate limiter API config.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -539,7 +564,11 @@ def test_rate_limiters_api_config(test_microvm_with_api):
 
 
 def test_api_patch_pre_boot(test_microvm_with_api):
-    """Tests PATCH updates before the microvm boots."""
+    """
+    Test that PATCH updates are not allowed before the microvm boots.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -556,15 +585,6 @@ def test_api_patch_pre_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False
-    )
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
-
-    # Configure metrics.
-    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
-    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
-
-    response = test_microvm.metrics.put(
-        metrics_path=test_microvm.create_jailed_resource(metrics_fifo.path)
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
@@ -615,7 +635,11 @@ def test_api_patch_pre_boot(test_microvm_with_api):
 
 
 def test_api_patch_post_boot(test_microvm_with_api):
-    """Test PATCH updates after the microvm boots."""
+    """
+    Test PATCH updates after the microvm boots.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -631,15 +655,6 @@ def test_api_patch_post_boot(test_microvm_with_api):
         path_on_host=test_microvm.create_jailed_resource(fs1.path),
         is_root_device=False,
         is_read_only=False
-    )
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
-
-    # Configure metrics.
-    metrics_fifo_path = os.path.join(test_microvm.path, 'metrics_fifo')
-    metrics_fifo = log_tools.Fifo(metrics_fifo_path)
-
-    response = test_microvm.metrics.put(
-        metrics_path=test_microvm.create_jailed_resource(metrics_fifo.path)
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
@@ -676,7 +691,11 @@ def test_api_patch_post_boot(test_microvm_with_api):
 
 
 def test_drive_patch(test_microvm_with_api):
-    """Test drive PATCH before and after boot."""
+    """
+    Extensively test drive PATCH scenarios before and after boot.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -715,11 +734,13 @@ def test_drive_patch(test_microvm_with_api):
     reason="not yet implemented on aarch64"
 )
 def test_send_ctrl_alt_del(test_microvm_with_api):
-    """Test shutting down the microVM gracefully, by sending CTRL+ALT+DEL.
-
-    This relies on i8042 and AT Keyboard support being present in the guest
-    kernel.
     """
+    Test shutting down the microVM gracefully on x86, by sending CTRL+ALT+DEL.
+
+    @type: functional
+    """
+    # This relies on the i8042 device and AT Keyboard support being present in
+    # the guest kernel.
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
 
@@ -885,7 +906,11 @@ def _drive_patch(test_microvm):
 
 
 def test_api_vsock(test_microvm_with_api):
-    """Test vsock related API commands."""
+    """
+    Test vsock related API commands.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
     test_microvm.basic_config()
@@ -929,7 +954,11 @@ def test_api_vsock(test_microvm_with_api):
 
 
 def test_api_balloon(test_microvm_with_ssh_and_balloon):
-    """Test balloon related API commands."""
+    """
+    Test balloon related API commands.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
@@ -1020,7 +1049,11 @@ def test_api_balloon(test_microvm_with_ssh_and_balloon):
 
 
 def test_get_full_config(test_microvm_with_ssh_and_balloon):
-    """Configure microVM with all resources and get configuration."""
+    """
+    Test the reported configuration of a microVM configured with all resources.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
 
     expected_cfg = {}

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -11,7 +11,6 @@ import time
 
 import pytest
 
-from framework.builder import MicrovmBuilder
 import framework.utils_cpuid as utils
 import host_tools.drive as drive_tools
 import host_tools.logging as log_tools
@@ -1116,20 +1115,3 @@ def test_get_full_config(test_microvm_with_ssh_and_balloon):
     response = test_microvm.full_cfg.get()
     assert test_microvm.api_session.is_status_ok(response.status_code)
     assert response.json() == expected_cfg
-
-
-def test_negative_api_lifecycle(bin_cloner_path):
-    """Test some vm lifecycle error scenarios."""
-    builder = MicrovmBuilder(bin_cloner_path)
-    vm_instance = builder.build_vm_nano()
-    basevm = vm_instance.vm
-
-    # Try to pause microvm when not running, it must fail.
-    response = basevm.vm.patch(state='Paused')
-    assert "not supported before starting the microVM" \
-        in response.text
-
-    # Try to resume microvm when not running, it must fail.
-    response = basevm.vm.patch(state='Resumed')
-    assert "not supported before starting the microVM" \
-        in response.text

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -348,7 +348,7 @@ def test_api_put_update_post_boot(test_microvm_with_api):
     """
     Test that PUT updates are rejected after the microvm boots.
 
-    @type: functional
+    @type: negative
     """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
@@ -567,7 +567,7 @@ def test_api_patch_pre_boot(test_microvm_with_api):
     """
     Test that PATCH updates are not allowed before the microvm boots.
 
-    @type: functional
+    @type: negative
     """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()
@@ -634,11 +634,11 @@ def test_api_patch_pre_boot(test_microvm_with_api):
            "microVM." in response.text
 
 
-def test_api_patch_post_boot(test_microvm_with_api):
+def test_negative_api_patch_post_boot(test_microvm_with_api):
     """
-    Test PATCH updates after the microvm boots.
+    Test PATCH updates that are not allowed after the microvm boots.
 
-    @type: functional
+    @type: negative
     """
     test_microvm = test_microvm_with_api
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_balloon.py
+++ b/tests/integration_tests/functional/test_balloon.py
@@ -157,11 +157,15 @@ def _test_rss_memory_lower(test_microvm):
 
 # pylint: disable=C0103
 def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
-    """Check inflating the balloon makes guest use less rss memory."""
+    """
+    Test that inflating the balloon makes guest use less rss memory.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -184,11 +188,15 @@ def test_rss_memory_lower(test_microvm_with_ssh_and_balloon, network_config):
 # pylint: disable=C0103
 def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
                               network_config):
-    """Check that the output of free in guest changes with inflate."""
+    """
+    Check that the output of free in guest changes with inflate.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -228,11 +236,15 @@ def test_inflate_reduces_free(test_microvm_with_ssh_and_balloon,
 # pylint: disable=C0103
 def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
                              network_config):
-    """Verify that setting the `deflate_on_oom` to True works correctly."""
+    """
+    Verify that setting the `deflate_on_oom` to True works correctly.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -269,11 +281,15 @@ def test_deflate_on_oom_true(test_microvm_with_ssh_and_balloon,
 # pylint: disable=C0103
 def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
                               network_config):
-    """Verify that setting the `deflate_on_oom` to False works correctly."""
+    """
+    Verify that setting the `deflate_on_oom` to False works correctly.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -306,11 +322,15 @@ def test_deflate_on_oom_false(test_microvm_with_ssh_and_balloon,
 
 # pylint: disable=C0103
 def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
-    """Verify that repeatedly inflating and deflating the balloon works."""
+    """
+    Verify that repeatedly inflating and deflating the balloon works.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -378,11 +398,15 @@ def test_reinflate_balloon(test_microvm_with_ssh_and_balloon, network_config):
 
 # pylint: disable=C0103
 def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
-    """Verify that ballooning reduces RSS usage on a newly booted guest."""
+    """
+    Verify that ballooning reduces RSS usage on a newly booted guest.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -423,11 +447,15 @@ def test_size_reduction(test_microvm_with_ssh_and_balloon, network_config):
 
 # pylint: disable=C0103
 def test_stats(test_microvm_with_ssh_and_balloon, network_config):
-    """Verify that balloon stats work as expected."""
+    """
+    Verify that balloon stats work as expected.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -503,11 +531,15 @@ def test_stats(test_microvm_with_ssh_and_balloon, network_config):
 
 
 def test_stats_update(test_microvm_with_ssh_and_balloon, network_config):
-    """Verify that balloon stats update correctly."""
+    """
+    Verify that balloon stats update correctly.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh_and_balloon
     test_microvm.spawn()
     test_microvm.basic_config()
-    _tap, _, _ = test_microvm.ssh_network_config(network_config, '1')
+    _, _, _ = test_microvm.ssh_network_config(network_config, '1')
     test_microvm.ssh_config['ssh_key_path'] = os.path.join(
         test_microvm.fsfiles,
         'debian.rootfs.id_rsa'
@@ -563,7 +595,11 @@ def test_balloon_snapshot(
     network_config,
     bin_cloner_path
 ):
-    """Test that the balloon works after pause/resume."""
+    """
+    Test that the balloon works after pause/resume.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     # Create the test matrix.
@@ -693,7 +729,11 @@ def test_snapshot_compatibility(
     network_config,
     bin_cloner_path
 ):
-    """Test that the balloon serializes correctly."""
+    """
+    Test that the balloon serializes correctly.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     # Create the test matrix.
@@ -757,9 +797,9 @@ def _test_snapshot_compatibility(context):
         # This should fail as the balloon was introduced in 0.24.0.
         assert microvm.api_session.is_status_bad_request(response.status_code)
         assert (
-                   'Target version does not implement the '
-                   'virtio-balloon device'
-               ) in response.json()['fault_message']
+            'Target version does not implement the '
+            'virtio-balloon device'
+        ) in response.json()['fault_message']
 
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(microvm)
@@ -778,7 +818,11 @@ def test_memory_scrub(
     network_config,
     bin_cloner_path
 ):
-    """Test that the memory is zeroed after deflate."""
+    """
+    Test that the memory is zeroed after deflate.
+
+    @type: functional
+    """
     logger = logging.getLogger()
 
     # Create the test matrix.

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -13,7 +13,11 @@ from framework.utils import get_firecracker_version_from_toml, run_cmd
 
 
 def test_describe_snapshot_all_versions(bin_cloner_path):
-    """Test `--describe-snapshot` correctness for all snapshot versions."""
+    """
+    Test `--describe-snapshot` correctness for all snapshot versions.
+
+    @type: functional
+    """
     logger = logging.getLogger("describe_snapshot")
     builder = MicrovmBuilder(bin_cloner_path)
     artifacts = ArtifactCollection(_test_images_s3_bucket())

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -45,7 +45,11 @@ def _configure_vm_from_json(test_microvm, vm_config_file):
     ["framework/vm_config.json"]
 )
 def test_config_start_with_api(test_microvm_with_ssh, vm_config_file):
-    """Test if a microvm configured from file boots successfully."""
+    """
+    Test if a microvm configured from file boots successfully.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
 
     _configure_vm_from_json(test_microvm, vm_config_file)
@@ -67,7 +71,11 @@ def test_config_start_with_api(test_microvm_with_ssh, vm_config_file):
     ["framework/vm_config.json"]
 )
 def test_config_start_no_api(test_microvm_with_ssh, vm_config_file):
-    """Test microvm start when API server thread is disabled."""
+    """
+    Test microvm start when API server thread is disabled.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
 
     _configure_vm_from_json(test_microvm, vm_config_file)
@@ -92,7 +100,7 @@ def test_config_start_no_api(test_microvm_with_ssh, vm_config_file):
             "cmd": cmd,
             "find_regex": re.compile("^(?!.*fc_api)(?:.*)?firecracker",
                                      re.DOTALL)
-            },
+        },
         exceptions=RuntimeError,
         tries=10,
         delay=1)

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -11,7 +11,11 @@ NO_OF_MICROVMS = 20
 
 @decorators.test_context('ssh', NO_OF_MICROVMS)
 def test_run_concurrency(test_multiple_microvms, network_config):
-    """Check we can spawn multiple microvms."""
+    """
+    Check we can spawn multiple microvms.
+
+    @type: functional
+    """
     microvms = test_multiple_microvms
 
     for i in range(NO_OF_MICROVMS):

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -48,7 +48,11 @@ def _check_cpu_features_arm(test_microvm):
     [True, False],
 )
 def test_cpuid(test_microvm_with_ssh, network_config, num_vcpus, htt):
-    """Check the CPUID for a microvm with the specified config."""
+    """
+    Check the CPUID for a microvm with the specified config.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)
@@ -62,7 +66,11 @@ def test_cpuid(test_microvm_with_ssh, network_config, num_vcpus, htt):
     reason="The CPU features on x86 are tested as part of the CPU templates."
 )
 def test_cpu_features(test_microvm_with_ssh, network_config):
-    """Check the CPU features for a microvm with the specified config."""
+    """
+    Check the CPU features for a microvm with the specified config.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
     vm.basic_config()
@@ -76,7 +84,8 @@ def test_cpu_features(test_microvm_with_ssh, network_config):
     reason="The CPU brand string is masked only on x86_64."
 )
 def test_brand_string(test_microvm_with_ssh, network_config):
-    """Ensure good formatting for the guest band string.
+    """
+    Ensure good formatting for the guest brand string.
 
     * For Intel CPUs, the guest brand string should be:
         Intel(R) Xeon(R) Processor @ {host frequency}
@@ -86,6 +95,8 @@ def test_brand_string(test_microvm_with_ssh, network_config):
         AMD EPYC
     * For other CPUs, the guest brand string should be:
         ""
+
+    @type: functional
     """
     cif = open('/proc/cpuinfo', 'r')
     host_brand_string = None
@@ -137,14 +148,14 @@ def test_brand_string(test_microvm_with_ssh, network_config):
 )
 @pytest.mark.parametrize("cpu_template", ["T2", "C3"])
 def test_cpu_template(test_microvm_with_ssh, network_config, cpu_template):
-    """Check that AVX2 & AVX512 instructions are disabled.
+    """
+    Test masked and enabled cpu features against the expected template.
 
-    This is a rather dummy test for checking that some features are not
-    exposed by mistake. It is a first step into checking the t2 & c3
-    templates. In a next iteration we should check **all** cpuid entries, not
-    just these features. We can achieve this with a template
-    containing all features on a t2/c3 instance and check that the cpuid in
-    the guest is an exact match of the template.
+    This test checks that all expected masked features are not present in the
+    guest and that expected enabled features are present for each of the
+    supported CPU templates.
+
+    @type: functional
     """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
@@ -168,13 +179,13 @@ def test_cpu_template(test_microvm_with_ssh, network_config, cpu_template):
         return
 
     assert test_microvm.api_session.is_status_no_content(
-            response.status_code)
+        response.status_code)
     check_masked_features(test_microvm, cpu_template)
     check_enabled_features(test_microvm, cpu_template)
 
 
 def check_masked_features(test_microvm, cpu_template):
-    """Check that AVX2 & AVX512 instructions are disabled."""
+    """Verify the masked features of the given template."""
     common_masked_features_lscpu = ["dtes64", "monitor", "ds_cpl", "tm2",
                                     "cnxt-id", "sdbg", "xtpr", "pdcm",
                                     "osxsave",

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -17,7 +17,11 @@ MB = 1024 * 1024
 
 
 def test_rescan_file(test_microvm_with_ssh, network_config):
-    """Verify that rescan works with a file-backed virtio device."""
+    """
+    Verify that rescan works with a file-backed virtio device.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -69,10 +73,13 @@ def test_rescan_file(test_microvm_with_ssh, network_config):
 
 
 def test_device_ordering(test_microvm_with_ssh, network_config):
-    """Verify device ordering.
+    """
+    Verify device ordering.
 
     The root device should correspond to /dev/vda in the guest and
     the order of the other devices should match their configuration order.
+
+    @type: functional
     """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
@@ -130,7 +137,11 @@ def test_device_ordering(test_microvm_with_ssh, network_config):
 
 
 def test_rescan_dev(test_microvm_with_ssh, network_config):
-    """Verify that rescan works with a device-backed virtio device."""
+    """
+    Verify that rescan works with a device-backed virtio device.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
     session = test_microvm.api_session
@@ -184,7 +195,11 @@ def test_rescan_dev(test_microvm_with_ssh, network_config):
 
 
 def test_non_partuuid_boot(test_microvm_with_ssh, network_config):
-    """Test the output reported by blockdev when booting from /dev/vda."""
+    """
+    Test the output reported by blockdev when booting from /dev/vda.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -222,7 +237,11 @@ def test_non_partuuid_boot(test_microvm_with_ssh, network_config):
 
 
 def test_partuuid_boot(test_microvm_with_partuuid, network_config):
-    """Test the output reported by blockdev when booting with PARTUUID."""
+    """
+    Test the output reported by blockdev when booting with PARTUUID.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_partuuid
     test_microvm.spawn()
 
@@ -256,7 +275,11 @@ def test_partuuid_boot(test_microvm_with_partuuid, network_config):
 
 
 def test_partuuid_update(test_microvm_with_ssh, network_config):
-    """Test successful switching from PARTUUID boot to /dev/vda boot."""
+    """
+    Test successful switching from PARTUUID boot to /dev/vda boot.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -296,7 +319,11 @@ def test_partuuid_update(test_microvm_with_ssh, network_config):
 
 
 def test_patch_drive(test_microvm_with_ssh, network_config):
-    """Test replacing the backing filesystem after guest boot works."""
+    """
+    Test replacing the backing filesystem after guest boot works.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -339,7 +366,11 @@ def test_patch_drive(test_microvm_with_ssh, network_config):
 
 
 def test_no_flush(test_microvm_with_ssh, network_config):
-    """Verify default block ignores flush."""
+    """
+    Verify default block ignores flush.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -384,7 +415,11 @@ def test_no_flush(test_microvm_with_ssh, network_config):
 
 
 def test_flush(test_microvm_with_ssh, network_config):
-    """Verify block with flush actually flushes."""
+    """
+    Verify block with flush actually flushes.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -426,7 +461,11 @@ def test_flush(test_microvm_with_ssh, network_config):
 
 
 def test_block_default_cache_old_version(test_microvm_with_ssh):
-    """Verify that saving a snapshot for old versions works correctly."""
+    """
+    Verify that saving a snapshot for old versions works correctly.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -451,11 +490,11 @@ def test_block_default_cache_old_version(test_microvm_with_ssh):
 
     # Create the snapshot for a version without block cache type.
     response = test_microvm.snapshot.create(
-            mem_file_path='memfile',
-            snapshot_path='snapsfile',
-            diff=False,
-            version='0.24.0'
-        )
+        mem_file_path='memfile',
+        snapshot_path='snapsfile',
+        diff=False,
+        version='0.24.0'
+    )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
     # We should find a warning in the logs for this case as this
@@ -494,7 +533,11 @@ def check_iops_limit(ssh_connection, block_size, count, min_time, max_time):
 
 
 def test_patch_drive_limiter(test_microvm_with_ssh, network_config):
-    """Test replacing the drive rate-limiter after guest boot works."""
+    """
+    Test replacing the drive rate-limiter after guest boot works.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.jailer.daemonize = False
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_error_code.py
+++ b/tests/integration_tests/functional/test_error_code.py
@@ -14,7 +14,11 @@ from framework.utils import wait_process_termination
            "under the same conditions."
 )
 def test_enosys_error_code(test_microvm_with_initrd):
-    """Test that ENOSYS error is caught and firecracker exits gracefully."""
+    """
+    Test that ENOSYS error is caught and firecracker exits gracefully.
+
+    @type: functional
+    """
     # On aarch64 we trigger this error by adding to initrd a C program that
     # maps a file into memory and then tries to load the content from an
     # offset in the file bigger than its length into a register asm volatile

--- a/tests/integration_tests/functional/test_initrd.py
+++ b/tests/integration_tests/functional/test_initrd.py
@@ -9,7 +9,11 @@ INITRD_FILESYSTEM = "rootfs"
 
 def test_microvm_initrd_with_serial(
         test_microvm_with_initrd):
-    """Check microvm started with an inird has / mounted as rootfs."""
+    """
+    Test that a boot using initrd successfully loads the root filesystem.
+
+    @type: functional
+    """
     vm = test_microvm_with_initrd
     vm.jailer.daemonize = False
     vm.spawn()

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -72,7 +72,11 @@ def check_log_message_format(log_str, instance_id, level, show_level,
 
 
 def test_no_origin_logs(test_microvm_with_ssh):
-    """Check that logs do not contain the origin (i.e file and line number)."""
+    """
+    Check that logs do not contain the origin (i.e file and line number).
+
+    @type: functional
+    """
     _test_log_config(
         microvm=test_microvm_with_ssh,
         show_level=True,
@@ -81,7 +85,11 @@ def test_no_origin_logs(test_microvm_with_ssh):
 
 
 def test_no_level_logs(test_microvm_with_ssh):
-    """Check that logs do not contain the level."""
+    """
+    Check that logs do not contain the level.
+
+    @type: functional
+    """
     _test_log_config(
         microvm=test_microvm_with_ssh,
         show_level=False,
@@ -90,7 +98,11 @@ def test_no_level_logs(test_microvm_with_ssh):
 
 
 def test_no_nada_logs(test_microvm_with_ssh):
-    """Check that logs do not contain either level or origin."""
+    """
+    Check that logs do not contain either level or origin.
+
+    @type: functional
+    """
     _test_log_config(
         microvm=test_microvm_with_ssh,
         show_level=False,
@@ -99,12 +111,20 @@ def test_no_nada_logs(test_microvm_with_ssh):
 
 
 def test_info_logs(test_microvm_with_ssh):
-    """Check output of logs when minimum level to be displayed is info."""
+    """
+    Check output of logs when minimum level to be displayed is info.
+
+    @type: functional
+    """
     _test_log_config(microvm=test_microvm_with_ssh)
 
 
 def test_warn_logs(test_microvm_with_ssh):
-    """Check output of logs when minimum level to be displayed is warning."""
+    """
+    Check output of logs when minimum level to be displayed is warning.
+
+    @type: functional
+    """
     _test_log_config(
         microvm=test_microvm_with_ssh,
         log_level='Warning'
@@ -112,7 +132,11 @@ def test_warn_logs(test_microvm_with_ssh):
 
 
 def test_error_logs(test_microvm_with_ssh):
-    """Check output of logs when minimum level of logs displayed is error."""
+    """
+    Check output of logs when minimum level of logs displayed is error.
+
+    @type: functional
+    """
     _test_log_config(
         microvm=test_microvm_with_ssh,
         log_level='Error'
@@ -120,7 +144,11 @@ def test_error_logs(test_microvm_with_ssh):
 
 
 def test_log_config_failure(test_microvm_with_api):
-    """Check passing invalid FIFOs is detected and reported as an error."""
+    """
+    Check passing invalid FIFOs is detected and reported as an error.
+
+    @type: functional
+    """
     microvm = test_microvm_with_api
     microvm.spawn(create_logger=False)
     microvm.basic_config()
@@ -136,7 +164,11 @@ def test_log_config_failure(test_microvm_with_api):
 
 
 def test_api_requests_logs(test_microvm_with_api):
-    """Test that API requests are logged."""
+    """
+    Test that API requests are logged.
+
+    @type: functional
+    """
     microvm = test_microvm_with_api
     microvm.spawn(create_logger=False)
     microvm.basic_config()
@@ -243,7 +275,7 @@ def _test_log_config(
         level=log_level,
         show_level=show_level,
         show_log_origin=show_origin
-       )
+    )
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     microvm.start_console_logger(log_fifo)

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -16,7 +16,11 @@ MAX_DEVICES_ATTACHED = 19
     reason="Firecracker supports 24 IRQs on x86_64."
 )
 def test_attach_maximum_devices(test_microvm_with_ssh, network_config):
-    """Test attaching maximum number of devices to the microVM."""
+    """
+    Test attaching maximum number of devices to the microVM.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -50,7 +54,11 @@ def test_attach_maximum_devices(test_microvm_with_ssh, network_config):
     reason="Firecracker supports 24 IRQs on x86_64."
 )
 def test_attach_too_many_devices(test_microvm_with_ssh, network_config):
-    """Test attaching to a microVM more devices than available IRQs."""
+    """
+    Test attaching to a microVM more devices than available IRQs.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -57,7 +57,7 @@ def test_attach_too_many_devices(test_microvm_with_ssh, network_config):
     """
     Test attaching to a microVM more devices than available IRQs.
 
-    @type: functional
+    @type: negative
     """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_max_vcpus.py
+++ b/tests/integration_tests/functional/test_max_vcpus.py
@@ -7,7 +7,11 @@ MAX_VCPUS = 32
 
 
 def test_max_vcpus(test_microvm_with_ssh, network_config):
-    """Test if all configured guest vcpus are online."""
+    """
+    Test if all configured guest vcpus are online.
+
+    @type: functional
+    """
     microvm = test_microvm_with_ssh
     microvm.spawn()
 

--- a/tests/integration_tests/functional/test_metrics.py
+++ b/tests/integration_tests/functional/test_metrics.py
@@ -10,7 +10,11 @@ import host_tools.logging as log_tools
 
 
 def test_flush_metrics(test_microvm_with_api):
-    """Check the `FlushMetrics` vmm action."""
+    """
+    Check the `FlushMetrics` vmm action.
+
+    @type: functional
+    """
     microvm = test_microvm_with_api
     microvm.spawn()
     microvm.basic_config()

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -14,7 +14,11 @@ def _assert_out(stdout, stderr, expected):
 
 
 def test_custom_ipv4(test_microvm_with_ssh, network_config):
-    """Test the API for MMDS custom ipv4 support."""
+    """
+    Test the API for MMDS custom ipv4 support.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -70,9 +74,9 @@ def test_custom_ipv4(test_microvm_with_ssh, network_config):
 
     test_microvm.basic_config(vcpu_count=1)
     _tap = test_microvm.ssh_network_config(
-         network_config,
-         '1',
-         allow_mmds_requests=True
+        network_config,
+        '1',
+        allow_mmds_requests=True
     )
 
     test_microvm.start()
@@ -114,7 +118,11 @@ def test_custom_ipv4(test_microvm_with_ssh, network_config):
 
 
 def test_json_response(test_microvm_with_ssh, network_config):
-    """Test the MMDS json response."""
+    """
+    Test the MMDS json response.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -149,9 +157,9 @@ def test_json_response(test_microvm_with_ssh, network_config):
 
     test_microvm.basic_config(vcpu_count=1)
     _tap = test_microvm.ssh_network_config(
-         network_config,
-         '1',
-         allow_mmds_requests=True
+        network_config,
+        '1',
+        allow_mmds_requests=True
     )
 
     test_microvm.start()
@@ -184,8 +192,12 @@ def test_json_response(test_microvm_with_ssh, network_config):
     assert json.load(stdout) == 512
 
 
-def test_imds_response(test_microvm_with_ssh, network_config):
-    """Test the MMDS IMDS response."""
+def test_mmds_response(test_microvm_with_ssh, network_config):
+    """
+    Test MMDS responses to various datastore requests.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -271,7 +283,11 @@ def test_imds_response(test_microvm_with_ssh, network_config):
 
 
 def test_larger_than_mss_payloads(test_microvm_with_ssh, network_config):
-    """Test MMDS content for payloads larger than MSS."""
+    """
+    Test MMDS content for payloads larger than MSS.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -343,7 +359,11 @@ def test_larger_than_mss_payloads(test_microvm_with_ssh, network_config):
 
 
 def test_mmds_dummy(test_microvm_with_ssh):
-    """Test the API and guest facing features of the Micro MetaData Service."""
+    """
+    Test the API and guest facing features of the microVM MetaData Service.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -396,7 +416,11 @@ def test_mmds_dummy(test_microvm_with_ssh):
 
 
 def test_guest_mmds_hang(test_microvm_with_ssh, network_config):
-    """Test the MMDS json response."""
+    """
+    Test the MMDS json endpoint when Content-Length larger than actual length.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -420,9 +444,9 @@ def test_guest_mmds_hang(test_microvm_with_ssh, network_config):
 
     test_microvm.basic_config(vcpu_count=1)
     _tap = test_microvm.ssh_network_config(
-         network_config,
-         '1',
-         allow_mmds_requests=True
+        network_config,
+        '1',
+        allow_mmds_requests=True
     )
 
     test_microvm.start()

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -11,7 +11,11 @@ IPERF_BINARY = 'iperf3'
 
 
 def test_high_ingress_traffic(test_microvm_with_ssh, network_config):
-    """Run iperf rx with high UDP traffic."""
+    """
+    Run iperf rx with high UDP traffic.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 

--- a/tests/integration_tests/functional/test_net_config_space.py
+++ b/tests/integration_tests/functional/test_net_config_space.py
@@ -19,7 +19,11 @@ PAYLOAD_DATA_SIZE = 20
 
 def test_net_change_mac_address(test_microvm_with_ssh, network_config,
                                 change_net_config_space_bin):
-    """Test changing the MAC address of the network device."""
+    """
+    Test changing the MAC address of the network device.
+
+    @type: functional
+    """
     global PAYLOAD_DATA_SIZE
 
     test_microvm = test_microvm_with_ssh

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -10,7 +10,7 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 
 
 def verify_net_emulation_paused(metrics):
-    """Verify net emulation is paused base on provided metrics."""
+    """Verify net emulation is paused based on provided metrics."""
     net_metrics = metrics['net']
     assert net_metrics['rx_queue_event_count'] == 0
     assert net_metrics['rx_partial_writes'] == 0
@@ -141,3 +141,24 @@ def test_describe_instance(bin_cloner_path):
     assert "Running" in response.text
 
     microvm.kill()
+
+
+def test_pause_resume_preboot(bin_cloner_path):
+    """
+    Test pause/resume operations are not allowed pre-boot.
+
+    @type: functional
+    """
+    builder = MicrovmBuilder(bin_cloner_path)
+    vm_instance = builder.build_vm_nano()
+    basevm = vm_instance.vm
+
+    # Try to pause microvm when not running, it must fail.
+    response = basevm.vm.patch(state='Paused')
+    assert "not supported before starting the microVM" \
+        in response.text
+
+    # Try to resume microvm when not running, it must fail.
+    response = basevm.vm.patch(state='Resumed')
+    assert "not supported before starting the microVM" \
+        in response.text

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -30,7 +30,11 @@ def verify_net_emulation_paused(metrics):
 
 
 def test_pause_resume(bin_cloner_path):
-    """Test scenario: boot/pause/resume."""
+    """
+    Test scenario: boot/pause/resume.
+
+    @type: functional
+    """
     builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = builder.build_vm_nano()
     microvm = vm_instance.vm
@@ -103,7 +107,11 @@ def test_pause_resume(bin_cloner_path):
 
 
 def test_describe_instance(bin_cloner_path):
-    """Test scenario: DescribeInstance different states."""
+    """
+    Test scenario: DescribeInstance different states.
+
+    @type: functional
+    """
     builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = builder.build_vm_nano()
     microvm = vm_instance.vm

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -155,7 +155,7 @@ def test_pause_resume_preboot(bin_cloner_path):
     """
     Test pause/resume operations are not allowed pre-boot.
 
-    @type: functional
+    @type: negative
     """
     builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = builder.build_vm_nano()

--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -31,7 +31,11 @@ MAX_TIME_DIFF = 25
 
 
 def test_tx_rate_limiting(test_microvm_with_ssh, network_config):
-    """Run iperf tx with and without rate limiting; check limiting effect."""
+    """
+    Run iperf tx with and without rate limiting; check limiting effect.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -91,7 +95,11 @@ def test_tx_rate_limiting(test_microvm_with_ssh, network_config):
 
 
 def test_rx_rate_limiting(test_microvm_with_ssh, network_config):
-    """Run iperf rx with and without rate limiting; check limiting effect."""
+    """
+    Run iperf rx with and without rate limiting; check limiting effect.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 
@@ -152,7 +160,11 @@ def test_rx_rate_limiting(test_microvm_with_ssh, network_config):
 
 
 def test_rx_rate_limiting_cpu_load(test_microvm_with_ssh, network_config):
-    """Run iperf rx with rate limiting; verify cpu load is below threshold."""
+    """
+    Run iperf rx with rate limiting; verify cpu load is below threshold.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()
 

--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -16,7 +16,11 @@ DMESG_LOG_REGEX = r'rtc-pl031\s+(\d+).rtc: setting system clock to'
     reason="RTC exists only on aarch64."
 )
 def test_rtc(test_microvm_with_ssh, network_config):
-    """Test RTC functionality on aarch64."""
+    """
+    Test RTC functionality on aarch64.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
     vm.memory_monitor = None

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -60,7 +60,11 @@ class TestFinished(TestState):  # pylint: disable=too-few-public-methods
 
 
 def test_serial_console_login(test_microvm_with_ssh):
-    """Test serial console login."""
+    """
+    Test serial console login.
+
+    @type: functional
+    """
     microvm = test_microvm_with_ssh
     microvm.jailer.daemonize = False
     microvm.spawn()
@@ -106,7 +110,11 @@ def send_bytes(tty, bytes_count, timeout=60):
 
 
 def test_serial_dos(test_microvm_with_ssh):
-    """Test serial console behavior under DoS."""
+    """
+    Test serial console behavior under DoS.
+
+    @type: functional
+    """
     microvm = test_microvm_with_ssh
     microvm.jailer.daemonize = False
     microvm.spawn()
@@ -134,7 +142,11 @@ def test_serial_dos(test_microvm_with_ssh):
 
 
 def test_serial_block(test_microvm_with_ssh, network_config):
-    """Test that writing to stdout never blocks the vCPU thread."""
+    """
+    Test that writing to stdout never blocks the vCPU thread.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.jailer.daemonize = False
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -13,7 +13,11 @@ import host_tools.network as net_tools  # pylint: disable=import-error
 
 
 def test_reboot(test_microvm_with_ssh, network_config):
-    """Test reboot from guest kernel."""
+    """
+    Test reboot from guest.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
     test_microvm.jailer.daemonize = False
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -31,7 +31,11 @@ signum_str = {
     [SIGBUS, SIGSEGV, SIGXFSZ, SIGXCPU, SIGPIPE, SIGHUP, SIGILL, SIGSYS]
 )
 def test_generic_signal_handler(test_microvm_with_api, signum):
-    """Test signal handling for all handled signals."""
+    """
+    Test signal handling for all handled signals.
+
+    @type: functional
+    """
     microvm = test_microvm_with_api
     microvm.spawn()
 
@@ -80,7 +84,11 @@ def test_generic_signal_handler(test_microvm_with_api, signum):
 
 
 def test_sigxfsz_handler(test_microvm_with_api):
-    """Test intercepting and handling SIGXFSZ."""
+    """
+    Test intercepting and handling SIGXFSZ.
+
+    @type: functional
+    """
     microvm = test_microvm_with_api
     microvm.spawn()
 
@@ -128,7 +136,11 @@ def test_sigxfsz_handler(test_microvm_with_api):
 
 
 def test_handled_signals(test_microvm_with_ssh, network_config):
-    """Test that handled signals don't kill the microVM."""
+    """
+    Test that handled signals don't kill the microVM.
+
+    @type: functional
+    """
     microvm = test_microvm_with_ssh
     microvm.spawn()
 

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -38,7 +38,11 @@ scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
     reason="Not supported yet."
 )
 def test_restore_old_snapshot_all_devices(bin_cloner_path):
-    """Test scenario: restore previous version snapshots in current version."""
+    """
+    Test scenario: restore previous version snapshots in current version.
+
+    @type: functional
+    """
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
@@ -89,7 +93,11 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
     reason="Not supported yet."
 )
 def test_restore_old_version_all_devices(bin_cloner_path):
-    """Test scenario: restore snapshot in previous versions of Firecracker."""
+    """
+    Test scenario: restore snapshot in previous versions of Firecracker.
+
+    @type: functional
+    """
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_version_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
@@ -142,7 +150,11 @@ def test_restore_old_version_all_devices(bin_cloner_path):
     reason="TSC is x86_64 specific."
 )
 def test_restore_no_tsc(bin_cloner_path):
-    """Test scenario: restore a snapshot without TSC in current version."""
+    """
+    Test scenario: restore a snapshot without TSC in current version.
+
+    @type: functional
+    """
     logger = logging.getLogger("no_tsc_snapshot")
     builder = MicrovmBuilder(bin_cloner_path)
 
@@ -194,7 +206,11 @@ def test_restore_no_tsc(bin_cloner_path):
     reason="TSC is x86_64 specific."
 )
 def test_save_tsc_old_version(bin_cloner_path):
-    """Test TSC warning message when saving old snapshot."""
+    """
+    Test TSC warning message when saving old snapshot.
+
+    @type: functional
+    """
     vm_builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = vm_builder.build_vm_nano()
     vm = vm_instance.vm

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -432,7 +432,7 @@ def test_negative_postload_api(bin_cloner_path):
     """
     Test APIs fail after loading from snapshot.
 
-    @type: functional
+    @type: negative
     """
     logger = logging.getLogger("snapshot_api_fail")
 
@@ -485,7 +485,7 @@ def test_negative_snapshot_permissions(bin_cloner_path):
     """
     Test missing permission error scenarios.
 
-    @type: functional
+    @type: negative
     """
     logger = logging.getLogger("snapshot_negative")
     vm_builder = MicrovmBuilder(bin_cloner_path)
@@ -572,7 +572,7 @@ def test_negative_snapshot_create(bin_cloner_path):
     """
     Test create snapshot before pause.
 
-    @type: functional
+    @type: negative
     """
     vm_builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = vm_builder.build_vm_nano()

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -203,7 +203,11 @@ def _test_compare_mem_files(context):
 
 
 def test_patch_drive_snapshot(bin_cloner_path):
-    """Test scenario: 5 full sequential snapshots."""
+    """
+    Test that a patched drive is correctly used by guests loaded from snapshot.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     vm_builder = MicrovmBuilder(bin_cloner_path)
@@ -265,7 +269,11 @@ def test_5_full_snapshots(network_config,
                           bin_cloner_path,
                           bin_vsock_path,
                           test_fc_session_root_path):
-    """Test scenario: 5 full sequential snapshots."""
+    """
+    Create and load 5 full sequential snapshots.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -305,7 +313,11 @@ def test_5_inc_snapshots(network_config,
                          bin_cloner_path,
                          bin_vsock_path,
                          test_fc_session_root_path):
-    """Test scenario: 5 incremental snapshots with disk intensive workload."""
+    """
+    Create and load 5 incremental snapshots.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -343,12 +355,9 @@ def test_5_inc_snapshots(network_config,
 
 def test_load_snapshot_failure_handling(test_microvm_with_api):
     """
-    Test scenario.
+    Test error case of loading empty snapshot files.
 
-    1. Create two empty files representing snapshot memory and
-    microvm state
-    2. Try to load a VM snapshot out of the empty files.
-    3. Verify that an error was shown and the FC process is terminated.
+    @type: functional
     """
     logger = logging.getLogger("snapshot_load_failure")
     vm = test_microvm_with_api
@@ -384,7 +393,11 @@ def test_load_snapshot_failure_handling(test_microvm_with_api):
 
 def test_cmp_full_and_first_diff_mem(network_config,
                                      bin_cloner_path):
-    """Test scenario: cmp memory of 2 consecutive full and diff snapshots."""
+    """
+    Compare memory of 2 consecutive full and diff snapshots.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_sequence")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -416,7 +429,11 @@ def test_cmp_full_and_first_diff_mem(network_config,
 
 
 def test_negative_postload_api(bin_cloner_path):
-    """Test APIs fail after loading from snapshot."""
+    """
+    Test APIs fail after loading from snapshot.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_api_fail")
 
     vm_builder = MicrovmBuilder(bin_cloner_path)
@@ -465,7 +482,11 @@ def test_negative_postload_api(bin_cloner_path):
 
 
 def test_negative_snapshot_permissions(bin_cloner_path):
-    """Test missing permission error scenarios."""
+    """
+    Test missing permission error scenarios.
+
+    @type: functional
+    """
     logger = logging.getLogger("snapshot_negative")
     vm_builder = MicrovmBuilder(bin_cloner_path)
 
@@ -548,7 +569,11 @@ def test_negative_snapshot_permissions(bin_cloner_path):
 
 
 def test_negative_snapshot_create(bin_cloner_path):
-    """Test create snapshot before pause."""
+    """
+    Test create snapshot before pause.
+
+    @type: functional
+    """
     vm_builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = vm_builder.build_vm_nano()
     vm = vm_instance.vm

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -115,7 +115,7 @@ def test_create_with_too_many_devices(test_microvm_with_ssh, network_config):
     """
     Create snapshot with unexpected device count for previous versions.
 
-    @type: functional
+    @type: negative
     """
     test_microvm = test_microvm_with_ssh
 

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -40,7 +40,11 @@ def _create_and_start_microvm_with_net_devices(test_microvm,
 
 
 def test_create_v0_23_snapshot(test_microvm_with_ssh):
-    """Exercise creating a snapshot targeting v0.23 on all platforms."""
+    """
+    Exercise creating a snapshot targeting v0.23 on all platforms.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
 
     _create_and_start_microvm_with_net_devices(test_microvm)
@@ -74,7 +78,11 @@ def test_create_v0_23_snapshot(test_microvm_with_ssh):
     reason="Exercises specific x86_64 functionality."
 )
 def test_create_with_prev_device_count(test_microvm_with_ssh, network_config):
-    """Create snapshot with expected device count for previous versions."""
+    """
+    Create snapshot with expected device count for previous versions.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
 
     # Create and start a microVM with (`FC_V0_23_MAX_DEVICES_ATTACHED` - 1)
@@ -104,7 +112,11 @@ def test_create_with_prev_device_count(test_microvm_with_ssh, network_config):
     reason="Exercises specific x86_64 functionality."
 )
 def test_create_with_too_many_devices(test_microvm_with_ssh, network_config):
-    """Create snapshot with unexpected device count for previous versions."""
+    """
+    Create snapshot with unexpected device count for previous versions.
+
+    @type: functional
+    """
     test_microvm = test_microvm_with_ssh
 
     # Create and start a microVM with `FC_V0_23_MAX_DEVICES_ATTACHED`
@@ -137,7 +149,11 @@ def test_create_with_too_many_devices(test_microvm_with_ssh, network_config):
 
 
 def test_create_invalid_version(bin_cloner_path):
-    """Test scenario: create snapshot targeting invalid version."""
+    """
+    Test scenario: create snapshot targeting invalid version.
+
+    @type: functional
+    """
     # Use a predefined vm instance.
     builder = MicrovmBuilder(bin_cloner_path)
     test_microvm = builder.build_vm_nano().vm

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -113,7 +113,11 @@ def _check_cache_topology_arm(test_microvm, no_cpus):
     [True, False],
 )
 def test_cpu_topology(test_microvm_with_ssh, network_config, num_vcpus, htt):
-    """Check the CPU topology for a microvm with the specified config."""
+    """
+    Check the CPU topology for a microvm with the specified config.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)
@@ -133,7 +137,11 @@ def test_cpu_topology(test_microvm_with_ssh, network_config, num_vcpus, htt):
     [True, False],
 )
 def test_cache_topology(test_microvm_with_ssh, network_config, num_vcpus, htt):
-    """Check the cache topology for a microvm with the specified config."""
+    """
+    Check the cache topology for a microvm with the specified config.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -38,7 +38,13 @@ def test_vsock(
         bin_vsock_path,
         test_fc_session_root_path
 ):
-    """Vsock tests. See the module docstring for a high-level description."""
+    """
+    Test guest and host vsock initiated connections.
+
+    Check the module docstring for details on the setup.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
 
@@ -126,7 +132,11 @@ def test_vsock_epipe(
         bin_vsock_path,
         test_fc_session_root_path
 ):
-    """Vsock negative test to validate SIGPIPE/EPIPE handling."""
+    """
+    Vsock negative test to validate SIGPIPE/EPIPE handling.
+
+    @type: functional
+    """
     vm = test_microvm_with_ssh
     vm.spawn()
 
@@ -204,6 +214,8 @@ def test_vsock_transport_reset(
        Else, the connection was not closed and the test fails.
     6. Close VM -> Load VM from Snapshot -> check that vsock
        device is still working.
+
+    @type: functional
     """
     vm_builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = vm_builder.build_vm_nano()

--- a/tests/integration_tests/functional/test_vsock.py
+++ b/tests/integration_tests/functional/test_vsock.py
@@ -135,7 +135,7 @@ def test_vsock_epipe(
     """
     Vsock negative test to validate SIGPIPE/EPIPE handling.
 
-    @type: functional
+    @type: negative
     """
     vm = test_microvm_with_ssh
     vm.spawn()

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -247,7 +247,11 @@ def consume_fio_output(cons, result, numjobs, mode, bs, env_id, logs_path):
 @pytest.mark.nonci
 @pytest.mark.timeout(CONFIG["time"] * 1000)  # 1.40 hours
 def test_block_performance(bin_cloner_path, results_file_dumper):
-    """Test network throughput driver for multiple artifacts."""
+    """
+    Test block performance for multiple vm configurations.
+
+    @type: performance
+    """
     logger = logging.getLogger(TEST_ID)
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_1024mb"))

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -18,7 +18,11 @@ TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'
 
 
 def test_no_boottime(test_microvm_with_api):
-    """Check that boot timer device not present by default."""
+    """
+    Check that boot timer device is not present by default.
+
+    @type: functional
+    """
     _ = _configure_and_run_vm(test_microvm_with_api)
     time.sleep(0.4)
     timestamps = re.findall(TIMESTAMP_LOG_REGEX,
@@ -27,7 +31,11 @@ def test_no_boottime(test_microvm_with_api):
 
 
 def test_boottime_no_network(test_microvm_with_boottime):
-    """Check boot time of microVM without network."""
+    """
+    Check boot time of microVM without a network device.
+
+    @type: performance
+    """
     vm = test_microvm_with_boottime
     vm.jailer.extra_args.update(
         {'boot-timer': None}
@@ -38,12 +46,18 @@ def test_boottime_no_network(test_microvm_with_boottime):
         vm.log_data)
     print("Boot time with no network is: " + str(boottime_us) + " us")
 
+    return f"{boottime_us} us", f"< {MAX_BOOT_TIME_US} us"
+
 
 def test_boottime_with_network(
         test_microvm_with_boottime,
         network_config
 ):
-    """Check boot time of microVM with network."""
+    """
+    Check boot time of microVM with a network device.
+
+    @type: performance
+    """
     vm = test_microvm_with_boottime
     vm.jailer.extra_args.update(
         {'boot-timer': None}
@@ -53,13 +67,19 @@ def test_boottime_with_network(
     })
     time.sleep(0.4)
     boottime_us = _test_microvm_boottime(
-            vm.log_data)
+        vm.log_data)
     print("Boot time with network configured is: " + str(boottime_us) + " us")
+
+    return f"{boottime_us} us", f"< {MAX_BOOT_TIME_US} us"
 
 
 def test_initrd_boottime(
         test_microvm_with_initrd):
-    """Check boot time of microVM when using an initrd."""
+    """
+    Check boot time of microVM when using an initrd.
+
+    @type: performance
+    """
     vm = test_microvm_with_initrd
     vm.jailer.extra_args.update(
         {'boot-timer': None}
@@ -71,6 +91,8 @@ def test_initrd_boottime(
         max_time_us=INITRD_BOOT_TIME_US)
     print("Boot time with initrd is: " + str(boottime_us) + " us")
 
+    return f"{boottime_us} us", f"< {INITRD_BOOT_TIME_US} us"
+
 
 def _test_microvm_boottime(log_fifo_data, max_time_us=MAX_BOOT_TIME_US):
     """Auxiliary function for asserting the expected boot time."""
@@ -80,7 +102,8 @@ def _test_microvm_boottime(log_fifo_data, max_time_us=MAX_BOOT_TIME_US):
         boot_time_us = int(timestamps[0])
 
     assert boot_time_us > 0
-    assert boot_time_us < max_time_us
+    assert boot_time_us < max_time_us, \
+        f"boot time {boot_time_us} cannot be greater than: {max_time_us} us"
     return boot_time_us
 
 

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -131,7 +131,11 @@ def consume_ping_output(cons, raw_data, requests):
                            "support need to be added for aarch64 and amd64.")
 @pytest.mark.timeout(3600)
 def test_network_latency(bin_cloner_path, results_file_dumper):
-    """Test network latency driver for multiple artifacts."""
+    """
+    Test network latency for multiple vm configurations.
+
+    @type: performance
+    """
     logger = logging.getLogger("network_latency")
     microvm_artifacts = ArtifactSet(
         ARTIFACTS_COLLECTION.microvms(keyword="1vcpu_1024mb")

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -303,7 +303,11 @@ def pipes(basevm, host_ip, current_avail_cpu, env_id):
 @pytest.mark.nonci
 @pytest.mark.timeout(3600)
 def test_network_tcp_throughput(bin_cloner_path, results_file_dumper):
-    """Test network throughput driver for multiple artifacts."""
+    """
+    Test network throughput for multiple vm confgurations.
+
+    @type: performance
+    """
     logger = logging.getLogger("network_tcp_throughput")
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_1024mb"))

--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -16,29 +16,38 @@ MAX_STARTUP_TIME_CPU_US = {'x86_64': 5500, 'aarch64': 2900}
 
 
 def test_startup_time_new_pid_ns(test_microvm_with_api):
-    """Check startup time when jailer is spawned in a new PID namespace."""
+    """
+    Check startup time when jailer is spawned in a new PID namespace.
+
+    @type: performance
+    """
     microvm = test_microvm_with_api
     microvm.bin_cloner_path = None
     microvm.jailer.new_pid_ns = True
-    _test_startup_time(microvm)
+    return _test_startup_time(microvm)
 
 
 def test_startup_time_daemonize(test_microvm_with_api):
-    """Check startup time when jailer spawns Firecracker in a new PID ns."""
+    """
+    Check startup time when jailer spawns Firecracker in a new PID ns.
+
+    @type: performance
+    """
     microvm = test_microvm_with_api
-    _test_startup_time(microvm)
+    return _test_startup_time(microvm)
 
 
 def test_startup_time_custom_seccomp(test_microvm_with_api):
-    """Check the startup time for jailer and Firecracker up to socket bind, ...
+    """
+    Check the startup time when using custom seccomp filters.
 
-    when using custom seccomp filters via the `--seccomp-filter` param.
+    @type: performance
     """
     microvm = test_microvm_with_api
 
     _custom_filter_setup(microvm)
 
-    _test_startup_time(microvm)
+    return _test_startup_time(microvm)
 
 
 def _test_startup_time(microvm):
@@ -68,8 +77,11 @@ def _test_startup_time(microvm):
     print('Process startup time is: {} us ({} CPU us)'
           .format(startup_time_us, cpu_startup_time_us))
 
+    max_startup_time = MAX_STARTUP_TIME_CPU_US[platform.machine()]
     assert cpu_startup_time_us > 0
-    assert cpu_startup_time_us <= MAX_STARTUP_TIME_CPU_US[platform.machine()]
+    assert cpu_startup_time_us <= max_startup_time
+
+    return f"{cpu_startup_time_us} us", f"<= {max_startup_time} us"
 
 
 def _custom_filter_setup(test_microvm):

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -11,7 +11,13 @@ from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.defs import DEFAULT_TEST_IMAGES_S3_BUCKET
 from framework.matrix import TestMatrix, TestContext
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.utils import CpuMap, get_firecracker_version_from_toml
+from framework.utils import eager_map, CpuMap, \
+    get_firecracker_version_from_toml
+from framework.stats import core, consumer, producer, types, criteria,\
+    function
+from integration_tests.performance.utils import handle_failure, \
+    dump_test_result
+
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.logging as log_tools
 
@@ -28,22 +34,38 @@ PLATFORM = platform.machine()
 CREATE_LATENCY_BASELINES = {
     'x86_64': {
         '2vcpu_256mb.json': {
-            'FULL':  180,
-            'DIFF':  70,
+            'FULL':  {
+                'target': 180
+            },
+            'DIFF':  {
+                'target': 70
+            }
         },
         '2vcpu_512mb.json': {
-            'FULL':  280,
-            'DIFF':  75,
+            'FULL':  {
+                'target': 280
+            },
+            'DIFF':  {
+                'target': 75
+            },
         }
     },
     'aarch64': {
         '2vcpu_256mb.json': {
-            'FULL':  160,
-            'DIFF':  70,
+            'FULL':  {
+                'target': 160
+            },
+            'DIFF':  {
+                'target': 70
+            },
         },
         '2vcpu_512mb.json': {
-            'FULL':  300,
-            'DIFF':  75,
+            'FULL':  {
+                'target': 300
+            },
+            'DIFF':  {
+                'target': 75
+            },
         }
     },
 }
@@ -54,20 +76,126 @@ CREATE_LATENCY_BASELINES = {
 # TODO: Update the table after fix. Target is < 5ms.
 LOAD_LATENCY_BASELINES = {
     'x86_64': {
-        '2vcpu_256mb.json': 9,
-        '2vcpu_512mb.json': 9,
+        '2vcpu_256mb.json': {
+            'target': 9
+        },
+        '2vcpu_512mb.json': {
+            'target': 9
+        },
     },
     'aarch64': {
-        '2vcpu_256mb.json': 3,
-        '2vcpu_512mb.json': 3,
+        '2vcpu_256mb.json': {
+            'target': 3
+        },
+        '2vcpu_512mb.json': {
+            'target': 3
+        },
     }
 }
+
+
+def snapshot_create_measurements(vm_type, snapshot_type):
+    """Define measurements for snapshot create tests."""
+    latency = types.MeasurementDef.create_measurement(
+        "latency",
+        "ms",
+        [function.Max("max")],
+        {
+            "max": criteria.LowerThan(
+                CREATE_LATENCY_BASELINES
+                [platform.machine()]
+                [vm_type]
+                ['FULL' if snapshot_type == SnapshotType.FULL else 'DIFF']
+            )
+        })
+
+    return [latency]
+
+
+def snapshot_resume_measurements(vm_type):
+    """Define measurements for snapshot resume tests."""
+    latency = types.MeasurementDef.create_measurement(
+        "latency",
+        "ms",
+        [function.Max("max")],
+        {
+            "max": criteria.LowerThan(
+                LOAD_LATENCY_BASELINES
+                [platform.machine()]
+                [vm_type]
+            )
+        })
+
+    return [latency]
+
+
+def snapshot_create_producer(
+        logger,
+        vm,
+        disks,
+        ssh_key,
+        target_version,
+        metrics_fifo,
+        snapshot_type):
+    """Produce results for snapshot create tests."""
+    snapshot_builder = SnapshotBuilder(vm)
+    snapshot_builder.create(disks=disks,
+                            ssh_key=ssh_key,
+                            snapshot_type=snapshot_type,
+                            target_version=target_version,
+                            use_ramdisk=True)
+    metrics = vm.flush_metrics(metrics_fifo)
+
+    if snapshot_type == SnapshotType.FULL:
+        value = metrics['latencies_us']['full_create_snapshot'] / USEC_IN_MSEC
+    else:
+        value = metrics['latencies_us']['diff_create_snapshot'] / USEC_IN_MSEC
+
+    logger.info("Latency {} ms".format(value))
+
+    return value
+
+
+def snapshot_resume_producer(
+        logger,
+        vm_builder,
+        snapshot,
+        snapshot_type,
+        use_ramdisk):
+    """Produce results for snapshot resume tests."""
+    microvm, metrics_fifo = vm_builder.build_from_snapshot(
+        snapshot,
+        True,
+        snapshot_type == SnapshotType.DIFF,
+        use_ramdisk=use_ramdisk)
+
+    # Attempt to connect to resumed microvm.
+    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+
+    # Verify if guest can run commands.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code == 0
+
+    value = 0
+    # Parse all metric data points in search of load_snapshot time.
+    metrics = microvm.get_all_metrics(metrics_fifo)
+    for data_point in metrics:
+        metrics = json.loads(data_point)
+        cur_value = metrics['latencies_us']['load_snapshot'] / USEC_IN_MSEC
+        if cur_value > 0:
+            value = cur_value
+            break
+
+    logger.info("Latency {} ms".format(value))
+
+    return value
 
 
 def _test_snapshot_create_latency(context):
     logger = context.custom['logger']
     vm_builder = context.custom['builder']
     snapshot_type = context.custom['snapshot_type']
+    file_dumper = context.custom['results_file_dumper']
     diff_snapshots = snapshot_type == SnapshotType.DIFF
 
     # Create a rw copy artifact.
@@ -92,79 +220,95 @@ def _test_snapshot_create_latency(context):
                             context.kernel.name(),
                             context.disk.name()))
 
-        # Measure a burst of snapshot create calls.
-        for i in range(SAMPLE_COUNT):
-            # Create a fresh microVM from artifacts.
-            vm_instance = vm_builder.build(kernel=context.kernel,
-                                           disks=[rw_disk],
-                                           ssh_key=ssh_key,
-                                           config=context.microvm,
-                                           diff_snapshots=diff_snapshots,
-                                           use_ramdisk=True)
-            vm = vm_instance.vm
-            # Configure metrics system.
-            metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
-            metrics_fifo = log_tools.Fifo(metrics_fifo_path)
+        # Create a fresh microVM from artifacts.
+        vm_instance = vm_builder.build(kernel=context.kernel,
+                                       disks=[rw_disk],
+                                       ssh_key=ssh_key,
+                                       config=context.microvm,
+                                       diff_snapshots=diff_snapshots,
+                                       use_ramdisk=True)
+        vm = vm_instance.vm
+        # Configure metrics system.
+        metrics_fifo_path = os.path.join(vm.path, 'metrics_fifo')
+        metrics_fifo = log_tools.Fifo(metrics_fifo_path)
 
-            response = vm.metrics.put(
-                metrics_path=vm.create_jailed_resource(metrics_fifo.path)
-            )
-            assert vm.api_session.is_status_no_content(response.status_code)
+        response = vm.metrics.put(
+            metrics_path=vm.create_jailed_resource(metrics_fifo.path)
+        )
+        assert vm.api_session.is_status_no_content(response.status_code)
 
-            vm.start()
+        vm.start()
 
-            # Check if the needed CPU cores are available. We have the API
-            # thread, VMM thread and then one thread for each configured vCPU.
-            assert CpuMap.len() >= 2 + vm.vcpus_count
+        # Check if the needed CPU cores are available. We have the API
+        # thread, VMM thread and then one thread for each configured vCPU.
+        assert CpuMap.len() >= 2 + vm.vcpus_count
 
-            # Pin uVM threads to physical cores.
-            current_cpu_id = 0
-            assert vm.pin_vmm(current_cpu_id), \
-                "Failed to pin firecracker thread."
+        # Pin uVM threads to physical cores.
+        current_cpu_id = 0
+        assert vm.pin_vmm(current_cpu_id), \
+            "Failed to pin firecracker thread."
+        current_cpu_id += 1
+        assert vm.pin_api(current_cpu_id), \
+            "Failed to pin fc_api thread."
+        for idx_vcpu in range(vm.vcpus_count):
             current_cpu_id += 1
-            assert vm.pin_api(current_cpu_id), \
-                "Failed to pin fc_api thread."
-            for idx_vcpu in range(vm.vcpus_count):
-                current_cpu_id += 1
-                assert vm.pin_vcpu(idx_vcpu, current_cpu_id + idx_vcpu), \
-                    f"Failed to pin fc_vcpu {idx_vcpu} thread."
+            assert vm.pin_vcpu(idx_vcpu, current_cpu_id + idx_vcpu), \
+                f"Failed to pin fc_vcpu {idx_vcpu} thread."
 
-            # Create a snapshot builder from a microVM.
-            snapshot_builder = SnapshotBuilder(vm)
-            snapshot_builder.create(disks=[rw_disk],
-                                    ssh_key=ssh_key,
-                                    snapshot_type=snapshot_type,
-                                    target_version=target_version,
-                                    use_ramdisk=True)
-            metrics = vm.flush_metrics(metrics_fifo)
-            vm_name = context.microvm.name()
+        st_core = core.Core(
+            name="snapshot_create_full_latency"
+            if snapshot_type == SnapshotType.FULL
+            else "snapshot_create_diff_latency",
+            iterations=SAMPLE_COUNT
+        )
 
-            if snapshot_type == SnapshotType.FULL:
-                value = metrics['latencies_us']['full_create_snapshot']
-                baseline = CREATE_LATENCY_BASELINES[PLATFORM][vm_name]['FULL']
-            else:
-                value = metrics['latencies_us']['diff_create_snapshot']
-                baseline = CREATE_LATENCY_BASELINES[PLATFORM][vm_name]['DIFF']
+        prod = producer.LambdaProducer(
+            func=snapshot_create_producer,
+            func_kwargs={
+                "logger": logger,
+                "vm": vm,
+                "disks": [rw_disk],
+                "ssh_key": ssh_key,
+                "target_version": target_version,
+                "metrics_fifo": metrics_fifo,
+                "snapshot_type": snapshot_type
+            }
+        )
 
-            value = value / USEC_IN_MSEC
+        cons = consumer.LambdaConsumer(
+            func=lambda cons, result: cons.consume_stat(
+                st_name="max", ms_name="latency", value=result),
+            func_kwargs={}
+        )
+        eager_map(
+            cons.set_measurement_def,
+            snapshot_create_measurements(context.microvm.name(), snapshot_type)
+        )
 
-            assert baseline > value, "CreateSnapshot latency degraded."
+        st_core.add_pipe(producer=prod, consumer=cons,
+                         tag=context.microvm.name())
 
-            logger.info("Latency {}/3: {} ms".format(i + 1, value))
-            vm.kill()
+    # Gather results and verify pass criteria.
+    try:
+        result = st_core.run_exercise()
+    except core.CoreException as err:
+        handle_failure(file_dumper, err)
+
+    dump_test_result(file_dumper, result)
 
 
 def _test_snapshot_resume_latency(context):
     logger = context.custom['logger']
     vm_builder = context.custom['builder']
     snapshot_type = context.custom['snapshot_type']
+    file_dumper = context.custom['results_file_dumper']
     diff_snapshots = snapshot_type == SnapshotType.DIFF
 
     logger.info("""Measuring snapshot resume({}) latency for microvm: \"{}\",
-kernel {}, disk {} """.format(snapshot_type,
-                              context.microvm.name(),
-                              context.kernel.name(),
-                              context.disk.name()))
+    kernel {}, disk {} """.format(snapshot_type,
+                                  context.microvm.name(),
+                                  context.kernel.name(),
+                                  context.disk.name()))
 
     # Create a rw copy artifact.
     rw_disk = context.disk.copy()
@@ -196,40 +340,124 @@ kernel {}, disk {} """.format(snapshot_type,
 
     basevm.kill()
 
-    for i in range(SAMPLE_COUNT):
-        microvm, metrics_fifo = vm_builder.build_from_snapshot(
-            snapshot,
-            True,
-            diff_snapshots,
-            use_ramdisk=True)
+    st_core = core.Core(
+        name="snapshot_resume_latency",
+        iterations=SAMPLE_COUNT
+    )
 
-        # Attempt to connect to resumed microvm.
-        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+    prod = producer.LambdaProducer(
+        func=snapshot_resume_producer,
+        func_kwargs={
+            "logger": logger,
+            "vm_builder": vm_builder,
+            "snapshot": snapshot,
+            "snapshot_type": snapshot_type,
+            "use_ramdisk": True
+        }
+    )
 
-        # Verify if guest can run commands.
-        exit_code, _, _ = ssh_connection.execute_command("ls")
-        assert exit_code == 0
+    cons = consumer.LambdaConsumer(
+        func=lambda cons, result: cons.consume_stat(
+            st_name="max", ms_name="latency", value=result),
+        func_kwargs={}
+    )
+    eager_map(cons.set_measurement_def,
+              snapshot_resume_measurements(context.microvm.name()))
 
-        value = 0
-        # Parse all metric data points in search of load_snapshot time.
-        metrics = microvm.get_all_metrics(metrics_fifo)
-        for data_point in metrics:
-            metrics = json.loads(data_point)
-            cur_value = metrics['latencies_us']['load_snapshot'] / USEC_IN_MSEC
-            if cur_value > 0:
-                value = cur_value
-                break
+    st_core.add_pipe(producer=prod, consumer=cons,
+                     tag=context.microvm.name())
 
-        baseline = LOAD_LATENCY_BASELINES[PLATFORM][context.microvm.name()]
-        logger.info("Latency {}/{}: {} ms".format(i + 1, SAMPLE_COUNT, value))
-        assert baseline > value, "LoadSnapshot latency degraded."
+    # Gather results and verify pass criteria.
+    try:
+        result = st_core.run_exercise()
+    except core.CoreException as err:
+        handle_failure(file_dumper, err)
 
-        microvm.kill()
+    dump_test_result(file_dumper, result)
+
+
+def _test_older_snapshot_resume_latency(context):
+    builder = context.custom["builder"]
+    logger = context.custom["logger"]
+    snapshot_type = context.custom['snapshot_type']
+    file_dumper = context.custom["results_file_dumper"]
+
+    firecracker = context.firecracker
+    jailer = firecracker.jailer()
+    jailer.download()
+    fc_version = firecracker.base_name()[1:]
+    logger.info("Firecracker version: %s", fc_version)
+    logger.info("Source Firecracker: %s", firecracker.local_path())
+    logger.info("Source Jailer: %s", jailer.local_path())
+
+    # Create a fresh microvm with the binary artifacts.
+    vm_instance = builder.build_vm_micro(firecracker.local_path(),
+                                         jailer.local_path())
+    basevm = vm_instance.vm
+    basevm.start()
+    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+
+    # Check if guest works.
+    exit_code, _, _ = ssh_connection.execute_command("ls")
+    assert exit_code == 0
+
+    # The snapshot builder expects disks as paths, not artifacts.
+    disks = []
+    for disk in vm_instance.disks:
+        disks.append(disk.local_path())
+
+    # Create a snapshot builder from a microvm.
+    snapshot_builder = SnapshotBuilder(basevm)
+    snapshot = snapshot_builder.create(disks,
+                                       vm_instance.ssh_key,
+                                       snapshot_type)
+
+    basevm.kill()
+
+    st_core = core.Core(
+        name="older_snapshot_resume_latency",
+        iterations=SAMPLE_COUNT
+    )
+
+    prod = producer.LambdaProducer(
+        func=snapshot_resume_producer,
+        func_kwargs={
+            "logger": logger,
+            "vm_builder": builder,
+            "snapshot": snapshot,
+            "snapshot_type": snapshot_type,
+            "use_ramdisk": False
+        }
+    )
+
+    cons = consumer.LambdaConsumer(
+        func=lambda cons, result: cons.consume_stat(
+            st_name="max", ms_name="latency", value=result),
+        func_kwargs={}
+    )
+    eager_map(cons.set_measurement_def,
+              snapshot_resume_measurements(context.microvm.name()))
+
+    st_core.add_pipe(producer=prod, consumer=cons,
+                     tag=context.microvm.name())
+
+    # Gather results and verify pass criteria.
+    try:
+        result = st_core.run_exercise()
+    except core.CoreException as err:
+        handle_failure(file_dumper, err)
+
+    dump_test_result(file_dumper, result)
 
 
 def test_snapshot_create_full_latency(network_config,
-                                      bin_cloner_path):
-    """Test scenario: Full snapshot create performance measurement."""
+                                      bin_cloner_path,
+                                      results_file_dumper):
+    """
+    Test scenario: Full snapshot create performance measurement.
+
+    @type: performance
+    """
     logger = logging.getLogger("snapshot_sequence")
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     # Testing matrix:
@@ -249,6 +477,8 @@ def test_snapshot_create_full_latency(network_config,
         'network_config': network_config,
         'logger': logger,
         'snapshot_type': SnapshotType.FULL,
+        'name': 'create_full_latency',
+        'results_file_dumper': results_file_dumper
     }
 
     # Create the test matrix.
@@ -263,8 +493,13 @@ def test_snapshot_create_full_latency(network_config,
 
 
 def test_snapshot_create_diff_latency(network_config,
-                                      bin_cloner_path):
-    """Test scenario: Diff snapshot create performance measurement."""
+                                      bin_cloner_path,
+                                      results_file_dumper):
+    """
+    Test scenario: Diff snapshot create performance measurement.
+
+    @type: performance
+    """
     logger = logging.getLogger("snapshot_sequence")
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     # Testing matrix:
@@ -284,6 +519,8 @@ def test_snapshot_create_diff_latency(network_config,
         'network_config': network_config,
         'logger': logger,
         'snapshot_type': SnapshotType.DIFF,
+        'name': 'create_diff_latency',
+        'results_file_dumper': results_file_dumper
     }
 
     # Create the test matrix.
@@ -298,8 +535,13 @@ def test_snapshot_create_diff_latency(network_config,
 
 
 def test_snapshot_resume_latency(network_config,
-                                 bin_cloner_path):
-    """Test scenario: Snapshot load performance measurement."""
+                                 bin_cloner_path,
+                                 results_file_dumper):
+    """
+    Test scenario: Snapshot load performance measurement.
+
+    @type: performance
+    """
     logger = logging.getLogger("snapshot_load")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
@@ -321,6 +563,8 @@ def test_snapshot_resume_latency(network_config,
         'network_config': network_config,
         'logger': logger,
         'snapshot_type': SnapshotType.FULL,
+        'name': 'resume_latency',
+        'results_file_dumper': results_file_dumper
     }
 
     # Create the test matrix.
@@ -334,73 +578,38 @@ def test_snapshot_resume_latency(network_config,
     test_matrix.run_test(_test_snapshot_resume_latency)
 
 
-def test_older_snapshot_resume_latency(bin_cloner_path):
-    """Test scenario: Older snapshot load performance measurement."""
-    logger = logging.getLogger("old_snapshot_load")
+def test_older_snapshot_resume_latency(bin_cloner_path, results_file_dumper):
+    """
+    Test scenario: Older snapshot load performance measurement.
 
-    builder = MicrovmBuilder(bin_cloner_path)
+    @type: performance
+    """
+    logger = logging.getLogger("old_snapshot_load")
 
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     # Fetch all firecracker binaries.
     # With each binary create a snapshot and try to restore in current
     # version.
-    firecracker_artifacts = artifacts.firecrackers(
-        older_than=get_firecracker_version_from_toml())
+    firecracker_artifacts = ArtifactSet(artifacts.firecrackers(
+        older_than=get_firecracker_version_from_toml()))
     assert len(firecracker_artifacts) > 0
 
-    for firecracker in firecracker_artifacts:
-        firecracker.download()
-        jailer = firecracker.jailer()
-        jailer.download()
-        fc_version = firecracker.base_name()[1:]
-        logger.info("Firecracker version: %s", fc_version)
-        logger.info("Source Firecracker: %s", firecracker.local_path())
-        logger.info("Source Jailer: %s", jailer.local_path())
+    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_512mb"))
 
-        for i in range(SAMPLE_COUNT):
-            # Create a fresh microvm with the binary artifacts.
-            vm_instance = builder.build_vm_micro(firecracker.local_path(),
-                                                 jailer.local_path())
-            basevm = vm_instance.vm
-            basevm.start()
-            ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+    test_context = TestContext()
+    test_context.custom = {
+        'builder': MicrovmBuilder(bin_cloner_path),
+        'logger': logger,
+        'snapshot_type': SnapshotType.FULL,
+        'name': 'old_snapshot_resume_latency',
+        'results_file_dumper': results_file_dumper
+    }
 
-            # Check if guest works.
-            exit_code, _, _ = ssh_connection.execute_command("ls")
-            assert exit_code == 0
+    # Create the test matrix.
+    test_matrix = TestMatrix(context=test_context,
+                             artifact_sets=[
+                                 firecracker_artifacts,
+                                 microvm_artifacts,
+                             ])
 
-            # The snapshot builder expects disks as paths, not artifacts.
-            disks = []
-            for disk in vm_instance.disks:
-                disks.append(disk.local_path())
-
-            # Create a snapshot builder from a microvm.
-            snapshot_builder = SnapshotBuilder(basevm)
-            snapshot = snapshot_builder.create(disks,
-                                               vm_instance.ssh_key,
-                                               SnapshotType.FULL)
-
-            basevm.kill()
-            microvm, metrics_fifo = builder.build_from_snapshot(snapshot,
-                                                                True,
-                                                                False)
-            # Attempt to connect to resumed microvm.
-            ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
-            # Check if guest still runs commands.
-            exit_code, _, _ = ssh_connection.execute_command("dmesg")
-            assert exit_code == 0
-
-            value = 0
-            # Parse all metric data points in search of load_snapshot time.
-            metrics = microvm.get_all_metrics(metrics_fifo)
-            for data_point in metrics:
-                metrics = json.loads(data_point)
-                cur_value = metrics['latencies_us']['load_snapshot']
-                if cur_value > 0:
-                    value = cur_value / USEC_IN_MSEC
-                    break
-
-            baseline = LOAD_LATENCY_BASELINES[PLATFORM]['2vcpu_512mb.json']
-            logger.info("Latency %s/%s: %s ms", i + 1, SAMPLE_COUNT, value)
-            assert baseline > value, "LoadSnapshot latency degraded."
-            microvm.kill()
+    test_matrix.run_test(_test_older_snapshot_resume_latency)

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -214,7 +214,11 @@ def consume_output(cons, result):
 @pytest.mark.nonci
 @pytest.mark.timeout(300 * 1000)  # 1.40 hours
 def test_snap_restore_performance(bin_cloner_path, results_file_dumper):
-    """Test the performance of snapshot restore."""
+    """
+    Test the performance of snapshot restore.
+
+    @type: performance
+    """
     logger = logging.getLogger(TEST_ID)
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_1024mb"))
@@ -243,7 +247,7 @@ def snapshot_scaling_vcpus(context, st_core, vcpu_count=10):
     """Restore snapshots with variable vcpu count."""
     for i in range(vcpu_count):
         env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
-             f"{BASE_VCPU_COUNT + i}vcpu_{BASE_MEM_SIZE_MIB}mb"
+            f"{BASE_VCPU_COUNT + i}vcpu_{BASE_MEM_SIZE_MIB}mb"
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
@@ -261,7 +265,7 @@ def snapshot_scaling_mem(context, st_core, mem_exponent=9):
     """Restore snapshots with variable memory size."""
     for i in range(1, mem_exponent):
         env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
-             f"{BASE_VCPU_COUNT}vcpu_{BASE_MEM_SIZE_MIB * (2 ** i)}mb"
+            f"{BASE_VCPU_COUNT}vcpu_{BASE_MEM_SIZE_MIB * (2 ** i)}mb"
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
@@ -279,7 +283,7 @@ def snapshot_scaling_net(context, st_core, net_count=4):
     """Restore snapshots with variable net device count."""
     for i in range(1, net_count):
         env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
-             f"{BASE_NET_COUNT + i}net_dev"
+            f"{BASE_NET_COUNT + i}net_dev"
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
@@ -302,7 +306,7 @@ def snapshot_scaling_block(context, st_core, block_count=4):
 
     for i in range(1, block_count):
         env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
-             f"{BASE_BLOCK_COUNT + i}block_dev"
+            f"{BASE_BLOCK_COUNT + i}block_dev"
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -109,13 +109,19 @@ def _check_statistics(directory, mean):
     assert low <= mean <= high, "Benchmark result {} has changed!" \
         .format(directory)
 
+    return directory, f"{mean} ms", f"{low} <= result <= {high}"
+
 
 @pytest.mark.skipif(
     platform.machine() != "x86_64",
     reason="Not supported yet."
 )
 def test_serialization_benchmark():
-    """Benchmark test for MicrovmState serialization/deserialization."""
+    """
+    Benchmark test for MicrovmState serialization/deserialization.
+
+    @type: performance
+    """
     logger = logging.getLogger("serialization_benchmark")
 
     # Move into the benchmark directory
@@ -125,6 +131,8 @@ def test_serialization_benchmark():
     cmd = 'cargo bench'
     result = utils.run_cmd_sync(cmd)
     assert result.returncode == 0
+
+    results_and_criteria = ["", ""]
 
     # Parse each Criterion benchmark from the result folder and
     # check the results against a baseline
@@ -147,7 +155,13 @@ def test_serialization_benchmark():
         mean = estimates['mean']['point_estimate'] / NSEC_IN_MSEC
         logger.info("Mean: %f", mean)
 
-        _check_statistics(directory, mean)
+        res = _check_statistics(directory, mean)
+
+        results_and_criteria[0] += f"{res[0]}: {res[1]}, "
+        results_and_criteria[1] += f"{res[0]}: {res[2]}, "
 
     # Cleanup the Target directory
     shutil.rmtree(results_dir)
+
+    # Return pretty formatted data for the test report.
+    return results_and_criteria[0], results_and_criteria[1]

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -255,7 +255,11 @@ def pipes(basevm, current_avail_cpu, env_id):
 @pytest.mark.nonci
 @pytest.mark.timeout(600)
 def test_vsock_throughput(bin_cloner_path, results_file_dumper):
-    """Test vsock throughput driver for multiple artifacts."""
+    """
+    Test vsock throughput for multiple vm configurations.
+
+    @type: performance
+    """
     logger = logging.getLogger("vsock_throughput")
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="1vcpu_1024mb"))

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -50,7 +50,11 @@ def _config_file_setup(test_microvm, vm_config_file):
 
 
 def test_allow_all(test_microvm_with_api):
-    """Test --seccomp-filter, allowing all syscalls."""
+    """
+    Test --seccomp-filter, allowing all syscalls.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_api
 
     _custom_filter_setup(test_microvm, """{
@@ -81,7 +85,11 @@ def test_allow_all(test_microvm_with_api):
 
 
 def test_working_filter(test_microvm_with_api):
-    """Test --seccomp-filter, rejecting some dangerous syscalls."""
+    """
+    Test --seccomp-filter, rejecting some dangerous syscalls.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_api
 
     _custom_filter_setup(test_microvm, """{
@@ -135,7 +143,11 @@ def test_working_filter(test_microvm_with_api):
 
 
 def test_failing_filter(test_microvm_with_api):
-    """Test --seccomp-filter, denying some needed syscalls."""
+    """
+    Test --seccomp-filter, denying some needed syscalls.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_api
 
     _custom_filter_setup(test_microvm, """{
@@ -204,7 +216,11 @@ def test_failing_filter(test_microvm_with_api):
     ["framework/vm_config.json"]
 )
 def test_invalid_bpf(test_microvm_with_ssh, vm_config_file):
-    """Test that FC does not start, given an invalid binary filter."""
+    """
+    Test that FC does not start, given an invalid binary filter.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_ssh
 
     # Configure VM from JSON. Otherwise, the test will error because

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -31,7 +31,11 @@ def check_stats(filepath, stats, uid, gid):
 
 
 def test_default_chroot(test_microvm_with_ssh):
-    """Test that the code base assigns a chroot if none is specified."""
+    """
+    Test that the jailer assigns a default chroot if none is specified.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_ssh
 
     # Start customizing arguments.
@@ -45,7 +49,11 @@ def test_default_chroot(test_microvm_with_ssh):
 
 
 def test_empty_jailer_id(test_microvm_with_ssh):
-    """Test that the jailer ID cannot be empty."""
+    """
+    Test that the jailer ID cannot be empty.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_ssh
     fc_binary, _ = build_tools.get_firecracker_binaries()
 
@@ -69,7 +77,11 @@ def test_empty_jailer_id(test_microvm_with_ssh):
 
 
 def test_default_chroot_hierarchy(test_microvm_with_initrd):
-    """Test the folder hierarchy created by default by the jailer."""
+    """
+    Test the folder hierarchy created by default by the jailer.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_initrd
 
     test_microvm.spawn()
@@ -93,7 +105,11 @@ def test_default_chroot_hierarchy(test_microvm_with_initrd):
 
 
 def test_arbitrary_usocket_location(test_microvm_with_initrd):
-    """Test arbitrary location scenario for the api socket."""
+    """
+    Test arbitrary location scenario for the api socket.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_initrd
     test_microvm.jailer.extra_args = {'api-sock': 'api.socket'}
 
@@ -131,7 +147,11 @@ def get_cpus(node):
 
 
 def test_cgroups(test_microvm_with_initrd):
-    """Test the cgroups are correctly set by the jailer."""
+    """
+    Test the cgroups are correctly set by the jailer.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_initrd
     test_microvm.jailer.cgroups = ['cpu.shares=2', 'cpu.cfs_period_us=200000']
     test_microvm.jailer.numa_node = 0
@@ -156,7 +176,11 @@ def test_cgroups(test_microvm_with_initrd):
 
 
 def test_node_cgroups(test_microvm_with_initrd):
-    """Test the cgroups are correctly set by the jailer."""
+    """
+    Test the --node cgroups are correctly set by the jailer.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_initrd
     test_microvm.jailer.cgroups = None
     test_microvm.jailer.numa_node = 0
@@ -180,8 +204,12 @@ def test_node_cgroups(test_microvm_with_initrd):
     check_cgroups(cgroups, sys_cgroup, test_microvm.jailer.jailer_id)
 
 
-def test_args_cgroups(test_microvm_with_initrd):
-    """Test the cgroups are correctly set by the jailer."""
+def test_cgroups_without_numa(test_microvm_with_initrd):
+    """
+    Test the cgroups are correctly set by the jailer, without numa assignment.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_initrd
     test_microvm.jailer.cgroups = ['cpu.shares=2', 'cpu.cfs_period_us=200000']
 
@@ -199,7 +227,11 @@ def test_args_cgroups(test_microvm_with_initrd):
 
 
 def test_new_pid_namespace(test_microvm_with_ssh):
-    """Test that Firecracker is spawned in a new PID namespace if requested."""
+    """
+    Test that Firecracker is spawned in a new PID namespace if requested.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_ssh
 
     test_microvm.jailer.daemonize = False

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -16,7 +16,11 @@ import framework.utils as utils
            "is identical on all platforms"
 )
 def test_cargo_audit():
-    """Fail if there are crates with security vulnerabilities."""
+    """
+    Run cargo audit to check for crates with security vulnerabilities.
+
+    @type: security
+    """
     cargo_lock_path = os.path.normpath(
         os.path.join(
             os.path.dirname(os.path.realpath(__file__)),

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -86,7 +86,11 @@ def _run_seccompiler_bin(json_data, basic=False):
 
 
 def test_seccomp_ls(bin_seccomp_paths):
-    """Assert that the seccomp filter denies an unallowed syscall."""
+    """
+    Assert that the seccomp filter denies an unallowed syscall.
+
+    @type: security
+    """
     # pylint: disable=redefined-outer-name
     # pylint: disable=subprocess-run-check
     # The fixture pattern causes a pylint false positive for that rule.
@@ -129,6 +133,8 @@ def test_advanced_seccomp(bin_seccomp_paths):
     Test that the demo jailer (with advanced seccomp) allows the harmless demo
     binary, denies the malicious demo binary and that an empty allowlist
     denies everything.
+
+    @type: security
     """
     # pylint: disable=redefined-outer-name
     # pylint: disable=subprocess-run-check
@@ -230,7 +236,11 @@ def test_advanced_seccomp(bin_seccomp_paths):
 
 
 def test_no_seccomp(test_microvm_with_api):
-    """Test Firecracker --no-seccomp."""
+    """
+    Test that Firecracker --no-seccomp installs no filter.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_api
     test_microvm.jailer.extra_args.update({"no-seccomp": None})
     test_microvm.spawn()
@@ -258,7 +268,11 @@ KERNEL_LEVEL = {"default": "2", "0": "0", "1": "2", "2": "2"}
     SECCOMP_LEVELS
 )
 def test_seccomp_level(test_microvm_with_api, level):
-    """Test Firecracker --seccomp-level value."""
+    """
+    Compare Firecracker's --seccomp-level with the kernel-reported value.
+
+    @type: security
+    """
     test_microvm = test_microvm_with_api
     test_microvm.jailer.daemonize = False
 
@@ -292,6 +306,8 @@ def test_seccomp_rust_panic(bin_seccomp_paths):
 
     Test that the Firecracker filters allow a Rust panic to run its
     course without triggering a seccomp violation.
+
+    @type: security
     """
     # pylint: disable=redefined-outer-name
     # pylint: disable=subprocess-run-check

--- a/tests/integration_tests/security/test_ssbd_mitigation.py
+++ b/tests/integration_tests/security/test_ssbd_mitigation.py
@@ -6,7 +6,11 @@ from framework.utils import run_cmd
 
 
 def test_ssbd_mitigation(test_microvm_with_initrd):
-    """Test that SSBD mitigation is enabled."""
+    """
+    Test that SSBD mitigation is enabled.
+
+    @type: security
+    """
     vm = test_microvm_with_initrd
     vm.jailer.daemonize = False
     vm.spawn()

--- a/tests/integration_tests/style/test_gitlint.py
+++ b/tests/integration_tests/style/test_gitlint.py
@@ -7,7 +7,11 @@ import framework.utils as utils
 
 
 def test_gitlint():
-    """Fail if the default gitlint rules do not apply."""
+    """
+    Test that all commit messages pass the gitlint rules.
+
+    @type: style
+    """
     os.environ['LC_ALL'] = 'C.UTF-8'
     os.environ['LANG'] = 'C.UTF-8'
     try:

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -51,7 +51,8 @@ def _look_for_license(file, license_msg):
 
 
 def _validate_license(filename):
-    """Validate licenses in all .rs, .py. and .sh file.
+    """
+    Validate license all .rs/.py. or .sh file.
 
     Python and Rust files should have the licenses on the first 2 lines
     Shell files license is located on lines 3-4 to account for shebang
@@ -93,7 +94,11 @@ def _validate_license(filename):
 
 
 def test_for_valid_licenses():
-    """Fail if a file lacks a valid license."""
+    """
+    Test that all *.py, *.rs and *.sh files contain a valid license.
+
+    @type: style
+    """
     python_files = utils.get_files_from(
         find_path="..",
         pattern="*.py",

--- a/tests/integration_tests/style/test_markdown.py
+++ b/tests/integration_tests/style/test_markdown.py
@@ -6,7 +6,11 @@ import framework.utils as utils
 
 
 def test_markdown_style():
-    """Fail if there's misbehaving markdown style in the test system."""
+    """
+    Test that markdown files adhere to the style rules.
+
+    @type: style
+    """
     # Get all *.md files from the project
     md_files = utils.get_files_from(
         find_path="..",

--- a/tests/integration_tests/style/test_python.py
+++ b/tests/integration_tests/style/test_python.py
@@ -6,7 +6,11 @@ import framework.utils as utils
 
 
 def test_python_style():
-    """Fail if there's misbehaving Python style in the test system."""
+    """
+    Test that python code passes style checks.
+
+    @type: style
+    """
     # List of linter commands that should be executed for each file
     linter_cmds = [
         # Pylint

--- a/tests/integration_tests/style/test_rust.py
+++ b/tests/integration_tests/style/test_rust.py
@@ -6,7 +6,11 @@ import framework.utils as utils
 
 
 def test_rust_style():
-    """Fail if there's misbehaving Rust style in this repo."""
+    """
+    Test that rust code passes style checks.
+
+    @type: style
+    """
     # Check that the output is empty.
     _, stdout, _ = utils.run_cmd(
         'cargo fmt --all -- --check')
@@ -16,7 +20,11 @@ def test_rust_style():
 
 
 def test_ensure_mod_tests():
-    """Check that files containing unit tests have a 'tests' module defined."""
+    """
+    Check that files containing unit tests have a 'tests' module defined.
+
+    @type: style
+    """
     # List all source files containing rust #[test] attribute,
     # (excluding generated files and integration test directories).
     # Take the list and check each file contains 'mod tests {', output file

--- a/tests/integration_tests/style/test_swagger.py
+++ b/tests/integration_tests/style/test_swagger.py
@@ -28,7 +28,11 @@ def validate_swagger(swagger_spec):
 
 
 def test_firecracker_swagger():
-    """Fail if Firecracker swagger specification is malformed."""
+    """
+    Test that Firecracker swagger specification is valid.
+
+    @type: style
+    """
     swagger_spec = os.path.normpath(
         os.path.join(os.getcwd(), '../src/api_server/swagger/firecracker.yaml')
     )


### PR DESCRIPTION
# Reason for This PR

Support for test reports had been merged in Firecracker, but most of the tests were not properly documented.

Note that the more complicated performance tests do not output the pass criteria and results in the same `test_results/report/test_report.json` file. They output the results in separate files under the same `test_results` folder. This is because of this issue: https://github.com/firecracker-microvm/firecracker/issues/2640 and because of the fact that the nightly performance tests contain a huge number of configs and the report would be more or less unreadable. It also helps with the automated baseline parsers.

## Description of Changes

- properly document tests with the test report descriptions.
- make the test description and type attrbutes required
- refactor the test_snapshot_perf.py test to use the statistics framework, so that it outputs separate test results

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
