### PR TITLE
Limit data store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `--http_api_max_payload_size` parameter to configure the maximum payload
   size for PUT and PATCH requests.
+- Limit MMDS data store size to `--http_api_max_payload_size`.
 
 ## [0.25.0]
 

--- a/docs/mmds/mmds-design.md
+++ b/docs/mmds/mmds-design.md
@@ -58,6 +58,10 @@ the MMDS contents. It leverages the recursive
 store supports at the moment storing and retrieving JSON values. Data store
 contents can be retrieved using the Firecracker API server from host and using
 the embedded MMDS HTTP/TCP/IPv4 network stack from guest.
+MMDS data store is upper bounded by a default maximum size of 51200 bytes. This
+limit can be modified using `--http_api_max_payload_size` command line parameter.
+All PUT and PATCH requests with Content-Length bigger than the imposed limit will
+receive HTTP 413 Payload Too Large response status code.
 
 ## Dumbo
 

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -107,6 +107,7 @@ impl ApiServer {
     /// # Example
     ///
     /// ```
+    /// use mmds::MAX_DATA_STORE_SIZE;
     /// use api_server::ApiServer;
     /// use mmds::MMDS;
     /// use std::{
@@ -130,7 +131,7 @@ impl ApiServer {
     /// let mmds_info = MMDS.clone();
     /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1), Some(1));
     /// let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
-    /// let payload_limit = Some(51200);
+    /// let payload_limit = Some(MAX_DATA_STORE_SIZE);
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -326,6 +327,10 @@ impl ApiServer {
                 data_store::Error::UnsupportedValueType => unreachable!(),
                 data_store::Error::NotInitialized => ApiServer::json_response(
                     StatusCode::BadRequest,
+                    ApiServer::json_fault_message(e.to_string()),
+                ),
+                data_store::Error::DataStoreLimitExceeded => ApiServer::json_response(
+                    StatusCode::PayloadTooLarge,
                     ApiServer::json_fault_message(e.to_string()),
                 ),
             },

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use mmds::MAX_DATA_STORE_SIZE;
 use std::io::prelude::*;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
@@ -135,6 +136,10 @@ pub(crate) fn run_with_api(
 
     // MMDS only supported with API.
     let mmds_info = MMDS.clone();
+    mmds_info
+        .lock()
+        .expect("Failed to acquire lock on MMDS info")
+        .set_data_store_limit(payload_limit.unwrap_or(MAX_DATA_STORE_SIZE));
     let to_vmm_event_fd = api_event_fd
         .try_clone()
         .expect("Failed to clone API event FD");

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
 use lazy_static::lazy_static;
 use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
+pub const MAX_DATA_STORE_SIZE: usize = 51200;
 
 lazy_static! {
     // A static reference to a global Mmds instance. We currently use this for ease of access during
@@ -125,6 +126,11 @@ fn convert_to_response(request: Request) -> Response {
             MmdsError::UnsupportedValueType => build_response(
                 request.http_version(),
                 StatusCode::NotImplemented,
+                Body::new(e.to_string()),
+            ),
+            MmdsError::DataStoreLimitExceeded => build_response(
+                request.http_version(),
+                StatusCode::PayloadTooLarge,
                 Body::new(e.to_string()),
             ),
             MmdsError::NotInitialized => unreachable!(),

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -44,11 +44,16 @@ class Session(requests.Session):
             """Return `True` when HTTP response code is 404 NotFound."""
             return response == 404
 
+        def is_status_payload_too_large(response: int):
+            """Return `True` when HTTP response code is 413 PayloadTooLarge."""
+            return response == 413
+
         self.is_good_response = is_good_response
         self.is_status_ok = is_status_ok
         self.is_status_no_content = is_status_no_content
         self.is_status_bad_request = is_status_bad_request
         self.is_status_not_found = is_status_not_found
+        self.is_status_payload_too_large = is_status_payload_too_large
 
     @decorators.timed_request
     def get(self, url, **kwargs):

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.73, "AMD": 84.13, "ARM": 82.83}
+COVERAGE_DICT = {"Intel": 84.67, "AMD": 84.13, "ARM": 82.82}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

- Make sure that MMDS data store size is less than the payload limit of requests.

## Description of Changes
- Limit MMDS data store size.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
