### PR TITLE
seccomp: fix large diff snapshot failure

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -191,19 +191,6 @@
             },
             {
                 "syscall": "mmap",
-                "comment": "Used for large buffers sent to api_server",
-                "args": [
-                    {
-                        "index": 3,
-                        "type": "dword",
-                        "op": "eq",
-                        "val": 34,
-                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
-                    }
-                ]
-            },
-            {
-                "syscall": "mmap",
                 "comment": "Used for reading the timezone in LocalTime::now()",
                 "args": [
                     {
@@ -534,6 +521,19 @@
                         "op": "eq",
                         "val": 1,
                         "comment": "libc::MAP_SHARED"
+                    }
+                ]
+            },
+            {
+                "syscall": "mmap",
+                "comment": "Used for large buffers sent to api_server",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
                     }
                 ]
             },

--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -203,6 +203,19 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used by rust's stdlib, particularly when creating a diff snapshot of a VM with ~16 GB of memory",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [
@@ -533,7 +546,7 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 34,
-                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
                     }
                 ]
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -203,6 +203,19 @@
                 ]
             },
             {
+                "syscall": "mmap",
+                "comment": "Used by rust's stdlib, particularly when creating a diff snapshot of a VM with ~16 GB of memory",
+                "args": [
+                    {
+                        "index": 3,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 34,
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                    }
+                ]
+            },
+            {
                 "syscall": "rt_sigaction",
                 "comment": "rt_sigaction is used by libc::abort during a panic to install the default handler for SIGABRT",
                 "args": [
@@ -532,7 +545,7 @@
                         "type": "dword",
                         "op": "eq",
                         "val": 34,
-                        "comment": " libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
+                        "comment": "libc::MAP_ANONYMOUS | libc::MAP_PRIVATE"
                     }
                 ]
             },

--- a/tests/framework/report.py
+++ b/tests/framework/report.py
@@ -101,7 +101,8 @@ class Report(mpsing.MultiprocessSingleton):
         # What kind of test we're running. We only accept a predefined list
         # of tests.
         "type": ReportItem("", True, ["build", "functional", "performance",
-                                      "security", "style", "negative"], True),
+                                      "security", "style", "negative",
+                                      "regression"], True),
 
         # What we take into account to pass a test
         "criteria": ReportItem("", False, None, False),

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1224,7 +1224,7 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
     call mmap with MAP_PRIVATE|MAP_ANONYMOUS. This would result in vmm being
     killed by the seccomp filter before this PR.
 
-    @type: functional
+    @type: regression
     """
     test_microvm = test_microvm_with_ssh
     test_microvm.spawn()

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -4,8 +4,6 @@
 
 # Disable pylint C0302: Too many lines in module
 # pylint: disable=C0302
-import array
-import itertools
 import os
 import platform
 import resource
@@ -1227,6 +1225,8 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
     @type: regression
     """
     test_microvm = test_microvm_with_ssh
+    test_microvm.jailer.extra_args.update(
+        {'http-api-max-payload-size': str(1024 * 1024 * 2)})
     test_microvm.spawn()
     test_microvm.api_session.untime()
 
@@ -1237,13 +1237,10 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
     data_store = {
         'latest': {
             'meta-data': {
+                'ami-id': 'b' * (1024 * 1024)
             }
         }
     }
 
-    slice_1mb = array.array('u', itertools.repeat('b', 1024 * 1024))
-    chars = array.array('u')
-    chars = [chars.extend(slice_1mb) for _ in range(190)]
-    data_store["latest"]["meta-data"]["ami-id"] = chars
     response = test_microvm.mmds.put(json=data_store)
     assert test_microvm.api_session.is_status_no_content(response.status_code)


### PR DESCRIPTION
# Reason for This PR

https://github.com/firecracker-microvm/firecracker/discussions/2811

## Description of Changes

- seccomp: allow mmap(MAP_PRIVATE|MAP_ANONYMOUS) on the vmm thread.
- add regression test for it
- fix error from commit https://github.com/firecracker-microvm/firecracker/pull/2701/commits/a3f5d47b063599e2eb73a116e537988de53b2929. The mmap call on aarch64 should have been allowed on the api thread, but was instead added to the vmm

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
