### PR TITLE
Test 5.10 guest kernel with development bucket

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -16,7 +16,7 @@ from framework.utils import compare_versions
 from host_tools.snapshot_helper import merge_memory_bitmaps
 
 
-ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts"
+ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts-dev"
 
 
 class ArtifactType(Enum):
@@ -299,7 +299,7 @@ class ArtifactCollection:
     PLATFORM = platform.machine()
 
     # S3 bucket structure.
-    ARTIFACTS_ROOT = 'ci-artifacts'
+    ARTIFACTS_ROOT = 'ci-artifacts-dev'
     ARTIFACTS_DISKS = '/disks/' + PLATFORM + "/"
     ARTIFACTS_KERNELS = '/kernels/' + PLATFORM + "/"
     ARTIFACTS_MICROVMS = '/microvms/'

--- a/tests/framework/stats/core.py
+++ b/tests/framework/stats/core.py
@@ -85,6 +85,7 @@ class Core:
             # Custom information extracted from all the iterations.
             if len(custom) > 0:
                 self._result['custom'][tag] = custom
+                print("Processor {}".format(custom))
 
         if self._failure_aggregator.has_any():
             self._failure_aggregator.result = self._result


### PR DESCRIPTION

# Reason for This PR

Tests behavior of CI against guest kernel 5.10 with a development bucket. 

DO NOT MERGE!

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
