### PR TITLE
remove deprecated --seccomp-level param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Changed
 
 - Deprecated `vsock_id` body field in `PUT`s on `/vsock`.
+- Removed the deprecated the `--seccomp-level parameter`.
 
 ### Fixed
 

--- a/src/utils/src/arg_parser.rs
+++ b/src/utils/src/arg_parser.rs
@@ -513,15 +513,15 @@ mod tests {
                     .help("'id' info."),
             )
             .arg(
-                Argument::new("seccomp-level")
+                Argument::new("seccomp-filter")
                     .takes_value(true)
-                    .default_value("2")
-                    .help("'seccomp-level' info."),
+                    .help("'seccomp-filter' info.")
+                    .forbids(vec!["no-seccomp"]),
             )
             .arg(
                 Argument::new("no-seccomp")
                     .help("'-no-seccomp' info.")
-                    .forbids(vec!["seccomp-level"]),
+                    .forbids(vec!["seccomp-filter"]),
             )
             .arg(
                 Argument::new("config-file")
@@ -628,9 +628,9 @@ mod tests {
         arg_parser = ArgParser::new()
             .arg(Argument::new("id").takes_value(true).help("'id' info."))
             .arg(
-                Argument::new("seccomp-level")
+                Argument::new("seccomp-filter")
                     .takes_value(true)
-                    .help("'seccomp-level' info."),
+                    .help("'seccomp-filter' info."),
             )
             .arg(
                 Argument::new("config-file")
@@ -641,9 +641,9 @@ mod tests {
         assert_eq!(
             arg_parser.formatted_help(),
             "optional arguments:\n  \
-             --config-file <config-file>       'config-file' info.\n  \
-             --id <id>                         'id' info.\n  \
-             --seccomp-level <seccomp-level>   'seccomp-level' info."
+             --config-file <config-file>         'config-file' info.\n  \
+             --id <id>                           'id' info.\n  \
+             --seccomp-filter <seccomp-filter>   'seccomp-filter' info."
         );
     }
 
@@ -856,7 +856,7 @@ mod tests {
             "bar",
             "--id",
             "foobar",
-            "--seccomp-level",
+            "--seccomp-filter",
             "0",
             "--no-seccomp",
         ]
@@ -868,7 +868,33 @@ mod tests {
             arguments.parse(&args),
             Err(Error::ForbiddenArgument(
                 "no-seccomp".to_string(),
-                "seccomp-level".to_string(),
+                "seccomp-filter".to_string(),
+            ))
+        );
+
+        arguments = arg_parser.arguments().clone();
+
+        let args = vec![
+            "binary-name",
+            "--exec-file",
+            "foo",
+            "--api-sock",
+            "bar",
+            "--id",
+            "foobar",
+            "--no-seccomp",
+            "--seccomp-filter",
+            "0",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+        assert_eq!(
+            arguments.parse(&args),
+            Err(Error::ForbiddenArgument(
+                "no-seccomp".to_string(),
+                "seccomp-filter".to_string(),
             ))
         );
 
@@ -913,7 +939,7 @@ mod tests {
             "bar",
             "--id",
             "foobar",
-            "--seccomp-level",
+            "--seccomp-filter",
             "0",
             "--",
             "--extra-flag",

--- a/src/vmm/build.rs
+++ b/src/vmm/build.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const ADVANCED_BINARY_FILTER_FILE_NAME: &str = "seccomp_filter.bpf";
-const BASIC_BINARY_FILTER_FILE_NAME: &str = "basic_seccomp_filter.bpf";
 
 const JSON_DIR: &str = "../../resources/seccomp";
 const SECCOMPILER_BUILD_DIR: &str = "../../build/seccompiler";
@@ -52,22 +51,11 @@ fn main() {
         &target,
         json_path,
         bpf_out_path.to_str().expect("Invalid bytes."),
-        false,
-    );
-
-    // Run seccompiler-bin with the `--basic` flag, getting the filter for `--seccomp-level 1`.
-    let mut bpf_out_path = PathBuf::from(&out_dir);
-    bpf_out_path.push(BASIC_BINARY_FILTER_FILE_NAME);
-    run_seccompiler_bin(
-        &target,
-        json_path,
-        bpf_out_path.to_str().expect("Invalid bytes."),
-        true,
     );
 }
 
 // Run seccompiler with the given arguments.
-fn run_seccompiler_bin(cargo_target: &str, json_path: &str, out_path: &str, basic: bool) {
+fn run_seccompiler_bin(cargo_target: &str, json_path: &str, out_path: &str) {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Missing target arch.");
 
     // Command for running seccompiler-bin
@@ -92,10 +80,6 @@ fn run_seccompiler_bin(cargo_target: &str, json_path: &str, out_path: &str, basi
         "--output-file",
         out_path,
     ]);
-
-    if basic {
-        command.arg("--basic");
-    }
 
     match command.output() {
         Err(error) => panic!("\nSeccompiler-bin error: {:?}\n", error),

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -138,7 +138,7 @@ def test_working_filter(test_microvm_with_api):
 
     test_microvm.start()
 
-    # seccomp-level should be 2, with no additional errors
+    # level should be 2, with no additional errors
     utils.assert_seccomp_level(test_microvm.jailer_clone_pid, "2")
 
 


### PR DESCRIPTION
# Reason for This PR

`--seccomp-level` was deprecated in Firecracker v0.25.0.
Given that we are preparing the v1.0.0 release, remove the deprecated parameter.
This also paves the way for consuming seccompiler from rust-vmm, as it removes the option for the `basic` option needed by `seccomp-level 1`.

The equivalent of seccomp-level 2 is the default for musl.
The equivalent of seccomp-level 0 is achievable by `--no-seccomp`.
The equivalent of seccomp-level 1 is achievable by using a custom filter.

## Description of Changes

- removes `--seccomp-level` parameter

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
