### PR TITLE
block: negative test for invalid guest address

### DIFF
--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -506,8 +506,11 @@ mod tests {
         // Create a custom test runner since we had to add some state buildup to the test.
         // (Referring to the the above initializations).
         let mut runner = TestRunner::new(Config {
+            #[cfg(target_arch = "x86_64")]
             cases: 1000, // Should run for about a minute.
-
+            // Lower the cases on ARM since they take longer and cause coverage test timeouts.
+            #[cfg(target_arch = "aarch64")]
+            cases: 500,
             ..Config::default()
         });
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.73, "AMD": 84.17, "ARM": 82.8}
+    COVERAGE_DICT = {"Intel": 84.79, "AMD": 84.24, "ARM": 82.92}
 else:
-    COVERAGE_DICT = {"Intel": 81.63, "AMD": 81.09, "ARM": 79.71}
+    COVERAGE_DICT = {"Intel": 81.71, "AMD": 81.17, "ARM": 79.81}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Description of Changes

- add negative block device unit test for invalid guest address.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
