### PR TITLE
[backport v0.25] 

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -997,8 +997,8 @@ cmd_build_release_archive() {
     say "Will start preparing release archive for v$version ..."
     get_user_confirmation || die "Aborted."
 
-    # Run tests, build release binaries and strip them from debug symbols.
-    ( cmd_build --release && cmd_strip && cmd_test ) || die "Aborted."
+    # Build release binaries and strip them from debug symbols.
+    ( cmd_build --release && cmd_strip ) || die "Aborted."
 
     release_suffix="v$version-$(uname -m)"
     release_dir="release-$release_suffix"
@@ -1015,17 +1015,28 @@ cmd_build_release_archive() {
     done
 
     add_swagger_artifact "$release_dir"
-    add_folder_artifact "$release_dir" "test_results" "$release_suffix"
     add_file_artifact "$release_dir" "$seccomp_json" "seccomp-filter-$release_suffix.json"
     for file in "LICENSE" "NOTICE" "THIRD-PARTY"; do
         add_file_artifact "$release_dir" "$file"
     done
+
+    # Run tests to obtain test reports dir.
+    cmd_test || cleanup_release_dir "$release_dir" "Tests failed."
+    add_folder_artifact "$release_dir" "test_results" "$release_suffix"
 
     # Create release archive.
     archive_name="firecracker-$release_suffix.tgz"
     say "Creating release archive..."
     tar -czf "$archive_name" "$release_dir"
     say "Done. Archive $archive_name successfully created."
+}
+
+cleanup_release_dir() {
+    release_dir="$1"
+    error_msg="$2"
+
+    rm -rf "$release_dir"
+    die "$error_msg"
 }
 
 check_file_existence() {


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Coverage tests overwrite binaries inside `release/` dir. Binary artifacts need to be copied before running the tests.

## Description of Changes

Copy release binaries and files before test run.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
