### PR TITLE
Fix Boot Timer

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -305,6 +305,10 @@ pub fn build_microvm_for_boot(
     seccomp_filters: &BpfThreadMap,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     use self::StartMicrovmError::*;
+
+    // Timestamp for measuring microVM boot duration.
+    let request_ts = TimestampUs::default();
+
     let boot_config = vm_resources.boot_source().ok_or(MissingKernelConfig)?;
 
     let track_dirty_pages = vm_resources.track_dirty_pages();
@@ -321,9 +325,6 @@ pub fn build_microvm_for_boot(
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
     let mut boot_cmdline = boot_config.cmdline.clone();
-
-    // Timestamp for measuring microVM boot duration.
-    let request_ts = TimestampUs::default();
 
     let (mut vmm, mut vcpus) = create_vmm_and_vcpus(
         instance_info,

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -11,7 +11,7 @@ MAX_BOOT_TIME_US = 150000
 # NOTE: for aarch64 most of the boot time is spent by the kernel to unpack the
 # initramfs in RAM. This time is influenced by the size and the compression
 # method of the used initrd image.
-INITRD_BOOT_TIME_US = 180000 if platform.machine() == "x86_64" else 200000
+INITRD_BOOT_TIME_US = 180000 if platform.machine() == "x86_64" else 205000
 # TODO: Keep a `current` boot time in S3 and validate we don't regress
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r'Guest-boot-time\s+\=\s+(\d+)\s+us'


### PR DESCRIPTION
The initial timestamp passed to the boot-timer to calculate uVM boot time was taken after creating guest memory, loading the kernel, and loading the initrd. These should be included in the overall boot time.

Signed-off-by: Ben Holmes <bencwholmes@gmail.com>

# Reason for This PR

Issue #2692

## Description of Changes

Moved the initial timestamp passed to the boot-timer to the beginning of  `build_microvm_for_boot()` to account for all steps in the build process. 

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
