### PR TITLE
Improve Display of VM Resource Errors

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -464,10 +464,7 @@ fn build_microvm_from_json(
     boot_timer_enabled: bool,
 ) -> std::result::Result<(VmResources, Arc<Mutex<vmm::Vmm>>), ExitCode> {
     let mut vm_resources = VmResources::from_json(&config_json, &instance_info).map_err(|err| {
-        error!(
-            "Configuration for VMM from one single json failed: {:?}",
-            err
-        );
+        error!("Configuration for VMM from one single json failed: {}", err);
         vmm::FC_EXIT_CODE_BAD_CONFIGURATION
     })?;
     vm_resources.boot_timer = boot_timer_enabled;

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.65, "AMD": 84.10, "ARM": 82.71}
+COVERAGE_DICT = {"Intel": 84.71, "AMD": 84.15, "ARM": 82.91}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fixes #2765

## Description of Changes

Adds an `std::fmt::Display` implementation for `vmm::resources::Error`
and uses it instead of the debug implementation when printing the error
in the CLI.

Here are is the error message before and after.

**Before:**

```bash
2021-10-29T15:14:13.216004769 [anonymous-instance:main:ERROR:src/firecracker/src/main.rs:321] Configuration for VMM from one single json failed: InvalidJson
```

**After:**

```bash
2021-10-29T15:37:12.523929871 [anonymous-instance:main:ERROR:src/firecracker/src/main.rs:444] Configuration for VMM from one single json failed: Invalid JSON: missing field `drives` at line 3 column 1
```

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion. ( I think so, though it doesn't have any feedback from a maintainer yet )
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
