### PR TITLE
Allow MMDS version to be configured when using MMDS with `--no-api`

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -375,22 +375,15 @@ impl ApiServer {
     }
 
     fn put_mmds(&self, value: serde_json::Value) -> Response {
-        let mmds_response = match self.unlock_mmds().as_mut() {
-            Some(mmds) => mmds.put_data(value),
-            None => {
-                return ApiServer::json_response(
-                    StatusCode::BadRequest,
-                    ApiServer::json_fault_message(MmdsError::NoMmds.to_string()),
-                )
+        match self.unlock_mmds().as_mut() {
+            Some(mmds) => {
+                mmds.put_data(value);
+                Response::new(Version::Http11, StatusCode::NoContent)
             }
-        };
-
-        match mmds_response {
-            Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
-            Err(e) => ApiServer::json_response(
+            None => ApiServer::json_response(
                 StatusCode::BadRequest,
-                ApiServer::json_fault_message(e.to_string()),
-            ),
+                ApiServer::json_fault_message(MmdsError::NoMmds.to_string()),
+            )
         }
     }
 

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -383,7 +383,7 @@ impl ApiServer {
             None => ApiServer::json_response(
                 StatusCode::BadRequest,
                 ApiServer::json_fault_message(MmdsError::NoMmds.to_string()),
-            )
+            ),
         }
     }
 

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -314,8 +314,7 @@ fn main_exitable() -> ExitCode {
     ) {
         mmds.put_data(
             serde_json::from_str(&data).expect("MMDS error: metadata provided not valid json"),
-        )
-        .expect("MMDS content load from file failed.");
+        );
 
         info!("Successfully added metadata to mmds from file");
     }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -18,7 +18,7 @@ pub struct Mmds {
 }
 
 /// MMDS version.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum MmdsVersion {
     V1,
     V2,

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -171,10 +171,9 @@ impl Mmds {
     // We do not check data_store size here because a request with a body
     // bigger than the imposed limit will be stopped by micro_http before
     // reaching here.
-    pub fn put_data(&mut self, data: Value) -> Result<(), Error> {
+    pub fn put_data(&mut self, data: Value) {
         self.data_store = data;
         self.is_initialized = true;
-        Ok(())
     }
 
     pub fn patch_data(&mut self, patch_data: Value) -> Result<(), Error> {
@@ -328,8 +327,7 @@ mod tests {
 
         let mut mmds_json = "{\"meta-data\":{\"iam\":\"dummy\"},\"user-data\":\"1522850095\"}";
 
-        mmds.put_data(serde_json::from_str(mmds_json).unwrap())
-            .unwrap();
+        mmds.put_data(serde_json::from_str(mmds_json).unwrap());
         assert!(mmds.check_data_store_initialized().is_ok());
 
         assert_eq!(mmds.get_data_str(), mmds_json);
@@ -360,7 +358,7 @@ mod tests {
             "balance": -24
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        mmds.put_data(data_store).unwrap();
+        mmds.put_data(data_store);
 
         // Test invalid path.
         assert_eq!(
@@ -512,7 +510,7 @@ mod tests {
             "age": "43"
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.put_data(data_store).is_ok());
+        mmds.put_data(data_store);
 
         let data = r#"{
             "name": {
@@ -532,7 +530,7 @@ mod tests {
             "age": 43
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.put_data(data_store).is_ok());
+        mmds.put_data(data_store);
 
         let data = r#"{
             "name": {

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -164,7 +164,17 @@ impl Mmds {
             .and_then(|ta| ta.generate_token_secret(ttl_seconds))
     }
 
-    pub fn set_data_store_limit(&mut self, data_store_limit: usize) {
+    /// Configure MMDS with limit for the data store contents, and metadata (if provided).
+    pub fn configure(&mut self, maybe_data_store_limit: Option<usize>, maybe_data: Option<Value>) {
+        self.set_data_store_limit(maybe_data_store_limit.unwrap_or(MAX_DATA_STORE_SIZE));
+
+        if let Some(data) = maybe_data {
+            self.put_data(data);
+        }
+    }
+
+    // Set size limit for the data store contents.
+    fn set_data_store_limit(&mut self, data_store_limit: usize) {
         self.data_store_limit = data_store_limit;
     }
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -383,8 +383,7 @@ mod tests {
             .expect("Poisoned lock")
             .as_mut()
             .unwrap()
-            .put_data(serde_json::from_str(data).unwrap())
-            .unwrap();
+            .put_data(serde_json::from_str(data).unwrap());
 
         mmds
     }

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -28,5 +28,5 @@
   "logger": null,
   "metrics": null,
   "mmds-config": null,
-  "mmds-version": null
+  "mmds-version": "V1"
 }

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -27,5 +27,6 @@
   "vsock": null,
   "logger": null,
   "metrics": null,
-  "mmds-config": null
+  "mmds-config": null,
+  "mmds-version": null
 }

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1276,6 +1276,7 @@ def test_get_full_config(test_microvm_with_api):
     expected_cfg['logger'] = None
     expected_cfg['metrics'] = None
     expected_cfg['mmds-config'] = None
+    expected_cfg['mmds-version'] = "V2"
 
     # Getting full vm configuration should be available pre-boot.
     response = test_microvm.full_cfg.get()

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -287,9 +287,47 @@ def test_start_with_invalid_metadata(test_microvm_with_api):
     )
 
 
+def test_with_config_and_metadata(test_microvm_with_api):
+    """
+    Test microvm start from config file and metadata file.
+
+    @type: functional
+    """
+    vm_config_file = "framework/vm_config.json"
+    metadata_file = "../resources/tests/metadata.json"
+    version_json = {
+        'version': 'V1'
+    }
+
+    test_microvm = test_microvm_with_api
+
+    _configure_vm_from_json(test_microvm, vm_config_file)
+    _add_metadata_file(test_microvm, metadata_file)
+
+    test_microvm.spawn()
+
+    test_microvm.check_log_message(
+        "Successfully added metadata to mmds from file"
+    )
+
+    response = test_microvm.machine_cfg.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert test_microvm.state == "Running"
+
+    response = test_microvm.mmds.get_mmds_version()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == version_json
+
+    response = test_microvm.mmds.get()
+    assert test_microvm.api_session.is_status_ok(response.status_code)
+
+    with open(metadata_file) as json_file:
+        assert response.json() == json.load(json_file)
+
+
 def test_with_config_and_metadata_no_api(test_microvm_with_api):
     """
-    Test microvm start when config/mmds and API server thread is disable.
+    Test microvm start when config/mmds and API server thread is disabled.
 
     @type: functional
     """


### PR DESCRIPTION
# Reason for This PR

Firecracker currently defaults the MMDS version to `V2` and supports both `V1` and `V2`, which can be configured through the `mmds/version` endpoint. As a conclusion of [this issue](https://github.com/firecracker-microvm/firecracker/issues/1292), we have introduced support for using MMDS when using `--no-api`, but there is no way to change the version. We need to add a mechanism to allow users to configure MMDS version when initializing the microVM from a config file.

## Description of Changes

- Add `mmds-version` field to `VmResources` and `VmmConfig` and make use of it to set MMDS version when using `--no-api`.
- Add metadata to MMDS after allowing version to be set when using config file.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
