### PR TITLE
[devtool] use full swagger path

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -711,7 +711,7 @@ check_file_existence() {
 
 add_swagger_artifact() {
     local release_dir="$1"
-    local swagger_path="src/api_server/swagger/firecracker.yaml"
+    local swagger_path="$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
 
     check_file_existence "$swagger_path"
 
@@ -945,7 +945,7 @@ cmd_prepare_release() {
 
     # Get current version from the swagger spec.
     swagger="$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
-    curr_ver=get_swagger_version "$swagger"
+    curr_ver=$(get_swagger_version "$swagger")
 
     say "Updating from $curr_ver to $version ..."
     get_user_confirmation || die "Aborted."


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Small fix: use absolute path for swagger file when fetching version.

## Description of Changes

Changed local variable to use absolute path for swagger.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
