### PR TITLE
Add support for cgroups v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Added
 
+- Added jailer option `--cgroup-version <1|2>` to support running the jailer
+  on systems that have cgroup-v2. Default value is `1` which means that if
+  `--cgroup-version` is not specified, the jailer will try to create cgroups
+  on cgroup-v1 hierarchies only.
 - Added devtool build `--ssh-keys` flag to support fetching from private
   git repositories.
 - Added option to configure block device flush.

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -15,6 +15,7 @@ jailer --id <id> \
        --exec-file <exec_file> \
        --uid <uid> \
        --gid <gid>
+       [--cgroup-version <cgroup-version>]
        [--cgroup <cgroup>]
        [--chroot-base-dir <chroot_base>]
        [--netns <netns>]
@@ -33,6 +34,10 @@ jailer --id <id> \
   the jailer is mostly Firecracker specific.
 - `uid` and `gid` are the uid and gid the jailer switches to as it execs the
   target binary.
+- `cgroup-version` is used to select which type of cgroup hierarchy to use for
+  the creation of cgroups. The default value is "1" which means that cgroups
+  specified with the `cgroup` argument will be created within a v1 hierarchy.
+  Supported options are "1" for cgroup-v1 and "2" for cgroup-v2.
 - `cgroup` cgroups can be passed to the jailer to let it set the values
   when the microVM process is spawned. The `--cgroup` argument must follow this format:
   `<cgroup_file>=<value>` (e.g cpuset.cpus=0). This argument can be used multiple

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -587,6 +587,7 @@ impl Env {
 mod tests {
     use super::*;
     use crate::build_arg_parser;
+    use crate::cgroup::test_util::MockCgroupFs;
 
     use std::os::linux::fs::MetadataExt;
     use std::os::unix::ffi::OsStrExt;
@@ -692,6 +693,9 @@ mod tests {
 
     #[test]
     fn test_new_env() {
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
+
         let good_arg_vals = ArgVals::new();
         let arg_parser = build_arg_parser();
         let mut args = arg_parser.arguments().clone();
@@ -827,6 +831,8 @@ mod tests {
 
     #[test]
     fn test_setup_jailed_folder() {
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
         let env = create_env();
 
         // Error case: non UTF-8 paths.
@@ -875,6 +881,8 @@ mod tests {
     fn test_mknod_and_own_dev() {
         use std::os::unix::fs::FileTypeExt;
 
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
         let env = create_env();
 
         // Ensure path buffers without NULL-termination are handled well.
@@ -926,6 +934,8 @@ mod tests {
         // Create a standard environment.
         let arg_parser = build_arg_parser();
         let mut args = arg_parser.arguments().clone();
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
 
         // Create tmp resources for `exec_file` and `chroot_base`.
         let some_file = TempFile::new_with_prefix("/tmp/").unwrap();
@@ -999,6 +1009,8 @@ mod tests {
     fn test_cgroups_parsing() {
         let arg_parser = build_arg_parser();
         let good_arg_vals = ArgVals::new();
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
 
         // Cases that should fail
 
@@ -1136,6 +1148,9 @@ mod tests {
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_copy_cache_info() {
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
+
         let env = create_env();
 
         // Create the required chroot dir hierarchy.
@@ -1159,6 +1174,9 @@ mod tests {
         let exec_file_name = "file";
         let pid_file_name = "file.pid";
         let pid = 1;
+
+        let mut mock_cgroups = MockCgroupFs::new().unwrap();
+        assert!(!mock_cgroups.add_v1_mounts().is_err());
 
         let mut env = create_env();
         env.save_exec_file_pid(pid, PathBuf::from(exec_file_name))

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -27,6 +27,9 @@ pub enum Error {
     CgroupInvalidFile(String),
     CgroupWrite(String, String, String),
     CgroupFormat(String),
+    CgroupHierarchyMissing(String),
+    CgroupControllerUnavailable(String),
+    CgroupInvalidVersion(String),
     ChangeFileOwner(PathBuf, io::Error),
     ChdirNewRoot(io::Error),
     Chmod(PathBuf, io::Error),
@@ -109,6 +112,11 @@ impl fmt::Display for Error {
                 evalue, file, rvalue
             ),
             CgroupFormat(ref arg) => write!(f, "Invalid format for cgroups: {}", arg,),
+            CgroupHierarchyMissing(ref arg) => write!(f, "Hierarchy not found: {}", arg,),
+            CgroupControllerUnavailable(ref arg) => write!(f, "Controller {} is unavailable", arg,),
+            CgroupInvalidVersion(ref arg) => {
+                write!(f, "{} is an invalid cgroup version specifier", arg,)
+            }
             ChangeFileOwner(ref path, ref err) => {
                 write!(f, "Failed to change owner for {:?}: {}", path, err)
             }
@@ -297,6 +305,12 @@ pub fn build_arg_parser() -> ArgParser<'static> {
              \t\tno-file: Specifies a value one greater than the maximum file descriptor number \
              that can be opened by this process.",
         ))
+        .arg(
+            Argument::new("cgroup-version")
+                .takes_value(true)
+                .default_value("1")
+                .help("Select the cgroup version used by the jailer."),
+        )
         .arg(
             Argument::new("version")
                 .takes_value(false)

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -37,6 +37,7 @@ class JailerContext:
     api_socket_name = None
     cgroups = None
     resource_limits = None
+    cgroup_ver = None
 
     def __init__(
             self,
@@ -51,6 +52,7 @@ class JailerContext:
             new_pid_ns=False,
             cgroups=None,
             resource_limits=None,
+            cgroup_ver=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -72,6 +74,7 @@ class JailerContext:
         self.api_socket_name = DEFAULT_USOCKET_NAME
         self.cgroups = cgroups
         self.resource_limits = resource_limits
+        self.cgroup_ver = cgroup_ver
         self.ramfs_subdir_name = 'ramfs'
         self._ramfs_path = None
 
@@ -113,6 +116,10 @@ class JailerContext:
             jailer_param_list.append('--daemonize')
         if self.new_pid_ns:
             jailer_param_list.append('--new-pid-ns')
+        if self.cgroup_ver:
+            jailer_param_list.extend(
+                ['--cgroup-version', str(self.cgroup_ver)]
+            )
         if self.cgroups is not None:
             for cgroup in self.cgroups:
                 jailer_param_list.extend(['--cgroup', str(cgroup)])

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,8 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.39, "ARM": 83.09}
+
+COVERAGE_DICT = {"Intel": 85.00, "AMD": 84.44, "ARM": 83.13}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Addresses #841 

## Description of Changes

This patch set adds the ability to use the jailer on systems that use cgroup-v2.
A new parameter named `--cgroup-version` was introduced in the jailer that enables the user to swap between using Cgroup-v1 and Cgroup-v2.

Hybrid mode is not supported as it is impractical for production use because controllers cannot be added to both v1 and v2 hierarchies at the same time. Typically on systems that use hybrid cgroups, all controllers are mounted to v1 hierarchies by default preventing controllers to be added to v2.

The default behaviour of the jailer (if `--cgroup-version` is not specified) is to use Cgroup-v1.
Using the jailer with `--cgroup-version 1` on a system that does not have Cgroup-v1 hierarchies mounted will result in an error. The same happens if `--cgroup-version 2` on a system that does not have Cgroup-v2

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
