### PR TITLE
Add checksum of release archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   Firecracker version.
 - Added `--metadata` paramater to enable MMDS content to be supplied from a file
   allowing the MMDS to be used when using `--no-api` to disable the API server.
+- Checksum file for the release assets.
 
 ### Changed
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -428,7 +428,7 @@ check_release_tag() {
     say "Fetching remote tags..."
     git fetch upstream --tags
 
-    if git rev-parse v$1 >/dev/null 2>&1; then
+    if git tag | grep v$1 >/dev/null 2>&1; then
         say_err "Seems that tag provided is already associated with a release! "
         say "Will skip drafting a new release for now."
         return 1

--- a/tools/devtool
+++ b/tools/devtool
@@ -1030,12 +1030,14 @@ cmd_build_release_archive() {
     validate_version "$version"
     say "Will start preparing release archive for v$version ..."
     get_user_confirmation || die "Aborted."
+    release_suffix="v$version-$(uname -m)"
+    archive_name="firecracker-$release_suffix.tgz"
+    archive_checksum="$archive_name.sha256.txt"
+    release_dir="release-$release_suffix"
 
     # Run tests, build release binaries and strip them from debug symbols.
     ( cmd_build --release && cmd_strip && cmd_test ) || die "Aborted."
 
-    release_suffix="v$version-$(uname -m)"
-    release_dir="release-$release_suffix"
     # Create release directory or overwrite if it already exists.
     rm -rf "$release_dir" && mkdir "$release_dir"
 
@@ -1056,10 +1058,12 @@ cmd_build_release_archive() {
     done
 
     # Create release archive.
-    archive_name="firecracker-$release_suffix.tgz"
     say "Creating release archive..."
     tar -czf "$archive_name" "$release_dir"
     say "Done. Archive $archive_name successfully created."
+    say "Calculating checksum for release archive..."
+    sha256sum "$archive_name"  | awk '{print $1}' > "$archive_checksum"
+    say "Done. Saved checksum in $archive_checksum."
 }
 
 check_file_existence() {


### PR DESCRIPTION
# Reason for This PR

Fixes #601.

## Description of Changes

From now on, a checksum of the release artefacts will also get uploaded together with the corresponding release archive.

For a model of what the assets of each release will look like, checkout: https://github.com/dianpopa/firecracker/releases/tag/v0.26.0.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
