### PR TITLE
Docs: mention that Firecracker doesn't support big-endian guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ virtualization, but any such platform is currently not supported and not fit
 for production. If you want to run Firecracker on such platforms, please
 [open a feature request](https://github.com/firecracker-microvm/firecracker/issues/new?assignees=&labels=&template=feature_request.md&title=%5BFeature+Request%5D+Title).
 
-Firecracker currently only supports little-endian platforms, which includes x86_64
-and many aarch64 CPUs. Other systems and architectures may not provide a little-endian
-mode, and Firecracker may not work correctly on such systems.
+Firecracker currently only supports little-endian platforms. Firecracker will
+not compile for big-endian architectures, and will not work correctly with
+big-endian configured guests.
 
 ## Known issues and Limitations
 


### PR DESCRIPTION
# Reason for This PR

Currently this is not mentioned explicitly. Documentation states, that Firecracker may not run correctly on big endian, but doesn't have any reference to the guest.
With this PR, we are making clear that big endian guests are not supported.

Fixes #2826 

## Description of Changes

Mention in the README that Firecracker won't compile on big endian architectures, and it won't run correctly big endian guests. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.