### PR TITLE
devtool: fixes to build_rootfs

### DIFF
--- a/docs/rootfs-and-kernel-setup.md
+++ b/docs/rootfs-and-kernel-setup.md
@@ -168,7 +168,7 @@ The disk images used in our CI to test Firecracker's features are obtained by
 using the recipe inside devtool:
 
 ```bash
-./tools/devtool build_rootfs -s 300
+./tools/devtool build_rootfs -s 300MB
 ```
 
 or

--- a/tools/devtool
+++ b/tools/devtool
@@ -691,7 +691,8 @@ cmd_help() {
 
     echo "    build_rootfs -s|--size [--partuuid]"
     echo "        Builds a rootfs image custom-tailored for use in our CI."
-    echo "        -s, --size      Size of the rootfs image. Defaults to 300M."
+    echo "        -s, --size      Size of the rootfs image. Defaults to 300MB.
+                                  The format is the same as that of 'truncates'."
     echo "        -p, --partuuid  Whether to build a partuuid image."
     echo ""
     echo "    checkenv"
@@ -2032,12 +2033,12 @@ cmd_build_kernel() {
     say "Kernel binary placed in: $kernel_dir_host/linux-$KERNEL_VERSION/$KERNEL_BINARY_NAME"
 }
 
-# `./devtool build_rootfs -s 500`
+# `./devtool build_rootfs -s 500MB`
 # Build a rootfs of custom size.
 #
 cmd_build_rootfs() {
-    # Default size for the resulting rootfs image is 250M.
-    SIZE="300"
+    # Default size for the resulting rootfs image is 300MB.
+    SIZE="300MB"
     FROM_CTR=ubuntu:18.04
     flavour="bionic"
 
@@ -2075,7 +2076,16 @@ cmd_build_rootfs() {
         gcc -o  $rootfs_dir_ctr/readmem $resources_dir_ctr/readmem.c"
 
     img_file="$rootfs_dir_host/$ROOTFS_NAME"
-    dd if=/dev/zero "of=$img_file" bs=1M count=$SIZE
+
+    # Check for pre-existence of rootfs image. See if we are allowed
+    # to delete it. If not, abort.
+    if [ -f "$img_file" ]; then
+        say "Rootfs image $img_file already exists. Do you want us to delete it for you?"
+        get_user_confirmation || die "Aborted."
+        rm -f "$img_file"
+    fi
+
+    truncate -s "$SIZE" "$img_file"
     mkfs.ext4 -F "$img_file"
     docker run --env ROOTFS_NAME=$ROOTFS_NAME --env PARTUUID=$PARTUUID --privileged --rm -i -v "$FC_ROOT_DIR:/firecracker"  "$FROM_CTR" bash -s <<'EOF'
 rootfs_dir=/firecracker/build/rootfs


### PR DESCRIPTION

# Reason for This PR

Fixes #2831.
Use truncate instead of dd for allocating the rootfs
image. Also, make it clear in the doc that the format
of the size parameter is the same as that of truncates.
## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
