### PR TITLE
[feature/io_uring] Undo skipping some snapshot integration tests

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -299,7 +299,7 @@ class ArtifactCollection:
     PLATFORM = platform.machine()
 
     # S3 bucket structure.
-    ARTIFACTS_ROOT = 'ci-artifacts'
+    ARTIFACTS_ROOT = 'ci-artifacts-io-uring'
     ARTIFACTS_DISKS = '/disks/' + PLATFORM + "/"
     ARTIFACTS_KERNELS = '/kernels/' + PLATFORM + "/"
     ARTIFACTS_MICROVMS = '/microvms/'

--- a/tests/integration_tests/functional/test_cmd_line_parameters.py
+++ b/tests/integration_tests/functional/test_cmd_line_parameters.py
@@ -9,7 +9,7 @@ from host_tools.cargo_build import get_firecracker_binaries
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.utils import run_cmd
+from framework.utils import run_cmd, get_firecracker_version_from_toml
 
 
 def test_describe_snapshot_all_versions(bin_cloner_path):
@@ -25,11 +25,8 @@ def test_describe_snapshot_all_versions(bin_cloner_path):
     # For each binary create a snapshot and verify the data version
     # of the snapshot state file.
 
-    # TODO: FIXME: Once we upload 1.0.0 binaries in
-    # S3 that include io_uring, replace the
-    # max_version with get_version_from_toml()
     firecracker_artifacts = artifacts.firecrackers(
-        max_version="0.25.0")
+        max_version=get_firecracker_version_from_toml())
 
     for firecracker in firecracker_artifacts:
         firecracker.download()

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -51,12 +51,8 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
     # Fetch all firecracker binaries.
     # With each binary create a snapshot and try to restore in current
     # version.
-
-    # TODO: FIXME: Once we upload 1.0.0 binaries in
-    # S3 that include io_uring, replace the
-    # max_version with get_version_from_toml()
     firecracker_artifacts = artifacts.firecrackers(
-        max_version="0.25.0")
+        max_version=get_firecracker_version_from_toml())
 
     for firecracker in firecracker_artifacts:
         firecracker.download()
@@ -93,10 +89,6 @@ def test_restore_old_snapshot_all_devices(bin_cloner_path):
         logger.debug(microvm.log_data)
 
 
-@pytest.mark.skip(
-    reason="Need to upload new binaries in S3 for v.1.0, but we first need to"
-    "finalise io_uring snapshotting support"
-)
 def test_restore_old_version_all_devices(bin_cloner_path):
     """
     Test scenario: restore snapshot in previous versions of Firecracker.

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import platform
-import pytest
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.defs import DEFAULT_TEST_IMAGES_S3_BUCKET
@@ -589,10 +588,6 @@ def test_snapshot_resume_latency(network_config,
     test_matrix.run_test(_test_snapshot_resume_latency)
 
 
-@pytest.mark.skip(
-    reason="Need to upload new binaries in S3 for v.1.0, but we first need to"
-    "finalise io_uring snapshotting support"
-)
 def test_older_snapshot_resume_latency(bin_cloner_path, results_file_dumper):
     """
     Test scenario: Older snapshot load performance measurement.


### PR DESCRIPTION
# Reason for This PR

Since io_uring snapshot support is now finalised, we no longer need to skip some tests that were being skipped due to
outdated artifacts in S3.
I've uploaded new binaries in S3 and now the tests pass.
However, the tests on the main branch would not pass with these artifacts so I created a separate temporary S3 folder for
the artifacts used on this branch.
We can remove the temporary folder in the PR that merges this feature branch into main.

## Description of Changes

View commit messages

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
