### PR TITLE
Add cargo-deny to x86_64 devtool Dockerfile

### DIFF
--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -84,6 +84,7 @@ RUN mkdir "$TMP_BUILD_DIR" \
         && cd "$TMP_BUILD_DIR" \
             && cargo install cargo-kcov \
             && cargo +"stable" install cargo-audit \
+            && cargo install --locked cargo-deny \
             && cargo kcov --print-install-kcov-sh | sh \
         && rm -rf "$CARGO_HOME/registry" \
         && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v31"
+DEVCTR_IMAGE_TAG="v32"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
# Reason for This PR

Cargo deny will be used to audit licenses in our project. Also updated the container images to fix a cargo audit, which was out of date.

## Description of Changes

Updated devtool Docker images for x86_64 and aarch64 and added cargo deny to the x86_64 container image.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
