### PR TITLE
[block] Define sync/async IO abstractions

### DIFF
--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -1,0 +1,94 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::virtio::block::io::{UserDataError, UserDataOk};
+use std::fs::File;
+use std::marker::PhantomData;
+use utils::eventfd::EventFd;
+use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+#[derive(Debug)]
+pub enum Error {
+    IO(std::io::Error),
+    OpNotImplemented,
+    SyncAll(std::io::Error),
+}
+
+pub struct AsyncFileEngine<T> {
+    file: File,
+    #[allow(unused)]
+    completion_evt: EventFd,
+    phantom: PhantomData<T>,
+}
+
+impl<T> AsyncFileEngine<T> {
+    #[allow(unused)]
+    pub fn from_file(file: File) -> std::io::Result<AsyncFileEngine<T>> {
+        let completion_evt = EventFd::new(libc::EFD_NONBLOCK)?;
+
+        Ok(AsyncFileEngine {
+            file,
+            completion_evt,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    #[allow(unused)]
+    pub fn completion_evt(&self) -> &EventFd {
+        &self.completion_evt
+    }
+
+    pub fn push_read(
+        &mut self,
+        _offset: u64,
+        _mem: &GuestMemoryMmap,
+        _addr: GuestAddress,
+        _count: u32,
+        user_data: Box<T>,
+    ) -> Result<(), UserDataError<T, Error>> {
+        Err(UserDataError {
+            user_data,
+            error: Error::OpNotImplemented,
+        })
+    }
+
+    pub fn push_write(
+        &mut self,
+        _offset: u64,
+        _mem: &GuestMemoryMmap,
+        _addr: GuestAddress,
+        _count: u32,
+        user_data: Box<T>,
+    ) -> Result<(), UserDataError<T, Error>> {
+        Err(UserDataError {
+            user_data,
+            error: Error::OpNotImplemented,
+        })
+    }
+
+    pub fn push_flush(&mut self, user_data: Box<T>) -> Result<(), UserDataError<T, Error>> {
+        Err(UserDataError {
+            user_data,
+            error: Error::OpNotImplemented,
+        })
+    }
+
+    #[allow(unused)]
+    pub fn kick_submission_queue(&self) -> Result<(), Error> {
+        Err(Error::OpNotImplemented)
+    }
+
+    /// Wait until all the entries in the submission queue are processed, then flush if requested.
+    pub fn drain(&mut self, _flush: bool) -> Result<(), Error> {
+        Err(Error::OpNotImplemented)
+    }
+
+    #[allow(unused)]
+    pub fn pop(&mut self) -> Option<Result<UserDataOk<T>, UserDataError<T, Error>>> {
+        None
+    }
+}

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -1,0 +1,310 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod async_io;
+pub mod sync_io;
+
+pub use self::async_io::AsyncFileEngine;
+pub use self::sync_io::SyncFileEngine;
+use std::fs::File;
+use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct UserDataOk<T> {
+    pub user_data: Box<T>,
+    pub count: u32,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum FileEngineOk<T> {
+    Submitted,
+    Executed(UserDataOk<T>),
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Sync(sync_io::Error),
+    Async(async_io::Error),
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct UserDataError<T, E> {
+    pub user_data: Box<T>,
+    pub error: E,
+}
+
+pub enum FileEngine<T> {
+    #[allow(unused)]
+    Async(AsyncFileEngine<T>),
+    Sync(SyncFileEngine),
+}
+
+impl<T> FileEngine<T> {
+    pub fn from_file(file: File) -> std::io::Result<FileEngine<T>> {
+        Ok(FileEngine::Sync(SyncFileEngine::from_file(file)))
+    }
+
+    pub fn file(&self) -> &File {
+        match self {
+            FileEngine::Async(engine) => engine.file(),
+            FileEngine::Sync(engine) => engine.file(),
+        }
+    }
+
+    pub fn read(
+        &mut self,
+        offset: u64,
+        mem: &GuestMemoryMmap,
+        addr: GuestAddress,
+        count: u32,
+        user_data: Box<T>,
+    ) -> Result<FileEngineOk<T>, UserDataError<T, Error>> {
+        match self {
+            FileEngine::Async(engine) => {
+                match engine.push_read(offset, mem, addr, count, user_data) {
+                    Ok(_) => Ok(FileEngineOk::Submitted),
+                    Err(e) => Err(UserDataError {
+                        user_data: e.user_data,
+                        error: Error::Async(e.error),
+                    }),
+                }
+            }
+            FileEngine::Sync(engine) => match engine.read(offset, mem, addr, count) {
+                Ok(count) => Ok(FileEngineOk::Executed(UserDataOk { user_data, count })),
+                Err(e) => Err(UserDataError {
+                    user_data,
+                    error: Error::Sync(e),
+                }),
+            },
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        offset: u64,
+        mem: &GuestMemoryMmap,
+        addr: GuestAddress,
+        count: u32,
+        user_data: Box<T>,
+    ) -> Result<FileEngineOk<T>, UserDataError<T, Error>> {
+        match self {
+            FileEngine::Async(engine) => {
+                match engine.push_write(offset, mem, addr, count, user_data) {
+                    Ok(_) => Ok(FileEngineOk::Submitted),
+                    Err(e) => Err(UserDataError {
+                        user_data: e.user_data,
+                        error: Error::Async(e.error),
+                    }),
+                }
+            }
+            FileEngine::Sync(engine) => match engine.write(offset, mem, addr, count) {
+                Ok(count) => Ok(FileEngineOk::Executed(UserDataOk { user_data, count })),
+                Err(e) => Err(UserDataError {
+                    user_data,
+                    error: Error::Sync(e),
+                }),
+            },
+        }
+    }
+
+    pub fn flush(&mut self, user_data: Box<T>) -> Result<FileEngineOk<T>, UserDataError<T, Error>> {
+        match self {
+            FileEngine::Async(engine) => match engine.push_flush(user_data) {
+                Ok(_) => Ok(FileEngineOk::Submitted),
+                Err(e) => Err(UserDataError {
+                    user_data: e.user_data,
+                    error: Error::Async(e.error),
+                }),
+            },
+            FileEngine::Sync(engine) => match engine.flush() {
+                Ok(_) => Ok(FileEngineOk::Executed(UserDataOk {
+                    user_data,
+                    count: 0,
+                })),
+                Err(e) => Err(UserDataError {
+                    user_data,
+                    error: Error::Sync(e),
+                }),
+            },
+        }
+    }
+
+    pub fn drain(&mut self, flush: bool) -> Result<(), Error> {
+        match self {
+            FileEngine::Async(engine) => engine.drain(flush).map_err(Error::Async),
+            FileEngine::Sync(engine) => {
+                if !flush {
+                    return Ok(());
+                }
+                engine.flush().map_err(Error::Sync)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::os::unix::ffi::OsStrExt;
+
+    use super::*;
+    use std::os::unix::io::FromRawFd;
+    use utils::tempfile::TempFile;
+    use vm_memory::{Bytes, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
+
+    const FILE_LEN: u32 = 1024;
+    const MEM_LEN: usize = 4096;
+
+    macro_rules! assert_err {
+        ($expression:expr, $($pattern:tt)+) => {
+            match $expression {
+                Err(UserDataError {
+                    user_data: _,
+                    error: $($pattern)+,
+                }) => (),
+                ref e => {
+                    println!("expected `{}` but got `{:?}`", stringify!($($pattern)+), e);
+                    assert!(false)
+                }
+            }
+        };
+    }
+
+    macro_rules! assert_executed {
+        ($expression:expr, $count:expr) => {
+            if let Ok(FileEngineOk::Executed(UserDataOk {
+                user_data: _,
+                count,
+            })) = $expression
+            {
+                assert_eq!(count, $count);
+            } else {
+                println!("expected Ok, received Err");
+                assert!(false);
+            }
+        };
+    }
+
+    fn clear_mem(mem: &GuestMemoryMmap) {
+        for region in mem.iter() {
+            let empty_data = vec![0u8; region.len() as usize];
+            region
+                .write_slice(&empty_data, MemoryRegionAddress(0))
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_sync() {
+        // Create guest memory
+        let mem =
+            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], false)
+                .unwrap();
+
+        // Check invalid file
+        let file = unsafe { File::from_raw_fd(-2) };
+        let mut engine = FileEngine::from_file(file).unwrap();
+        let res = engine.read(0, &mem, GuestAddress(0), 0, Box::new(()));
+        assert_err!(res, Error::Sync(sync_io::Error::Seek(_e)));
+        let res = engine.write(0, &mem, GuestAddress(0), 0, Box::new(()));
+        assert_err!(res, Error::Sync(sync_io::Error::Seek(_e)));
+        let res = engine.flush(Box::new(()));
+        assert_err!(res, Error::Sync(sync_io::Error::SyncAll(_e)));
+
+        // Create backing file.
+        let file = TempFile::new().unwrap().into_file();
+        let mut engine = FileEngine::from_file(file).unwrap();
+
+        let data = utils::rand::rand_alphanumerics(FILE_LEN as usize)
+            .as_bytes()
+            .to_vec();
+
+        // Partial write
+        let partial_len = 50;
+        let addr = GuestAddress(MEM_LEN as u64 - partial_len);
+        mem.write(&data, addr).unwrap();
+        assert_executed!(
+            engine.write(0, &mem, addr, FILE_LEN, Box::new(())),
+            partial_len as u32
+        );
+        // Partial read
+        clear_mem(&mem);
+        assert_executed!(
+            engine.read(0, &mem, addr, FILE_LEN, Box::new(())),
+            partial_len as u32
+        );
+        // Check data
+        let mut buf = vec![0u8; partial_len as usize];
+        mem.read_slice(&mut buf, addr).unwrap();
+        assert_eq!(buf, data[..partial_len as usize]);
+
+        // Offset write
+        let offset = 100;
+        let partial_len = 50;
+        let addr = GuestAddress(0);
+        mem.write(&data, addr).unwrap();
+        assert_executed!(
+            engine.write(offset, &mem, addr, partial_len, Box::new(())),
+            partial_len as u32
+        );
+        // Offset read
+        clear_mem(&mem);
+        assert_executed!(
+            engine.read(offset, &mem, addr, partial_len, Box::new(())),
+            partial_len as u32
+        );
+        // Check data
+        let mut buf = vec![0u8; partial_len as usize];
+        mem.read_slice(&mut buf, addr).unwrap();
+        assert_eq!(buf, data[..partial_len as usize]);
+
+        // Full write
+        mem.write(&data, GuestAddress(0)).unwrap();
+        assert_executed!(
+            engine.write(0, &mem, GuestAddress(0), FILE_LEN, Box::new(())),
+            FILE_LEN
+        );
+        // Full read
+        clear_mem(&mem);
+        assert_executed!(
+            engine.read(0, &mem, GuestAddress(0), FILE_LEN, Box::new(())),
+            FILE_LEN
+        );
+        // Check data
+        let mut buf = vec![0u8; FILE_LEN as usize];
+        mem.read_slice(&mut buf, GuestAddress(0)).unwrap();
+        assert_eq!(buf, data.as_slice());
+
+        // Check other ops
+        assert!(engine.flush(Box::new(())).is_ok());
+        assert!(engine.drain(true).is_ok());
+        assert!(engine.drain(false).is_ok());
+    }
+
+    #[test]
+    fn test_async() {
+        // Create guest memory
+        let mem =
+            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], false)
+                .unwrap();
+
+        // Create backing file.
+        let file = TempFile::new().unwrap().into_file();
+        let mut engine = FileEngine::Async(AsyncFileEngine::from_file(file).unwrap());
+
+        // All ops should return an Error
+        let addr = GuestAddress(0);
+        let res = engine.write(0, &mem, addr, FILE_LEN, Box::new(()));
+        assert_err!(res, Error::Async(async_io::Error::OpNotImplemented));
+        let res = engine.read(0, &mem, addr, FILE_LEN, Box::new(()));
+        assert_err!(res, Error::Async(async_io::Error::OpNotImplemented));
+        let res = engine.flush(Box::new(()));
+        assert_err!(res, Error::Async(async_io::Error::OpNotImplemented));
+        assert!(engine.drain(true).is_err());
+        assert!(engine.drain(false).is_err());
+
+        if let FileEngine::Async(mut engine) = engine {
+            assert!(engine.kick_submission_queue().is_err());
+            assert!(engine.pop().is_none());
+        }
+    }
+}

--- a/src/devices/src/virtio/block/io/sync_io.rs
+++ b/src/devices/src/virtio/block/io/sync_io.rs
@@ -1,0 +1,69 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Seek, SeekFrom, Write};
+use std::result::Result;
+
+use std::fs::File;
+use vm_memory::{Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+
+#[derive(Debug)]
+pub enum Error {
+    Flush(std::io::Error),
+    Seek(std::io::Error),
+    SyncAll(std::io::Error),
+    Transfer(GuestMemoryError),
+}
+
+pub struct SyncFileEngine {
+    file: File,
+}
+
+unsafe impl Send for SyncFileEngine {}
+
+impl SyncFileEngine {
+    pub fn from_file(file: File) -> SyncFileEngine {
+        SyncFileEngine { file }
+    }
+
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    pub fn read(
+        &mut self,
+        offset: u64,
+        mem: &GuestMemoryMmap,
+        addr: GuestAddress,
+        count: u32,
+    ) -> Result<u32, Error> {
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .map_err(Error::Seek)?;
+        mem.read_from(addr, &mut self.file, count as usize)
+            .map(|count| count as u32)
+            .map_err(Error::Transfer)
+    }
+
+    pub fn write(
+        &mut self,
+        offset: u64,
+        mem: &GuestMemoryMmap,
+        addr: GuestAddress,
+        count: u32,
+    ) -> Result<u32, Error> {
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .map_err(Error::Seek)?;
+        mem.write_to(addr, &mut self.file, count as usize)
+            .map(|count| count as u32)
+            .map_err(Error::Transfer)
+    }
+
+    pub fn flush(&mut self) -> Result<(), Error> {
+        // flush() first to force any cached data out of rust buffers.
+        self.file.flush().map_err(Error::Flush)?;
+        // Sync data out to physical media on host.
+        self.file.sync_all().map_err(Error::SyncAll)
+    }
+}

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod device;
 pub mod event_handler;
+mod io;
 pub mod persist;
 pub mod request;
 pub mod test_utils;

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -6,26 +6,23 @@
 // found in the THIRD-PARTY file.
 
 use std::convert::From;
-use std::io::{self, Seek, SeekFrom, Write};
 use std::result;
 
 use logger::{error, IncMetric, METRICS};
-use rate_limiter::{RateLimiter, TokenType};
 use virtio_gen::virtio_blk::*;
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
 use super::super::DescriptorChain;
-use super::device::DiskProperties;
-use super::{Error, SECTOR_SHIFT, SECTOR_SIZE};
+use super::{io as block_io, Error, SECTOR_SHIFT};
+use crate::virtio::block::device::DiskProperties;
+use crate::virtio::SECTOR_SIZE;
+use rate_limiter::{RateLimiter, TokenType};
 
 #[derive(Debug)]
 pub enum IoErr {
-    GetDeviceId(GuestMemoryError),
-    Flush(io::Error),
+    GetId(GuestMemoryError),
     PartialTransfer { completed: u32, expected: u32 },
-    Seek(io::Error),
-    SyncAll(io::Error),
-    Transfer(GuestMemoryError),
+    FileEngine(block_io::Error),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -323,6 +320,10 @@ impl Request {
         false
     }
 
+    fn offset(&self) -> u64 {
+        self.sector << SECTOR_SHIFT
+    }
+
     fn to_pending_request(&self, desc_idx: u16) -> PendingRequest {
         PendingRequest {
             r#type: self.r#type,
@@ -332,52 +333,48 @@ impl Request {
         }
     }
 
-    fn execute_seek(&self, disk: &mut DiskProperties) -> result::Result<(), IoErr> {
-        disk.file_mut()
-            .seek(SeekFrom::Start(self.sector << SECTOR_SHIFT))
-            .map(|_| ())
-            .map_err(IoErr::Seek)
-    }
-
     pub(crate) fn execute(
-        &self,
+        self,
         disk: &mut DiskProperties,
         desc_idx: u16,
         mem: &GuestMemoryMmap,
-    ) -> FinishedRequest {
-        let pending = self.to_pending_request(desc_idx);
+    ) -> Option<FinishedRequest> {
+        let pending = Box::new(self.to_pending_request(desc_idx));
         let res = match self.r#type {
-            RequestType::In => self.execute_seek(disk).and_then(|_| {
-                mem.read_from(self.data_addr, disk.file_mut(), self.data_len as usize)
-                    .map(|count| count as u32)
-                    .map_err(IoErr::Transfer)
-            }),
-            RequestType::Out => self.execute_seek(disk).and_then(|_| {
-                mem.write_to(self.data_addr, disk.file_mut(), self.data_len as usize)
-                    .map(|count| count as u32)
-                    .map_err(IoErr::Transfer)
-            }),
-            RequestType::Flush => {
-                // flush() first to force any cached data out.
-                disk.file_mut()
-                    .flush()
-                    .map_err(IoErr::Flush)
-                    .and_then(|_| {
-                        // Sync data out to physical media on host.
-                        disk.file_mut().sync_all().map_err(IoErr::SyncAll)
-                    })
-                    .map(|_| 0)
+            RequestType::In => disk.file_engine_mut().read(
+                self.offset(),
+                mem,
+                self.data_addr,
+                self.data_len,
+                pending,
+            ),
+            RequestType::Out => disk.file_engine_mut().write(
+                self.offset(),
+                mem,
+                self.data_addr,
+                self.data_len,
+                pending,
+            ),
+            RequestType::Flush => disk.file_engine_mut().flush(pending),
+            RequestType::GetDeviceID => {
+                let res = mem
+                    .write_slice(disk.image_id(), self.data_addr)
+                    .map(|_| VIRTIO_BLK_ID_BYTES)
+                    .map_err(IoErr::GetId);
+                return Some(pending.finish(mem, res));
             }
-            RequestType::GetDeviceID => mem
-                .write_slice(disk.image_id(), self.data_addr)
-                .map(|_| VIRTIO_BLK_ID_BYTES)
-                .map_err(IoErr::Transfer),
-            RequestType::Unsupported(_op) => {
-                return pending.finish(mem, Ok(0));
+            RequestType::Unsupported(_) => {
+                return Some(pending.finish(mem, Ok(0)));
             }
         };
 
-        pending.finish(mem, res)
+        match res {
+            Ok(block_io::FileEngineOk::Submitted) => None,
+            Ok(block_io::FileEngineOk::Executed(res)) => {
+                Some(res.user_data.finish(mem, Ok(res.count)))
+            }
+            Err(e) => Some(e.user_data.finish(mem, Err(IoErr::FileEngine(e.error)))),
+        }
     }
 }
 


### PR DESCRIPTION
# Reason for This PR

Define sync/async IO abstractions. This functionality will be needed in order to be able to leverage io_uring later.

## Description of Changes

Define a FileEngine abstraction that can be used in order to perform
operations like read/write between a file and the guest memory or flush
on the file. The FileEngine supports both sync and async backends. For
the moment we implement only the sync one.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
