### PR TITLE
[v0.25] Backport: kernel: fix bug in cmdline setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Adapt T2 and C3 CPU templates for kernel 5.10. Firecracker was not previously
   masking some CPU features of the host or emulated by KVM, introduced in more
   recent kernels: `umip`, `vmx`, `avx512_vnni`.
+- Fixed incorrect propagation of init parameters in kernel commandline.
+  Related to:
+  [#2709](https://github.com/firecracker-microvm/firecracker/issues/2709).
 
 ## [0.25.1]
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -318,12 +318,29 @@ pub fn build_microvm_for_boot(
     let vcpu_config = vm_resources.vcpu_config();
     let entry_addr = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;
-    // Clone the command-line so that a failed boot doesn't pollute the original.
-    #[allow(unused_mut)]
-    let mut boot_cmdline = boot_config.cmdline.clone();
-
+    let mut boot_cmdline = kernel::cmdline::Cmdline::new(arch::CMDLINE_MAX_SIZE);
     // Timestamp for measuring microVM boot duration.
     let request_ts = TimestampUs::default();
+
+    // We're splitting the boot_args in regular parameters and init arguments.
+    // This is needed because on x86_64 we're altering the boot arguments by
+    // adding the virtio device configuration. We need to make sure that the init
+    // parameters are last, specified after -- as specified in the kernel docs
+    // (https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html).
+    let init_and_regular = boot_config
+        .cmdline
+        .as_str()
+        .split("--")
+        .collect::<Vec<&str>>();
+    if init_and_regular.len() > 2 {
+        return Err(StartMicrovmError::KernelCmdline(
+            "Too many `--` in kernel cmdline.".to_string(),
+        ));
+    }
+    let boot_args = init_and_regular[0];
+    let init_params = init_and_regular.get(1);
+
+    boot_cmdline.insert_str(boot_args)?;
 
     let (mut vmm, mut vcpus) = create_vmm_and_vcpus(
         instance_info,
@@ -358,6 +375,10 @@ pub fn build_microvm_for_boot(
     )?;
     if let Some(unix_vsock) = vm_resources.vsock.get() {
         attach_unixsock_vsock_device(&mut vmm, &mut boot_cmdline, unix_vsock, event_manager)?;
+    }
+
+    if let Some(init) = init_params {
+        boot_cmdline.insert_str(format!("--{}", init))?;
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -24,7 +24,7 @@ import host_tools.proc as proc
 # this contains the frequency while on AMD it does not.
 # Checkout the cpuid crate. In the future other
 # differences may appear.
-COVERAGE_DICT = {"Intel": 84.68, "AMD": 84.11, "ARM": 83.03}
+COVERAGE_DICT = {"Intel": 84.68, "AMD": 84.11, "ARM": 82.89}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test kernel commandline behavior."""
+
+from framework.microvm import Serial
+
+
+def test_init_params(test_microvm_with_api):
+    """Correct propagation of boot args to the kernel's command line.
+
+    Test that init's parameters (the ones present after "--") do not get
+    altered or misplaced.
+
+    @type: functional
+    """
+    vm = test_microvm_with_api
+    vm.jailer.daemonize = False
+    vm.spawn()
+    vm.memory_monitor = None
+
+    # We will override the init with /bin/cat so that we try to read the
+    # Ubuntu version from the /etc/issue file.
+    vm.basic_config(
+        vcpu_count=1,
+        boot_args='console=ttyS0 reboot=k panic=1 pci=off'
+                  ' init=/bin/cat -- /etc/issue',
+    )
+
+    vm.start()
+    serial = Serial(vm)
+    serial.open()
+    # If the string does not show up, the test will fail.
+    serial.rx(token='Ubuntu 18.04 LTS')


### PR DESCRIPTION
# Reason for This PR

Backports https://github.com/firecracker-microvm/firecracker/pull/2716 in v0.25

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
