### PR TITLE
Update micro http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added `--http_api_max_payload_size` parameter to configure the maximum payload
+  size for PUT and PATCH requests.
+
 ## [0.25.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?rev=49240ce#49240ce1d5a81a594aa12895c1ef4091c0fd8e9b"
+source = "git+https://github.com/firecracker-microvm/micro-http?rev=36e59a0#36e59a083e76a2449e0f58e4283d201bc72fdf13"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -435,6 +435,10 @@
                 "comment": "Used to retrieve data from the socket"
             },
             {
+                "syscall": "recvmsg",
+                "comment": "Needed by micro-http to read from the byte stream."
+            },
+            {
                 "syscall": "rt_sigprocmask",
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -434,6 +434,10 @@
                 "comment": "Used to retrieve data from the socket"
             },
             {
+                "syscall": "recvmsg",
+                "comment": "Needed by micro-http to read from the byte stream."
+            },
+            {
                 "syscall": "rt_sigprocmask",
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = ">=1.0.9"
 libc = ">=0.2.39"
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 mmds = { path = "../mmds" }
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -130,6 +130,7 @@ impl ApiServer {
     /// let mmds_info = MMDS.clone();
     /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1), Some(1));
     /// let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
+    /// let payload_limit = Some(51200);
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -144,6 +145,7 @@ impl ApiServer {
     ///             PathBuf::from(api_thread_path_to_socket),
     ///             time_reporter,
     ///             seccomp_filters.get("api").unwrap(),
+    ///             payload_limit,
     ///         )
     ///         .unwrap();
     ///     })
@@ -166,6 +168,7 @@ impl ApiServer {
         path: PathBuf,
         process_time_reporter: ProcessTimeReporter,
         seccomp_filter: BpfProgramRef,
+        maybe_request_size: Option<usize>,
     ) -> Result<()> {
         let mut server = HttpServer::new(path).unwrap_or_else(|e| {
             error!("Error creating the HTTP server: {}", e);
@@ -641,6 +644,7 @@ mod tests {
                     PathBuf::from(api_thread_path_to_socket),
                     ProcessTimeReporter::new(Some(1), Some(1), Some(1)),
                     seccomp_filters.get("api").unwrap(),
+                    None,
                 )
                 .unwrap();
             })

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -9,7 +9,7 @@ bitflags = ">=1.0.4"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -312,7 +312,7 @@ fn build_response(http_version: Version, status_code: StatusCode, body: Body) ->
 
 /// Parses the request bytes and builds a `micro_http::Response` by the given callback function.
 fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) -> Response {
-    let request = Request::try_from(byte_stream);
+    let request = Request::try_from(byte_stream, None);
     match request {
         Ok(request) => callback(request),
         Err(e) => match e {

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -361,6 +361,11 @@ fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) ->
                 StatusCode::BadRequest,
                 Body::new(e.to_string()),
             ),
+            RequestError::SizeLimitExceeded(_, _) => build_response(
+                Version::default(),
+                StatusCode::PayloadTooLarge,
+                Body::new(e.to_string()),
+            ),
         },
     }
 }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -123,6 +123,7 @@ pub(crate) fn run_with_api(
     instance_info: InstanceInfo,
     process_time_reporter: ProcessTimeReporter,
     boot_timer_enabled: bool,
+    payload_limit: Option<usize>,
 ) -> ExitCode {
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
@@ -149,6 +150,7 @@ pub(crate) fn run_with_api(
                 api_bind_path,
                 process_time_reporter,
                 &api_seccomp_filter,
+                payload_limit,
             ) {
                 Ok(_) => (),
                 Err(api_server::Error::Io(inner)) => match inner.kind() {

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -200,6 +200,11 @@ fn main_exitable() -> ExitCode {
             Argument::new("describe-snapshot")
                 .takes_value(true)
                 .help("Print the data format version of the provided snapshot state file.")
+        )
+        .arg(
+            Argument::new("http_api_max_payload_size")
+                .takes_value(true)
+                .help("Http API request payload max size.")
         );
 
     let arguments = match arg_parser.parse_from_cmdline() {
@@ -302,6 +307,13 @@ fn main_exitable() -> ExitCode {
             .single_value("api-sock")
             .map(PathBuf::from)
             .expect("Missing argument: api-sock");
+        let payload_limit = arg_parser
+            .arguments()
+            .single_value("http_api_max_payload_size")
+            .map(|lim| {
+                lim.parse::<usize>()
+                    .expect("'http_api_max_payload_size' parameter expected to be of 'usize' type.")
+            });
 
         let start_time_us = arguments.single_value("start-time-us").map(|s| {
             s.parse::<u64>()
@@ -327,6 +339,7 @@ fn main_exitable() -> ExitCode {
             instance_info,
             process_time_reporter,
             boot_timer_enabled,
+            payload_limit,
         )
     } else {
         let seccomp_filters: BpfThreadMap = seccomp_filters

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -12,7 +12,7 @@ versionize_derive = ">=0.1.3"
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 utils = { path = "../utils" }
 snapshot = { path = "../snapshot" }
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
 
         // Test resource not found.
         let request_bytes = b"GET http://169.254.169.254/invalid HTTP/1.0\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::NotFound);
         expected_response.set_body(Body::new("Resource not found: /invalid.".to_string()));
         let actual_response = convert_to_response(request);
@@ -186,7 +186,7 @@ mod tests {
 
         // Test NotImplemented.
         let request_bytes = b"GET /age HTTP/1.1\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
         let body = "Cannot retrieve value. The value has an unsupported type.".to_string();
         expected_response.set_body(Body::new(body));
@@ -197,7 +197,7 @@ mod tests {
         let not_allowed_methods = ["PUT", "PATCH"];
         for method in not_allowed_methods.iter() {
             let request_bytes = format!("{} http://169.254.169.255/ HTTP/1.0\r\n\r\n", method);
-            let request = Request::try_from(request_bytes.as_bytes()).unwrap();
+            let request = Request::try_from(request_bytes.as_bytes(), None).unwrap();
             let mut expected_response =
                 Response::new(Version::Http10, StatusCode::MethodNotAllowed);
             expected_response.set_body(Body::new("Not allowed HTTP method.".to_string()));
@@ -208,7 +208,7 @@ mod tests {
 
         // Test invalid (empty absolute path) URI.
         let request_bytes = b"GET http:// HTTP/1.0\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
         expected_response.set_body(Body::new("Invalid URI.".to_string()));
         let actual_response = convert_to_response(request);
@@ -217,7 +217,7 @@ mod tests {
         // Test Ok path.
         let request_bytes = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
                                     Accept: application/json\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
         let mut body = r#"{
                 "age": 43,

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.96, "AMD": 84.39, "ARM": 83.18}
+COVERAGE_DICT = {"Intel": 84.88, "AMD": 84.32, "ARM": 83.18}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Updated micro-http dependency to latest version which limits the payload size for PUT and PATCH requests.

## Description of Changes

-> consumed latest version of micro-http and updated API calls.
-> Added recvmsg on seccomp allowlist becase on upstream micro-http `read` call was replaced with `recv_with_fd`
-> Added cmdline parameter to customize the request upper limit.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
