### PR TITLE
[v0.25] Backport commits from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added `--http_api_max_payload_size` parameter to configure the maximum payload
+  size for PUT and PATCH requests.
+
 ## [0.25.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `--http_api_max_payload_size` parameter to configure the maximum payload
   size for PUT and PATCH requests.
+- Limit MMDS data store size to `--http_api_max_payload_size`.
 
 ## [0.25.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `--http_api_max_payload_size` parameter to configure the maximum payload
   size for PUT and PATCH requests.
 - Limit MMDS data store size to `--http_api_max_payload_size`.
+- Cleanup all environment variables in Jailer.
 
 ## [0.25.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -65,11 +65,10 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -90,15 +89,15 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -108,30 +107,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -167,9 +160,9 @@ checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
 
 [[package]]
 name = "criterion"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
@@ -193,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
  "itertools",
@@ -203,11 +196,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -217,7 +210,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -228,7 +221,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -241,15 +234,15 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -347,44 +340,44 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "half"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jailer"
@@ -397,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -441,9 +434,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libfdt-bindings"
@@ -454,11 +447,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -476,15 +469,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -544,14 +537,30 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "plotters"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
- "js-sys",
  "num-traits",
+ "plotters-backend",
+ "plotters-svg",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -562,9 +571,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -603,18 +612,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -624,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -634,18 +643,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
@@ -674,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -686,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -699,39 +708,35 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -744,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -797,18 +802,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -821,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -842,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -863,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -878,7 +874,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -896,15 +892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "timerfd"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
@@ -931,9 +918,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utils"
@@ -965,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "versionize_derive"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67c253de6afad304491afbe93081a75f59632b47b0e5ab3214405441fe2c6a2"
+checksum = "140aa9fd298f667ea50fa1cb0d8530076924079285c623b18b8f8a1c28386b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1052,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi",
@@ -1069,19 +1056,19 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1094,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1104,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1117,15 +1104,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?rev=49240ce#49240ce1d5a81a594aa12895c1ef4091c0fd8e9b"
+source = "git+https://github.com/firecracker-microvm/micro-http?rev=36e59a0#36e59a083e76a2449e0f58e4283d201bc72fdf13"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -82,6 +82,7 @@ After starting, the Jailer goes through the following operations:
 - Validate **all provided paths** and the VM `id`.
 - Close all open file descriptors based on `/proc/<jailer-pid>/fd` except
   input, output and error.
+- Cleanup all environment variables received from the parent process.
 - Create the `<chroot_base>/<exec_file_name>/<id>/root` folder, which will be
   henceforth referred to as `chroot_dir`. `exec_file_name` is the
   last path component of `exec_file` (for example, that would be `firecracker`

--- a/docs/mmds/mmds-design.md
+++ b/docs/mmds/mmds-design.md
@@ -58,6 +58,10 @@ the MMDS contents. It leverages the recursive
 store supports at the moment storing and retrieving JSON values. Data store
 contents can be retrieved using the Firecracker API server from host and using
 the embedded MMDS HTTP/TCP/IPv4 network stack from guest.
+MMDS data store is upper bounded by a default maximum size of 51200 bytes. This
+limit can be modified using `--http_api_max_payload_size` command line parameter.
+All PUT and PATCH requests with Content-Length bigger than the imposed limit will
+receive HTTP 413 Payload Too Large response status code.
 
 ## Dumbo
 

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -435,6 +435,10 @@
                 "comment": "Used to retrieve data from the socket"
             },
             {
+                "syscall": "recvmsg",
+                "comment": "Needed by micro-http to read from the byte stream."
+            },
+            {
                 "syscall": "rt_sigprocmask",
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -434,6 +434,10 @@
                 "comment": "Used to retrieve data from the socket"
             },
             {
+                "syscall": "recvmsg",
+                "comment": "Needed by micro-http to read from the byte stream."
+            },
+            {
                 "syscall": "rt_sigprocmask",
                 "comment": "rt_sigprocmask is used by Rust stdlib to remove custom signal handler during thread teardown."
             },

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = ">=1.0.9"
 libc = ">=0.2.39"
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 mmds = { path = "../mmds" }
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -107,6 +107,7 @@ impl ApiServer {
     /// # Example
     ///
     /// ```
+    /// use mmds::MAX_DATA_STORE_SIZE;
     /// use api_server::ApiServer;
     /// use mmds::MMDS;
     /// use std::{
@@ -130,7 +131,7 @@ impl ApiServer {
     /// let mmds_info = MMDS.clone();
     /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1), Some(1));
     /// let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
-    /// let payload_limit = Some(51200);
+    /// let payload_limit = Some(MAX_DATA_STORE_SIZE);
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -326,6 +327,10 @@ impl ApiServer {
                 data_store::Error::UnsupportedValueType => unreachable!(),
                 data_store::Error::NotInitialized => ApiServer::json_response(
                     StatusCode::BadRequest,
+                    ApiServer::json_fault_message(e.to_string()),
+                ),
+                data_store::Error::DataStoreLimitExceeded => ApiServer::json_response(
+                    StatusCode::PayloadTooLarge,
                     ApiServer::json_fault_message(e.to_string()),
                 ),
             },

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -130,6 +130,7 @@ impl ApiServer {
     /// let mmds_info = MMDS.clone();
     /// let time_reporter = ProcessTimeReporter::new(Some(1), Some(1), Some(1));
     /// let seccomp_filters = get_filters(SeccompConfig::None).unwrap();
+    /// let payload_limit = Some(51200);
     ///
     /// thread::Builder::new()
     ///     .name("fc_api_test".to_owned())
@@ -144,6 +145,7 @@ impl ApiServer {
     ///             PathBuf::from(api_thread_path_to_socket),
     ///             time_reporter,
     ///             seccomp_filters.get("api").unwrap(),
+    ///             payload_limit,
     ///         )
     ///         .unwrap();
     ///     })
@@ -166,6 +168,7 @@ impl ApiServer {
         path: PathBuf,
         process_time_reporter: ProcessTimeReporter,
         seccomp_filter: BpfProgramRef,
+        maybe_request_size: Option<usize>,
     ) -> Result<()> {
         let mut server = HttpServer::new(path).unwrap_or_else(|e| {
             error!("Error creating the HTTP server: {}", e);
@@ -641,6 +644,7 @@ mod tests {
                     PathBuf::from(api_thread_path_to_socket),
                     ProcessTimeReporter::new(Some(1), Some(1), Some(1)),
                     seccomp_filters.get("api").unwrap(),
+                    None,
                 )
                 .unwrap();
             })

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -9,7 +9,7 @@ bitflags = ">=1.0.4"
 
 utils = { path = "../utils" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 
 [dev-dependencies]
 serde_json = ">=1.0.9"

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -312,7 +312,7 @@ fn build_response(http_version: Version, status_code: StatusCode, body: Body) ->
 
 /// Parses the request bytes and builds a `micro_http::Response` by the given callback function.
 fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) -> Response {
-    let request = Request::try_from(byte_stream);
+    let request = Request::try_from(byte_stream, None);
     match request {
         Ok(request) => callback(request),
         Err(e) => match e {

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -361,6 +361,11 @@ fn parse_request_bytes(byte_stream: &[u8], callback: fn(Request) -> Response) ->
                 StatusCode::BadRequest,
                 Body::new(e.to_string()),
             ),
+            RequestError::SizeLimitExceeded(_, _) => build_response(
+                Version::default(),
+                StatusCode::PayloadTooLarge,
+                Body::new(e.to_string()),
+            ),
         },
     }
 }

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -123,6 +123,7 @@ pub(crate) fn run_with_api(
     instance_info: InstanceInfo,
     process_time_reporter: ProcessTimeReporter,
     boot_timer_enabled: bool,
+    payload_limit: Option<usize>,
 ) -> ExitCode {
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
@@ -149,6 +150,7 @@ pub(crate) fn run_with_api(
                 api_bind_path,
                 process_time_reporter,
                 &api_seccomp_filter,
+                payload_limit,
             ) {
                 Ok(_) => (),
                 Err(api_server::Error::Io(inner)) => match inner.kind() {

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use mmds::MAX_DATA_STORE_SIZE;
 use std::io::prelude::*;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
@@ -135,6 +136,10 @@ pub(crate) fn run_with_api(
 
     // MMDS only supported with API.
     let mmds_info = MMDS.clone();
+    mmds_info
+        .lock()
+        .expect("Failed to acquire lock on MMDS info")
+        .set_data_store_limit(payload_limit.unwrap_or(MAX_DATA_STORE_SIZE));
     let to_vmm_event_fd = api_event_fd
         .try_clone()
         .expect("Failed to clone API event FD");

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -200,6 +200,11 @@ fn main_exitable() -> ExitCode {
             Argument::new("describe-snapshot")
                 .takes_value(true)
                 .help("Print the data format version of the provided snapshot state file.")
+        )
+        .arg(
+            Argument::new("http_api_max_payload_size")
+                .takes_value(true)
+                .help("Http API request payload max size.")
         );
 
     let arguments = match arg_parser.parse_from_cmdline() {
@@ -302,6 +307,13 @@ fn main_exitable() -> ExitCode {
             .single_value("api-sock")
             .map(PathBuf::from)
             .expect("Missing argument: api-sock");
+        let payload_limit = arg_parser
+            .arguments()
+            .single_value("http_api_max_payload_size")
+            .map(|lim| {
+                lim.parse::<usize>()
+                    .expect("'http_api_max_payload_size' parameter expected to be of 'usize' type.")
+            });
 
         let start_time_us = arguments.single_value("start-time-us").map(|s| {
             s.parse::<u64>()
@@ -327,6 +339,7 @@ fn main_exitable() -> ExitCode {
             instance_info,
             process_time_reporter,
             boot_timer_enabled,
+            payload_limit,
         )
     } else {
         let seccomp_filters: BpfThreadMap = seccomp_filters

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -4,6 +4,7 @@ mod cgroup;
 mod chroot;
 mod env;
 mod resource_limits;
+use std::env as p_env;
 
 use std::ffi::{CString, NulError, OsString};
 use std::fmt;
@@ -346,6 +347,18 @@ fn sanitize_process() {
             }
         }
     }
+
+    // Cleanup environment variables
+    clean_env_vars();
+}
+
+fn clean_env_vars() {
+    // Remove environment variables received from
+    // the parent process so there are no leaks
+    // inside the jailer environment
+    for (key, _) in p_env::vars() {
+        p_env::remove_var(key);
+    }
 }
 
 /// Turns an AsRef<Path> into a CString (c style string).
@@ -409,6 +422,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs::File;
     use std::os::unix::io::IntoRawFd;
 
@@ -436,6 +450,25 @@ mod tests {
         }
 
         assert!(fs::remove_dir_all(tmp_dir_path).is_ok());
+    }
+
+    #[test]
+    fn test_clean_env_vars() {
+        let env_vars: [&str; 5] = ["VAR1", "VAR2", "VAR3", "VAR4", "VAR5"];
+
+        // Set environment variables
+        for env_var in env_vars.iter() {
+            env::set_var(env_var, "0");
+        }
+
+        // Cleanup the environment
+        clean_env_vars();
+
+        // Assert that the variables set beforehand
+        // do not exist anymore
+        for env_var in env_vars.iter() {
+            assert_eq!(env::var_os(env_var), None);
+        }
     }
 
     #[allow(clippy::cognitive_complexity)]

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -12,7 +12,7 @@ versionize_derive = ">=0.1.3"
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "49240ce" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "36e59a0" }
 utils = { path = "../utils" }
 snapshot = { path = "../snapshot" }
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
 
         // Test resource not found.
         let request_bytes = b"GET http://169.254.169.254/invalid HTTP/1.0\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::NotFound);
         expected_response.set_body(Body::new("Resource not found: /invalid.".to_string()));
         let actual_response = convert_to_response(request);
@@ -186,7 +186,7 @@ mod tests {
 
         // Test NotImplemented.
         let request_bytes = b"GET /age HTTP/1.1\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http11, StatusCode::NotImplemented);
         let body = "Cannot retrieve value. The value has an unsupported type.".to_string();
         expected_response.set_body(Body::new(body));
@@ -197,7 +197,7 @@ mod tests {
         let not_allowed_methods = ["PUT", "PATCH"];
         for method in not_allowed_methods.iter() {
             let request_bytes = format!("{} http://169.254.169.255/ HTTP/1.0\r\n\r\n", method);
-            let request = Request::try_from(request_bytes.as_bytes()).unwrap();
+            let request = Request::try_from(request_bytes.as_bytes(), None).unwrap();
             let mut expected_response =
                 Response::new(Version::Http10, StatusCode::MethodNotAllowed);
             expected_response.set_body(Body::new("Not allowed HTTP method.".to_string()));
@@ -208,7 +208,7 @@ mod tests {
 
         // Test invalid (empty absolute path) URI.
         let request_bytes = b"GET http:// HTTP/1.0\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
         expected_response.set_body(Body::new("Invalid URI.".to_string()));
         let actual_response = convert_to_response(request);
@@ -217,7 +217,7 @@ mod tests {
         // Test Ok path.
         let request_bytes = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
                                     Accept: application/json\r\n\r\n";
-        let request = Request::try_from(request_bytes).unwrap();
+        let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
         let mut body = r#"{
                 "age": 43,

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
 use lazy_static::lazy_static;
 use micro_http::{Body, MediaType, Method, Request, Response, StatusCode, Version};
+pub const MAX_DATA_STORE_SIZE: usize = 51200;
 
 lazy_static! {
     // A static reference to a global Mmds instance. We currently use this for ease of access during
@@ -125,6 +126,11 @@ fn convert_to_response(request: Request) -> Response {
             MmdsError::UnsupportedValueType => build_response(
                 request.http_version(),
                 StatusCode::NotImplemented,
+                Body::new(e.to_string()),
+            ),
+            MmdsError::DataStoreLimitExceeded => build_response(
+                request.http_version(),
+                StatusCode::PayloadTooLarge,
                 Body::new(e.to_string()),
             ),
             MmdsError::NotInitialized => unreachable!(),

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -3,6 +3,7 @@ name = "seccompiler"
 version = "0.25.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
+build = "../../build.rs"
 description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."
 homepage = "https://firecracker-microvm.github.io/"
 license = "Apache-2.0"

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -51,7 +51,7 @@ use compiler::{Compiler, Error as FilterFormatError, JsonFile};
 use serde_json::error::Error as JSONError;
 use utils::arg_parser::{ArgParser, Argument, Arguments as ArgumentsBag};
 
-const SECCOMPILER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const SECCOMPILER_VERSION: &str = env!("FIRECRACKER_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";
 const EXIT_CODE_ERROR: i32 = 1;
 

--- a/tests/framework/http.py
+++ b/tests/framework/http.py
@@ -44,11 +44,16 @@ class Session(requests.Session):
             """Return `True` when HTTP response code is 404 NotFound."""
             return response == 404
 
+        def is_status_payload_too_large(response: int):
+            """Return `True` when HTTP response code is 413 PayloadTooLarge."""
+            return response == 413
+
         self.is_good_response = is_good_response
         self.is_status_ok = is_status_ok
         self.is_status_no_content = is_status_no_content
         self.is_status_bad_request = is_status_bad_request
         self.is_status_not_found = is_status_not_found
+        self.is_status_payload_too_large = is_status_payload_too_large
 
     @decorators.timed_request
     def get(self, url, **kwargs):

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -46,10 +46,12 @@ SECCOMPILER_BUILD_DIR = '../build/seccompiler'
 
 @pytest.mark.timeout(400)
 def test_coverage(test_fc_session_root_path, test_session_tmp_path):
-    """Test line coverage with kcov.
+    """Test line coverage for rust tests is within bounds.
 
     The result is extracted from the $KCOV_COVERAGE_FILE file created by kcov
     after a coverage run.
+
+    @type: build
     """
     proc_model = [item for item in COVERAGE_DICT if item in PROC_MODEL]
     assert len(proc_model) == 1, "Could not get processor model!"
@@ -126,3 +128,6 @@ def test_coverage(test_fc_session_root_path, test_session_tmp_path):
 
     assert coverage - coverage_target_pct <= COVERAGE_MAX_DELTA,\
         coverage_high_msg
+
+    return f"{coverage}%", \
+        f"{coverage_target_pct}% +/- {COVERAGE_MAX_DELTA * 100}%"

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.84, "AMD": 84.22, "ARM": 83.16}
+COVERAGE_DICT = {"Intel": 84.68, "AMD": 84.11, "ARM": 83.03}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -96,3 +96,88 @@ def test_config_start_no_api(test_microvm_with_ssh, vm_config_file):
         exceptions=RuntimeError,
         tries=10,
         delay=1)
+
+
+@pytest.mark.parametrize(
+    "vm_config_file",
+    ["framework/vm_config.json"]
+)
+def test_config_start_with_limit(test_microvm_with_api, vm_config_file):
+    """
+    Negative test for customised request payload limit.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_api
+
+    _configure_vm_from_json(test_microvm, vm_config_file)
+    test_microvm.jailer.extra_args.update({'http_api_max_payload_size': "250"})
+    test_microvm.spawn()
+
+    response = test_microvm.machine_cfg.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert test_microvm.state == "Running"
+
+    cmd = "curl --unix-socket {} -i".format(test_microvm.api_socket)
+    cmd += " -X PUT \"http://localhost/mmds/config\""
+    cmd += " -H  \"Content-Length: 260\""
+    cmd += " -H \"Accept: application/json\""
+    cmd += " -d \"some body\""
+
+    response = "HTTP/1.1 400 \r\n"
+    response += "Server: Firecracker API\r\n"
+    response += "Connection: keep-alive\r\n"
+    response += "Content-Type: application/json\r\n"
+    response += "Content-Length: 145\r\n\r\n"
+    response += "{ \"error\": \"Request payload with size 260 is larger than "
+    response += "the limit of 250 allowed by server.\n"
+    response += "All previous unanswered requests will be dropped.\" }"
+    _, stdout, _stderr = utils.run_cmd(cmd)
+    assert stdout.encode("utf-8") == response.encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "vm_config_file",
+    ["framework/vm_config.json"]
+)
+def test_config_with_default_limit(test_microvm_with_api, vm_config_file):
+    """
+    Test for request payload limit.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_api
+
+    _configure_vm_from_json(test_microvm, vm_config_file)
+    test_microvm.spawn()
+
+    response = test_microvm.machine_cfg.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert test_microvm.state == "Running"
+
+    data_store = {
+        'latest': {
+            'meta-data': {
+            }
+        }
+    }
+    data_store["latest"]["meta-data"]["ami-id"] = "abc"
+    response = test_microvm.mmds.put(json=data_store)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    cmd_err = "curl --unix-socket {} -i".format(test_microvm.api_socket)
+    cmd_err += " -X PUT \"http://localhost/mmds/config\""
+    cmd_err += " -H  \"Content-Length: 51201\""
+    cmd_err += " -H \"Accept: application/json\""
+    cmd_err += " -d \"some body\""
+
+    response_err = "HTTP/1.1 400 \r\n"
+    response_err += "Server: Firecracker API\r\n"
+    response_err += "Connection: keep-alive\r\n"
+    response_err += "Content-Type: application/json\r\n"
+    response_err += "Content-Length: 149\r\n\r\n"
+    response_err += "{ \"error\": \"Request payload with size 51201 is larger "
+    response_err += "than the limit of 51200 allowed by server.\n"
+    response_err += "All previous unanswered requests will be dropped.\" }"
+    _, stdout, _stderr = utils.run_cmd(cmd_err)
+    assert stdout.encode("utf-8") == response_err.encode("utf-8")

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -454,3 +454,91 @@ def test_guest_mmds_hang(test_microvm_with_ssh, network_config):
 
     _, stdout, _ = ssh_connection.execute_command(cmd)
     assert 'Invalid request' in stdout.read()
+
+
+def test_patch_dos_scenario(test_microvm_with_api):
+    """
+    Test the MMDS json endpoint when data store size reaches the limit.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_api
+    test_microvm.spawn()
+
+    dummy_json = {
+        'latest': {
+            'meta-data': {
+                'ami-id': 'dummy'
+            }
+        }
+    }
+
+    # Create MMDS data-store.
+    response = test_microvm.mmds.put(json=dummy_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Send a request that will fill the data store.
+    aux = "a" * 51137
+    dummy_json = {
+        'latest': {
+            'meta-data': {
+                'ami-id': "smth",
+                'secret_key': aux
+            }
+        }
+    }
+    response = test_microvm.mmds.patch(json=dummy_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Try to send a new patch thaw will increase the data store size. Since the
+    # actual size is equal with the limit this request should fail with
+    # PayloadTooLarge.
+    aux = "b" * 10
+    dummy_json = {
+        'latest': {
+            'meta-data': {
+                'ami-id': "smth",
+                'secret_key2': aux
+            }
+        }
+    }
+    response = test_microvm.mmds.patch(json=dummy_json)
+    assert test_microvm.api_session.\
+        is_status_payload_too_large(response.status_code)
+    # Check that the patch actually failed and the contents of the data store
+    # has not changed.
+    response = test_microvm.mmds.get()
+    assert str(response.json()).find(aux) == -1
+
+    # Delete something from the mmds so we will be able to send new data.
+    dummy_json = {
+        'latest': {
+            'meta-data': {
+                'ami-id': "smth",
+                'secret_key': "a"
+            }
+        }
+    }
+    response = test_microvm.mmds.patch(json=dummy_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Check that the size has shrunk.
+    response = test_microvm.mmds.get()
+    assert len(str(response.json()).replace(" ", "")) == 59
+
+    # Try to send a new patch, this time the request should succeed.
+    aux = "a" * 100
+    dummy_json = {
+        'latest': {
+            'meta-data': {
+                'ami-id': "smth",
+                'secret_key': aux
+            }
+        }
+    }
+    response = test_microvm.mmds.patch(json=dummy_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Check that the size grew as expected.
+    response = test_microvm.mmds.get()
+    assert len(str(response.json()).replace(" ", "")) == 158


### PR DESCRIPTION
# Reason for This PR

Backport significant commits from main to firecracker-v0.25.

## Description of Changes

Cherry-picked commits from main addressing the following:
- cargo update
- add MMDS data store size limit
- add cmd-line parameter to configure maximum payload size for MMDS patch requests
- clean-up environment variables in Jailer
- fix seccomp-bin being able to correctly report version by making use of `FIRECRACKER_VERSION` env variable

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
