### PR TITLE
Small fixes for MMDS

### DIFF
--- a/src/dumbo/src/pdu/ipv4.rs
+++ b/src/dumbo/src/pdu/ipv4.rs
@@ -30,7 +30,7 @@ const OPTIONS_OFFSET: usize = 20;
 /// Indicates version 4 of the IP protocol
 pub const IPV4_VERSION: u8 = 0x04;
 /// Default TTL value
-pub const DEFAULT_TTL: u8 = 200;
+pub const DEFAULT_TTL: u8 = 1;
 
 /// The IP protocol number associated with TCP.
 pub const PROTOCOL_TCP: u8 = 0x06;

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -142,6 +142,7 @@ pub(crate) fn run_with_api(
         .as_mut()
     {
         mmds.set_data_store_limit(payload_limit.unwrap_or(MAX_DATA_STORE_SIZE));
+        mmds.set_aad(&instance_info.id);
     }
 
     let to_vmm_event_fd = api_event_fd

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -148,6 +148,14 @@ impl Mmds {
         }
     }
 
+    /// Sets the Additional Authenticated Data to be used for encryption and
+    /// decryption of the session token when MMDS version 2 is enabled.
+    pub fn set_aad(&mut self, instance_id: &str) {
+        if let Some(ta) = self.token_authority.as_mut() {
+            ta.set_aad(instance_id);
+        }
+    }
+
     /// Checks if the provided token has not expired.
     pub fn is_valid_token(&self, token: &str) -> Result<bool, TokenError> {
         self.token_authority

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ import host_tools.proc as proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.42, "ARM": 83.15}
+    COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.42, "ARM": 83.11}
 else:
-    COVERAGE_DICT = {"Intel": 81.95, "AMD": 81.42, "ARM": 80.15}
+    COVERAGE_DICT = {"Intel": 81.95, "AMD": 81.42, "ARM": 80.13}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Small mmds fixes:
- include microVM instance ID into the AAD (Additional Authentication Data) used by the AES-GCM cipher when encrypting session tokens, which allows cryptographic code to add context information to the ciphering/deciphering processing.
- set TTL for MMDS response packets to 1

## Description of Changes

- AAD used by the AES-GCM cipher during encryption/decryption consists of a bytes sequence in the following format "microvmid=<microvm-id>"
- `DEFAULT_TTL = 1`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[] The issue which led to this PR has a clear conclusion.~
- ~[] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- ~[] Any API changes follow the [Runbook for Firecracker API changes][2].~
- ~[] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
