### PR TITLE
Configure MMDS version through `/mmds/config` instead of `/mmds/version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
   See `docs/api_requests/block-io-engine.md`.
 - Added `block.io_engine_throttled_events` metric for measuring the number of
   virtio events throttled because of the IO engine.
+- New optional `version` field to PUT requests towards `/mmds/config` to
+  configure MMDS version. Accepted values are `V1` and `V2` and default is
+  `V1`. Known limitation: `V2` does not currently work after snapshot load.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@
   `X-metadata-token`, which accepts a string value that provides a session
   token for MMDS requests; and `X-metadata-token-ttl-seconds`, which
   specifies the lifetime of the session token in seconds.
-- Added `PUT` request on `/mmds/version` that configures the MMDS version.
-  Accepted values are either `V1` or `V2`.
-- Added `GET` request on `/mmds/version` that provides the MMDS version.
-  Default value is `V2`.
 - Support and validation for host and guest kernel 5.10.
 - A [kernel support policy](docs/kernel-policy.md).
 - Added `io_engine` to the pre-boot block device configuration.

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -347,15 +347,8 @@ impl ApiServer {
     }
 
     fn put_mmds(&self, value: serde_json::Value) -> Response {
-        let mmds_response = self.unlock_mmds().put_data(value);
-
-        match mmds_response {
-            Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
-            Err(e) => ApiServer::json_response(
-                StatusCode::BadRequest,
-                ApiServer::json_fault_message(e.to_string()),
-            ),
-        }
+        self.unlock_mmds().put_data(value);
+        Response::new(Version::Http11, StatusCode::NoContent)
     }
 
     /// An HTTP response which also includes a body.

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -430,7 +430,8 @@ paths:
     put:
       summary: Set MMDS configuration. Pre-boot only.
       description:
-        Creates MMDS configuration to be used by the MMDS network stack.
+        Configures MMDS version, IPv4 address used by the MMDS network stack
+        and interfaces that allow MMDS requests.
       parameters:
         - name: body
           in: body
@@ -963,6 +964,13 @@ definitions:
     description:
       Defines the MMDS configuration.
     properties:
+      version:
+        description: Enumeration indicating the MMDS version to be configured.
+        type: string
+        enum:
+          - V1
+          - V2
+        default: V1
       ipv4_address:
         type: string
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -450,40 +450,6 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /mmds/version:
-    put:
-      summary: Sets MMDS version.
-      operationId: putMmdsVersion
-      parameters:
-        - name: version
-          in: body
-          required: true
-          schema:
-            $ref: "#/definitions/MmdsVersion"
-      responses:
-        204:
-          description: MMDS version set.
-        400:
-          description: MMDS version cannot be set due to bad input.
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error.
-          schema:
-            $ref: "#/definitions/Error"
-    get:
-      summary: Get the MMDS version.
-      operationId: getMmdsVersion
-      responses:
-        200:
-          description: The MMDS version.
-          schema:
-            $ref: "#/definitions/MmdsVersion"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-
   /network-interfaces/{iface_id}:
     put:
       summary: Creates a network interface. Pre-boot only.
@@ -1002,21 +968,6 @@ definitions:
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
         default: "169.254.169.254"
         description: A valid IPv4 link-local address.
-
-  MmdsVersion:
-    type: object
-    description:
-      Variant wrapper containing the MMDS version.
-    required:
-      - version
-    properties:
-      version:
-        description: Enumeration indicating the MMDS version configured.
-        type: string
-        enum:
-          - V1
-          - V2
-        default: V2
 
   NetworkInterface:
     type: object

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -134,17 +134,10 @@ pub(crate) fn run_with_api(
     let (to_vmm, from_api) = channel();
     let (to_api, from_vmm) = channel();
 
-    // MMDS only supported with API.
+    MMDS.lock()
+        .expect("Failed to acquire lock on MMDS")
+        .set_data_store_limit(payload_limit.unwrap_or(MAX_DATA_STORE_SIZE));
     let mmds_info = MMDS.clone();
-    if let Some(mmds) = mmds_info
-        .lock()
-        .expect("Failed to acquire lock on MMDS info")
-        .as_mut()
-    {
-        mmds.set_data_store_limit(payload_limit.unwrap_or(MAX_DATA_STORE_SIZE));
-        mmds.set_aad(&instance_info.id);
-    }
-
     let to_vmm_event_fd = api_event_fd
         .try_clone()
         .expect("Failed to clone API event FD");

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -306,16 +306,13 @@ fn main_exitable() -> ExitCode {
         .map(fs::read_to_string)
         .map(|x| x.expect("Unable to open or read from the mmds content file"));
 
-    if let (Some(data), Some(mmds)) = (
-        metadata_json,
+    if let Some(data) = metadata_json {
         MMDS.lock()
             .expect("Failed to acquire lock on MMDS")
-            .as_mut(),
-    ) {
-        mmds.put_data(
-            serde_json::from_str(&data).expect("MMDS error: metadata provided not valid json"),
-        )
-        .expect("MMDS content load from file failed.");
+            .put_data(
+                serde_json::from_str(&data).expect("MMDS error: metadata provided not valid json"),
+            )
+            .expect("MMDS content load from file failed.");
 
         info!("Successfully added metadata to mmds from file");
     }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -311,8 +311,7 @@ fn main_exitable() -> ExitCode {
             .expect("Failed to acquire lock on MMDS")
             .put_data(
                 serde_json::from_str(&data).expect("MMDS error: metadata provided not valid json"),
-            )
-            .expect("MMDS content load from file failed.");
+            );
 
         info!("Successfully added metadata to mmds from file");
     }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -171,10 +171,9 @@ impl Mmds {
     // We do not check data_store size here because a request with a body
     // bigger than the imposed limit will be stopped by micro_http before
     // reaching here.
-    pub fn put_data(&mut self, data: Value) -> Result<(), Error> {
+    pub fn put_data(&mut self, data: Value) {
         self.data_store = data;
         self.is_initialized = true;
-        Ok(())
     }
 
     pub fn patch_data(&mut self, patch_data: Value) -> Result<(), Error> {
@@ -329,8 +328,7 @@ mod tests {
 
         let mut mmds_json = "{\"meta-data\":{\"iam\":\"dummy\"},\"user-data\":\"1522850095\"}";
 
-        mmds.put_data(serde_json::from_str(mmds_json).unwrap())
-            .unwrap();
+        mmds.put_data(serde_json::from_str(mmds_json).unwrap());
         assert!(mmds.check_data_store_initialized().is_ok());
 
         assert_eq!(mmds.get_data_str(), mmds_json);
@@ -361,7 +359,7 @@ mod tests {
             "balance": -24
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        mmds.put_data(data_store).unwrap();
+        mmds.put_data(data_store);
 
         // Test invalid path.
         assert_eq!(
@@ -513,7 +511,7 @@ mod tests {
             "age": "43"
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.put_data(data_store).is_ok());
+        mmds.put_data(data_store);
 
         let data = r#"{
             "name": {
@@ -533,7 +531,7 @@ mod tests {
             "age": 43
         }"#;
         let data_store: Value = serde_json::from_str(data).unwrap();
-        assert!(mmds.put_data(data_store).is_ok());
+        mmds.put_data(data_store);
 
         let data = r#"{
             "name": {

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -18,7 +18,7 @@ pub struct Mmds {
 }
 
 /// MMDS version.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum MmdsVersion {
     V1,
     V2,
@@ -306,15 +306,15 @@ mod tests {
         let mut mmds = Mmds::default();
 
         // Test default MMDS version.
-        assert_eq!(mmds.version().to_string(), MmdsVersion::V1.to_string());
+        assert_eq!(mmds.version(), MmdsVersion::V1);
 
         // Test setting MMDS version to v2.
         mmds.set_version(MmdsVersion::V2).unwrap();
-        assert_eq!(mmds.version().to_string(), MmdsVersion::V2.to_string());
+        assert_eq!(mmds.version(), MmdsVersion::V2);
 
         // Test setting MMDS version back to default.
         mmds.set_version(MmdsVersion::V1).unwrap();
-        assert_eq!(mmds.version().to_string(), MmdsVersion::V1.to_string());
+        assert_eq!(mmds.version(), MmdsVersion::V1);
     }
 
     #[test]
@@ -575,7 +575,7 @@ mod tests {
         let mut mmds = Mmds::default();
         // Set MMDS version to V2.
         mmds.set_version(MmdsVersion::V2).unwrap();
-        assert_eq!(mmds.version().to_string(), MmdsVersion::V2.to_string());
+        assert_eq!(mmds.version(), MmdsVersion::V2);
 
         assert!(!mmds.is_valid_token("aaa").unwrap());
 
@@ -591,7 +591,7 @@ mod tests {
         let mut mmds = Mmds::default();
         // Set MMDS version to V2.
         mmds.set_version(MmdsVersion::V2).unwrap();
-        assert_eq!(mmds.version().to_string(), MmdsVersion::V2.to_string());
+        assert_eq!(mmds.version(), MmdsVersion::V2);
 
         let token = mmds.generate_token(1).unwrap();
         assert!(mmds.is_valid_token(&token).unwrap());

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -347,8 +347,7 @@ mod tests {
         let mmds = MMDS.clone();
         mmds.lock()
             .expect("Poisoned lock")
-            .put_data(serde_json::from_str(data).unwrap())
-            .unwrap();
+            .put_data(serde_json::from_str(data).unwrap());
 
         mmds
     }

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -399,8 +399,8 @@ mod tests {
             .set_version(MmdsVersion::V1)
             .unwrap();
         assert_eq!(
-            mmds.lock().expect("Poisoned lock").version().to_string(),
-            MmdsVersion::V1.to_string()
+            mmds.lock().expect("Poisoned lock").version(),
+            MmdsVersion::V1
         );
 
         // Test resource not found.
@@ -476,8 +476,8 @@ mod tests {
             .set_version(MmdsVersion::V2)
             .unwrap();
         assert_eq!(
-            mmds.lock().expect("Poisoned lock").version().to_string(),
-            MmdsVersion::V2.to_string()
+            mmds.lock().expect("Poisoned lock").version(),
+            MmdsVersion::V2
         );
 
         // Test not allowed PATCH HTTP Method.

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use mmds::data_store;
+use mmds::data_store::MmdsVersion;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result};
 use std::net::Ipv4Addr;
@@ -9,11 +11,19 @@ use std::net::Ipv4Addr;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MmdsConfig {
+    /// MMDS version.
+    #[serde(default)]
+    pub version: MmdsVersion,
     /// MMDS IPv4 configured address.
     pub ipv4_address: Option<Ipv4Addr>,
 }
 
 impl MmdsConfig {
+    /// Returns the MMDS version configured.
+    pub fn version(&self) -> MmdsVersion {
+        self.version
+    }
+
     /// Returns the MMDS IPv4 address if one was configured.
     /// Otherwise returns None.
     pub fn ipv4_addr(&self) -> Option<Ipv4Addr> {
@@ -26,6 +36,8 @@ impl MmdsConfig {
 pub enum MmdsConfigError {
     /// The provided IPv4 address is not link-local valid.
     InvalidIpv4Addr,
+    /// MMDS version could not be configured.
+    MmdsVersion(MmdsVersion, data_store::Error),
 }
 
 impl Display for MmdsConfigError {
@@ -33,6 +45,13 @@ impl Display for MmdsConfigError {
         match self {
             MmdsConfigError::InvalidIpv4Addr => {
                 write!(f, "The MMDS IPv4 address is not link local.")
+            }
+            MmdsConfigError::MmdsVersion(version, err) => {
+                write!(
+                    f,
+                    "The MMDS could not be configured to version {}: {}",
+                    version, err
+                )
             }
         }
     }

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -656,13 +656,6 @@ class MMDS():
             json=args['json']
         )
 
-    def put_mmds_version(self, **args):
-        """Send a new MMDS version request."""
-        return self._api_session.put(
-            "{}".format(self._mmds_cfg_url + "/version"),
-            json=args['json']
-        )
-
     def patch(self, **args):
         """Update the details of some MMDS request."""
         return self._api_session.patch(
@@ -674,12 +667,6 @@ class MMDS():
         """Get the status of the MMDS request."""
         return self._api_session.get(
             self._mmds_cfg_url
-        )
-
-    def get_mmds_version(self):
-        """Get the MMDS version."""
-        return self._api_session.get(
-            "{}".format(self._mmds_cfg_url + "/version")
         )
 
 

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -27,5 +27,8 @@
   "vsock": null,
   "logger": null,
   "metrics": null,
-  "mmds-config": null
+  "mmds-config": {
+    "version": "V2",
+    "ipv4_address": "169.254.169.250"
+  }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.04, "AMD": 84.51, "ARM": 84.05}
+    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.13}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 80.99}
+    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.07}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1323,68 +1323,6 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
 
-def test_api_mmds_version(test_microvm_with_api, network_config):
-    """
-    Test MMDS version related API commands.
-
-    @type: functional
-    """
-    test_microvm = test_microvm_with_api
-    test_microvm.spawn()
-
-    v2_json = {
-        'version': 'V2'
-    }
-    # Test default MMDS version is V2.
-    response = test_microvm.mmds.get_mmds_version()
-    assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json() == v2_json
-
-    # Configure MMDS to version 1.
-    v1_json = {
-        'version': 'V1'
-    }
-    response = test_microvm.mmds.put_mmds_version(json=v1_json)
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
-
-    # Test MMDS version has been updated.
-    response = test_microvm.mmds.get_mmds_version()
-    assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json() == v1_json
-
-    test_microvm.basic_config(vcpu_count=1)
-    _tap = test_microvm.ssh_network_config(
-        network_config,
-        '1',
-        allow_mmds_requests=True
-    )
-
-    # Empty json should reset MMDS version to default.
-    response = test_microvm.mmds.put_mmds_version(json={})
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
-
-    # Ensure MMDS version has been reset.
-    response = test_microvm.mmds.get_mmds_version()
-    assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json() == v2_json
-
-    test_microvm.start()
-
-    # Ensure MMDS version post-boot is consistent.
-    response = test_microvm.mmds.get_mmds_version()
-    assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json() == v2_json
-
-    # Configure MMDS version to V1 after vm has started.
-    response = test_microvm.mmds.put_mmds_version(json=v1_json)
-    assert test_microvm.api_session.is_status_no_content(response.status_code)
-
-    # Test MMDS version has been updated.
-    response = test_microvm.mmds.get_mmds_version()
-    assert test_microvm.api_session.is_status_ok(response.status_code)
-    assert response.json() == v1_json
-
-
 def test_negative_api_mmds_version(test_microvm_with_api):
     """
     Test negative scenarios of MMDS version API.


### PR DESCRIPTION
# Reason for This PR

## Description of Changes

- Make MMDS V1 as default
- Configure MMDS version through `/mmds/config` instead of `/mmds/version`
- Remove `/mmds/version` endpoint

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
