### PR TITLE
Deprecate `vsock_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Added permanent HTTP endpoint for `GET` on `/version` for getting the
   Firecracker version.
 
+### Changed
+
+- Deprecated `vsock_id` body field in `PUT`s on `/vsock`.
+
 ### Fixed
 
 - Fixed incorrect propagation of init parameters in kernel commandline.

--- a/docs/vsock.md
+++ b/docs/vsock.md
@@ -88,7 +88,7 @@ images/vsock-connections.png?raw=true
 
 ## Setting up the virtio-vsock device
 
-The virtio-vsock device will require an ID, a CID, and the path to a backing
+The virtio-vsock device will require a CID, and the path to a backing
 AF_UNIX socket:
 
 ```bash
@@ -97,7 +97,6 @@ curl --unix-socket /tmp/firecracker.socket -i \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
-      "vsock_id": "1",
       "guest_cid": 3,
       "uds_path": "./v.sock"
   }'

--- a/src/api_server/src/request/instance_info.rs
+++ b/src/api_server/src/request/instance_info.rs
@@ -13,11 +13,12 @@ pub(crate) fn parse_get_instance_info() -> Result<ParsedRequest, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestAction;
 
     #[test]
     fn test_parse_get_instance_info_request() {
-        match parse_get_instance_info() {
-            Ok(ParsedRequest::Sync(action)) if *action == VmmAction::GetVmInstanceInfo => {}
+        match parse_get_instance_info().unwrap().into_parts() {
+            (RequestAction::Sync(action), _) if *action == VmmAction::GetVmInstanceInfo => {}
             _ => panic!("Test failed."),
         }
     }

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::parsed_request::{Error, ParsedRequest};
+use crate::parsed_request::{Error, ParsedRequest, RequestAction};
 use crate::request::Body;
 use logger::{IncMetric, METRICS};
 use micro_http::StatusCode;
@@ -9,7 +9,7 @@ use vmm::rpc_interface::VmmAction::SetMmdsConfiguration;
 
 pub(crate) fn parse_get_mmds() -> Result<ParsedRequest, Error> {
     METRICS.get_api_requests.mmds_count.inc();
-    Ok(ParsedRequest::GetMMDS)
+    Ok(ParsedRequest::new(RequestAction::GetMMDS))
 }
 
 pub(crate) fn parse_put_mmds(
@@ -18,12 +18,12 @@ pub(crate) fn parse_put_mmds(
 ) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.mmds_count.inc();
     match path_second_token {
-        None => Ok(ParsedRequest::PutMMDS(
+        None => Ok(ParsedRequest::new(RequestAction::PutMMDS(
             serde_json::from_slice(body.raw()).map_err(|e| {
                 METRICS.put_api_requests.mmds_fails.inc();
                 Error::SerdeJson(e)
             })?,
-        )),
+        ))),
         Some(&"config") => Ok(ParsedRequest::new_sync(SetMmdsConfiguration(
             serde_json::from_slice(body.raw()).map_err(|e| {
                 METRICS.put_api_requests.mmds_fails.inc();
@@ -42,12 +42,12 @@ pub(crate) fn parse_put_mmds(
 
 pub(crate) fn parse_patch_mmds(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.mmds_count.inc();
-    Ok(ParsedRequest::PatchMMDS(
+    Ok(ParsedRequest::new(RequestAction::PatchMMDS(
         serde_json::from_slice(body.raw()).map_err(|e| {
             METRICS.patch_api_requests.mmds_fails.inc();
             Error::SerdeJson(e)
         })?,
-    ))
+    )))
 }
 
 #[cfg(test)]

--- a/src/api_server/src/request/version.rs
+++ b/src/api_server/src/request/version.rs
@@ -13,11 +13,12 @@ pub(crate) fn parse_get_version() -> Result<ParsedRequest, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestAction;
 
     #[test]
     fn test_parse_get_version_request() {
-        match parse_get_version() {
-            Ok(ParsedRequest::Sync(action)) if *action == VmmAction::GetVmmVersion => {}
+        match parse_get_version().unwrap().into_parts() {
+            (RequestAction::Sync(action), _) if *action == VmmAction::GetVmmVersion => {}
             _ => panic!("Test failed."),
         }
     }

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -4,32 +4,71 @@
 use super::super::VmmAction;
 use crate::parsed_request::{Error, ParsedRequest};
 use crate::request::Body;
+use logger::{IncMetric, METRICS};
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
-    Ok(ParsedRequest::new_sync(VmmAction::SetVsockDevice(
-        serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(Error::SerdeJson)?,
-    )))
+    METRICS.put_api_requests.vsock_count.inc();
+    let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(|e| {
+        METRICS.put_api_requests.vsock_fails.inc();
+        Error::SerdeJson(e)
+    })?;
+
+    // Check for the presence of deprecated `vsock_id` field.
+    let mut deprecation_message = None;
+    if vsock_cfg.vsock_id.is_some() {
+        // vsock_id field in request is deprecated.
+        METRICS.deprecated_api.deprecated_http_api_calls.inc();
+        deprecation_message = Some("PUT /vsock: vsock_id field is deprecated.");
+    }
+
+    // Construct the `ParsedRequest` object.
+    let mut parsed_req = ParsedRequest::new_sync(VmmAction::SetVsockDevice(vsock_cfg));
+    // If `vsock_id` was present, set the deprecation message in `parsing_info`.
+    if let Some(msg) = deprecation_message {
+        parsed_req.parsing_info().append_deprecation_message(msg);
+    }
+
+    Ok(parsed_req)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsed_request::tests::depr_action_from_req;
 
     #[test]
     fn test_parse_put_vsock_request() {
         let body = r#"{
-                "vsock_id": "foo",
                 "guest_cid": 42,
                 "uds_path": "vsock.sock"
               }"#;
         assert!(parse_put_vsock(&Body::new(body)).is_ok());
 
         let body = r#"{
-                "vsock_id": "foo",
                 "guest_cid": 42,
                 "invalid_field": false
               }"#;
         assert!(parse_put_vsock(&Body::new(body)).is_err());
+    }
+
+    #[test]
+    fn test_depr_vsock_id() {
+        let body = r#"{
+                "vsock_id": "foo",
+                "guest_cid": 42,
+                "uds_path": "vsock.sock"
+              }"#;
+        depr_action_from_req(
+            parse_put_vsock(&Body::new(body)).unwrap(),
+            Some("PUT /vsock: vsock_id field is deprecated.".to_string()),
+        );
+
+        let body = r#"{
+                "guest_cid": 42,
+                "uds_path": "vsock.sock"
+              }"#;
+        let (_, mut parsing_info) = parse_put_vsock(&Body::new(body)).unwrap().into_parts();
+        assert!(!parsing_info.take_deprecation_message().is_some());
     }
 }

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -1147,7 +1147,6 @@ definitions:
     required:
       - guest_cid
       - uds_path
-      - vsock_id
     properties:
       guest_cid:
         type: integer
@@ -1158,3 +1157,4 @@ definitions:
         description: Path to UNIX domain socket, used to proxy vsock connections.
       vsock_id:
         type: string
+        description: This parameter has been deprecated since v1.0.0.

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -18,6 +18,7 @@ use std::os::unix::io::AsRawFd;
 use crate::virtio::persist::Error as VirtioStateError;
 
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
+pub use self::defs::VSOCK_DEV_ID;
 pub use self::device::Vsock;
 pub use self::unix::{Error as VsockUnixBackendError, VsockUnixBackend};
 

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -397,6 +397,10 @@ pub struct PutRequestsMetrics {
     pub mmds_count: SharedIncMetric,
     /// Number of failures in creating a new mmds.
     pub mmds_fails: SharedIncMetric,
+    /// Number of PUTs for creating a vsock device.
+    pub vsock_count: SharedIncMetric,
+    /// Number of failures in creating a vsock device.
+    pub vsock_fails: SharedIncMetric,
 }
 
 /// Metrics specific to PATCH API Requests for counting user triggered actions and/or failures.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -979,6 +979,7 @@ pub mod tests {
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vmm_config::vsock::{VsockBuilder, VsockDeviceConfig};
     use arch::DeviceType;
+    use devices::virtio::vsock::VSOCK_DEV_ID;
     use devices::virtio::{TYPE_BALLOON, TYPE_BLOCK, TYPE_VSOCK};
     use linux_loader::cmdline::Cmdline;
     use utils::tempfile::TempFile;
@@ -1127,7 +1128,7 @@ pub mod tests {
         event_manager: &mut EventManager,
         vsock_config: VsockDeviceConfig,
     ) {
-        let vsock_dev_id = vsock_config.vsock_id.clone();
+        let vsock_dev_id = VSOCK_DEV_ID.to_owned();
         let vsock = VsockBuilder::create_unixsock_vsock(vsock_config).unwrap();
         let vsock = Arc::new(Mutex::new(vsock));
 

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -584,7 +584,7 @@ mod tests {
             // Add a vsock device.
             let vsock_dev_id = "vsock";
             let vsock_config = VsockDeviceConfig {
-                vsock_id: vsock_dev_id.to_string(),
+                vsock_id: Some(vsock_dev_id.to_string()),
                 guest_cid: 3,
                 uds_path: tmp_sock_file.as_path().to_str().unwrap().to_string(),
             };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -360,6 +360,7 @@ mod tests {
     use crate::vmm_config::vsock::tests::default_config;
     use crate::vmm_config::RateLimiterConfig;
     use crate::vstate::vcpu::VcpuConfig;
+    use devices::virtio::vsock::VSOCK_DEV_ID;
     use logger::{LevelFilter, LOGGER};
     use utils::net::mac::MacAddr;
     use utils::tempfile::TempFile;
@@ -961,14 +962,9 @@ mod tests {
         tmp_sock_file.remove().unwrap();
         let new_vsock_cfg = default_config(&tmp_sock_file);
         assert!(vm_resources.vsock.get().is_none());
-        vm_resources
-            .set_vsock_device(new_vsock_cfg.clone())
-            .unwrap();
+        vm_resources.set_vsock_device(new_vsock_cfg).unwrap();
         let actual_vsock_cfg = vm_resources.vsock.get().unwrap();
-        assert_eq!(
-            actual_vsock_cfg.lock().unwrap().id(),
-            &new_vsock_cfg.vsock_id
-        );
+        assert_eq!(actual_vsock_cfg.lock().unwrap().id(), VSOCK_DEV_ID);
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1178,7 +1178,7 @@ mod tests {
     #[test]
     fn test_preboot_set_vsock_dev() {
         let req = VmmAction::SetVsockDevice(VsockDeviceConfig {
-            vsock_id: String::new(),
+            vsock_id: Some(String::new()),
             guest_cid: 0,
             uds_path: String::new(),
         });
@@ -1188,7 +1188,7 @@ mod tests {
         });
 
         let req = VmmAction::SetVsockDevice(VsockDeviceConfig {
-            vsock_id: String::new(),
+            vsock_id: Some(String::new()),
             guest_cid: 0,
             uds_path: String::new(),
         });
@@ -1584,7 +1584,7 @@ mod tests {
         );
         check_runtime_request_err(
             VmmAction::SetVsockDevice(VsockDeviceConfig {
-                vsock_id: String::new(),
+                vsock_id: Some(String::new()),
                 guest_cid: 0,
                 uds_path: String::new(),
             }),
@@ -1596,7 +1596,7 @@ mod tests {
         );
         check_runtime_request_err(
             VmmAction::SetVsockDevice(VsockDeviceConfig {
-                vsock_id: String::new(),
+                vsock_id: Some(String::new()),
                 guest_cid: 0,
                 uds_path: String::new(),
             }),
@@ -1676,7 +1676,7 @@ mod tests {
         verify_load_snap_disallowed_after_boot_resources(req, "SetBalloonDevice");
 
         let req = VmmAction::SetVsockDevice(VsockDeviceConfig {
-            vsock_id: String::new(),
+            vsock_id: Some(String::new()),
             guest_cid: 0,
             uds_path: String::new(),
         });

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -752,14 +752,15 @@ class Vsock():
 
     @staticmethod
     def create_json(
-            vsock_id,
             guest_cid,
-            uds_path):
+            uds_path,
+            vsock_id=None):
         """Create the json for the vsock specific API request."""
         datax = {
-            'vsock_id': vsock_id,
             'guest_cid': guest_cid,
             'uds_path': uds_path
         }
+        if vsock_id:
+            datax['vsock_id'] = vsock_id
 
         return datax


### PR DESCRIPTION
# Reason for This PR

`vsock_id` serves no purpose in our API, as the vsock device always has the same internal ID when registering it.

## Description of Changes

Deprecated the `vsock_id` field in PUTs on /vsock.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
