### PR TITLE
[block] Use the async file engine in unit tests on kernel >= 5.10

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -90,7 +90,7 @@ impl DiskProperties {
             nsectors: disk_size >> SECTOR_SHIFT,
             image_id: Self::build_disk_image_id(&disk_image),
             file_path: disk_image_path,
-            file_engine: FileEngine::from_file_sync(disk_image).map_err(Error::FileEngine)?,
+            file_engine: FileEngine::from_file(disk_image).map_err(Error::FileEngine)?,
         })
     }
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -553,7 +553,7 @@ pub(crate) mod tests {
 
     use crate::check_metric_after_block;
     use crate::virtio::block::test_utils::{
-        default_block, invoke_handler_for_queue_event, set_queue, set_rate_limiter,
+        default_block, set_queue, set_rate_limiter, simulate_queue_event,
     };
     use crate::virtio::test_utils::{default_mem, initialize_virtqueue, VirtQueue};
 
@@ -676,7 +676,7 @@ pub(crate) mod tests {
         mem.write_obj::<u32>(VIRTIO_BLK_T_IN, request_type_addr)
             .unwrap();
 
-        invoke_handler_for_queue_event(&mut block);
+        simulate_queue_event(&mut block, Some(true));
 
         assert_eq!(vq.used.idx.get(), 1);
         assert_eq!(vq.used.ring[0].get().id, 0);
@@ -711,7 +711,7 @@ pub(crate) mod tests {
             check_metric_after_block!(
                 &METRICS.block.invalid_reqs_count,
                 1,
-                invoke_handler_for_queue_event(&mut block)
+                simulate_queue_event(&mut block, Some(true))
             );
         }
     }
@@ -737,7 +737,7 @@ pub(crate) mod tests {
             mem.write_obj::<RequestHeader>(request_header, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -757,7 +757,7 @@ pub(crate) mod tests {
             mem.write_obj::<RequestHeader>(request_header, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -784,7 +784,7 @@ pub(crate) mod tests {
         mem.write_obj::<RequestHeader>(request_header, request_type_addr)
             .unwrap();
 
-        invoke_handler_for_queue_event(&mut block);
+        simulate_queue_event(&mut block, Some(true));
 
         assert_eq!(vq.used.idx.get(), 1);
         assert_eq!(vq.used.ring[0].get().id, 0);
@@ -818,7 +818,7 @@ pub(crate) mod tests {
         check_metric_after_block!(
             &METRICS.block.read_count,
             1,
-            invoke_handler_for_queue_event(&mut block)
+            simulate_queue_event(&mut block, Some(true))
         );
 
         assert_eq!(vq.used.idx.get(), 1);
@@ -853,7 +853,7 @@ pub(crate) mod tests {
             vq.dtable[1].len.set(511);
             mem.write_slice(&rand_data[..511], data_addr).unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -881,7 +881,7 @@ pub(crate) mod tests {
             check_metric_after_block!(
                 &METRICS.block.write_count,
                 1,
-                invoke_handler_for_queue_event(&mut block)
+                simulate_queue_event(&mut block, Some(true))
             );
 
             assert_eq!(vq.used.idx.get(), 1);
@@ -903,7 +903,7 @@ pub(crate) mod tests {
             vq.dtable[1].len.set(511);
             mem.write_slice(empty_data.as_slice(), data_addr).unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -932,7 +932,7 @@ pub(crate) mod tests {
             check_metric_after_block!(
                 &METRICS.block.read_count,
                 1,
-                invoke_handler_for_queue_event(&mut block)
+                simulate_queue_event(&mut block, Some(true))
             );
 
             assert_eq!(vq.used.idx.get(), 1);
@@ -964,7 +964,7 @@ pub(crate) mod tests {
             mem.write_obj(10, GuestAddress(request_type_addr.0 + 8))
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -995,7 +995,7 @@ pub(crate) mod tests {
                 .unwrap();
 
             // This will attempt to read past end of file.
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -1030,7 +1030,7 @@ pub(crate) mod tests {
             block.disk.file().seek(SeekFrom::Start(512)).unwrap();
             block.disk.file().write_all(&rand_data[512..]).unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
 
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
@@ -1069,7 +1069,7 @@ pub(crate) mod tests {
             mem.write_obj::<u32>(VIRTIO_BLK_T_FLUSH, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
             assert_eq!(vq.used.ring[0].get().len, 1);
@@ -1085,7 +1085,7 @@ pub(crate) mod tests {
             mem.write_obj::<u32>(VIRTIO_BLK_T_FLUSH, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
             // status byte length.
@@ -1115,7 +1115,7 @@ pub(crate) mod tests {
             mem.write_obj::<u32>(VIRTIO_BLK_T_GET_ID, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
             assert_eq!(vq.used.ring[0].get().len, 21);
@@ -1149,7 +1149,7 @@ pub(crate) mod tests {
             mem.write_obj::<u32>(VIRTIO_BLK_T_GET_ID, request_type_addr)
                 .unwrap();
 
-            invoke_handler_for_queue_event(&mut block);
+            simulate_queue_event(&mut block, Some(true));
             assert_eq!(vq.used.idx.get(), 1);
             assert_eq!(vq.used.ring[0].get().id, 0);
             assert_eq!(vq.used.ring[0].get().len, 0);
@@ -1186,17 +1186,14 @@ pub(crate) mod tests {
         // Following write procedure should fail because of bandwidth rate limiting.
         {
             // Trigger the attempt to write.
-            block.queue_evts[0].write(1).unwrap();
             check_metric_after_block!(
                 &METRICS.block.rate_limiter_throttled_events,
                 1,
-                block.process_queue_event()
+                simulate_queue_event(&mut block, Some(false))
             );
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter.is_blocked());
-            // Assert that no operation actually completed (limiter blocked it).
-            assert!(!block.irq_trigger.has_pending_irq(IrqType::Vring));
             // Make sure the data is still queued for processing.
             assert_eq!(vq.used.idx.get(), 0);
         }
@@ -1256,17 +1253,14 @@ pub(crate) mod tests {
         // Following write procedure should fail because of ops rate limiting.
         {
             // Trigger the attempt to write.
-            block.queue_evts[0].write(1).unwrap();
             check_metric_after_block!(
                 &METRICS.block.rate_limiter_throttled_events,
                 1,
-                block.process_queue_event()
+                simulate_queue_event(&mut block, Some(false))
             );
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter.is_blocked());
-            // Assert that no operation actually completed (limiter blocked it).
-            assert!(!block.irq_trigger.has_pending_irq(IrqType::Vring));
             // Make sure the data is still queued for processing.
             assert_eq!(vq.used.idx.get(), 0);
         }
@@ -1274,17 +1268,14 @@ pub(crate) mod tests {
         // Do a second write that still fails but this time on the fast path.
         {
             // Trigger the attempt to write.
-            block.queue_evts[0].write(1).unwrap();
             check_metric_after_block!(
                 &METRICS.block.rate_limiter_throttled_events,
                 1,
-                block.process_queue_event()
+                simulate_queue_event(&mut block, Some(false))
             );
 
             // Assert that limiter is blocked.
             assert!(block.rate_limiter.is_blocked());
-            // Assert that no operation actually completed (limiter blocked it).
-            assert!(!block.irq_trigger.has_pending_irq(IrqType::Vring));
             // Make sure the data is still queued for processing.
             assert_eq!(vq.used.idx.get(), 0);
         }

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -201,7 +201,7 @@ pub mod tests {
 
     fn assert_async_execution(mem: &GuestMemoryMmap, engine: &mut FileEngine<()>, count: u32) {
         if let FileEngine::Async(ref mut engine) = engine {
-            engine.kick_submission_queue_and_wait(1).unwrap();
+            engine.drain_submission_queue().unwrap();
             assert_eq!(engine.pop(mem).unwrap().unwrap().result().unwrap(), count);
         }
     }

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -50,11 +50,13 @@ pub fn rate_limiter(blk: &mut Block) -> &RateLimiter {
 }
 
 #[cfg(test)]
-pub fn invoke_handler_for_queue_event(b: &mut Block) {
+pub fn simulate_queue_event(b: &mut Block, maybe_expected_irq: Option<bool>) {
     // Trigger the queue event.
     b.queue_evts[0].write(1).unwrap();
     // Handle event.
     b.process_queue_event();
     // Validate the queue operation finished successfully.
-    assert!(b.irq_trigger.has_pending_irq(IrqType::Vring));
+    if let Some(expected_irq) = maybe_expected_irq {
+        assert_eq!(b.irq_trigger.has_pending_irq(IrqType::Vring), expected_irq);
+    }
 }

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -102,11 +102,11 @@ impl IoUring {
         self.cqueue.pop().map_err(Error::CQueue)
     }
 
-    pub fn submit(&mut self) -> Result<u64> {
+    pub fn submit(&mut self) -> Result<u32> {
         self.squeue.submit(0).map_err(Error::SQueue)
     }
 
-    pub fn submit_and_wait(&mut self, min_complete: u32) -> Result<u64> {
+    pub fn submit_and_wait(&mut self, min_complete: u32) -> Result<u32> {
         self.squeue.submit(min_complete).map_err(Error::SQueue)
     }
 

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -43,7 +43,7 @@ pub struct SubmissionQueue {
     sqes: MmapRegion,
 
     // Number of values yet to be submitted.
-    to_submit: u64,
+    to_submit: u32,
 }
 
 impl SubmissionQueue {
@@ -116,7 +116,7 @@ impl SubmissionQueue {
         Ok(())
     }
 
-    pub fn submit(&mut self, min_complete: u32) -> Result<u64, Error> {
+    pub fn submit(&mut self, min_complete: u32) -> Result<u32, Error> {
         if self.to_submit == 0 && min_complete == 0 {
             // Nothing to submit and nothing to wait for.
             return Ok(0);

--- a/src/io_uring/tests/integration_tests.rs
+++ b/src/io_uring/tests/integration_tests.rs
@@ -156,7 +156,7 @@ fn test_ring_submit() {
 }
 
 #[test]
-fn test_submit_and_wait() {
+fn test_submit_and_wait_all() {
     skip_if_kernel_lt_5_10!();
 
     let file = TempFile::new().unwrap().into_file();
@@ -167,7 +167,7 @@ fn test_submit_and_wait() {
     ring.register_file(&file).unwrap();
 
     // Return 0 if we didn't push any sqes.
-    assert_eq!(ring.submit_and_wait(0).unwrap(), 0);
+    assert_eq!(ring.submit_and_wait_all().unwrap(), 0);
 
     // Now push an sqe.
     ring.push(Operation::read(0, buf.as_ptr() as usize, 4, 0, user_data))
@@ -175,7 +175,7 @@ fn test_submit_and_wait() {
     assert_eq!(ring.pending_sqes().unwrap(), 1);
 
     // A correct waiting period yields the completed entries.
-    assert_eq!(ring.submit_and_wait(1).unwrap(), 1);
+    assert_eq!(ring.submit_and_wait_all().unwrap(), 1);
     assert_eq!(ring.pop::<u8>().unwrap().unwrap().user_data(), user_data);
     assert_eq!(ring.pending_sqes().unwrap(), 0);
 
@@ -189,7 +189,7 @@ fn test_submit_and_wait() {
     ring.push(Operation::read(0, buf.as_ptr() as usize, 4, 0, 75))
         .unwrap();
     assert_eq!(ring.pending_sqes().unwrap(), 4);
-    assert_eq!(ring.submit_and_wait(4).unwrap(), 4);
+    assert_eq!(ring.submit_and_wait_all().unwrap(), 4);
     assert_eq!(ring.pending_sqes().unwrap(), 0);
 
     assert!(ring.pop::<u8>().unwrap().is_some());

--- a/src/io_uring/tests/test_utils/mod.rs
+++ b/src/io_uring/tests/test_utils/mod.rs
@@ -61,7 +61,7 @@ pub fn drive_submission_and_completion(
                 Ok(()) => {}
                 Err(err_tuple) if matches!(err_tuple.0, Error::SQueue(SQueueError::FullQueue)) => {
                     // Stop and wait.
-                    ring.submit_and_wait(ring.pending_sqes().unwrap()).unwrap();
+                    ring.submit_and_wait_all().unwrap();
                     drain_cqueue(ring);
 
                     // Decrement the left_at because we need to retry this op.
@@ -77,7 +77,7 @@ pub fn drive_submission_and_completion(
         }
     }
 
-    ring.submit_and_wait(ring.pending_sqes().unwrap()).unwrap();
+    ring.submit_and_wait_all().unwrap();
     drain_cqueue(ring);
     assert_eq!(ring.pending_sqes().unwrap(), 0);
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.compare_versions(utils.get_kernel_version(), "5.4.0") > 0:
-    COVERAGE_DICT = {"Intel": 84.29, "AMD": 84.17, "ARM": 82.37}
+    COVERAGE_DICT = {"Intel": 84.69, "AMD": 84.17, "ARM": 82.85}
 else:
-    COVERAGE_DICT = {"Intel": 82.01, "AMD": 81.45, "ARM": 80.05}
+    COVERAGE_DICT = {"Intel": 81.94, "AMD": 81.38, "ARM": 80.10}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

[block] Use the async file engine in unit tests on kernel >= 5.10

## Description of Changes

[block] Use the async file engine in unit tests on kernel >= 5.10

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
