### PR TITLE
[MMDS] add API to set MMDS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   specifies the lifetime of the session token in seconds.
 - Added `PUT` request on `/mmds/version` that configures the MMDS version.
   Accepted values are either `V1` or `V2`.
+- Added `GET` request on `/mmds/version` that provides the MMDS version.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@
 - Added metrics for accesses to deprecated HTTP and command line API endpoints.
 - Added permanent HTTP endpoint for `GET` on `/version` for getting the
   Firecracker version.
-- Added `--metadata` paramater to enable MMDS content to be supplied from a file
+- Added `--metadata` parameter to enable MMDS content to be supplied from a file
   allowing the MMDS to be used when using `--no-api` to disable the API server.
 - Added support for custom headers to MMDS requests. Accepted headers are:
   `X-metadata-token`, which accepts a string value that provides a session
   token for MMDS requests; and `X-metadata-token-ttl-seconds`, which
   specifies the lifetime of the session token in seconds.
+- Added `PUT` request on `/mmds/version` that configures the MMDS version.
+  Accepted values are either `V1` or `V2`.
 
 ### Changed
 

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -25,12 +25,14 @@ use crate::ApiServer;
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 
 use logger::{error, info};
+use mmds::data_store::MmdsVersion;
 use vmm::rpc_interface::{VmmAction, VmmActionError};
 
 pub(crate) enum RequestAction {
     GetMMDS,
     PatchMMDS(Value),
     PutMMDS(Value),
+    SetMMDSVersion(MmdsVersion),
     Sync(Box<VmmAction>),
     ShutdownInternal, // !!! not an API, used by shutdown to thread::join the API thread
 }
@@ -337,6 +339,11 @@ pub(crate) mod tests {
                 (RequestAction::PatchMMDS(ref val), RequestAction::PatchMMDS(ref other_val)) => {
                     val == other_val
                 }
+                (
+                    &RequestAction::SetMMDSVersion(ref version),
+                    &RequestAction::SetMMDSVersion(ref other_version),
+                ) => version.to_string() == other_version.to_string(),
+
                 _ => false,
             }
         }
@@ -816,15 +823,36 @@ pub(crate) mod tests {
     fn test_try_from_put_mmds() {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
+
+        // `/mmds`
         sender
             .write_all(http_request("PUT", "/mmds", Some(&"{}")).as_bytes())
             .unwrap();
         assert!(connection.try_read().is_ok());
         let req = connection.pop_parsed_request().unwrap();
         assert!(ParsedRequest::try_from_request(&req).is_ok());
-        let body = "{\"ipv4_address\":\"169.254.170.2\"}";
+
+        let body = "{\"foo\":\"bar\"}";
         sender
             .write_all(http_request("PUT", "/mmds", Some(&body)).as_bytes())
+            .unwrap();
+        assert!(connection.try_read().is_ok());
+        let req = connection.pop_parsed_request().unwrap();
+        assert!(ParsedRequest::try_from_request(&req).is_ok());
+
+        // `/mmds/config`
+        let body = "{\"ipv4_address\":\"169.254.170.2\"}";
+        sender
+            .write_all(http_request("PUT", "/mmds/config", Some(&body)).as_bytes())
+            .unwrap();
+        assert!(connection.try_read().is_ok());
+        let req = connection.pop_parsed_request().unwrap();
+        assert!(ParsedRequest::try_from_request(&req).is_ok());
+
+        // `/mmds/version`
+        let body = "{\"version\":\"V2\"}";
+        sender
+            .write_all(http_request("PUT", "/mmds/version", Some(&body)).as_bytes())
             .unwrap();
         assert!(connection.try_read().is_ok());
         let req = connection.pop_parsed_request().unwrap();

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -450,6 +450,40 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /mmds/version:
+    put:
+      summary: Sets MMDS version.
+      operationId: putMmdsVersion
+      parameters:
+        - name: version
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/MmdsVersion"
+      responses:
+        204:
+          description: MMDS version set.
+        400:
+          description: MMDS version cannot be set due to bad input.
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+    get:
+      summary: Get the MMDS version.
+      operationId: getMmdsVersion
+      responses:
+        200:
+          description: The MMDS version.
+          schema:
+            $ref: "#/definitions/MmdsVersion"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+
   /network-interfaces/{iface_id}:
     put:
       summary: Creates a network interface. Pre-boot only.
@@ -960,6 +994,21 @@ definitions:
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
         default: "169.254.169.254"
         description: A valid IPv4 link-local address.
+
+  MmdsVersion:
+    type: object
+    description:
+      Variant wrapper containing the MMDS version.
+    required:
+      - version
+    properties:
+      version:
+        description: Enumeration indicating the MMDS version configured.
+        type: string
+        enum:
+          - V1
+          - V2
+        default: V1
 
   NetworkInterface:
     type: object

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -4,6 +4,7 @@
 use crate::MAX_DATA_STORE_SIZE;
 use serde_json::{to_vec, Value};
 use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// The Mmds is the Microvm Metadata Service represented as an untyped json.
 #[derive(Clone)]
@@ -19,6 +20,15 @@ pub struct Mmds {
 pub enum MmdsVersion {
     V1,
     V2,
+}
+
+impl Display for MmdsVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            MmdsVersion::V1 => write!(f, "V1"),
+            MmdsVersion::V2 => write!(f, "V2"),
+        }
+    }
 }
 
 /// MMDS possible outputs.
@@ -212,6 +222,28 @@ impl Mmds {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_display_mmds_version() {
+        assert_eq!(MmdsVersion::V1.to_string(), "V1");
+        assert_eq!(MmdsVersion::V2.to_string(), "V2");
+    }
+
+    #[test]
+    fn test_mmds_version() {
+        let mut mmds = Mmds::default();
+
+        // Test default MMDS version.
+        assert_eq!(mmds.version().to_string(), MmdsVersion::V1.to_string());
+
+        // Test setting MMDS version to v1.
+        mmds.set_version(MmdsVersion::V2);
+        assert_eq!(mmds.version().to_string(), MmdsVersion::V2.to_string());
+
+        // Test setting MMDS version back to default.
+        mmds.set_version(MmdsVersion::V1);
+        assert_eq!(mmds.version().to_string(), MmdsVersion::V1.to_string());
+    }
 
     #[test]
     fn test_mmds() {

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::MAX_DATA_STORE_SIZE;
+use serde::Deserialize;
 use serde_json::{to_vec, Value};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -16,10 +17,16 @@ pub struct Mmds {
 }
 
 /// MMDS version.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Deserialize)]
 pub enum MmdsVersion {
     V1,
     V2,
+}
+
+impl Default for MmdsVersion {
+    fn default() -> Self {
+        MmdsVersion::V1
+    }
 }
 
 impl Display for MmdsVersion {
@@ -35,6 +42,28 @@ impl Display for MmdsVersion {
 pub enum OutputFormat {
     Json,
     Imds,
+}
+
+/// Keeps the MMDS version configuration.
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MmdsVersionType {
+    /// MMDS configured version
+    #[serde(default)]
+    pub version: MmdsVersion,
+}
+
+impl MmdsVersionType {
+    /// Returns the IMDS version.
+    pub fn version(&self) -> MmdsVersion {
+        self.version
+    }
+}
+
+impl From<MmdsVersion> for MmdsVersionType {
+    fn from(version: MmdsVersion) -> Self {
+        MmdsVersionType { version }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -65,7 +94,7 @@ impl Default for Mmds {
             data_store: Value::default(),
             is_initialized: false,
             data_store_limit: MAX_DATA_STORE_SIZE,
-            version: MmdsVersion::V1,
+            version: MmdsVersion::default(),
         }
     }
 }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::MAX_DATA_STORE_SIZE;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{to_vec, Value};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -17,7 +17,7 @@ pub struct Mmds {
 }
 
 /// MMDS version.
-#[derive(Clone, Copy, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 pub enum MmdsVersion {
     V1,
     V2,
@@ -45,7 +45,7 @@ pub enum OutputFormat {
 }
 
 /// Keeps the MMDS version configuration.
-#[derive(Default, Deserialize)]
+#[derive(Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MmdsVersionType {
     /// MMDS configured version

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -611,6 +611,13 @@ class MMDS():
             json=args['json']
         )
 
+    def put_mmds_version(self, **args):
+        """Send a new MMDS version request."""
+        return self._api_session.put(
+            "{}".format(self._mmds_cfg_url + "/version"),
+            json=args['json']
+        )
+
     def patch(self, **args):
         """Update the details of some MMDS request."""
         return self._api_session.patch(
@@ -619,9 +626,15 @@ class MMDS():
         )
 
     def get(self):
-        """Get the status of the mmds request."""
+        """Get the status of the MMDS request."""
         return self._api_session.get(
             self._mmds_cfg_url
+        )
+
+    def get_mmds_version(self):
+        """Get the MMDS version."""
+        return self._api_session.get(
+            "{}".format(self._mmds_cfg_url + "/version")
         )
 
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1247,3 +1247,91 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
     data_store["latest"]["meta-data"]["ami-id"] = chars
     response = test_microvm.mmds.put(json=data_store)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+
+def test_api_mmds_version(test_microvm_with_api, network_config):
+    """
+    Test MMDS version related API commands.
+
+    @type: functional
+    """
+    test_microvm = test_microvm_with_api
+    test_microvm.spawn()
+
+    v1_json = {
+        'version': 'V1'
+    }
+    # Test default MMDS version is V1.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v1_json
+
+    # Configure MMDS to version 2.
+    v2_json = {
+        'version': 'V2'
+    }
+    response = test_microvm.mmds.put_mmds_version(json=v2_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Test MMDS version has been updated.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v2_json
+
+    test_microvm.basic_config(vcpu_count=1)
+    _tap = test_microvm.ssh_network_config(
+        network_config,
+        '1',
+        allow_mmds_requests=True
+    )
+
+    # Empty json should reset MMDS version to default.
+    response = test_microvm.mmds.put_mmds_version(json={})
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Ensure MMDS version has been reset.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v1_json
+
+    # Configure MMDS back to version 2.
+    response = test_microvm.mmds.put_mmds_version(json=v2_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Ensure MMDS version has been updated.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v2_json
+
+    test_microvm.start()
+
+    # Ensure MMDS version post-boot is consistent.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v2_json
+
+    # Configure MMDS version to V1 after vm has started.
+    response = test_microvm.mmds.put_mmds_version(json=v1_json)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Test MMDS version has been updated.
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == v1_json
+
+
+def test_negative_api_mmds_version(test_microvm_with_api):
+    """
+    Test negative scenarios of MMDS version API.
+
+    @type: negative
+    """
+    test_microvm = test_microvm_with_api
+    test_microvm.spawn()
+
+    # Test invalid value for MMDS version.
+    response = test_microvm.mmds.put_mmds_version(json={'version': 'foo'})
+    err_msg = "An error occurred when deserializing the json body of a " \
+              "request: unknown variant `foo`, expected `V1` or `V2`"
+    assert test_microvm.api_session.is_status_bad_request(response.status_code)
+    assert err_msg in response.text


### PR DESCRIPTION
# Reason for This PR

We need a way to configure MMDS version either to version 1 or to version 2.

## Description of Changes

Add a `/mmds/version` endpoint for configuring MMDS  version. The accepted values are `V1` or `V2` and it defaults on `V1`.

We also add a GET API request for `/mmds/version` endpoint to have a facile way of fetching current MMDS configuration used.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] The issue which led to this PR has a clear conclusion.~
- ~[ ] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] Any newly added `unsafe` code is properly documented.~
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
