### PR TITLE
bitmap: Calculate page count correctly

### DIFF
--- a/src/vm-memory/src/bitmap.rs
+++ b/src/vm-memory/src/bitmap.rs
@@ -53,7 +53,8 @@ impl Bitmap {
     /// Set a range of bits starting at `start_addr` and continuing for the next `len` bytes.
     pub fn set_addr_range(&self, start_addr: usize, len: usize) {
         let first_bit = start_addr / self.page_size;
-        let page_count = (len + self.page_size - 1) / self.page_size;
+        let page_count =
+            ((start_addr % self.page_size) + len + self.page_size - 1) / self.page_size;
         for n in first_bit..(first_bit + page_count) {
             if n > self.size {
                 // Attempts to set bits beyond the end of the bitmap are simply ignored.
@@ -125,6 +126,17 @@ mod tests {
         assert!(!b.is_addr_set(128));
         assert!(!b.is_addr_set(256));
         assert!(!b.is_addr_set(384));
+    }
+
+    #[test]
+    fn bitmap_addr_roll_over() {
+        use super::Bitmap;
+        let b = Bitmap::new(1024, 128);
+        assert!(!b.is_addr_set(127));
+        assert!(!b.is_addr_set(128));
+        b.set_addr_range(127, 2);
+        assert!(b.is_addr_set(127));
+        assert!(b.is_addr_set(128));
     }
 
     #[test]


### PR DESCRIPTION
# Reason for This PR

Currently page count won't be correctly set when start_addr is close to
the end of the page and the range crosses the page boundary. This
condition is likely never hit because start_addr is usually page
aligned, but hooray correctness's sake.

## Description of Changes

Correctly calculate page count in bitmap module.

- [x] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm)

Yes, I think so, but looks like [they have some slightly different logic](https://github.com/rust-vmm/vm-memory/blob/5bd7138758183a73ac0da27ce40c004d95f1a7e9/src/bitmap/backend/atomic_bitmap.rs#L72) with the [saturating add](https://doc.rust-lang.org/std/intrinsics/fn.saturating_add.html) function...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
