### PR TITLE
[firecracker-v0.25] Build release archive

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -397,21 +397,22 @@ get_user_confirmation() {
 }
 
 # Validate the user supplied version number.
-# It must be composed of 3 groups of integers separated by dot.
+# It must be composed of 3 groups of integers separated by dot and can
+# be followed by a `-` and alpha characters.
 #
 validate_version() {
-    declare version_regex="^([0-9]+.){2}[0-9]+$"
+    declare version_regex="^([0-9]+.){2}[0-9]+(-[a-z]+)?$"
     version="$1"
 
     if [ -z "$version" ]; then
         die "Version cannot be empty."
     elif [[ ! "$version" =~ $version_regex ]]; then
-        die "Invalid version number: $version (expected: \$Major.\$Minor.\$Build)."
+        die "Invalid version number: $version (expected: \$Major.\$Minor.\$Build or \$Major.\$Minor.\$Build-[a-z])."
     fi
 
 }
 
-# Validate that the repo targetted for a release exists.
+# Validate that the repo targeted for a release exists.
 #
 validate_repo() {
     user="$1"
@@ -676,6 +677,9 @@ cmd_help() {
     echo "        Builds the development container from its Dockerfile."
     echo "        -n, --no-python-package-update  Do not update python packages."
     echo ""
+
+    help_build_release_archive
+
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
     echo ""
@@ -760,6 +764,17 @@ help_release() {
     echo "        -r, --repo                The name of the repository where the release will be posted."
     echo "        -m, --remote              The name of the remote where the release tag will be pushed."
     echo "        -p, --prerelease          Marks the release as a pre-release."
+}
+
+help_build_release_archive() {
+    echo "    build_release_archive -v <val>"
+    echo "        Building the release archive involves the following steps:"
+    echo "            1. Running integration tests."
+    echo "            2. Building release binaries and stripping them of debug symbols."
+    echo "            3. Verifying artifacts' version against release version targeted."
+    echo "            4. Packing all artifacts into \`release-v{X.Y.Z}-{arch}\` directory."
+    echo "            5. Creating firecracker-v{X.Y.Z}-{arch} release archive."
+    echo "        -v, --version             The targeted release version."
 }
 
 # `$0 build` - build Firecracker
@@ -960,6 +975,135 @@ cmd_strip() {
     }
 
     return $ret
+}
+
+cmd_build_release_archive() {
+    target="$TARGET_PREFIX""musl"
+    profile="release"
+    seccomp_json="resources/seccomp/$target.json"
+
+    # Parse any command line args.
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "-h"|"--help")      { help_build_release_archive; exit 1; } ;;
+            "-v"|"--version")   { version="$2"; shift 2;              } ;;
+            *)
+                die "Unknown argument: $1. Please use --help for help."
+        esac
+    done
+
+    validate_version "$version"
+    say "Will start preparing release archive for v$version ..."
+    get_user_confirmation || die "Aborted."
+
+    # Run tests, build release binaries and strip them from debug symbols.
+    ( cmd_test && cmd_build --release && cmd_strip ) || die "Aborted."
+
+    release_suffix="v$version-$(uname -m)"
+    release_dir="release-$release_suffix"
+    # Create release directory or overwrite if it already exists.
+    rm -rf "$release_dir" && mkdir "$release_dir"
+
+    # Copy release artifacts to release directory.
+    say "Populating release artifacts directory..."
+    bin_paths=( "$(build_fc_bin_path "$target" "$profile")"
+                "$(build_jailer_bin_path "$target" "$profile")"
+                "$(build_seccomp_bin_path "$target" "$profile")" )
+    for bin_path in "${bin_paths[@]}"; do
+        add_bin_artifact "$release_dir" "$bin_path" "$release_suffix"
+    done
+
+    add_swagger_artifact "$release_dir"
+    add_folder_artifact "$release_dir" "test_results" "$release_suffix"
+    add_file_artifact "$release_dir" "$seccomp_json" "seccomp-filter-$release_suffix.json"
+    for file in "LICENSE" "NOTICE" "THIRD-PARTY"; do
+        add_file_artifact "$release_dir" "$file"
+    done
+
+    # Create release archive.
+    archive_name="firecracker-$release_suffix.tgz"
+    say "Creating release archive..."
+    tar -czf "$archive_name" "$release_dir"
+    say "Done. Archive $archive_name successfully created."
+}
+
+check_file_existence() {
+    artifact="$1"
+    if [ ! -f "$artifact" ]; then
+        die "Artifact $artifact does not exist!"
+    fi
+}
+
+add_swagger_artifact() {
+    local release_dir="$1"
+    local swagger_path="src/api_server/swagger/firecracker.yaml"
+
+    check_file_existence "$swagger_path"
+
+    # Validate swagger version against target version.
+    swagger_ver=$(get_swagger_version "$swagger_path")
+    if [ ! "$swagger_ver" == "$version" ]; then
+        die "Swagger version: $swagger_ver does not match release version: $version."
+    fi
+
+    copy_release_artifact "$swagger_path" "$release_dir/firecracker_spec-v$version.yaml"
+}
+
+add_file_artifact() {
+    local release_dir="$1"
+    local path="$2"
+    local name="${3:-"$path"}"
+
+    check_file_existence "$path"
+    copy_release_artifact "$path" "$release_dir/$name"
+}
+
+add_bin_artifact() {
+    local release_dir="$1"
+    local path="$2"
+    local release_suffix="$3"
+
+    check_file_existence "$path"
+
+    # Validate binary version against target version.
+    output=$("$path" --version)
+    bin_version=$( echo "$output" | head -1 | grep -oP ' v\K.*')
+    if [[ ! "$bin_version" == "$version" ]]; then
+        die "Artifact $path's version: $bin_version does not match release version $version."
+    fi
+
+    formatted_name="$(basename "$path")-$release_suffix"
+    copy_release_artifact "$path" "$release_dir/$formatted_name"
+}
+
+add_folder_artifact() {
+    local release_dir="$1"
+    local path="$2"
+    local release_suffix="$3"
+
+    # Ensure the directory exists.
+    if [ ! -d "$path" ]; then
+        die "Artifact $path does not exist!"
+    fi
+    formatted_name="$(basename "$path")-$release_suffix"
+    copy_release_artifact "$path" "$release_dir/$formatted_name"
+}
+
+copy_release_artifact() {
+    local from_path="$1"
+    local to_path="$2"
+
+    say "Copying release artifact from $from_path to $to_path."
+    if [[ -f "$from_path" ]]; then
+        cp "$from_path" "$to_path"
+    elif [[ -d "$from_path" ]]; then
+        cp -r "$from_path" "$to_path"
+    fi
+}
+
+get_swagger_version() {
+    local file="$1"
+    grep -oP 'version: \K.*' "$file"
 }
 
 mount_ramdisk() {
@@ -1200,7 +1344,7 @@ cmd_prepare_release() {
 
     # Get current version from the swagger spec.
     swagger="$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
-    curr_ver=$(grep "version: " "$swagger" | awk -F : '{print $2}' | tr -d ' ')
+    curr_ver=get_swagger_version "$swagger"
 
     say "Updating from $curr_ver to $version ..."
     get_user_confirmation || die "Aborted."


### PR DESCRIPTION
# Reason for This PR

Have a way of creating release archive for a target version.

## Description of Changes

- Added logic to build release binaries and wrap all release artifacts into an archive.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
