### PR TITLE
[main] cpuid: adapt templates for kernel 5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 - Fixed incorrect propagation of init parameters in kernel commandline.
   Related to:
   [#2709](https://github.com/firecracker-microvm/firecracker/issues/2709).
+- Adapt T2 and C3 CPU templates for kernel 5.10. Firecracker was not previously
+  masking some CPU features of the host or emulated by KVM, introduced in more
+  recent kernels: `umip`, `vmx`, `avx512_vnni`.
 
 ## [0.25.0]
 

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -34,7 +34,8 @@ pub mod leaf_0x1 {
         pub const MONITOR_BITINDEX: u32 = 3;
         // CPL Qualified Debug Store
         pub const DS_CPL_SHIFT: u32 = 4;
-        // 5 = VMX (Virtual Machine Extensions)
+        // Virtual Machine Extensions
+        pub const VMX_BITINDEX: u32 = 5;
         // 6 = SMX (Safer Mode Extensions)
         // 7 = EIST (Enhanced Intel SpeedStep® technology)
         // TM2 = Thermal Monitor 2
@@ -165,15 +166,22 @@ pub mod leaf_0x7 {
             // 0 = PREFETCHWT1 (move data closer to the processor in anticipation of future use)
             // AVX512_VBMI = AVX-512 Vector Byte Manipulation Instructions
             pub const AVX512_VBMI_BITINDEX: u32 = 1;
-            // 2 = UMIP (User Mode Instruction Prevention)
+            // UMIP (User Mode Instruction Prevention)
+            pub const UMIP_BITINDEX: u32 = 2;
             // PKU = Protection Keys for user-mode pages
             pub const PKU_BITINDEX: u32 = 3;
             // OSPKE = If 1, OS has set CR4.PKE to enable protection keys
             pub const OSPKE_BITINDEX: u32 = 4;
             // 5 = WAITPKG
-            // 7-6 reserved
+            // 6 = AVX512_VBMI2
+            // 7 reserved
             // 8 = GFNI
-            // 13-09 reserved
+            // 9 = VAES
+            // 10 = VPCLMULQDQ
+            // AVX512_VNNI = Vector Neural Network Instructions
+            pub const AVX512_VNNI_BITINDEX: u32 = 11;
+            // 12 = AVX512_BITALG
+            // 13 = TME
             // AVX512_VPOPCNTDQ = Vector population count instruction (Intel® Xeon Phi™ only.)
             pub const AVX512_VPOPCNTDQ_BITINDEX: u32 = 14;
             // 21 - 17 = The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.

--- a/src/cpuid/src/template/intel/c3.rs
+++ b/src/cpuid/src/template/intel/c3.rs
@@ -31,6 +31,7 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         .write_bit(ecx::DTES64_BITINDEX, false)
         .write_bit(ecx::MONITOR_BITINDEX, false)
         .write_bit(ecx::DS_CPL_SHIFT, false)
+        .write_bit(ecx::VMX_BITINDEX, false)
         .write_bit(ecx::TM2_BITINDEX, false)
         .write_bit(ecx::CNXT_ID_BITINDEX, false)
         .write_bit(ecx::SDBG_BITINDEX, false)
@@ -90,8 +91,10 @@ fn update_structured_extended_entry(
         entry
             .ecx
             .write_bit(ecx::AVX512_VBMI_BITINDEX, false)
+            .write_bit(ecx::UMIP_BITINDEX, false)
             .write_bit(ecx::PKU_BITINDEX, false)
             .write_bit(ecx::OSPKE_BITINDEX, false)
+            .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
             .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
             .write_bit(ecx::RDPID_BITINDEX, false)
             .write_bit(ecx::SGX_LC_BITINDEX, false);

--- a/src/cpuid/src/template/intel/t2.rs
+++ b/src/cpuid/src/template/intel/t2.rs
@@ -31,6 +31,7 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         .write_bit(ecx::DTES64_BITINDEX, false)
         .write_bit(ecx::MONITOR_BITINDEX, false)
         .write_bit(ecx::DS_CPL_SHIFT, false)
+        .write_bit(ecx::VMX_BITINDEX, false)
         .write_bit(ecx::TM2_BITINDEX, false)
         .write_bit(ecx::CNXT_ID_BITINDEX, false)
         .write_bit(ecx::SDBG_BITINDEX, false)
@@ -84,8 +85,10 @@ fn update_structured_extended_entry(
         entry
             .ecx
             .write_bit(ecx::AVX512_VBMI_BITINDEX, false)
+            .write_bit(ecx::UMIP_BITINDEX, false)
             .write_bit(ecx::PKU_BITINDEX, false)
             .write_bit(ecx::OSPKE_BITINDEX, false)
+            .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
             .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
             .write_bit(ecx::RDPID_BITINDEX, false)
             .write_bit(ecx::SGX_LC_BITINDEX, false);

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -192,8 +192,8 @@ def check_masked_features(test_microvm, cpu_template):
                                     "psn", "ds", "acpi", "tm", "ss", "pbe",
                                     "fpdp", "rdt_m", "rdt_a", "mpx", "avx512f",
                                     "intel_pt",
-                                    "avx512_vpopcntdq",
-                                    "3dnowprefetch", "pdpe1gb"]
+                                    "avx512_vpopcntdq", "avx512_vnni",
+                                    "3dnowprefetch", "pdpe1gb", "vmx", "umip"]
 
     common_masked_features_cpuid = {"SGX": "false", "HLE": "false",
                                     "RTM": "false", "RDSEED": "false",
@@ -208,7 +208,8 @@ def check_masked_features(test_microvm, cpu_template):
                                     "AVX512_4VNNIW": "false",
                                     "AVX512_4FMAPS": "false",
                                     "XSAVEC": "false", "XGETBV": "false",
-                                    "XSAVES": "false"}
+                                    "XSAVES": "false", "UMIP": "false",
+                                    "VMX": "false"}
 
     # These are all discoverable by cpuid -1.
     c3_masked_features = {"FMA": "false", "MOVBE": "false", "BMI": "false",


### PR DESCRIPTION
# Reason for This PR

There are a couple of new features that appear in the guests created with T2 and C3 cpu templates, on newer kernels (5.10).

**`umip`**
Newer KVM versions perform some CPU feature emulation in kernel space. These features are returned by `KVM_GET_SUPPORTED_CPUID` and `KVM_GET_EMULATED_CPUID`. Firecracker issues the `KVM_GET_SUPPORTED_CPUID` ioctl to get the set of features supported by the host plus the ones emulated by KVM. Firecracker then performs transformations on it, by masking specific features (like the ones for CPU templates), but it does not perform masking of features emulated by KVM.
This is the case for the `umip` feature.

**`avx512_vnni`**
In recent kernels, the code responsible for setting the cpuid features in kvm has had a redesign: https://lwn.net/Articles/811336/

Assuming that a guest CPU feature is not explicitly enabled or disabled by Firecracker, a host cpu feature is exposed in the guest if the following 3 conditions are true:

- All of the host CPUs contain this feature (checked using the global boot_cpu_data kernel variable).
- KVM allows this CPU feature (this is a hardcoded allowlist)
- the runtime cpuid of the current host CPU renders this feature as supported

On kernel 5.10, the KVM allowlist has had some additions, notably the avx512_vnni which should not be present on C3/T2

**VMX related features**
In 5.10, other VMX-related cpu features appear as present in guests 'ept', 'flexpriority', 'tpr_shadow', 'vmx', 'vnmi', 'vpid'.

Only `vmx` is a true cpuid feature. The rest of them are being set locally by the guest kernel as synthetic capabilities, based on specific MSR values, only if the VMX feature is advertised.

Firecracker is not explicitly masking the VMX CPUID feature.

Nested virt is a special feature which is advertised based on the value of a hardcoded global variable in the kernel: `nested`.
In older versions, the variable was hardcoded to 0 for x86 CPUs so the T2/C3 guests did not advertise it.
In newer kernels (including 5.10), support was added for nested virt for x86 as well, so now Firecracker guests will see this feature.

## Description of Changes

Explicitly mask the aforementioned features

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
