### PR TITLE
CI: enable snapshot tests on ARM

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -33,13 +33,9 @@ net_ifaces = [NetIfaceConfig(),
 scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="Not supported yet."
-)
-def test_restore_old_snapshot_all_devices(bin_cloner_path):
+def test_restore_old_snapshot(bin_cloner_path):
     """
-    Test scenario: restore previous version snapshots in current version.
+    Restore from snapshots obtained with previous versions of Firecracker.
 
     @type: functional
     """
@@ -88,13 +84,9 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
         logger.debug(microvm.log_data)
 
 
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="Not supported yet."
-)
-def test_restore_old_version_all_devices(bin_cloner_path):
+def test_restore_old_version(bin_cloner_path):
     """
-    Test scenario: restore snapshot in previous versions of Firecracker.
+    Restore current snapshot with previous versions of Firecracker.
 
     @type: functional
     """


### PR DESCRIPTION
# Reason for This PR

Enable 2 tests from test_snapshot_advanced
that also make sense for aarch64. These tests
ensure snapshot compatibility across different
Firecracker versions.

Fixes #2784 

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
