### PR TITLE
[v0.25.0] [build_release_archive] build before running tests

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -773,8 +773,8 @@ help_build_release_archive() {
     echo "            1. Running integration tests."
     echo "            2. Building release binaries and stripping them of debug symbols."
     echo "            3. Verifying artifacts' version against release version targeted."
-    echo "            4. Packing all artifacts into \`release-v{X.Y.Z}-{arch}\` directory."
-    echo "            5. Creating firecracker-v{X.Y.Z}-{arch} release archive."
+    echo "            4. Packing all artifacts into \`release-v{version}-{arch}\` directory."
+    echo "            5. Creating firecracker-v{version}-{arch} release archive."
     echo "        -v, --version             The targeted release version."
 }
 
@@ -998,7 +998,7 @@ cmd_build_release_archive() {
     get_user_confirmation || die "Aborted."
 
     # Run tests, build release binaries and strip them from debug symbols.
-    ( cmd_test && cmd_build --release && cmd_strip ) || die "Aborted."
+    ( cmd_build --release && cmd_strip && cmd_test ) || die "Aborted."
 
     release_suffix="v$version-$(uname -m)"
     release_dir="release-$release_suffix"


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

When creating the release archive, build binaries before running tests.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
