### PR TITLE
[block] mark dirtied mem when executing io_uring ops

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -351,7 +351,7 @@ impl Block {
         let queue = &mut self.queues[0];
 
         loop {
-            match engine.pop() {
+            match engine.pop(mem) {
                 Err(error) => {
                     error!("Failed to read completed io_uring entry: {:?}", error);
                     break;

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -157,7 +157,7 @@ pub mod tests {
     use super::*;
     use utils::kernel_version::KernelVersion;
     use utils::tempfile::TempFile;
-    use vm_memory::{Bytes, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
+    use vm_memory::Bytes;
 
     const FILE_LEN: u32 = 1024;
     const MEM_LEN: usize = 4096;
@@ -198,32 +198,22 @@ pub mod tests {
         };
     }
 
-    macro_rules! assert_async_execution {
-        ($engine:expr, $count:expr) => {
-            if let FileEngine::Async(ref mut engine) = $engine {
-                engine.kick_submission_queue_and_wait(1).unwrap();
-                assert_eq!(engine.pop().unwrap().unwrap().result().unwrap(), $count);
-            }
-        };
+    fn assert_async_execution(engine: &mut FileEngine<()>, count: u32) {
+        if let FileEngine::Async(ref mut engine) = engine {
+            engine.kick_submission_queue_and_wait(1).unwrap();
+            assert_eq!(engine.pop().unwrap().unwrap().result().unwrap(), count);
+        }
     }
 
-    fn clear_mem(mem: &GuestMemoryMmap) {
-        for region in mem.iter() {
-            let empty_data = vec![0u8; region.len() as usize];
-            region
-                .write_slice(&empty_data, MemoryRegionAddress(0))
-                .unwrap();
-        }
+    fn create_mem() -> GuestMemoryMmap {
+        vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], true)
+            .unwrap()
     }
 
     #[test]
     fn test_sync() {
-        // Create guest memory
-        let mem =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], false)
-                .unwrap();
-
         // Check invalid file
+        let mem = create_mem();
         let file = unsafe { File::from_raw_fd(-2) };
         let mut engine = FileEngine::from_file_sync(file).unwrap();
         let res = engine.read(0, &mem, GuestAddress(0), 0, ());
@@ -250,7 +240,7 @@ pub mod tests {
             partial_len as u32
         );
         // Partial read
-        clear_mem(&mem);
+        let mem = create_mem();
         assert_sync_execution!(engine.read(0, &mem, addr, FILE_LEN, ()), partial_len as u32);
         // Check data
         let mut buf = vec![0u8; partial_len as usize];
@@ -267,7 +257,7 @@ pub mod tests {
             partial_len as u32
         );
         // Offset read
-        clear_mem(&mem);
+        let mem = create_mem();
         assert_sync_execution!(
             engine.read(offset, &mem, addr, partial_len, ()),
             partial_len as u32
@@ -284,7 +274,7 @@ pub mod tests {
             FILE_LEN
         );
         // Full read
-        clear_mem(&mem);
+        let mem = create_mem();
         assert_sync_execution!(
             engine.read(0, &mem, GuestAddress(0), FILE_LEN, ()),
             FILE_LEN
@@ -306,10 +296,6 @@ pub mod tests {
             return;
         }
 
-        // Create guest memory
-        let mem =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], false)
-                .unwrap();
         // Check invalid file
         let file = unsafe { File::from_raw_fd(-2) };
         assert!(FileEngine::<()>::from_file_async(file).is_err());
@@ -326,16 +312,17 @@ pub mod tests {
         // code for trying to write to unmapped memory.
 
         // Offset write
+        let mem = create_mem();
         let offset = 100;
         let partial_len = 50;
         let addr = GuestAddress(0);
         mem.write(&data, addr).unwrap();
         assert_queued!(engine.write(offset, &mem, addr, partial_len, ()));
-        assert_async_execution!(engine, partial_len as u32);
+        assert_async_execution(&mut engine, partial_len as u32);
         // Offset read
-        clear_mem(&mem);
+        let mem = create_mem();
         assert_queued!(engine.read(offset, &mem, addr, partial_len, ()));
-        assert_async_execution!(engine, partial_len as u32);
+        assert_async_execution(&mut engine, partial_len as u32);
         // Check data
         let mut buf = vec![0u8; partial_len as usize];
         mem.read_slice(&mut buf, addr).unwrap();
@@ -344,12 +331,12 @@ pub mod tests {
         // Full write
         mem.write(&data, GuestAddress(0)).unwrap();
         assert_queued!(engine.write(0, &mem, addr, FILE_LEN, ()));
-        assert_async_execution!(engine, FILE_LEN as u32);
+        assert_async_execution(&mut engine, FILE_LEN as u32);
 
         // Full read
-        clear_mem(&mem);
+        let mem = create_mem();
         assert_queued!(engine.read(0, &mem, addr, FILE_LEN, ()));
-        assert_async_execution!(engine, FILE_LEN as u32);
+        assert_async_execution(&mut engine, FILE_LEN as u32);
         // Check data
         let mut buf = vec![0u8; FILE_LEN as usize];
         mem.read_slice(&mut buf, GuestAddress(0)).unwrap();
@@ -357,7 +344,7 @@ pub mod tests {
 
         // Check other ops
         assert_queued!(engine.flush(()));
-        assert_async_execution!(engine, 0);
+        assert_async_execution(&mut engine, 0);
 
         assert!(engine.drain(true).is_ok());
         assert!(engine.drain(false).is_ok());

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.compare_versions(utils.get_kernel_version(), "5.4.0") > 0:
-    COVERAGE_DICT = {"Intel": 84.29, "AMD": 84.17, "ARM": 82.55}
+    COVERAGE_DICT = {"Intel": 84.29, "AMD": 84.17, "ARM": 82.37}
 else:
-    COVERAGE_DICT = {"Intel": 82.20, "AMD": 81.67, "ARM": 80.41}
+    COVERAGE_DICT = {"Intel": 82.01, "AMD": 81.45, "ARM": 80.05}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

[block] mark dirtied mem when executing io_uring ops

## Description of Changes

[block] mark dirtied mem when executing io_uring ops

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
