### PR TITLE
mmds: fix faulty unit test

### DIFF
--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -405,7 +405,7 @@ mod tests {
         );
 
         // Test ciphertext with corrupted payload.
-        payload[0] += 1;
+        payload[0] = u8::MAX - payload[0];
         assert_eq!(
             token_authority
                 .decrypt_expiry(&mut payload, &tag, iv.as_mut())
@@ -415,7 +415,7 @@ mod tests {
         );
 
         // Test ciphertext with corrupted tag.
-        tag[0] += 1;
+        tag[0] = u8::MAX - tag[0];
         let mut ciphertext = vec![];
         ciphertext.extend_from_slice(&payload);
         ciphertext.extend_from_slice(&tag);


### PR DESCRIPTION
The unit test attempts to change just one byte from the payload or
tag sequences obtained after AES-GCM encryption, in order to
validate that such a change makes the ciphertext invalid.
Adding 1 to the first byte in the sequence might cause an
overflow. In order to fix this, we now replace the first byte
with its complementary value, which guarantees:
- sequence is changed (replacement value will never be equal to
the value replaced)
- will never overflow

Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Provided in the commit message output above.

## Description of Changes

Provided in the commit message output above.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
