### PR TITLE
[CI]: Fix snapshot perf test

### DIFF
--- a/tests/framework/stats/core.py
+++ b/tests/framework/stats/core.py
@@ -72,7 +72,7 @@ class Core:
                     pipe.consumer.ingest(iteration, raw_data)
             try:
                 stats, custom = pipe.consumer.process(fail_fast)
-            except ProcessingException as err:
+            except (ProcessingException, AssertionError) as err:
                 self._failure_aggregator.add_row(f"Failed on '{tag}':")
                 self._failure_aggregator.add_row(err)
                 stats = err.stats

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -87,7 +87,7 @@ def construct_scratch_drives():
         drive_tools.FilesystemFile(tempfile.mktemp(), size=64)
         for _ in scratchdisks
     ]
-    return zip(scratchdisks, disk_files)
+    return list(zip(scratchdisks, disk_files))
 
 
 def default_lambda_consumer(env_id):
@@ -139,7 +139,7 @@ def get_snap_restore_latency(
 
     extra_disk_paths = []
     if blocks > 1:
-        for (name, diskfile) in list(scratch_drives)[:(blocks - 1)]:
+        for (name, diskfile) in scratch_drives[:(blocks - 1)]:
             basevm.add_drive(name, diskfile.path, use_ramdisk=True)
             extra_disk_paths.append(diskfile.path)
         assert len(extra_disk_paths) > 0


### PR DESCRIPTION
We are using a global list to store the scratch drives info.
In function that makes the setup for block scaling test we
were changing the type of that global variable from list to
zip, thus in test function the list was seen as empty. Saved
the constructor result in an aux variable and unziped it in
the global variable to solve this issue. Also added catch
for AssertionError in run_exercise.

Signed-off-by: AlexandruCihodaru <cihodar@amazon.com>

# Reason for This PR

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Fixes #

## Description of Changes
Changed the way we initialize the scratch drives list in performance test pipeline.
`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
