### PR TITLE
[snap] update versioning documentation

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -141,13 +141,30 @@ The baseline for snapshot resume latency target on Intel is under **8ms** with
 
 ## Snapshot versioning
 
-Firecracker snapshotting implementation offers support for microVM versioning
+The Firecracker snapshotting implementation offers support for snapshot versioning
 (`cross-version snapshots`) in the following contexts:
 
-- saving snapshots at older versions (being able to create a snapshot with any
-  version in the `[N, N + o]` interval, while being in Firecracker
-  version `N+o`),
-- loading snapshots from older versions (being able to load a snapshot created
+- Saving snapshots at older versions
+
+  This refers to being able to create a snapshot with any version in the
+  `[N, N + o]` interval, while running Firecracker version `N+o`.
+
+  The possibility to save snapshots at older versions might not be offered by
+  all Firecracker releases. Depending on the features that it introduces, a new
+  Firecracker release `v` might drop the possibility to save snapshots at any
+  versions older than `v`.
+
+  For example Firecracker v1.0 adds support for some additional virtio features
+  (e.g. notification suppression). These features lead the guest drivers to
+  behave in a very specific way and as a consequence the Firecracker devices
+  have to respond accordingly. As a result, the snapshots that are created
+  while these features are in use will not be backwards compatible with
+  previous versions of Firecracker since the devices that come with these older
+  versions do not behave in a way that’s compatible with the snapshotted guest
+  drivers.
+
+  The list of versions that break snapshot backwards compatibility: `1.0`
+- Loading snapshots from older versions (being able to load a snapshot created
   by any Firecracker version in the `[N, N + o]` interval, in a Firecracker
   version `N+o`).
 


### PR DESCRIPTION
# Reason for This PR

[snap] update versioning documentation

## Description of Changes
Mention the fact that a new Firecracker release `v` might drop the
possibility to save snapshots at any versions older than `v`.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
