### PR TITLE
Fix seccomp

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -191,6 +191,19 @@
             },
             {
                 "syscall": "mmap",
+                "comment": "Used for large buffers sent to api_server",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -521,6 +521,19 @@
             },
             {
                 "syscall": "mmap",
+                "comment": "Used for large buffers sent to api_server",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -4,6 +4,8 @@
 
 # Disable pylint C0302: Too many lines in module
 # pylint: disable=C0302
+import array
+import itertools
 import os
 import platform
 import resource
@@ -1133,3 +1135,36 @@ def test_negative_api_lifecycle(bin_cloner_path):
     response = basevm.vm.patch(state='Resumed')
     assert "not supported before starting the microVM" \
         in response.text
+
+
+def test_map_private_seccomp_regression(test_microvm_with_ssh):
+    """
+    Seccomp mmap MAP_PRIVATE regression test.
+
+    When sending large buffer to an api endpoint there will be an attempt to
+    call mmap with MAP_PRIVATE|MAP_ANONYMOUS. This would result in vmm being
+    killed by the seccomp filter before this PR.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_ssh
+    test_microvm.spawn()
+    test_microvm.api_session.untime()
+
+    response = test_microvm.mmds.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == {}
+
+    data_store = {
+        'latest': {
+            'meta-data': {
+            }
+        }
+    }
+
+    slice_1mb = array.array('u', itertools.repeat('b', 1024 * 1024))
+    chars = array.array('u')
+    chars = [chars.extend(slice_1mb) for _ in range(190)]
+    data_store["latest"]["meta-data"]["ami-id"] = chars
+    response = test_microvm.mmds.put(json=data_store)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)


### PR DESCRIPTION
# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

When there is a large enough buffer there will be an attempt to map it using MAP_PRIVATE|MAP_ANONYMOUS. As mmap was not allowed with this flags on api_server thread the vmm was killed by seccomp filter.

## Description of Changes

-> Added rule to allow mmap with MAP_PRIVATE|MAP_ANONYMOUS
-> Added integration test.
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
