### PR TITLE
Update to latest micro-http version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?rev=36e59a0#36e59a083e76a2449e0f58e4283d201bc72fdf13"
+source = "git+https://github.com/firecracker-microvm/micro-http?rev=0a58eb1#0a58eb1ece68e326e68365c4297d0a7c08ecd9bc"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = ">=1.0.9"
 libc = ">=0.2.39"
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
 mmds = { path = "../mmds" }
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -9,7 +9,7 @@ bitflags = ">=1.0.4"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -12,7 +12,7 @@ versionize_derive = ">=0.1.3"
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
 utils = { path = "../utils" }
 snapshot = { path = "../snapshot" }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.75, "AMD": 84.17, "ARM": 82.80}
+COVERAGE_DICT = {"Intel": 84.75, "AMD": 84.17, "ARM": 82.75}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

We have introduced new functionality in micro-http and we need to update our dependency.

## Description of Changes

This PR updates the micro-http dependency to revision 0a58eb1 where we introduced a new `Deprecation` header.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
