### PR TITLE
Partial fix for restore snapshot GET /vm/config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@
 
 ### Fixed
 
+- GET `/vm/config` was returning a default config object after restoring from a
+  snapshot. It now correctly returns the config of the original microVM, except
+  for boot_config and the cpu_template and smt fields of the machine config,
+  which are currently lost.
 - Fixed incorrect propagation of init parameters in kernel commandline.
   Related to:
   [#2709](https://github.com/firecracker-microvm/firecracker/issues/2709).

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -612,7 +612,8 @@ paths:
     get:
       summary: Gets the full VM configuration.
       description:
-        Gets configuration for all VM resources.
+        Gets configuration for all VM resources. If the VM is restored from a snapshot, the boot-source,
+        machine-config.smt and machine-config.cpu_template will be empty.
       operationId: getExportVmConfig
       responses:
         200:

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -122,7 +122,7 @@ pub struct Net {
     pub(crate) device_state: DeviceState,
     pub(crate) activate_evt: EventFd,
 
-    pub(crate) mmds_ns: Option<MmdsNetworkStack>,
+    pub mmds_ns: Option<MmdsNetworkStack>,
 
     #[cfg(test)]
     pub(crate) mocks: Mocks,

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -332,6 +332,10 @@ impl VsockMuxer {
         Ok(muxer)
     }
 
+    pub fn host_sock_path(&self) -> &str {
+        &self.host_sock_path
+    }
+
     /// Handle/dispatch an epoll event to its listener.
     fn handle_event(&mut self, fd: RawFd, event_set: EventSet) {
         debug!(

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -61,7 +61,7 @@ pub struct MmdsNetworkStack {
     // The Ethernet MAC address of the MMDS server.
     pub(crate) mac_addr: MacAddr,
     // MMDS server IPv4 address.
-    pub(crate) ipv4_addr: Ipv4Addr,
+    pub ipv4_addr: Ipv4Addr,
     // ARP reply destination IPv4 address (requester of address resolution reply).
     // It is the Ipv4Addr of the network interface for which the MmdsNetworkStack
     // routes the packets.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -26,6 +26,7 @@ use crate::{Error as VmmError, EventManager, Vmm};
 #[cfg(target_arch = "x86_64")]
 use cpuid::common::{get_vendor_id_from_cpuid, get_vendor_id_from_host};
 
+use crate::resources::VmResources;
 use crate::vmm_config::instance_info::InstanceInfo;
 #[cfg(target_arch = "aarch64")]
 use arch::regs::{get_manufacturer_id_from_host, get_manufacturer_id_from_state};
@@ -439,6 +440,7 @@ pub fn restore_from_snapshot(
     seccomp_filters: &BpfThreadMap,
     params: &LoadSnapshotParams,
     version_map: VersionMap,
+    vm_resources: &mut VmResources,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, LoadSnapshotError> {
     use self::LoadSnapshotError::*;
     let track_dirty_pages = params.enable_diff_snapshots;
@@ -452,6 +454,7 @@ pub fn restore_from_snapshot(
         &microvm_state.memory_state,
         track_dirty_pages,
     )?;
+
     builder::build_microvm_from_snapshot(
         instance_info,
         event_manager,
@@ -459,6 +462,7 @@ pub fn restore_from_snapshot(
         guest_memory,
         track_dirty_pages,
         seccomp_filters,
+        vm_resources,
     )
     .map_err(BuildMicroVm)
 }

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -151,6 +151,11 @@ impl BalloonBuilder {
         Ok(())
     }
 
+    /// Inserts an existing balloon device.
+    pub fn set_device(&mut self, balloon: MutexBalloon) {
+        self.inner = Some(balloon);
+    }
+
     /// Provides a reference to the Balloon if present.
     pub fn get(&self) -> Option<&MutexBalloon> {
         self.inner.as_ref()

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -253,4 +253,12 @@ pub(crate) mod tests {
         let err = StatsNotFound;
         let _ = format!("{}{:?}", err, err);
     }
+
+    #[test]
+    fn test_set_device() {
+        let mut builder = BalloonBuilder::new();
+        let balloon = Balloon::new(0, true, 0, true).unwrap();
+        builder.set_device(Arc::new(Mutex::new(balloon)));
+        assert!(builder.inner.is_some());
+    }
 }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -156,6 +156,15 @@ impl BlockBuilder {
             .position(|b| b.lock().expect("Poisoned lock").id().eq(drive_id))
     }
 
+    /// Inserts an existing block device.
+    pub fn add_device(&mut self, block_device: Arc<Mutex<Block>>) {
+        if block_device.lock().expect("Poisoned lock").is_root_device() {
+            self.list.push_front(block_device);
+        } else {
+            self.list.push_back(block_device);
+        }
+    }
+
     /// Inserts a `Block` in the block devices list using the specified configuration.
     /// If a block with the same id already exists, it will overwrite it.
     /// Inserting a secondary root block device will fail.

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -132,6 +132,11 @@ impl NetBuilder {
         self.net_devices.iter_mut()
     }
 
+    /// Adds an existing network device in the builder.
+    pub fn add_device(&mut self, device: Arc<Mutex<Net>>) {
+        self.net_devices.push(device);
+    }
+
     /// Builds a network device based on a network interface config. Keeps a device reference
     /// in the builder's internal list.
     pub fn build(&mut self, netif_config: NetworkInterfaceConfig) -> Result<Arc<Mutex<Net>>> {

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -192,4 +192,24 @@ pub(crate) mod tests {
         ));
         let _ = format!("{}{:?}", err, err);
     }
+
+    #[test]
+    fn test_set_device() {
+        let mut vsock_builder = VsockBuilder::new();
+        let mut tmp_sock_file = TempFile::new().unwrap();
+        tmp_sock_file.remove().unwrap();
+        let vsock = Vsock::new(
+            0,
+            VsockUnixBackend::new(1, tmp_sock_file.as_path().to_str().unwrap().to_string())
+                .unwrap(),
+        )
+        .unwrap();
+
+        vsock_builder.set_device(Arc::new(Mutex::new(vsock)));
+        assert!(vsock_builder.inner.is_some());
+        assert_eq!(
+            vsock_builder.inner.unwrap().uds_path,
+            tmp_sock_file.as_path().to_str().unwrap().to_string()
+        )
+    }
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -77,6 +77,19 @@ impl VsockBuilder {
         Self { inner: None }
     }
 
+    /// Inserts an existing vsock device.
+    pub fn set_device(&mut self, device: Arc<Mutex<Vsock<VsockUnixBackend>>>) {
+        self.inner = Some(VsockAndUnixPath {
+            uds_path: device
+                .lock()
+                .expect("Poisoned lock")
+                .backend()
+                .host_sock_path()
+                .to_owned(),
+            vsock: device.clone(),
+        });
+    }
+
     /// Inserts a Unix backend Vsock in the store.
     /// If an entry already exists, it will overwrite it.
     pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<()> {

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -220,6 +220,8 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
     let mem = GuestMemoryMmap::restore(memory_file.as_file(), &microvm_state.memory_state, false)
         .unwrap();
 
+    let vm_resources = &mut VmResources::default();
+
     // Build microVM from state.
     let vmm = build_microvm_from_snapshot(
         &InstanceInfo::default(),
@@ -228,6 +230,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
         mem,
         false,
         &mut empty_seccomp_filters,
+        vm_resources,
     )
     .unwrap();
     // For now we're happy we got this far, we don't test what the guest is actually doing.

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -231,7 +231,7 @@ class MicrovmBuilder:
                              kernel, disks, cpu_template,
                              net_ifaces=None, diff_snapshots=False,
                              fc_binary=None, jailer_binary=None,
-                             daemonize=True):
+                             daemonize=True, io_engine=None):
         """Spawns a new Firecracker and applies specified config."""
         artifacts = ArtifactCollection(_test_images_s3_bucket())
         # Pick the first artifact in the set.
@@ -258,10 +258,12 @@ class MicrovmBuilder:
                           cpu_template=cpu_template,
                           fc_binary=fc_binary,
                           jailer_binary=jailer_binary,
-                          daemonize=daemonize)
+                          daemonize=daemonize,
+                          io_engine=io_engine)
 
     def build_vm_nano(self, fc_binary=None, jailer_binary=None,
-                      net_ifaces=None, diff_snapshots=False, daemonize=True):
+                      net_ifaces=None, diff_snapshots=False, daemonize=True,
+                      io_engine=None):
         """Create a clean VM in an initial state."""
         return self.build_from_artifacts("2vcpu_256mb",
                                          "vmlinux-4.14",
@@ -271,7 +273,8 @@ class MicrovmBuilder:
                                          diff_snapshots=diff_snapshots,
                                          fc_binary=fc_binary,
                                          jailer_binary=jailer_binary,
-                                         daemonize=daemonize)
+                                         daemonize=daemonize,
+                                         io_engine=io_engine)
 
     def build_vm_micro(self, fc_binary=None, jailer_binary=None,
                        net_ifaces=None, diff_snapshots=False):

--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -17,13 +17,17 @@ class CpuVendor(Enum):
 
     AMD = auto()
     INTEL = auto()
+    ARM = auto()
 
 
 def get_cpu_vendor():
     """Return the CPU vendor."""
     brand_str = subprocess.check_output("lscpu", shell=True).strip().decode()
+    machine_str = platform.machine()
     if 'AuthenticAMD' in brand_str:
         return CpuVendor.AMD
+    if 'aarch64' in machine_str:
+        return CpuVendor.ARM
     return CpuVendor.INTEL
 
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.99, "AMD": 84.48, "ARM": 84.29}
+    COVERAGE_DICT = {"Intel": 85.08, "AMD": 84.57, "ARM": 84.37}
 else:
-    COVERAGE_DICT = {"Intel": 82.0, "AMD": 81.46, "ARM": 81.2}
+    COVERAGE_DICT = {"Intel": 82.10, "AMD": 81.58, "ARM": 81.33}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -19,8 +19,9 @@ import host_tools.network as net_tools
 from conftest import _test_images_s3_bucket
 
 from framework.utils import is_io_uring_supported
-from framework.artifacts import ArtifactCollection
-from framework.builder import MicrovmBuilder
+from framework.artifacts import ArtifactCollection, SnapshotType, \
+    NetIfaceConfig, DEFAULT_DEV_NAME, DEFAULT_TAP_NAME
+from framework.builder import MicrovmBuilder, SnapshotBuilder
 
 MEM_LIMIT = 1000000000
 
@@ -554,7 +555,7 @@ def test_api_machine_config(test_microvm_with_api):
         assert "CPU templates are not supported on aarch64" in response.text
 
     response = test_microvm.actions.put(action_type='InstanceStart')
-    if utils.get_cpu_vendor() != utils.CpuVendor.INTEL:
+    if utils.get_cpu_vendor() == utils.CpuVendor.AMD:
         # We shouldn't be able to apply Intel templates on AMD hosts
         fail_msg = "Internal error while starting microVM: Error configuring" \
                    " the vcpu for boot: Cpuid error: InvalidVendor"
@@ -1359,6 +1360,141 @@ def test_api_balloon(test_microvm_with_api):
     # requesting u32::MAX / 128.
     response = test_microvm.balloon.patch(amount_mib=33554432)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
+
+
+def test_get_full_config_after_restoring_snapshot(bin_cloner_path):
+    """
+    Test the configuration of a microVM after restoring from a snapshot.
+
+    @type: functional
+    """
+    microvm_builder = MicrovmBuilder(bin_cloner_path)
+    net_iface = NetIfaceConfig()
+    vm_instance = microvm_builder.build_vm_nano(
+        net_ifaces=[net_iface],
+        io_engine='Sync')
+    test_microvm = vm_instance.vm
+    root_disk = vm_instance.disks[0]
+    ssh_key = vm_instance.ssh_key
+    cpu_vendor = utils.get_cpu_vendor()
+
+    setup_cfg = {}
+
+    # Basic config also implies a root block device.
+    setup_cfg['machine-config'] = {
+        'vcpu_count': 2,
+        'mem_size_mib': 256,
+        'smt': True,
+        'track_dirty_pages': False
+    }
+
+    if cpu_vendor == utils.CpuVendor.INTEL:
+        setup_cfg['machine-config']['cpu_template'] = 'C3'
+
+    test_microvm.machine_cfg.patch(**setup_cfg['machine-config'])
+
+    setup_cfg['drives'] = [{
+        'drive_id': 'rootfs',
+        'path_on_host': f"/{os.path.basename(root_disk.local_path())}",
+        'is_root_device': True,
+        'partuuid': None,
+        'is_read_only': False,
+        'cache_type': 'Unsafe',
+        'rate_limiter': None,
+        'io_engine': 'Sync'
+    }]
+
+    # Add a memory balloon device.
+    response = test_microvm.balloon.put(amount_mib=1, deflate_on_oom=True)
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    setup_cfg['balloon'] = {
+        'amount_mib': 1,
+        'deflate_on_oom': True,
+        'stats_polling_interval_s': 0
+    }
+
+    # Add a vsock device.
+    response = test_microvm.vsock.put(
+        guest_cid=15,
+        uds_path='vsock.sock'
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    setup_cfg['vsock'] = {
+        'guest_cid': 15,
+        'uds_path': 'vsock.sock'
+    }
+
+    setup_cfg['logger'] = None
+    setup_cfg['metrics'] = None
+    setup_cfg['mmds-config'] = {
+        'version': "V1",
+        'network_interfaces': [DEFAULT_DEV_NAME]
+    }
+
+    response = test_microvm.mmds.put_config(json=setup_cfg['mmds-config'])
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    # Start the microvm.
+    test_microvm.start()
+
+    # Add a tx rate limiter to the net device.
+    tx_rl = {
+        'bandwidth': {
+            'size': 1000000,
+            'refill_time': 100,
+            'one_time_burst': None
+        },
+        'ops': None
+    }
+
+    response = test_microvm.network.patch(
+        iface_id=DEFAULT_DEV_NAME,
+        tx_rate_limiter=tx_rl
+    )
+    assert test_microvm.api_session.is_status_no_content(response.status_code)
+    setup_cfg['network-interfaces'] = [{
+        'guest_mac': net_tools.mac_from_ip(net_iface.guest_ip),
+        'iface_id': DEFAULT_DEV_NAME,
+        'host_dev_name': DEFAULT_TAP_NAME,
+        'rx_rate_limiter': None,
+        'tx_rate_limiter': tx_rl
+    }]
+    # Create a snapshot builder from a microvm.
+    snapshot_builder = SnapshotBuilder(test_microvm)
+
+    # Create base snapshot.
+    snapshot = snapshot_builder.create([root_disk.local_path()],
+                                       ssh_key,
+                                       SnapshotType.FULL)
+
+    microvm, _ = microvm_builder.build_from_snapshot(snapshot, True, False)
+
+    expected_cfg = setup_cfg.copy()
+
+    # We expect boot-source, machine-config.smt, and
+    # machine-config.cpu_template to all be empty/default after restoring
+    # from a snapshot.
+    expected_cfg['boot-source'] = {
+        'kernel_image_path': '',
+        'initrd_path': None
+    }
+    expected_cfg['machine-config']['smt'] = False
+
+    if cpu_vendor == utils.CpuVendor.INTEL:
+        expected_cfg['machine-config'].pop('cpu_template')
+
+    # no ipv4 specified during PUT /mmds/config so we expect the default
+    expected_cfg['mmds-config'] = {
+        'version': 'V1',
+        'ipv4_address': '169.254.169.254',
+        'network_interfaces': [DEFAULT_DEV_NAME]
+    }
+
+    # Validate full vm configuration post-restore.
+    response = microvm.full_cfg.get()
+    assert microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() != setup_cfg
+    assert response.json() == expected_cfg
 
 
 def test_get_full_config(test_microvm_with_api):


### PR DESCRIPTION
Fixed the issue where GET /vm/config would return the default config for a VM restored from a snapshot. The config now updates after restoring from a snapshot.

# Reason for This PR

This PR exists to fix the bug described in issue #2783. 

## Description of Changes

Changed restoring a snapshot to include updating the `VmResources` so that the correct config would be returned for the GET /vm/config endpoint. The only parts of the config that are still using default values after restoring a snapshot are the following:  boot-source (which is reasonable since there is no boot-source in the case of a restore), machine-config.smt and machine-config.cpu_template. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
