### PR TITLE
IrqManager: don't allocate RTC interrupt number

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -293,9 +293,7 @@ impl MMIODeviceManager {
         dev_info_opt: Option<MMIODeviceInfo>,
     ) -> Result<()> {
         // Create and attach a new RTC device.
-        // We allocate an IRQ even though we do not need it so that
-        // we do not break snapshot compatibility.
-        let slot = dev_info_opt.unwrap_or(self.allocate_new_slot(1)?);
+        let slot = dev_info_opt.unwrap_or(self.allocate_new_slot(0)?);
 
         let identifier = (DeviceType::Rtc, DeviceType::Rtc.to_string());
         self.register_mmio_device(identifier, slot, rtc)


### PR DESCRIPTION
We've removed the RTC device interrupt from the FDT
and we also no longer allocate an irqfd for it, so
we may safely remove the leftover allocated irq number.

Signed-off-by: alindima <alindima@amazon.com>

# Reason for This PR

View commit message

## Description of Changes

Remove the irq number allocation for the RTC device.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
