### PR TITLE
jailer: add parameter to specify custom parent cgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Added jailer option `--parent-cgroup <relative_path>` to allow the placement
+  of microvm cgroups in custom cgroup nested hierarchies. The default value is
+  `<exec-file>` which is backwards compatible to the behavior before this
+  change.
+- Added jailer option `--cgroup-version <1|2>` to support running the jailer
+  on systems that have cgroup-v2. Default value is `1` which means that if
+  `--cgroup-version` is not specified, the jailer will try to create cgroups
+  on cgroup-v1 hierarchies only.
 - Added `--http-api-max-payload-size` parameter to configure the maximum payload
   size for PUT and PATCH requests.
 - Limit MMDS data store size to `--http-api-max-payload-size`.
@@ -28,10 +36,6 @@
 
 ### Added
 
-- Added jailer option `--cgroup-version <1|2>` to support running the jailer
-  on systems that have cgroup-v2. Default value is `1` which means that if
-  `--cgroup-version` is not specified, the jailer will try to create cgroups
-  on cgroup-v1 hierarchies only.
 - Added devtool build `--ssh-keys` flag to support fetching from private
   git repositories.
 - Added option to configure block device flush.

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -31,6 +31,7 @@ pub enum Error {
     CgroupHierarchyMissing(String),
     CgroupControllerUnavailable(String),
     CgroupInvalidVersion(String),
+    CgroupInvalidParentPath(),
     ChangeFileOwner(PathBuf, io::Error),
     ChdirNewRoot(io::Error),
     Chmod(PathBuf, io::Error),
@@ -117,6 +118,12 @@ impl fmt::Display for Error {
             CgroupControllerUnavailable(ref arg) => write!(f, "Controller {} is unavailable", arg,),
             CgroupInvalidVersion(ref arg) => {
                 write!(f, "{} is an invalid cgroup version specifier", arg,)
+            }
+            CgroupInvalidParentPath() => {
+                write!(
+                    f,
+                    "Parent cgroup path is invalid. Path should not be absolute or contain '..' or '.'",
+                )
             }
             ChangeFileOwner(ref path, ref err) => {
                 write!(f, "Failed to change owner for {:?}: {}", path, err)
@@ -311,6 +318,11 @@ pub fn build_arg_parser() -> ArgParser<'static> {
                 .takes_value(true)
                 .default_value("1")
                 .help("Select the cgroup version used by the jailer."),
+        )
+        .arg(
+            Argument::new("parent-cgroup")
+                .takes_value(true)
+                .help("Parent cgroup in which the cgroup of this microvm will be placed."),
         )
         .arg(
             Argument::new("version")

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -38,6 +38,7 @@ class JailerContext:
     cgroups = None
     resource_limits = None
     cgroup_ver = None
+    parent_cgroup = None
 
     def __init__(
             self,
@@ -53,6 +54,7 @@ class JailerContext:
             cgroups=None,
             resource_limits=None,
             cgroup_ver=None,
+            parent_cgroup=None,
             **extra_args
     ):
         """Set up jailer fields.
@@ -75,6 +77,7 @@ class JailerContext:
         self.cgroups = cgroups
         self.resource_limits = resource_limits
         self.cgroup_ver = cgroup_ver
+        self.parent_cgroup = parent_cgroup
         self.ramfs_subdir_name = 'ramfs'
         self._ramfs_path = None
 
@@ -116,6 +119,10 @@ class JailerContext:
             jailer_param_list.append('--daemonize')
         if self.new_pid_ns:
             jailer_param_list.append('--new-pid-ns')
+        if self.parent_cgroup:
+            jailer_param_list.extend(
+                ['--parent-cgroup', str(self.parent_cgroup)]
+            )
         if self.cgroup_ver:
             jailer_param_list.extend(
                 ['--cgroup-version', str(self.cgroup_ver)]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.68, "AMD": 84.10, "ARM": 82.71}
+COVERAGE_DICT = {"Intel": 84.65, "AMD": 84.10, "ARM": 82.71}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fixes #2788

## Description of Changes

Add ability to specify a custom parent cgroup where the microvm cgroup will be created.
This allows users to start microvms in cgroups that already have resource management configured.

In order to achieve this, a new parameter has been added to the jailer. `--parent-cgroup` allows for customisation of the path within the cgroup hierarchy where the microVM cgroup will be created.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [N/A] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
