### PR TITLE
Mask IceLake `la57` feature in CPUID for templates

### DIFF
--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -184,6 +184,8 @@ pub mod leaf_0x7 {
             // 13 = TME
             // AVX512_VPOPCNTDQ = Vector population count instruction (Intel® Xeon Phi™ only.)
             pub const AVX512_VPOPCNTDQ_BITINDEX: u32 = 14;
+            // LA57 = 5-level page tables.
+            pub const LA57: u32 = 16;
             // 21 - 17 = The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.
             // Read Processor ID
             pub const RDPID_BITINDEX: u32 = 22;

--- a/src/cpuid/src/template/intel/c3.rs
+++ b/src/cpuid/src/template/intel/c3.rs
@@ -96,6 +96,7 @@ fn update_structured_extended_entry(
             .write_bit(ecx::OSPKE_BITINDEX, false)
             .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
             .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
+            .write_bit(ecx::LA57, false)
             .write_bit(ecx::RDPID_BITINDEX, false)
             .write_bit(ecx::SGX_LC_BITINDEX, false);
 

--- a/src/cpuid/src/template/intel/t2.rs
+++ b/src/cpuid/src/template/intel/t2.rs
@@ -90,6 +90,7 @@ fn update_structured_extended_entry(
             .write_bit(ecx::OSPKE_BITINDEX, false)
             .write_bit(ecx::AVX512_VNNI_BITINDEX, false)
             .write_bit(ecx::AVX512_VPOPCNTDQ_BITINDEX, false)
+            .write_bit(ecx::LA57, false)
             .write_bit(ecx::RDPID_BITINDEX, false)
             .write_bit(ecx::SGX_LC_BITINDEX, false);
 


### PR DESCRIPTION
# Reason for This PR

IceLake introduced 5-level addressing, which appears as `la57` in the CPUID feature list if enabled. The templates should not present this feature.

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Fixes #

## Description of Changes
Masked the feature in our CPUID templates.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
