### PR TITLE
Add API support policy

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -6,9 +6,12 @@ customers effectively plan their Firecracker based operations.
 
 ## Firecracker releases
 
-Firecracker uses [semantic versioning](http://semver.org/) for all releases.
-Semantic versions are comprised of three fields in the form:
-`vMAJOR.MINOR.PATCH`.
+Firecracker uses [semantic versioning 2.0.0](http://semver.org/) for all
+releases. By definition, the API version implemented by a Firecracker binary
+is equivalent to that binary’s version. Semantic versions are comprised of
+three fields in the form: `vMAJOR.MINOR.PATCH`. Additional labels for
+pre-release and build metadata are available as extensions to the
+MAJOR.MINOR.PATCH format.
 
 For example: v0.20.0, v0.22.0-beta5, and v99.123.77+foo.bar.baz.5.
 
@@ -75,6 +78,34 @@ security issues when they are found, for:
   is the last minor of v2 and has less than one year since release while v3.0
   and v3.1 will be patched since were the last two Firecracker releases and
   less than 6 months have passed since release time.
+
+## API support
+
+The Firecracker API follows the semantic versioning standard. For a new
+release, we will increment the:
+
+* MAJOR version when we make breaking changes in our API;
+* MINOR version when we add or change functionality in a backwards compatible
+  manner;
+* PATCH version when we make backwards compatible bug fixes.
+
+Given a Firecracker version X.Y.Z user-generated client, it is guaranteed to
+work as expected with all Firecracker binary versions X.V.W, where V >= Y.
+
+### Deprecation of elements in the API
+
+We will consider a deprecated API endpoint to be an endpoint which still has
+backing functionality and can be used, but will be removed completely along
+with said functionality in an upcoming API version. All deprecated endpoints
+are supported until at least the next MAJOR version release, where they _may
+be removed_.
+
+When elements of the API are deprecated in a MINOR release, they will still
+work for the longest of the following:
+
+* all subsequent Firecracker MINOR releases of the same MAJOR release;
+* any Firecracker MINOR release for at least 6 months from release date;
+* the next 2 Firecracker releases, regardless if they are MAJOR or MINOR.
 
 ## Developer preview features
 


### PR DESCRIPTION
# Reason for This PR

Effort towards making our API backwards compatible.

## Description of Changes

Added support policy for the API in our `docs/RELEASE_POLICY.md`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
