### PR TITLE
Clarify jailer usage in documentation

### DIFF
--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -2,8 +2,12 @@
 
 ## Disclaimer
 
-The jailer is designed to work only with statically linked binaries (with
-the default musl toolchain) and will not work with experimental gnu builds.
+The jailer is a program designed to isolate the Firecracker process in
+order to enhance Firecracker's security posture. It is meant to address the
+security needs of Firecracker only and is not intended to work with other
+binaries. Additionally, each jailer binary should be used with a statically
+linked Firecracker binary (with the default musl toolchain) of the same
+version. Experimental gnu builds are not supported.
 
 ## Jailer Usage
 


### PR DESCRIPTION
# Reason for This PR

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Jailer documentation is unclear regarding jailer intended usage.

## Description of Changes
Added disclaimer in jailer documentation stating that the jailer binary is intended to be used with Firecracker only.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
