### PR TITLE
docs: update to include MMDS V2 behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
   virtio events throttled because of the IO engine.
 - New optional `version` field to PUT requests towards `/mmds/config` to
   configure MMDS version. Accepted values are `V1` and `V2` and default is
-  `V1`. Known limitation: `V2` does not currently work after snapshot load.
+  `V1`. MMDS `V2` is **developer preview only** (NOT for production use) and
+  it does not currently work after snapshot load.
 - Mandatory `network_interfaces` field to PUT requests towards
   `/mmds/config` which contains a list of network interface IDs capable of
   forwarding packets to MMDS.

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -20,82 +20,81 @@ depends on the device (see [issue #2173](https://github.com/firecracker-microvm/
 
 ## API Endpoints
 
-| Endpoint                  | keyboard | serial console | virtio-block |   virtio-net   | virtio-vsock |
-| ------------------------- | :------: | :------------: | :----------: | :------------: | :----------: |
-| `boot-source`             |    O     |       O        |      O       |       O        |      O       |
-| `drives/{id}`             |    O     |       O        |    **R**     |       O        |      O       |
-| `logger`                  |    O     |       O        |      O       |       O        |      O       |
-| `machine-config`          |    O     |       O        |      O       |       O        |      O       |
-| `metrics`                 |    O     |       O        |      O       |       O        |      O       |
-| `mmds`                    |    O     |       O        |      O       |     **R**      |      O       |
-| `mmds/config`             |    O     |       O        |      O       | O<sup>*</sup> |      O       |
-| `network-interfaces/{id}` |    O     |       O        |      O       |     **R**      |      O       |
-| `snapshot/create`         |    O     |       O        |      O       |       O        |      O       |
-| `snapshot/load`           |    O     |       O        |      O       |       O        |      O       |
-| `vm`                      |    O     |       O        |      O       |       O        |      O       |
-| `vsock`                   |    O     |       O        |      O       |       O        |      O       |
-
-<sup>*</sup>: See [issue #2174](https://github.com/firecracker-microvm/firecracker/issues/2174)
+| Endpoint                  | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
+| ------------------------- | :------: | :------------: | :----------: |:----------:| :----------: |
+| `boot-source`             |    O     |       O        |      O       |     O      |      O       |
+| `drives/{id}`             |    O     |       O        |    **R**     |     O      |      O       |
+| `logger`                  |    O     |       O        |      O       |     O      |      O       |
+| `machine-config`          |    O     |       O        |      O       |     O      |      O       |
+| `metrics`                 |    O     |       O        |      O       |     O      |      O       |
+| `mmds`                    |    O     |       O        |      O       |   **R**    |      O       |
+| `mmds/config`             |    O     |       O        |      O       |   **R**    |      O       |
+| `network-interfaces/{id}` |    O     |       O        |      O       |   **R**    |      O       |
+| `snapshot/create`         |    O     |       O        |      O       |     O      |      O       |
+| `snapshot/load`           |    O     |       O        |      O       |     O      |      O       |
+| `vm`                      |    O     |       O        |      O       |     O      |      O       |
+| `vsock`                   |    O     |       O        |      O       |     O      |      O       |
 
 ## Input Schema
 
 All input schema fields can be found in the [Swagger](https://swagger.io)
 specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 
-| Schema                     | Property              | keyboard | serial console | virtio-block | virtio-net | virtio-vsock |
-| -------------------------- | --------------------- | :------: | :------------: | :----------: | :--------: | :----------: |
-| `BootSource`               | boot_args             |    O     |       O        |      O       |     O      |      O       |
-|                            | initrd_path           |    O     |       O        |      O       |     O      |      O       |
-|                            | kernel_image_path     |    O     |       O        |      O       |     O      |      O       |
-| `CpuTemplate`              | enum                  |    O     |       O        |      O       |     O      |      O       |
-| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |     O      |      O       |
-|                            | snapshot_path         |    O     |       O        |      O       |     O      |      O       |
-|                            | snapshot_type         |    O     |       O        |      O       |     O      |      O       |
-|                            | version               |    O     |       O        |      O       |     O      |      O       |
-| `Drive`                    | drive_id              |    O     |       O        |    **R**     |     O      |      O       |
-|                            | is_read_only          |    O     |       O        |    **R**     |     O      |      O       |
-|                            | is_root_device        |    O     |       O        |    **R**     |     O      |      O       |
-|                            | partuuid              |    O     |       O        |    **R**     |     O      |      O       |
-|                            | path_on_host          |    O     |       O        |    **R**     |     O      |      O       |
-|                            | rate_limiter          |    O     |       O        |    **R**     |     O      |      O       |
-| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |     O      |      O       |
-| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |     O      |      O       |
-|                            | mem_file_path         |    O     |       O        |      O       |     O      |      O       |
-|                            | snapshot_path         |    O     |       O        |      O       |     O      |      O       |
-| `Logger`                   | level                 |    O     |       O        |      O       |     O      |      O       |
-|                            | log_path              |    O     |       O        |      O       |     O      |      O       |
-|                            | show_level            |    O     |       O        |      O       |     O      |      O       |
-|                            | show_log_origin       |    O     |       O        |      O       |     O      |      O       |
-| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |     O      |      O       |
-|                            | ht_enabled            |    O     |       O        |      O       |     O      |      O       |
-|                            | mem_size_mib          |    O     |       O        |      O       |     O      |      O       |
-|                            | track_dirty_pages     |    O     |       O        |      O       |     O      |      O       |
-|                            | vcpu_count            |    O     |       O        |      O       |     O      |      O       |
-| `Metrics`                  | metrics_path          |    O     |       O        |      O       |     O      |      O       |
-| `MmdsConfig`               | ipv4_address          |    O     |       O        |      O       |   **R**    |      O       |
-| `NetworkInterface`         | allow_mmds_requests   |    O     |       O        |      O       |   **R**    |      O       |
-|                            | guest_mac             |    O     |       O        |      O       |   **R**    |      O       |
-|                            | host_dev_name         |    O     |       O        |      O       |   **R**    |      O       |
-|                            | iface_id              |    O     |       O        |      O       |   **R**    |      O       |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |   **R**    |      O       |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |   **R**    |      O       |
-| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |     O      |      O       |
-|                            | path_on_host          |    O     |       O        |    **R**     |     O      |      O       |
-| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |   **R**    |      O       |
-|                            | rx_rate_limiter       |    O     |       O        |      O       |   **R**    |      O       |
-|                            | tx_rate_limiter       |    O     |       O        |      O       |   **R**    |      O       |
-| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |   **R**    |      O       |
-|                            | ops                   |    O     |       O        |    **R**     |     O      |      O       |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |    **R**     |     O      |      O       |
-|                            | refill_time           |    O     |       O        |    **R**     |     O      |      O       |
-|                            | size                  |    O     |       O        |    **R**     |     O      |      O       |
-| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |      O       |   **R**    |      O       |
-|                            | refill_time           |    O     |       O        |      O       |   **R**    |      O       |
-|                            | size                  |    O     |       O        |      O       |   **R**    |      O       |
-| `Vm`                       | state                 |    O     |       O        |      O       |     O      |      O       |
-| `Vsock`                    | guest_cid             |    O     |       O        |      O       |     O      |    **R**     |
-|                            | uds_path              |    O     |       O        |      O       |     O      |    **R**     |
-|                            | vsock_id              |    O     |       O        |      O       |     O      |    **R**     |
+| Schema                     | Property              | keyboard | serial console | virtio-block |  virtio-net   | virtio-vsock |
+|----------------------------|-----------------------| :------: | :------------: | :----------: |:-------------:| :----------: |
+| `BootSource`               | boot_args             |    O     |       O        |      O       |       O       |      O       |
+|                            | initrd_path           |    O     |       O        |      O       |       O       |      O       |
+|                            | kernel_image_path     |    O     |       O        |      O       |       O       |      O       |
+| `CpuTemplate`              | enum                  |    O     |       O        |      O       |       O       |      O       |
+| `CreateSnapshotParams`     | mem_file_path         |    O     |       O        |      O       |       O       |      O       |
+|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |
+|                            | snapshot_type         |    O     |       O        |      O       |       O       |      O       |
+|                            | version               |    O     |       O        |      O       |       O       |      O       |
+| `Drive`                    | drive_id              |    O     |       O        |    **R**     |       O       |      O       |
+|                            | is_read_only          |    O     |       O        |    **R**     |       O       |      O       |
+|                            | is_root_device        |    O     |       O        |    **R**     |       O       |      O       |
+|                            | partuuid              |    O     |       O        |    **R**     |       O       |      O       |
+|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |
+|                            | rate_limiter          |    O     |       O        |    **R**     |       O       |      O       |
+| `InstanceActionInfo`       | action_type           |    O     |       O        |      O       |       O       |      O       |
+| `LoadSnapshotParams`       | enable_diff_snapshots |    O     |       O        |      O       |       O       |      O       |
+|                            | mem_file_path         |    O     |       O        |      O       |       O       |      O       |
+|                            | snapshot_path         |    O     |       O        |      O       |       O       |      O       |
+| `Logger`                   | level                 |    O     |       O        |      O       |       O       |      O       |
+|                            | log_path              |    O     |       O        |      O       |       O       |      O       |
+|                            | show_level            |    O     |       O        |      O       |       O       |      O       |
+|                            | show_log_origin       |    O     |       O        |      O       |       O       |      O       |
+| `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |       O       |      O       |
+|                            | ht_enabled            |    O     |       O        |      O       |       O       |      O       |
+|                            | mem_size_mib          |    O     |       O        |      O       |       O       |      O       |
+|                            | track_dirty_pages     |    O     |       O        |      O       |       O       |      O       |
+|                            | vcpu_count            |    O     |       O        |      O       |       O       |      O       |
+| `Metrics`                  | metrics_path          |    O     |       O        |      O       |       O       |      O       |
+| `MmdsConfig`               | network_interfaces    |    O     |       O        |      O       |     **R**     |      O       |
+|                            | version               |    O     |       O        |      O       |     **R**     |      O       |
+|                            | ipv4_address          |    O     |       O        |      O       |     **R**     |      O       |
+| `NetworkInterface`         | guest_mac             |    O     |       O        |      O       |     **R**     |      O       |
+|                            | host_dev_name         |    O     |       O        |      O       |     **R**     |      O       |
+|                            | iface_id              |    O     |       O        |      O       |     **R**     |      O       |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
+| `PartialDrive`             | drive_id              |    O     |       O        |    **R**     |       O       |      O       |
+|                            | path_on_host          |    O     |       O        |    **R**     |       O       |      O       |
+| `PartialNetworkInterface`  | iface_id              |    O     |       O        |      O       |     **R**     |      O       |
+|                            | rx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
+|                            | tx_rate_limiter       |    O     |       O        |      O       |     **R**     |      O       |
+| `RateLimiter`              | bandwidth             |    O     |       O        |      O       |     **R**     |      O       |
+|                            | ops                   |    O     |       O        |    **R**     |       O       |      O       |
+| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |    **R**     |       O       |      O       |
+|                            | refill_time           |    O     |       O        |    **R**     |       O       |      O       |
+|                            | size                  |    O     |       O        |    **R**     |       O       |      O       |
+| `TokenBucket`<sup>\*</sup> | one_time_burst        |    O     |       O        |      O       |     **R**     |      O       |
+|                            | refill_time           |    O     |       O        |      O       |     **R**     |      O       |
+|                            | size                  |    O     |       O        |      O       |     **R**     |      O       |
+| `Vm`                       | state                 |    O     |       O        |      O       |       O       |      O       |
+| `Vsock`                    | guest_cid             |    O     |       O        |      O       |       O       |    **R**     |
+|                            | uds_path              |    O     |       O        |      O       |       O       |    **R**     |
+|                            | vsock_id              |    O     |       O        |      O       |       O       |    **R**     |
 
 <sup>\*</sup>: The `TokenBucket` can be configured with either the virtio-net
 or virtio-block drivers, or both.


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Include documentation describing MMDS v2 behavior.
This PR is work in progress because it lacks specification regarding MMDS default behavior and version configuration.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
