### PR TITLE
[block] Handle io_uring FullSq Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added metrics for accesses to deprecated HTTP and command line API endpoints.
 - Added permanent HTTP endpoint for `GET` on `/version` for getting the
   Firecracker version.
+- Added `block.io_engine_throttled_events` metric for measuring the number of
+  virtio events throttled because of the IO engine.
 
 ### Fixed
 

--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -14,7 +14,7 @@ use utils::eventfd::EventFd;
 use vm_memory::{mark_dirty_mem, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 use crate::virtio::block::io::UserDataError;
-use crate::virtio::block::QUEUE_SIZE;
+use crate::virtio::block::IO_URING_NUM_ENTRIES;
 
 #[derive(Debug)]
 pub enum Error {
@@ -66,7 +66,7 @@ impl<T> AsyncFileEngine<T> {
     #[allow(unused)]
     pub fn from_file(file: File) -> Result<AsyncFileEngine<T>, Error> {
         let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-        let mut ring = IoUring::new(QUEUE_SIZE as u32).map_err(Error::IoUring)?;
+        let mut ring = IoUring::new(IO_URING_NUM_ENTRIES as u32).map_err(Error::IoUring)?;
         ring.register_eventfd(completion_evt.as_raw_fd())
             .map_err(Error::IoUring)?;
 

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -27,6 +27,15 @@ pub enum Error {
     Async(async_io::Error),
 }
 
+impl Error {
+    pub fn is_full_sq(&self) -> bool {
+        if let Error::Async(async_io::Error::IoUring(e)) = self {
+            return e.is_full_sq();
+        }
+        false
+    }
+}
+
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct UserDataError<T, E> {
     pub user_data: T,

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -177,7 +177,7 @@ pub mod tests {
     // 2 pages of memory should be enough to test read/write ops and also dirty tracking.
     const MEM_LEN: usize = 8192;
 
-    fn is_kernel_lt_5_10() -> bool {
+    pub fn is_kernel_lt_5_10() -> bool {
         KernelVersion::get().unwrap() < KernelVersion::new(5, 10, 0)
     }
 

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -20,6 +20,9 @@ pub const SECTOR_SIZE: u64 = (0x01_u64) << SECTOR_SHIFT;
 pub const QUEUE_SIZE: u16 = 256;
 pub const NUM_QUEUES: usize = 1;
 pub const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
+// The virtio queue can hold up to 256 descriptors, but 1 request spreads across 2-3 descriptors.
+// So we can use 128 IO_URING entries without ever triggering a FullSq Error.
+pub const IO_URING_NUM_ENTRIES: u16 = 128;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -181,7 +181,11 @@ pub(crate) mod tests {
 
     impl IrqTrigger {
         pub fn has_pending_irq(&self, irq_type: IrqType) -> bool {
-            if let Ok(1) = self.irq_evt.read() {
+            if let Ok(num_irqs) = self.irq_evt.read() {
+                if num_irqs == 0 {
+                    return false;
+                }
+
                 let irq_status = self.irq_status.load(Ordering::SeqCst) as u32;
                 return matches!(
                     (irq_status, irq_type),

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -41,6 +41,15 @@ pub enum Error {
     UnsupportedOperation(&'static str),
 }
 
+impl Error {
+    pub fn is_full_sq(&self) -> bool {
+        if let Error::SQueue(SQueueError::FullQueue) = self {
+            return true;
+        }
+        false
+    }
+}
+
 pub struct IoUring {
     fd: File,
     registered_fds_count: u32,

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -481,6 +481,9 @@ pub struct BlockDeviceMetrics {
     pub write_count: SharedIncMetric,
     /// Number of rate limiter throttling events.
     pub rate_limiter_throttled_events: SharedIncMetric,
+    /// Number of virtio events throttled because of the IO engine.
+    /// This happens when the io_uring submission queue is full.
+    pub io_engine_throttled_events: SharedIncMetric,
 }
 
 /// Metrics specific to the i8042 device.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.compare_versions(utils.get_kernel_version(), "5.4.0") > 0:
-    COVERAGE_DICT = {"Intel": 84.69, "AMD": 84.17, "ARM": 82.85}
+    COVERAGE_DICT = {"Intel": 84.75, "AMD": 84.17, "ARM": 82.90}
 else:
-    COVERAGE_DICT = {"Intel": 81.94, "AMD": 81.38, "ARM": 80.10}
+    COVERAGE_DICT = {"Intel": 81.80, "AMD": 81.25, "ARM": 79.95}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

At the moment, if the io_uring submission queue is full we simply reject the block request, which is not correct. With the current queue size, this should not happen, but it's safer to handle this corner case.

## Description of Changes

When the io_uring submission queue is full we have to:
 - undo the pop() operation from the block device virtio queue
 - call process_queue() at the end of process_async_completion_evt()

Marking this PR as a draft until #2772 is merged since it's based on it.

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes are reflected in `firecracker/swagger.yaml`.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
