### PR TITLE
io_uring: document public interface, limit visibility and rework unsafe usage

### DIFF
--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -7,6 +7,7 @@ mod probe;
 mod queue;
 pub mod restriction;
 
+pub use queue::completion::Error as CQueueError;
 pub use queue::submission::Error as SQueueError;
 
 use std::collections::HashSet;
@@ -19,7 +20,7 @@ use utils::syscall::SyscallReturnCode;
 use bindings::io_uring_params;
 use operation::{Cqe, OpCode, Operation};
 use probe::{ProbeWrapper, PROBE_LEN};
-use queue::completion::{CompletionQueue, Error as CQueueError};
+use queue::completion::CompletionQueue;
 use queue::submission::SubmissionQueue;
 use restriction::Restriction;
 
@@ -28,7 +29,7 @@ const REQUIRED_OPS: [OpCode; 2] = [OpCode::Read, OpCode::Write];
 // Taken from linux/fs/io_uring.c
 const IORING_MAX_FIXED_FILES: usize = 1 << 15;
 
-pub type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/io_uring/src/operation/cqe.rs
+++ b/src/io_uring/src/operation/cqe.rs
@@ -17,7 +17,7 @@ impl<T> Cqe<T> {
     /// Unsafe because we assume full ownership of the inner.user_data address.
     /// We assume that it points to a valid address created with a Box<T>, with the correct type T,
     /// and that ownership of that address is passed to this function.
-    pub unsafe fn new(inner: io_uring_cqe) -> Self {
+    pub(crate) unsafe fn new(inner: io_uring_cqe) -> Self {
         Self {
             res: inner.res,
             user_data: Box::from_raw(inner.user_data as *mut T),

--- a/src/io_uring/src/operation/cqe.rs
+++ b/src/io_uring/src/operation/cqe.rs
@@ -7,12 +7,15 @@ use vm_memory::ByteValued;
 
 unsafe impl ByteValued for io_uring_cqe {}
 
+/// Wrapper over a completed operation.
 pub struct Cqe<T> {
     res: i32,
     user_data: Box<T>,
 }
 
 impl<T> Cqe<T> {
+    /// Construct a Cqe object from a raw `io_uring_cqe`.
+    ///
     /// # Safety
     /// Unsafe because we assume full ownership of the inner.user_data address.
     /// We assume that it points to a valid address created with a Box<T>, with the correct type T,
@@ -24,10 +27,12 @@ impl<T> Cqe<T> {
         }
     }
 
+    /// Return the number of bytes successfully transferred by this operation.
     pub fn count(&self) -> u32 {
         i32::max(self.res, 0) as u32
     }
 
+    /// Return the result associated to the IO operation.
     pub fn result(&self) -> Result<u32, std::io::Error> {
         let res = self.res;
 
@@ -38,6 +43,7 @@ impl<T> Cqe<T> {
         }
     }
 
+    /// Create a new Cqe, applying the passed function to the user_data.
     pub fn map_user_data<U, F: FnOnce(T) -> U>(self, op: F) -> Cqe<U> {
         Cqe {
             res: self.res,
@@ -45,6 +51,7 @@ impl<T> Cqe<T> {
         }
     }
 
+    /// Consume the object and return the user_data.
     pub fn user_data(self) -> T {
         *self.user_data
     }

--- a/src/io_uring/src/operation/mod.rs
+++ b/src/io_uring/src/operation/mod.rs
@@ -5,7 +5,7 @@ mod cqe;
 mod sqe;
 
 pub use cqe::Cqe;
-pub use sqe::Sqe;
+pub(crate) use sqe::Sqe;
 
 #[cfg(test)]
 use core::fmt::{self, Debug, Formatter};
@@ -102,7 +102,7 @@ impl<T> Operation<T> {
         }
     }
 
-    pub fn fd(&self) -> FixedFd {
+    pub(crate) fn fd(&self) -> FixedFd {
         self.fd
     }
 
@@ -112,14 +112,14 @@ impl<T> Operation<T> {
 
     // Needed for proptesting.
     #[cfg(test)]
-    pub fn set_linked(&mut self) {
+    pub(crate) fn set_linked(&mut self) {
         self.flags |= 1 << bindings::IOSQE_IO_LINK_BIT;
     }
 
     /// # Safety
     /// Unsafe because we turn the Boxed user_data into a raw pointer contained in the sqe.
     /// It's up to the caller to make sure that this value is freed (not leaked).
-    pub unsafe fn into_sqe(self) -> Sqe {
+    pub(crate) unsafe fn into_sqe(self) -> Sqe {
         // Safe because all-zero value is valid. The sqe is made up of integers and raw pointers.
         let mut inner: io_uring_sqe = std::mem::zeroed();
 

--- a/src/io_uring/src/operation/sqe.rs
+++ b/src/io_uring/src/operation/sqe.rs
@@ -7,13 +7,17 @@ use crate::bindings::io_uring_sqe;
 
 unsafe impl ByteValued for io_uring_sqe {}
 
+/// Newtype wrapper over a raw sqe.
 pub(crate) struct Sqe(pub(crate) io_uring_sqe);
 
 impl Sqe {
+    /// Construct a new sqe.
     pub(crate) fn new(inner: io_uring_sqe) -> Self {
         Self(inner)
     }
 
+    /// Consume the sqe and return the `user_data`.
+    ///
     /// # Safety
     /// Safe only if you guarantee that this is a valid pointer to some memory where there is a
     /// value of type T created from a Box<T>.

--- a/src/io_uring/src/operation/sqe.rs
+++ b/src/io_uring/src/operation/sqe.rs
@@ -7,17 +7,17 @@ use crate::bindings::io_uring_sqe;
 
 unsafe impl ByteValued for io_uring_sqe {}
 
-pub struct Sqe(pub(crate) io_uring_sqe);
+pub(crate) struct Sqe(pub(crate) io_uring_sqe);
 
 impl Sqe {
-    pub fn new(inner: io_uring_sqe) -> Self {
+    pub(crate) fn new(inner: io_uring_sqe) -> Self {
         Self(inner)
     }
 
     /// # Safety
     /// Safe only if you guarantee that this is a valid pointer to some memory where there is a
     /// value of type T created from a Box<T>.
-    pub unsafe fn user_data<T>(self) -> T {
+    pub(crate) unsafe fn user_data<T>(self) -> T {
         *Box::from_raw(self.0.user_data as *mut T)
     }
 }

--- a/src/io_uring/src/probe.rs
+++ b/src/io_uring/src/probe.rs
@@ -8,7 +8,7 @@ use crate::bindings::{io_uring_probe, io_uring_probe_op};
 
 // There is no max for the number of operations returned by probing. So we fallback to using the
 // number of values representable in a u8;
-pub const PROBE_LEN: usize = u8::MAX as usize + 1;
+pub(crate) const PROBE_LEN: usize = u8::MAX as usize + 1;
 
 generate_fam_struct_impl!(
     io_uring_probe,
@@ -19,4 +19,4 @@ generate_fam_struct_impl!(
     PROBE_LEN
 );
 
-pub type ProbeWrapper = FamStructWrapper<io_uring_probe>;
+pub(crate) type ProbeWrapper = FamStructWrapper<io_uring_probe>;

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -5,7 +5,7 @@ use std::num::Wrapping;
 use std::os::unix::io::RawFd;
 use std::result::Result;
 use std::sync::atomic::Ordering;
-use vm_memory::{mmap::MmapRegionError, Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
+use vm_memory::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
 
 use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;
@@ -13,10 +13,8 @@ use crate::operation::Cqe;
 
 #[derive(Debug)]
 pub enum Error {
-    EmptyQueue,
     Mmap(MmapError),
     VolatileMemory(VolatileMemoryError),
-    BuildMmapRegion(MmapRegionError),
 }
 
 pub struct CompletionQueue {

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -17,7 +17,7 @@ pub enum Error {
     VolatileMemory(VolatileMemoryError),
 }
 
-pub struct CompletionQueue {
+pub(crate) struct CompletionQueue {
     // Offsets.
     head_off: usize,
     tail_off: usize,
@@ -33,7 +33,10 @@ pub struct CompletionQueue {
 }
 
 impl CompletionQueue {
-    pub fn new(io_uring_fd: RawFd, params: &bindings::io_uring_params) -> Result<Self, Error> {
+    pub(crate) fn new(
+        io_uring_fd: RawFd,
+        params: &bindings::io_uring_params,
+    ) -> Result<Self, Error> {
         let offsets = params.cq_off;
 
         // Map the CQ_ring. The actual size of the ring is `num_entries * size_of(entry_type)`.
@@ -67,7 +70,7 @@ impl CompletionQueue {
         self.count
     }
 
-    pub fn pop<T>(&mut self) -> Result<Option<Cqe<T>>, Error> {
+    pub(crate) fn pop<T>(&mut self) -> Result<Option<Cqe<T>>, Error> {
         let ring = self.cqes.as_volatile_slice();
         // get the head & tail
         let head = self.unmasked_head.0 & self.ring_mask;

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -12,8 +12,11 @@ use crate::bindings;
 use crate::operation::Cqe;
 
 #[derive(Debug)]
+/// CQueue Error.
 pub enum Error {
+    /// Error mapping the ring.
     Mmap(MmapError),
+    /// Error reading/writing volatile memory.
     VolatileMemory(VolatileMemoryError),
 }
 

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -16,10 +16,15 @@ use crate::bindings;
 use crate::operation::Sqe;
 
 #[derive(Debug)]
+/// SQueue Error.
 pub enum Error {
+    /// The queue is full.
     FullQueue,
+    /// Error mapping the ring.
     Mmap(MmapError),
+    /// Error reading/writing volatile memory.
     VolatileMemory(VolatileMemoryError),
+    /// Error returned by `io_uring_enter`.
     Submit(IOError),
 }
 

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -23,7 +23,7 @@ pub enum Error {
     Submit(IOError),
 }
 
-pub struct SubmissionQueue {
+pub(crate) struct SubmissionQueue {
     io_uring_fd: RawFd,
 
     // Offsets.
@@ -45,7 +45,10 @@ pub struct SubmissionQueue {
 }
 
 impl SubmissionQueue {
-    pub fn new(io_uring_fd: RawFd, params: &bindings::io_uring_params) -> Result<Self, Error> {
+    pub(crate) fn new(
+        io_uring_fd: RawFd,
+        params: &bindings::io_uring_params,
+    ) -> Result<Self, Error> {
         let (ring, sqes) = Self::mmap(io_uring_fd, params)?;
         let ring_slice = ring.as_volatile_slice();
 
@@ -78,7 +81,7 @@ impl SubmissionQueue {
         })
     }
 
-    pub fn push<T>(&mut self, sqe: Sqe) -> Result<(), (Error, T)> {
+    pub(crate) fn push<T>(&mut self, sqe: Sqe) -> Result<(), (Error, T)> {
         let ring_slice = self.ring.as_volatile_slice();
 
         // get the sqe tail
@@ -179,7 +182,7 @@ impl SubmissionQueue {
         Ok((sqe_ring, sqes))
     }
 
-    pub fn pending(&self) -> Result<u32, Error> {
+    pub(crate) fn pending(&self) -> Result<u32, Error> {
         let ring_slice = self.ring.as_volatile_slice();
         // get the sqe head
         let unmasked_head = ring_slice

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -9,7 +9,7 @@ use std::result::Result;
 use std::sync::atomic::Ordering;
 
 use utils::syscall::SyscallReturnCode;
-use vm_memory::{mmap::MmapRegionError, Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
+use vm_memory::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
 
 use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;
@@ -17,10 +17,8 @@ use crate::operation::Sqe;
 
 #[derive(Debug)]
 pub enum Error {
-    EmptyQueue,
     FullQueue,
     Mmap(MmapError),
-    BuildMmapRegion(MmapRegionError),
     VolatileMemory(VolatileMemoryError),
     Submit(IOError),
 }

--- a/src/io_uring/src/restriction.rs
+++ b/src/io_uring/src/restriction.rs
@@ -1,12 +1,21 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Seccomp-like restrictions for the allowed operations on an IoUring instance.
+//!
+//! One can configure the restrictions to only allow certain operations and/or allow only ops on
+//! registered files.
+//! If passed to the [`IoUring`] constructor, they take effect immediately and can never be
+//! deactivated.
+//!
+//! [`IoUring`]: ../struct.IoUring.html
+
 use std::convert::From;
 
 use crate::bindings;
 use crate::operation::OpCode;
 
-/// Adds support for restricting the operations allowed by io_uring, in a similar way to seccomp.
+/// Adds support for restricting the operations allowed by io_uring.
 pub enum Restriction {
     /// Allow an operation.
     AllowOpCode(OpCode),

--- a/src/io_uring/src/restriction.rs
+++ b/src/io_uring/src/restriction.rs
@@ -27,6 +27,7 @@ impl From<&Restriction> for bindings::io_uring_restriction {
     fn from(restriction: &Restriction) -> Self {
         use Restriction::*;
 
+        // Safe because it only contains integer values.
         let mut instance: Self = unsafe { std::mem::zeroed() };
 
         match restriction {

--- a/src/io_uring/tests/test_utils/mod.rs
+++ b/src/io_uring/tests/test_utils/mod.rs
@@ -5,7 +5,7 @@ use io_uring::{operation::OpCode, operation::Operation, Error, IoUring, SQueueEr
 use vm_memory::{MmapRegion, VolatileMemory};
 
 fn drain_cqueue(ring: &mut IoUring) {
-    while let Some(entry) = ring.pop::<usize>().unwrap() {
+    while let Some(entry) = unsafe { ring.pop::<usize>().unwrap() } {
         assert!(entry.result().is_ok());
     }
 }
@@ -47,7 +47,7 @@ pub fn drive_submission_and_completion(
                 _ => panic!("Only supports read and write."),
             };
 
-            match ring.push(operation) {
+            match unsafe { ring.push(operation) } {
                 Ok(()) => {}
                 Err(err_tuple) if matches!(err_tuple.0, Error::SQueue(SQueueError::FullQueue)) => {
                     // Stop and wait.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.73, "AMD": 84.17, "ARM": 82.75}
+    COVERAGE_DICT = {"Intel": 84.73, "AMD": 84.17, "ARM": 82.8}
 else:
-    COVERAGE_DICT = {"Intel": 81.63, "AMD": 81.09, "ARM": 79.63}
+    COVERAGE_DICT = {"Intel": 81.63, "AMD": 81.09, "ARM": 79.71}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fixes https://github.com/firecracker-microvm/firecracker/issues/2759

Also adds some other minor refactoring: see the commits

## Description of Changes

See the commits

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
