### PR TITLE
[io_uring] add support for restrictions

### DIFF
--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -66,11 +66,12 @@ impl<T> AsyncFileEngine<T> {
     #[allow(unused)]
     pub fn from_file(file: File) -> Result<AsyncFileEngine<T>, Error> {
         let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-        let mut ring = IoUring::new(IO_URING_NUM_ENTRIES as u32).map_err(Error::IoUring)?;
-        ring.register_eventfd(completion_evt.as_raw_fd())
-            .map_err(Error::IoUring)?;
-
-        ring.register_file(&file).map_err(Error::IoUring)?;
+        let mut ring = IoUring::new(
+            IO_URING_NUM_ENTRIES as u32,
+            vec![&file],
+            Some(completion_evt.as_raw_fd()),
+        )
+        .map_err(Error::IoUring)?;
 
         Ok(AsyncFileEngine {
             file,

--- a/src/io_uring/src/restriction.rs
+++ b/src/io_uring/src/restriction.rs
@@ -1,0 +1,36 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::From;
+
+use crate::bindings;
+use crate::operation::OpCode;
+
+/// Adds support for restricting the operations allowed by io_uring, in a similar way to seccomp.
+pub enum Restriction {
+    /// Allow an operation.
+    AllowOpCode(OpCode),
+    /// Only allow operations on pre-registered fds.
+    RequireFixedFds,
+}
+
+impl From<&Restriction> for bindings::io_uring_restriction {
+    fn from(restriction: &Restriction) -> Self {
+        use Restriction::*;
+
+        let mut instance: Self = unsafe { std::mem::zeroed() };
+
+        match restriction {
+            AllowOpCode(opcode) => {
+                instance.opcode = bindings::IORING_RESTRICTION_SQE_OP as u16;
+                instance.__bindgen_anon_1.sqe_op = *opcode as u8;
+            }
+            RequireFixedFds => {
+                instance.opcode = bindings::IORING_RESTRICTION_SQE_FLAGS_REQUIRED as u16;
+                instance.__bindgen_anon_1.sqe_flags = 1 << bindings::IOSQE_FIXED_FILE_BIT;
+            }
+        };
+
+        instance
+    }
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -31,7 +31,7 @@ import host_tools.proc as proc
 if utils.compare_versions(utils.get_kernel_version(), "5.4.0") > 0:
     COVERAGE_DICT = {"Intel": 84.75, "AMD": 84.17, "ARM": 82.90}
 else:
-    COVERAGE_DICT = {"Intel": 81.80, "AMD": 81.25, "ARM": 79.95}
+    COVERAGE_DICT = {"Intel": 81.53, "AMD": 80.98, "ARM": 79.73}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

io_uring exposes an alternative to syscalls, but without the ability of restricting the allowed list of syscalls via seccomp.
Starting with kernel 5.10, there is support for restrictions, an interface that enables a user to configure per-ring rules that are validated for each operation.

Installing restrictions require that we setup the ring in a disabled state and enable it after setting the restrictions.

For more context view the latest liburing man pages: https://github.com/axboe/liburing/blob/master/man/io_uring_register.2
and https://lwn.net/Articles/826053/

## Description of Changes

- add restrictions support in the io_uring crate
- add block async restrictions: only allow read,write and fsync on the pre-registered fds.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
