### PR TITLE
rename max payload size cmdline argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 
-- Added `--http_api_max_payload_size` parameter to configure the maximum payload
+- Added `--http-api-max-payload-size` parameter to configure the maximum payload
   size for PUT and PATCH requests.
-- Limit MMDS data store size to `--http_api_max_payload_size`.
+- Limit MMDS data store size to `--http-api-max-payload-size`.
 - Cleanup all environment variables in Jailer.
 - Added metrics for accesses to deprecated HTTP and command line API endpoints.
 - Added permanent HTTP endpoint for `GET` on `/version` for getting the

--- a/docs/mmds/mmds-design.md
+++ b/docs/mmds/mmds-design.md
@@ -59,7 +59,7 @@ store supports at the moment storing and retrieving JSON values. Data store
 contents can be retrieved using the Firecracker API server from host and using
 the embedded MMDS HTTP/TCP/IPv4 network stack from guest.
 MMDS data store is upper bounded by a default maximum size of 51200 bytes. This
-limit can be modified using `--http_api_max_payload_size` command line parameter.
+limit can be modified using `--http-api-max-payload-size` command line parameter.
 All PUT and PATCH requests with Content-Length bigger than the imposed limit will
 receive HTTP 413 Payload Too Large response status code.
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -202,7 +202,7 @@ fn main_exitable() -> ExitCode {
                 .help("Print the data format version of the provided snapshot state file.")
         )
         .arg(
-            Argument::new("http_api_max_payload_size")
+            Argument::new("http-api-max-payload-size")
                 .takes_value(true)
                 .help("Http API request payload max size.")
         );
@@ -309,10 +309,10 @@ fn main_exitable() -> ExitCode {
             .expect("Missing argument: api-sock");
         let payload_limit = arg_parser
             .arguments()
-            .single_value("http_api_max_payload_size")
+            .single_value("http-api-max-payload-size")
             .map(|lim| {
                 lim.parse::<usize>()
-                    .expect("'http_api_max_payload_size' parameter expected to be of 'usize' type.")
+                    .expect("'http-api-max-payload-size' parameter expected to be of 'usize' type.")
             });
 
         let start_time_us = arguments.single_value("start-time-us").map(|s| {

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -119,7 +119,7 @@ def test_config_start_with_limit(test_microvm_with_api, vm_config_file):
     test_microvm = test_microvm_with_api
 
     _configure_vm_from_json(test_microvm, vm_config_file)
-    test_microvm.jailer.extra_args.update({'http_api_max_payload_size': "250"})
+    test_microvm.jailer.extra_args.update({'http-api-max-payload-size': "250"})
     test_microvm.spawn()
 
     response = test_microvm.machine_cfg.get()


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Max payload size parameter is not aligned with cmdline arguments' naming convention.

## Description of Changes

Renamed `--http_api_max_payload_size` parameter to `--http-api-max-payload-size`.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
