### PR TITLE
Enforce sync mechanisms for accessing log data in CI

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -614,6 +614,13 @@ class Microvm:
         """Wait until `message` appears in logging output."""
         assert message in self.log_data
 
+    @retry(delay=0.1, tries=5)
+    def find_log_message(self, regex):
+        """Wait until `regex` appears in logging output and return it."""
+        reg_res = re.findall(regex, self.log_data)
+        assert reg_res
+        return reg_res
+
     def serial_input(self, input_string):
         """Send a string to the Firecracker serial console via screen."""
         input_cmd = 'screen -S {session} -p 0 -X stuff "{input_string}"'

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -259,7 +259,11 @@ class Microvm:
 
     @property
     def log_data(self):
-        """Return the log data."""
+        """Return the log data.
+
+        !!!!OBS!!!!: Do not use this to check for message existence and
+        rather use self.check_log_message or self.find_log_message.
+        """
         with data_lock:
             log_data = self.__log_data
         return log_data

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -73,9 +73,9 @@ def test_drive_io_engine(test_microvm_with_api, network_config):
         assert test_microvm.api_session.is_status_bad_request(
             response.status_code)
 
-        assert "Received Error. Status code: 400 Bad Request. Message: Unable"\
-            " to create the block device FileEngine(UnsupportedEngine(Async))"\
-            in test_microvm.log_data
+        test_microvm.check_log_message(
+            "Received Error. Status code: 400 Bad Request. Message: Unable"
+            " to create the block device FileEngine(UnsupportedEngine(Async))")
 
         # Now configure the default engine type and check that it works.
         response = test_microvm.drive.put_with_default_io_engine(

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -500,9 +500,9 @@ def test_block_default_cache_old_version(test_microvm_with_api):
     # We should find a warning in the logs for this case as this
     # cache type was not supported in 0.24.0 and we should default
     # to "Unsafe" mode.
-    log_data = test_microvm.log_data
-    assert "Target version does not implement the current cache type. "\
-        "Defaulting to \"unsafe\" mode." in log_data
+    test_microvm.check_log_message("Target version does not implement the"
+                                   " current cache type. "
+                                   "Defaulting to \"unsafe\" mode.")
 
 
 def check_iops_limit(ssh_connection, block_size, count, min_time, max_time):

--- a/tests/integration_tests/functional/test_error_code.py
+++ b/tests/integration_tests/functional/test_error_code.py
@@ -41,7 +41,6 @@ def test_enosys_error_code(test_microvm_with_initrd):
     # Check if FC process is closed
     wait_process_termination(vm.jailer_clone_pid)
 
-    log_data = vm.log_data
-    assert "Received ENOSYS error because KVM failed to emulate " \
-           "an instruction." in log_data
-    assert "Vmm is stopping." in log_data
+    vm.check_log_message("Received ENOSYS error because KVM failed to"
+                         " emulate an instruction.")
+    vm.check_log_message("Vmm is stopping.")

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -216,8 +216,7 @@ def test_save_tsc_old_version(bin_cloner_path):
         version='0.24.0'
     )
 
-    log_data = vm.log_data
-    assert "Saving to older snapshot version, TSC freq" in log_data
+    vm.check_log_message("Saving to older snapshot version, TSC freq")
     vm.kill()
 
 

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -195,8 +195,8 @@ def test_failing_filter(test_microvm_with_api):
     test_microvm.expect_kill_by_signal = True
     # Check the logger output
     ioctl_num = 16 if platform.machine() == "x86_64" else 29
-    assert "Shutting down VM after intercepting a bad syscall ({})".format(
-        str(ioctl_num)) in test_microvm.log_data
+    test_microvm.check_log_message("Shutting down VM after intercepting a bad"
+                                   " syscall ({})".format(str(ioctl_num)))
 
     # Check the metrics
     lines = metrics_fifo.sequential_reader(100)


### PR DESCRIPTION
# Reason for This PR

* enforce sync mechanism on read/write of the log_data
* use `check_log_message` instead of directly accessing the log_data

Try to avoid situations like these: https://buildkite.com/firecracker/firecracker-x86-64-intel-kernel-4-dot-14-ci/builds/409#6bad3298-4bfe-4a54-8d59-c86e37830d8f

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
