### PR TITLE
Avoid overflow on computing vsock packet used length

### DIFF
--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -237,7 +237,7 @@ where
                     if err.kind() == ErrorKind::WouldBlock =>
                 {
                     // This shouldn't actually happen (receiving EWOULDBLOCK after EPOLLIN), but
-                    // apparently it does, so we need to handle it greacefully.
+                    // apparently it does, so we need to handle it gracefully.
                     warn!(
                         "vsock: unexpected EWOULDBLOCK while reading from backing stream: \
                          lp={}, pp={}, err={:?}",

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -148,10 +148,14 @@ where
                 Ok(mut pkt) => {
                     if self.backend.recv_pkt(&mut pkt, mem).is_ok() {
                         match pkt.commit_hdr(mem) {
+                            // This addition cannot overflow, because packet length
+                            // is previously validated against `MAX_PKT_BUF_SIZE`
+                            // bound as part of `commit_hdr()`.
                             Ok(()) => VSOCK_PKT_HDR_SIZE as u32 + pkt.len(),
                             Err(e) => {
                                 warn!(
-                                    "vsock: Error writing packet header to guest memory: {:?}",
+                                    "vsock: Error writing packet header to guest memory: {:?}.\
+                                     Discarding the package.",
                                     e
                                 );
                                 0
@@ -165,7 +169,7 @@ where
                     }
                 }
                 Err(e) => {
-                    warn!("vsock: RX queue error: {:?}", e);
+                    warn!("vsock: RX queue error: {:?}. Discarding the package.", e);
                     0
                 }
             };


### PR DESCRIPTION
# Reason for This PR

Avoid overflow during computing vsock packet used length.

## Description of Changes

Check package length before commiting the header to guest memory. If len is too big, we return `InvalidPktLen` error. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] ~Any required documentation changes (code and docs) are included in this PR.~
- [X] ~Any newly added `unsafe` code is properly documented.~
- [X] ~Any API changes are reflected in `firecracker/swagger.yaml`.~
- [X] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [ ] All added/changed functionality is tested.
