### PR TITLE
devtool: set memlock:unlimited on container

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -1219,6 +1219,7 @@ cmd_test() {
         --security-opt seccomp=unconfined \
         --ulimit core=0 \
         --ulimit nofile=4096:4096 \
+        --ulimit memlock=-1:-1 \
         --workdir "$CTR_FC_ROOT_DIR/tests" \
         --cpuset-cpus="$cpuset_cpus" \
         --cpuset-mems="$cpuset_mems" \
@@ -1285,6 +1286,7 @@ cmd_shell() {
         run_devctr \
             --privileged \
             --ulimit nofile=4096:4096 \
+            --ulimit memlock=-1:-1 \
             --security-opt seccomp=unconfined \
             --workdir "$CTR_FC_ROOT_DIR" \
             ${ramdisk_args} \
@@ -1310,6 +1312,7 @@ cmd_shell() {
         run_devctr \
             --user "$(id -u):$(id -g)" \
             --ulimit nofile=4096:4096 \
+            --ulimit memlock=-1:-1 \
             --device=/dev/kvm:/dev/kvm \
             --workdir "$CTR_FC_ROOT_DIR" \
             --env PS1="$(whoami)@\h:\w\$ " \


### PR DESCRIPTION
# Reason for This PR

This is needed because the `io_uring_setup` system call
memlocks the rings and on some distros (e.g. ubuntu),
the default allowed limit is 65536, which only allows
creating up to 4 microVMs (based on the static size
of the rings).

We have tests which spawn more than 4 VMs, which would
otherwise fail with ENOMEM.

## Description of Changes

Set memlock unlimited on devtool `shell` and `test` commands

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
