### PR TITLE
cgroup: allow files containing multiple '.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Adapt T2 and C3 CPU templates for kernel 5.10. Firecracker was not previously
   masking some CPU features of the host or emulated by KVM, introduced in more
   recent kernels: `umip`, `vmx`, `avx512_vnni`.
+- Fix jailer's cgroup implementation to accept properties that contain multiple
+  dots.
 
 ## [0.25.0]
 

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -83,7 +83,7 @@ impl CgroupBuilder {
                 } else if ver == 1 && capture["ver"].is_empty() {
                     // Found a cgroupv1 mountpoint; with cgroupsv1 we can have multiple hierarchies.
                     // Since we don't know which one will be used, we cache the mountpoints now,
-                    // and will create the hierachies on demand when a cgroup is built.
+                    // and will create the hierarchies on demand when a cgroup is built.
                     b.mount_points.push(CgroupMountPoint {
                         dir: String::from(&capture["dir"]),
                         options: String::from(&capture["options"]),
@@ -136,7 +136,7 @@ impl CgroupBuilder {
     // Cgroups for a controller are arranged in a hierarchy; multiple controllers
     // may share the same hierarchy
     fn get_v1_hierarchy_path(&mut self, controller: &str) -> Result<&PathBuf> {
-        // First try and see if the path is alrady discovered
+        // First try and see if the path is already discovered.
         match self.hierarchies.entry(controller.to_string()) {
             Occupied(e) => Ok(e.into_mut()),
             Vacant(e) => {
@@ -357,7 +357,7 @@ impl CgroupV2 {
     // Enables the specified controller along the cgroup nested path.
     // To be able to use a leaf controller within a nested cgroup hierarchy,
     // the controller needs to be enabled by writing to the cgroup.subtree_control
-    // of it's parent. This rule applies recursivelly.
+    // of it's parent. This rule applies recursively.
     fn write_all_subtree_control<P>(path: P, controller: &str) -> Result<()>
     where
         P: AsRef<Path>,
@@ -467,7 +467,7 @@ pub mod test_util {
     }
 
     // Helper object that simulates the layout of the cgroup file system
-    // This can be used for testing regardless of the availablity of a particular
+    // This can be used for testing regardless of the availability of a particular
     // version of cgroups on the system
     impl MockCgroupFs {
         const MOCK_PROCDIR: &'static str = "/tmp/firecracker/test/jailer/proc";

--- a/src/jailer/src/cgroup.rs
+++ b/src/jailer/src/cgroup.rs
@@ -291,7 +291,7 @@ fn get_controller_from_filename(file: &str) -> Result<&str> {
     let v: Vec<&str> = file.split('.').collect();
 
     // Check format <cgroup_controller>.<cgroup_property>
-    if v.len() != 2 {
+    if v.len() < 2 {
         return Err(Error::CgroupInvalidFile(file.to_string()));
     }
 
@@ -755,14 +755,14 @@ mod tests {
         assert!(result.is_ok());
         assert!(matches!(result, Ok(ctrl) if ctrl == "cpuset"));
 
-        // Check invalid file
-        file = "cpusetcpu";
+        // Check valid file with multiple '.'.
+        file = "memory.swap.high";
         result = get_controller_from_filename(file);
-        assert!(result.is_err());
-        assert!(format!("{:?}", result).contains("CgroupInvalidFile"));
+        assert!(result.is_ok());
+        assert!(matches!(result, Ok(ctrl) if ctrl == "memory"));
 
         // Check invalid file
-        file = "cpu.set.cpu";
+        file = "cpusetcpu";
         result = get_controller_from_filename(file);
         assert!(result.is_err());
         assert!(format!("{:?}", result).contains("CgroupInvalidFile"));

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -1051,15 +1051,6 @@ mod tests {
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 
-        // Check string with multiple "."
-        let mut args = arg_parser.arguments().clone();
-        let invalid_cgroup_arg_vals = ArgVals {
-            cgroups: vec!["cpu.set.cpus=2"],
-            ..good_arg_vals.clone()
-        };
-        args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
-        assert!(Env::new(&args, 0, 0).is_err());
-
         // Check empty string
         let mut args = arg_parser.arguments().clone();
         let invalid_cgroup_arg_vals = ArgVals {
@@ -1102,6 +1093,15 @@ mod tests {
         let mut args = arg_parser.arguments().clone();
         let invalid_cgroup_arg_vals = ArgVals {
             cgroups: vec!["cpuset.cpus=2"],
+            ..good_arg_vals.clone()
+        };
+        args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
+        assert!(Env::new(&args, 0, 0).is_ok());
+
+        // Check file with multiple "."
+        let mut args = arg_parser.arguments().clone();
+        let invalid_cgroup_arg_vals = ArgVals {
+            cgroups: vec!["memory.swap.high=2"],
             ..good_arg_vals.clone()
         };
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -1087,7 +1087,7 @@ mod tests {
         args.parse(&make_args(&invalid_cgroup_arg_vals)).unwrap();
         assert!(Env::new(&args, 0, 0).is_err());
 
-        // Cases that should success
+        // Cases that should succeed
 
         // Check value with special characters (',', '.', '-')
         let mut args = arg_parser.arguments().clone();

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -282,7 +282,7 @@ def test_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
     test_microvm.jailer.numa_node = 0
     test_microvm.jailer.cgroup_ver = sys_setup_cgroups
     if test_microvm.jailer.cgroup_ver == 2:
-        test_microvm.jailer.cgroups = ['cpu.weight=2']
+        test_microvm.jailer.cgroups = ['cpu.weight.nice=10']
     else:
         test_microvm.jailer.cgroups = [
             'cpu.shares=2',

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -163,7 +163,7 @@ def sys_setup_cgroups():
         # non-root cgroups can distribute domain resources to their children
         # only when they don’t have any processes of their own.
         # When a Docker container is created, the processes running inside
-        # the container are added to the a cgroup which the container sees
+        # the container are added to a cgroup which the container sees
         # as the root cgroup. This prevents creation of using domain cgroups.
         cgroup_root = None
 
@@ -184,7 +184,7 @@ def sys_setup_cgroups():
             with open(f'{cgroup_root}/cgroup.procs') as procs:
                 root_procs = [x.strip() for x in procs.readlines()]
 
-            # now create a new domain cgroup and migrate the procesesses
+            # now create a new domain cgroup and migrate the processes
             # to that cgroup
             os.makedirs(f'{cgroup_root}/system', exist_ok=True)
             for pid in root_procs:
@@ -294,7 +294,7 @@ def test_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
     # Retrieve CPUs from NUMA node 0.
     node_cpus = get_cpus(test_microvm.jailer.numa_node)
 
-    # Apending the cgroups that should be creating by --node option
+    # Appending the cgroups that should be creating by --node option
     # This must be changed once --node options is removed
     cgroups = test_microvm.jailer.cgroups + [
         'cpuset.mems=0',
@@ -335,7 +335,7 @@ def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
     # Retrieve CPUs from NUMA node 0.
     node_cpus = get_cpus(test_microvm.jailer.numa_node)
 
-    # Apending the cgroups that should be creating by --node option
+    # Appending the cgroups that should be creating by --node option
     # This must be changed once --node options is removed
     cgroups = test_microvm.jailer.cgroups + [
         'cpuset.mems=0',
@@ -379,7 +379,7 @@ def test_node_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
     # Retrieve CPUs from NUMA node 0.
     node_cpus = get_cpus(test_microvm.jailer.numa_node)
 
-    # Apending the cgroups that should be creating by --node option
+    # Appending the cgroups that should be creating by --node option
     # This must be changed once --node options is removed
     cgroups = [
         'cpuset.mems=0',


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Fixes #2800:
Jailer's cgroup implementation considers that cgroup controllers and their associated properties follow the syntax of controller-name.property, both being separated by a dot.

However some cgroup controllers expose read/write properties that themselves contain dots that can be used to constrain the resource of a specific controller.

## Description of Changes

`[Author TODO: add description of changes.]`
- Change jailer behavior to accept properties that contain multiple '.'

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] The issue which led to this PR has a clear conclusion.~
- ~[ ] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] Any newly added `unsafe` code is properly documented.~
- ~[ ] Any API changes follow the [Runbook for Firecracker API changes][2].~
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
