### PR TITLE
Block - perform some validations when parsing the request

### DIFF
--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -293,13 +293,12 @@ impl Request {
                 Ok(0)
             }
             RequestType::GetDeviceID => {
-                let disk_id = disk.image_id();
-                if (self.data_len as usize) < disk_id.len() {
+                if self.data_len < VIRTIO_BLK_ID_BYTES {
                     return Err(ErrStatus::IoErr(IoErrStatus::BadRequest(
-                        Error::InvalidOffset,
+                        Error::InvalidDataLength,
                     )));
                 }
-                mem.write_slice(disk_id, self.data_addr)
+                mem.write_slice(disk.image_id(), self.data_addr)
                     .map(|_| VIRTIO_BLK_ID_BYTES)
                     .map_err(|e| ErrStatus::IoErr(IoErrStatus::Write(e)))
             }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.96, "AMD": 84.39, "ARM": 83.24}
+COVERAGE_DICT = {"Intel": 84.96, "AMD": 84.39, "ARM": 83.18}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Block - perform some validations when parsing the request

Addresses a comment from an older PR: https://github.com/firecracker-microvm/firecracker/pull/2629#discussion_r656187051

## Description of Changes

This simplifies the request execution logic which will make it easier for us to add io_uring support.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
