### PR TITLE
Remove `pl031` interrupt from FDT

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ big-endian configured guests.
 - The [SendCtrlAltDel](docs/api_requests/actions.md#sendctrlaltdel) API request
   is not supported for aarch64 enabled microVMs.
 - Configuring CPU templates is only supported for Intel enabled microVMs.
+- The `pl031` RTC device on aarch64 does not support interrupts, so guest
+  programs which use an RTC alarm (e.g. `hwclock`) will not work.
 
 ## Performance
 

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -379,15 +379,15 @@ fn create_rtc_node<T: DeviceInfoForFDT + Clone + Debug>(
     fdt: &mut FdtWriter,
     dev_info: &T,
 ) -> Result<()> {
+    // Driver requirements:
+    // https://elixir.bootlin.com/linux/latest/source/Documentation/devicetree/bindings/rtc/arm,pl031.yaml
+    // We do not offer the `interrupt` property because the device
+    // does not implement interrupt support.
     let compatible = b"arm,pl031\0arm,primecell\0";
 
     let rtc = fdt.begin_node(&format!("rtc@{:x}", dev_info.addr()))?;
     fdt.property("compatible", compatible)?;
     fdt.property_array_u64("reg", &[dev_info.addr(), dev_info.length()])?;
-    fdt.property_array_u32(
-        "interrupts",
-        &[GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_LEVEL_HI],
-    )?;
     fdt.property_u32("clocks", CLOCK_PHANDLE)?;
     fdt.property_string("clock-names", "apb_pclk")?;
     fdt.end_node(rtc)?;


### PR DESCRIPTION
# Reason for This PR

The interrupt is not implemented by the pl031 device, but it is present in the device tree.

## Description of Changes

Removed the interrupt from the device tree, as it is not required (see [driver requirements](https://elixir.bootlin.com/linux/latest/source/Documentation/devicetree/bindings/rtc/arm,pl031.yaml)).

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
