### PR TITLE
fix test_5_inc_snapshots

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -24,7 +24,7 @@ ECHO_SERVER_PORT = 5252
 
 
 def _guest_run_fio_iteration(ssh_connection, iteration):
-    fio = """fio --filename=/dev/vda --direct=1 --rw=randread --bs=4k \
+    fio = """fio --filename=/dev/vdb --direct=1 --rw=randread --bs=4k \
         --ioengine=libaio --iodepth=16 --runtime=10 --numjobs=4 --time_based \
         --group_reporting --name=iops-test-job --eta-newline=1 --readonly \
         --output /tmp/fio{} > /dev/null &""".format(iteration)
@@ -70,11 +70,13 @@ def _test_seq_snapshots(context):
 
     # Create a rw copy artifact.
     root_disk = context.disk.copy()
+    # Create a scratch 128MB RW non-root block device.
+    scratchdisk = drive_tools.FilesystemFile(tempfile.mktemp(), size=128)
     # Get ssh key from read-only artifact.
     ssh_key = context.disk.ssh_key()
     # Create a fresh microvm from artifacts.
     vm_instance = vm_builder.build(kernel=context.kernel,
-                                   disks=[root_disk],
+                                   disks=[root_disk, scratchdisk.path],
                                    ssh_key=ssh_key,
                                    config=context.microvm,
                                    diff_snapshots=diff_snapshots)


### PR DESCRIPTION
# Reason for This PR

fix `test_5_inc_snapshots`

## Description of Changes

Attach a scratch disk and run fio on it instead of the rootfs disk.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
