### PR TITLE
jailer: remove --node parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Changed
 
+- Removed the `--node` jailer parameter.
 - Deprecated `vsock_id` body field in `PUT`s on `/vsock`.
 - Removed the deprecated the `--seccomp-level parameter`.
 - Added `io_engine` to the pre-boot block device configuration.

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -15,7 +15,6 @@ The jailer is invoked in this manner:
 
 ``` bash
 jailer --id <id> \
-       --node <numa_node>\
        --exec-file <exec_file> \
        --uid <uid> \
        --gid <gid>
@@ -32,8 +31,6 @@ jailer --id <id> \
 
 - `id` is the unique VM identification string, which may contain alphanumeric
   characters and hyphens. The maximum `id` length is currently 64 characters.
-- `numa_node` represents the NUMA node the process gets assigned to. More
-  details are available below.
 - `exec_file` is the path to the Firecracker binary that will be exec-ed by the
   jailer. The user can provide a path to any binary, but the interaction with
   the jailer is mostly Firecracker specific.
@@ -264,8 +261,7 @@ Note: default value for `<api-sock>` is `/run/firecracker.socket`.
   device.
 - By default the VMs are not asigned to any NUMA node or pinned to any CPU.
   The user must manage any fine tuning of resource partitioning via
-  cgroups, by using the `--cgroup` command line argument or by using the
-  `--node` argument.
+  cgroups, by using the `--cgroup` command line argument.
 - It’s up to the user to handle cleanup after running the jailer. One way to do
   this involves registering handlers with the cgroup `notify_on_release`
   mechanism, while being wary about potential race conditions (the instance

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -56,7 +56,6 @@ pub enum Error {
     MountPropagationSlave(io::Error),
     NotAFile(PathBuf),
     NotADirectory(PathBuf),
-    NumaNode(String),
     OpenDevNull(io::Error),
     OsStringParsing(PathBuf, OsString),
     PivotRoot(io::Error),
@@ -192,7 +191,6 @@ impl fmt::Display for Error {
                 "{}",
                 format!("{:?} is not a directory", path).replace("\"", "")
             ),
-            NumaNode(ref node) => write!(f, "Invalid numa node: {}", node),
             OpenDevNull(ref err) => write!(f, "Failed to open /dev/null: {}", err),
             OsStringParsing(ref path, _) => write!(
                 f,
@@ -260,12 +258,6 @@ pub fn build_arg_parser() -> ArgParser<'static> {
                 .required(true)
                 .takes_value(true)
                 .help("File path to exec into."),
-        )
-        .arg(
-            Argument::new("node")
-                .required(false)
-                .takes_value(true)
-                .help("NUMA node to assign this microVM to."),
         )
         .arg(
             Argument::new("uid")
@@ -685,10 +677,6 @@ mod tests {
         assert_eq!(
             format!("{}", Error::NotADirectory(file_path.clone())),
             "/foo/bar is not a directory",
-        );
-        assert_eq!(
-            format!("{}", Error::NumaNode(id.to_string())),
-            "Invalid numa node: foobar",
         );
         assert_eq!(
             format!("{}", Error::OpenDevNull(io::Error::from_raw_os_error(42))),

--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -26,7 +26,6 @@ class JailerContext:
     # Keep in sync with parameters from code base.
     jailer_id = None
     exec_file = None
-    numa_node = None
     uid = None
     gid = None
     chroot_base = None
@@ -44,7 +43,6 @@ class JailerContext:
             self,
             jailer_id,
             exec_file,
-            numa_node=None,
             uid=1234,
             gid=1234,
             chroot_base=DEFAULT_CHROOT_PATH,
@@ -65,7 +63,6 @@ class JailerContext:
         """
         self.jailer_id = jailer_id
         self.exec_file = exec_file
-        self.numa_node = numa_node
         self.uid = uid
         self.gid = gid
         self.chroot_base = chroot_base
@@ -103,8 +100,6 @@ class JailerContext:
             jailer_param_list.extend(['--id', str(self.jailer_id)])
         if self.exec_file is not None:
             jailer_param_list.extend(['--exec-file', str(self.exec_file)])
-        if self.numa_node is not None:
-            jailer_param_list.extend(['--node', str(self.numa_node)])
         if self.uid is not None:
             jailer_param_list.extend(['--uid', str(self.uid)])
         if self.gid is not None:

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -279,7 +279,6 @@ def test_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
     """
     # pylint: disable=redefined-outer-name
     test_microvm = test_microvm_with_initrd
-    test_microvm.jailer.numa_node = 0
     test_microvm.jailer.cgroup_ver = sys_setup_cgroups
     if test_microvm.jailer.cgroup_ver == 2:
         test_microvm.jailer.cgroups = ['cpu.weight.nice=10']
@@ -289,26 +288,33 @@ def test_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
             'cpu.cfs_period_us=200000'
         ]
 
-    test_microvm.spawn()
-
     # Retrieve CPUs from NUMA node 0.
-    node_cpus = get_cpus(test_microvm.jailer.numa_node)
+    node_cpus = get_cpus(0)
 
-    # Appending the cgroups that should be creating by --node option
-    # This must be changed once --node options is removed
-    cgroups = test_microvm.jailer.cgroups + [
+    # Appending the cgroups for numa node 0.
+    test_microvm.jailer.cgroups = test_microvm.jailer.cgroups + [
         'cpuset.mems=0',
         'cpuset.cpus={}'.format(node_cpus)
     ]
+
+    test_microvm.spawn()
 
     # We assume sysfs cgroups are mounted here.
     sys_cgroup = '/sys/fs/cgroup'
     assert os.path.isdir(sys_cgroup)
 
     if test_microvm.jailer.cgroup_ver == 1:
-        check_cgroups_v1(cgroups, sys_cgroup, test_microvm.jailer.jailer_id)
+        check_cgroups_v1(
+            test_microvm.jailer.cgroups,
+            sys_cgroup,
+            test_microvm.jailer.jailer_id
+        )
     else:
-        check_cgroups_v2(cgroups, sys_cgroup, test_microvm.jailer.jailer_id)
+        check_cgroups_v2(
+            test_microvm.jailer.cgroups,
+            sys_cgroup,
+            test_microvm.jailer.jailer_id
+        )
 
 
 def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
@@ -319,7 +325,6 @@ def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
     """
     # pylint: disable=redefined-outer-name
     test_microvm = test_microvm_with_initrd
-    test_microvm.jailer.numa_node = 0
     test_microvm.jailer.cgroup_ver = sys_setup_cgroups
     test_microvm.jailer.parent_cgroup = "custom_cgroup/group2"
     if test_microvm.jailer.cgroup_ver == 2:
@@ -330,17 +335,15 @@ def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
             'cpu.cfs_period_us=200000'
         ]
 
-    test_microvm.spawn()
-
     # Retrieve CPUs from NUMA node 0.
-    node_cpus = get_cpus(test_microvm.jailer.numa_node)
+    node_cpus = get_cpus(0)
 
-    # Appending the cgroups that should be creating by --node option
-    # This must be changed once --node options is removed
-    cgroups = test_microvm.jailer.cgroups + [
+    test_microvm.jailer.cgroups = test_microvm.jailer.cgroups + [
         'cpuset.mems=0',
         'cpuset.cpus={}'.format(node_cpus)
     ]
+
+    test_microvm.spawn()
 
     # We assume sysfs cgroups are mounted here.
     sys_cgroup = '/sys/fs/cgroup'
@@ -348,14 +351,14 @@ def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
 
     if test_microvm.jailer.cgroup_ver == 1:
         check_cgroups_v1(
-            cgroups,
+            test_microvm.jailer.cgroups,
             sys_cgroup,
             test_microvm.jailer.jailer_id,
             test_microvm.jailer.parent_cgroup
         )
     else:
         check_cgroups_v2(
-            cgroups,
+            test_microvm.jailer.cgroups,
             sys_cgroup,
             test_microvm.jailer.jailer_id,
             test_microvm.jailer.parent_cgroup
@@ -364,36 +367,41 @@ def test_cgroups_custom_parent(test_microvm_with_initrd, sys_setup_cgroups):
 
 def test_node_cgroups(test_microvm_with_initrd, sys_setup_cgroups):
     """
-    Test the --node cgroups are correctly set by the jailer.
+    Test the numa node cgroups are correctly set by the jailer.
 
     @type: security
     """
     # pylint: disable=redefined-outer-name
     test_microvm = test_microvm_with_initrd
-    test_microvm.jailer.cgroups = None
-    test_microvm.jailer.numa_node = 0
     test_microvm.jailer.cgroup_ver = sys_setup_cgroups
 
-    test_microvm.spawn()
-
     # Retrieve CPUs from NUMA node 0.
-    node_cpus = get_cpus(test_microvm.jailer.numa_node)
+    node_cpus = get_cpus(0)
 
-    # Appending the cgroups that should be creating by --node option
-    # This must be changed once --node options is removed
-    cgroups = [
+    # Appending the cgroups for numa node 0
+    test_microvm.jailer.cgroups = [
         'cpuset.mems=0',
         'cpuset.cpus={}'.format(node_cpus)
     ]
+
+    test_microvm.spawn()
 
     # We assume sysfs cgroups are mounted here.
     sys_cgroup = '/sys/fs/cgroup'
     assert os.path.isdir(sys_cgroup)
 
     if test_microvm.jailer.cgroup_ver == 1:
-        check_cgroups_v1(cgroups, sys_cgroup, test_microvm.jailer.jailer_id)
+        check_cgroups_v1(
+            test_microvm.jailer.cgroups,
+            sys_cgroup,
+            test_microvm.jailer.jailer_id
+        )
     else:
-        check_cgroups_v2(cgroups, sys_cgroup, test_microvm.jailer.jailer_id)
+        check_cgroups_v2(
+            test_microvm.jailer.cgroups,
+            sys_cgroup,
+            test_microvm.jailer.jailer_id
+        )
 
 
 def test_cgroups_without_numa(test_microvm_with_initrd, sys_setup_cgroups):


### PR DESCRIPTION
# Reason for This PR

Fixes #2613

## Description of Changes

Remove the jailer --node parameter since it's duplicate functionality.
A user can set the numa node where Firecracker can run using the cpuset
cgroup controller.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [] The issue which led to this PR has a clear conclusion.
- [] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
