### PR TITLE
[CI][build] do not run musl unittests for ARM

### DIFF
--- a/tests/integration_tests/build/test_unittests.py
+++ b/tests/integration_tests/build/test_unittests.py
@@ -4,31 +4,21 @@
 
 import platform
 
-import pytest
-
 import host_tools.cargo_build as host  # pylint:disable=import-error
 
 MACHINE = platform.machine()
-TARGETS = ["{}-unknown-linux-gnu".format(MACHINE),
-           "{}-unknown-linux-musl".format(MACHINE)]
+# No need to run unittests for musl since
+# we run coverage with musl for all platforms.
+TARGET = "{}-unknown-linux-gnu".format(MACHINE)
 
 
-@pytest.mark.parametrize(
-    "target",
-    TARGETS
-)
-def test_unittests(test_fc_session_root_path, target):
+def test_unittests(test_fc_session_root_path):
     """
     Run unit and doc tests for all supported targets.
 
     @type: build
     """
-    extra_args = "--release --target {} ".format(target)
-
-    if "musl" in target and MACHINE == "x86_64":
-        pytest.skip("On x86_64 with musl target unit tests"
-                    " are already run as part of testing"
-                    " code-coverage.")
+    extra_args = "--release --target {} ".format(TARGET)
 
     host.cargo_test(
         test_fc_session_root_path,


### PR DESCRIPTION
# Reason for This PR

Superfluous musl unit testing on ARM.

## Description of Changes

We do not run musl unittests for x86 since
coverage will run them anyways with musl.
In the meantime, we also enabled coverage on
ARM so do the same for it too.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
