### PR TITLE
[cargo]: upgrade kvm-bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,8 +407,8 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.4.0"
-source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.4.0-1#9a5fbd29ad9011aa1e004849de7f28b2b3002b01"
+version = "0.5.0"
+source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.5.0-1#4569d3f5b7746b66fc58a14cd05e5dbf9368932b"
 dependencies = [
  "versionize",
  "versionize_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ panic = "abort"
 lto = true
 
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.4.0-1", features = ["fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.5.0-1", features = ["fam-wrappers"] }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 libc = ">=0.2.39"
 vm-memory = { path = "../vm-memory" }

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 
 utils = { path = "../utils"}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,7 +18,7 @@ vm-memory = { path = "../vm-memory" }
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
-kvm-bindings = { version = ">=0.4.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 logger = { path = "../logger" }
 mmds = { path = "../mmds" }


### PR DESCRIPTION
Signed-off-by: AlexandruCihodaru <cihodar@amazon.com>

# Reason for This PR

Rust-vmm team released a new version of kvm-bindings.

## Description of Changes

Use the newest release of kvm-bindings

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
