### PR TITLE
logger: move deny_docs to lib.rs

### DIFF
--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -1,5 +1,9 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#![deny(missing_docs)]
+//! Crate that implements Firecracker specific functionality as far as logging and metrics collecting.
+
 mod init;
 mod logger;
 mod metrics;
@@ -25,6 +29,7 @@ fn extract_guard<G>(lock_result: LockResult<G>) -> G {
     }
 }
 
+/// Helper function for updating the value of a store metric with elapsed time since some time in a past.
 pub fn update_metric_with_elapsed_time(metric: &SharedStoreMetric, start_time_us: u64) -> u64 {
     let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time_us;
     metric.store(delta_us as usize);

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![deny(missing_docs)]
 //! Utility for sending log related messages to a storing destination or simply to stdout/stderr.
 //! The logging destination is specified upon the initialization of the logging system.
 //!

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -236,6 +236,8 @@ pub trait StoreMetric {
 #[derive(Default)]
 pub struct SharedIncMetric(AtomicUsize, AtomicUsize);
 
+/// Representation of a metric that is expected to hold a value that can be accessed
+/// from more than one thread, so more synchronization is necessary.
 #[derive(Default)]
 pub struct SharedStoreMetric(AtomicUsize);
 
@@ -297,6 +299,7 @@ pub struct ProcessTimeReporter {
 }
 
 impl ProcessTimeReporter {
+    /// Constructor for the process time-related reporter.
     pub fn new(
         start_time_us: Option<u64>,
         start_time_cpu_us: Option<u64>,
@@ -309,6 +312,7 @@ impl ProcessTimeReporter {
         }
     }
 
+    /// Obtain process start time in microseconds.
     pub fn report_start_time(&self) {
         if let Some(start_time) = self.start_time_us {
             let delta_us = utils::time::get_time_us(utils::time::ClockType::Monotonic) - start_time;
@@ -319,6 +323,7 @@ impl ProcessTimeReporter {
         }
     }
 
+    /// Obtain process CPU start time in microseconds.
     pub fn report_cpu_start_time(&self) {
         if let Some(cpu_start_time) = self.start_time_cpu_us {
             let delta_us = utils::time::get_time_us(utils::time::ClockType::ProcessCpu)


### PR DESCRIPTION
Due to previous refactorization, deny_docs
was left behind in what used to be the lib.rs
of the crate: logger/src/logger.rs.

Signed-off-by: Diana Popa <dpopa@amazon.com>

# Reason for This PR

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Fixes #

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
