### PR TITLE
Add custom headers for MMDS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   Firecracker version.
 - Added `--metadata` paramater to enable MMDS content to be supplied from a file
   allowing the MMDS to be used when using `--no-api` to disable the API server.
+- Added support for custom headers to MMDS requests. Accepted headers are:
+  `X-metadata-token`, which accepts a string value that provides a session
+  token for MMDS requests; and `X-metadata-token-ttl-seconds`, which
+  specifies the lifetime of the session token in seconds.
 
 ### Changed
 

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -172,7 +172,7 @@ impl Endpoint {
             // If we got here, then we still have some response bytes to send (which are
             // stored in self.response_buf).
 
-            // It seems we just recevied the last ACK we were waiting for, so the entire
+            // It seems we just received the last ACK we were waiting for, so the entire
             // response has been successfully received. Set the new response_seq and clear
             // the response_buf.
             self.response_seq = self.connection.highest_ack_received();

--- a/src/dumbo/src/tcp/endpoint.rs
+++ b/src/dumbo/src/tcp/endpoint.rs
@@ -209,7 +209,7 @@ impl Endpoint {
                         response.write_all(&mut self.response_buf).unwrap();
 
                         // Sanity check because the current logic operates under this assumption.
-                        assert!(self.response_buf.len() < u32::max_value() as usize);
+                        assert!(self.response_buf.len() < u32::MAX as usize);
 
                         // We have to remove the bytes up to end from receive_buf, by shifting the
                         // others to the beginning of the buffer, and updating receive_buf_left.

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -196,14 +196,14 @@ impl TcpIPv4Handler {
         self.max_connections
     }
 
-    /// Returns the max pending resetes of this TCP handler.
+    /// Returns the max pending resets of this TCP handler.
     pub fn max_pending_resets(&self) -> usize {
         self.max_pending_resets
     }
 
     /// Contains logic for handling incoming segments.
     ///
-    /// Any changes to the state if the handler are communicated through an `Ok(RecvEvent)`.
+    /// Any changes to the state of the handler are communicated through an `Ok(RecvEvent)`.
     pub fn receive_packet<T: NetworkBytes>(
         &mut self,
         packet: &IPv4Packet<T>,

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -11,6 +11,14 @@ pub struct Mmds {
     data_store: Value,
     is_initialized: bool,
     data_store_limit: usize,
+    version: MmdsVersion,
+}
+
+/// MMDS version.
+#[derive(Clone, Copy)]
+pub enum MmdsVersion {
+    V1,
+    V2,
 }
 
 /// MMDS possible outputs.
@@ -21,22 +29,22 @@ pub enum OutputFormat {
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    DataStoreLimitExceeded,
     NotFound,
     NotInitialized,
     UnsupportedValueType,
-    DataStoreLimitExceeded,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
             Error::NotFound => write!(f, "The MMDS resource does not exist."),
             Error::NotInitialized => write!(f, "The MMDS data store is not initialized."),
             Error::UnsupportedValueType => write!(
                 f,
                 "Cannot retrieve value. The value has an unsupported type."
             ),
-            Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
         }
     }
 }
@@ -47,6 +55,7 @@ impl Default for Mmds {
             data_store: Value::default(),
             is_initialized: false,
             data_store_limit: MAX_DATA_STORE_SIZE,
+            version: MmdsVersion::V1,
         }
     }
 }
@@ -61,6 +70,16 @@ impl Mmds {
         } else {
             Err(Error::NotInitialized)
         }
+    }
+
+    /// Set the MMDS version.
+    pub fn set_version(&mut self, version: MmdsVersion) {
+        self.version = version;
+    }
+
+    /// Return the MMDS version.
+    pub fn version(&self) -> MmdsVersion {
+        self.version
     }
 
     pub fn set_data_store_limit(&mut self, data_store_limit: usize) {

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -4,9 +4,12 @@
 pub mod data_store;
 pub mod ns;
 pub mod persist;
+pub mod token_headers;
 
 use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
+
+use token_headers::TokenHeaders;
 
 use crate::data_store::{Error as MmdsError, Mmds, OutputFormat};
 use lazy_static::lazy_static;
@@ -96,6 +99,17 @@ fn convert_to_response(request: Request) -> Response {
         response.allow_method(Method::Get);
         return response;
     }
+
+    let _token_headers = match TokenHeaders::try_from(request.headers.custom_entries()) {
+        Ok(token_headers) => token_headers,
+        Err(err) => {
+            return build_response(
+                request.http_version(),
+                StatusCode::BadRequest,
+                Body::new(err.to_string()),
+            )
+        }
+    };
 
     // The data store expects a strict json path, so we need to
     // sanitize the URI.
@@ -217,6 +231,30 @@ mod tests {
         let request = Request::try_from(request_bytes, None).unwrap();
         let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
         expected_response.set_body(Body::new("Invalid URI.".to_string()));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
+        // Test invalid value for custom header.
+        let request_bytes = b"GET http://169.254.169.254/ HTTP/1.0\r\n\
+                                    Accept: application/json\r\n
+                                    X-metadata-token-ttl-seconds: application/json\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::BadRequest);
+        expected_response.set_body(Body::new(
+            "Invalid header. Reason: Invalid value. \
+            Key:X-metadata-token-ttl-seconds; Value:application/json"
+                .to_string(),
+        ));
+        let actual_response = convert_to_response(request);
+        assert_eq!(actual_response, expected_response);
+
+        // Test valid values for custom headers.
+        let request_bytes = b"GET http://169.254.169.254/name/first HTTP/1.0\r\n\
+                                    X-metadata-token: application/json\r\n
+                                    X-metadata-token-ttl-seconds: 100\r\n\r\n";
+        let request = Request::try_from(request_bytes, None).unwrap();
+        let mut expected_response = Response::new(Version::Http10, StatusCode::OK);
+        expected_response.set_body(Body::new("John"));
         let actual_response = convert_to_response(request);
         assert_eq!(actual_response, expected_response);
 

--- a/src/mmds/src/token_headers.rs
+++ b/src/mmds/src/token_headers.rs
@@ -1,0 +1,130 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use micro_http::{HttpHeaderError, RequestError};
+use std::collections::HashMap;
+use std::result::Result;
+
+/// Wrapper over the list of token headers associated with a Request.
+#[derive(Debug, PartialEq)]
+pub struct TokenHeaders {
+    /// The `X-metadata-token` header might be used by HTTP clients to specify a token in order
+    /// to authenticate to the session. This is used for guest requests to MMDS only.
+    x_metadata_token: Option<String>,
+    /// The `X-metadata-token-ttl-seconds` header might be used by HTTP clients to specify
+    /// the expiry time of a token. This is used for PUT requests issued by the guest to MMDS only.
+    x_metadata_token_ttl_seconds: Option<u32>,
+}
+
+impl Default for TokenHeaders {
+    /// Token headers are not present in the request by default.
+    fn default() -> Self {
+        Self {
+            x_metadata_token: None,
+            x_metadata_token_ttl_seconds: None,
+        }
+    }
+}
+
+impl TokenHeaders {
+    /// `X-metadata-token` header.
+    const X_METADATA_TOKEN: &'static str = "X-metadata-token";
+    /// `X-metadata-token-ttl-seconds` header.
+    const X_METADATA_TOKEN_TTL_SECONDS: &'static str = "X-metadata-token-ttl-seconds";
+
+    /// Return `TokenHeaders` from headers map.
+    pub fn try_from(map: &HashMap<String, String>) -> Result<TokenHeaders, RequestError> {
+        let mut headers = Self::default();
+
+        if let Some(token) = map.get(TokenHeaders::X_METADATA_TOKEN) {
+            headers.x_metadata_token = Some(token.to_string());
+        }
+
+        if let Some(value) = map.get(TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS) {
+            match value.parse::<u32>() {
+                Ok(seconds) => {
+                    headers.x_metadata_token_ttl_seconds = Some(seconds);
+                }
+                Err(_) => {
+                    return Err(RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                        TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS.to_string(),
+                        value.to_string(),
+                    )));
+                }
+            }
+        }
+
+        Ok(headers)
+    }
+
+    /// Returns the `XMetadataToken` token.
+    pub fn x_metadata_token(&self) -> Option<&String> {
+        self.x_metadata_token.as_ref()
+    }
+
+    /// Returns the `XMetadataTokenTtlSeconds` token.
+    pub fn x_metadata_token_ttl_seconds(&self) -> Option<u32> {
+        self.x_metadata_token_ttl_seconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        let headers = TokenHeaders::default();
+        assert_eq!(headers.x_metadata_token(), None);
+        assert_eq!(headers.x_metadata_token_ttl_seconds(), None);
+    }
+
+    #[test]
+    fn test_try_from_headers() {
+        // Empty token header map.
+        let map: HashMap<String, String> = HashMap::default();
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers, TokenHeaders::default());
+
+        // Unrecognised headers.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert("Some-Header".to_string(), "10".to_string());
+        map.insert("Another-Header".to_string(), "value".to_string());
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers, TokenHeaders::default());
+
+        // Valid headers.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert("Some-Header".to_string(), "10".to_string());
+        map.insert(
+            TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS.to_string(),
+            "60".to_string(),
+        );
+        map.insert(
+            TokenHeaders::X_METADATA_TOKEN.to_string(),
+            "foo".to_string(),
+        );
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers.x_metadata_token_ttl_seconds().unwrap(), 60);
+        assert_eq!(*headers.x_metadata_token().unwrap(), "foo".to_string());
+
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert(TokenHeaders::X_METADATA_TOKEN.to_string(), "".to_string());
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(*headers.x_metadata_token().unwrap(), "".to_string());
+
+        // Invalid value.
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert(
+            TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS.to_string(),
+            "-60".to_string(),
+        );
+        assert_eq!(
+            TokenHeaders::try_from(&map).unwrap_err(),
+            RequestError::HeaderError(HttpHeaderError::InvalidValue(
+                TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS.to_string(),
+                "-60".to_string()
+            ))
+        );
+    }
+}

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -13,9 +13,9 @@ MACHINE = platform.machine()
 
 SIZES_DICT = {
     "x86_64": {
-        "FC_BINARY_SIZE_TARGET": 2206048,
+        "FC_BINARY_SIZE_TARGET": 2231016,
         "JAILER_BINARY_SIZE_TARGET": 797632,
-        "FC_BINARY_SIZE_LIMIT": 2226817,
+        "FC_BINARY_SIZE_LIMIT": 2342569,
         "JAILER_BINARY_SIZE_LIMIT": 869608,
     },
     "aarch64": {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.65, "AMD": 84.10, "ARM": 82.71}
+COVERAGE_DICT = {"Intel": 84.72, "AMD": 84.15, "ARM": 82.77}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

In order to be able to add IMDSv2 capabilities to Firecracker's MMDS, the backend needs to be able to process custom mmds-related headers. 

IMDSv2 uses session-oriented requests. With session-oriented requests, the guest creates a session token that defines the session duration and then uses that token for subsequent requests.

## Description of Changes

- Make use of micro-http's custom headers hash-map to fetch custom headers when processing the header of a request
- Add MMDS v2 headers:
  `X-metadata-ttl-seconds` - used when fetching the session token to provide token lifetime in seconds
  `X-metadata-token` - used to provide session token

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[] The issue which led to this PR has a clear conclusion.~
- ~[ ] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] Any newly added `unsafe` code is properly documented.~
- ~[ ] Any API changes follow the [Runbook for Firecracker API changes][2].~
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
