### PR TITLE
[feature/io_uring] Fix destructor call order

### DIFF
--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
     use vm_memory::{Bytes, MmapRegion, VolatileMemory};
 
     fn drain_cqueue(ring: &mut IoUring) {
-        while let Some(entry) = ring.pop::<usize>().unwrap() {
+        while let Some(entry) = ring.pop::<u32>().unwrap() {
             assert!(entry.result().is_ok());
 
             // Assert that there were no partial writes.


### PR DESCRIPTION
# Reason for This PR

The kernel memory associated to the rings was not getting freed upon freeing the io_uring resources.
The correct order is: `munmap` -> `close`

## Description of Changes

- enforce the correct order of destructor calls for the io_uring resources (by leveraging the rust order of `Drop` calls, which is well defined: https://doc.rust-lang.org/reference/destructors.html)
- misc change: fix the cqe `user_data` type on the io_uring proptest

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
