### PR TITLE
Specify network interfaces that accept MMDS requests through `/mmds/config` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - New optional `version` field to PUT requests towards `/mmds/config` to
   configure MMDS version. Accepted values are `V1` and `V2` and default is
   `V1`. Known limitation: `V2` does not currently work after snapshot load.
+- Mandatory `network_interfaces` field to PUT requests towards
+  `/mmds/config` which contains a list of network interface IDs capable of
+  forwarding packets to MMDS.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
   `X-metadata-token` header when using V2.
 - Allow `PUT` requests to MMDS in order to generate a session token
   to be used for future `GET` requests when version 2 is used.
+- Remove `allow_mmds_requests` field from the request body that attaches network
+  interfaces. Specifying interfaces that allow forwarding requests to MMDS is done
+  by adding the network interface's ID to the `network_interfaces` field of PUT
+  `/mmds/config` request's body.
 
 ### Fixed
 

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -836,7 +836,10 @@ pub(crate) mod tests {
         assert!(ParsedRequest::try_from_request(&req).is_ok());
 
         // `/mmds/config`
-        let body = "{\"ipv4_address\":\"169.254.170.2\"}";
+        let body = "{ \
+            \"ipv4_address\": \"169.254.170.2\", \
+            \"network_interfaces\": [\"iface0\"] \
+        }";
         sender
             .write_all(http_request("PUT", "/mmds/config", Some(&body)).as_bytes())
             .unwrap();

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -856,7 +856,6 @@ pub(crate) mod tests {
             \"iface_id\": \"string\", \
             \"guest_mac\": \"12:34:56:78:9a:BC\", \
             \"host_dev_name\": \"string\", \
-            \"allow_mmds_requests\": true, \
             \"rx_rate_limiter\": { \
                 \"bandwidth\": { \
                     \"size\": 0, \

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -73,19 +73,38 @@ mod tests {
 
         // Test `config` path.
         let body = r#"{
-                "ipv4_address": "169.254.170.2"
+                "version": "V2",
+                "ipv4_address": "169.254.170.2",
+                "network_interfaces": []
               }"#;
         let config_path = "config";
         assert!(parse_put_mmds(&Body::new(body), Some(&config_path)).is_ok());
 
         let body = r#"{
-                "ipv4_address": ""
+                "network_interfaces": []
               }"#;
+        let config_path = "config";
+        assert!(parse_put_mmds(&Body::new(body), Some(&config_path)).is_ok());
+
+        let body = r#"{
+                "version": "foo",
+                "ipv4_address": "169.254.170.2",
+                "network_interfaces": []
+              }"#;
+        let config_path = "config";
         assert!(parse_put_mmds(&Body::new(body), Some(&config_path)).is_err());
 
-        // Equivalent to reset the mmds configuration.
-        let empty_body = r#"{}"#;
-        assert!(parse_put_mmds(&Body::new(empty_body), Some(&config_path)).is_ok());
+        let body = r#"{
+                "version": "V2"
+              }"#;
+        let config_path = "config";
+        assert!(parse_put_mmds(&Body::new(body), Some(&config_path)).is_err());
+
+        let body = r#"{
+                "ipv4_address": "",
+                "network_interfaces": []
+              }"#;
+        assert!(parse_put_mmds(&Body::new(body), Some(&config_path)).is_err());
 
         let invalid_config_body = r#"{
                 "invalid_config": "invalid_value"

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -74,8 +74,7 @@ mod tests {
         let body = r#"{
                 "iface_id": "foo",
                 "host_dev_name": "bar",
-                "guest_mac": "12:34:56:78:9A:BC",
-                "allow_mmds_requests": false
+                "guest_mac": "12:34:56:78:9A:BC"
               }"#;
         // 1. Exercise infamous "The id from the path does not match id from the body!".
         assert!(parse_put_net(&Body::new(body), Some(&"bar")).is_err());

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -999,14 +999,6 @@ definitions:
       - host_dev_name
       - iface_id
     properties:
-      allow_mmds_requests:
-        type: boolean
-        description:
-          If this field is set, the device model will reply to HTTP GET
-          requests sent to the MMDS address via this interface. In this case,
-          both ARP requests for 169.254.169.254 and TCP segments heading to the
-          same address are intercepted by the device model, and do not reach
-          the associated TAP device.
       guest_mac:
         type: string
       host_dev_name:

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -963,6 +963,8 @@ definitions:
     type: object
     description:
       Defines the MMDS configuration.
+    required:
+      - network_interfaces
     properties:
       version:
         description: Enumeration indicating the MMDS version to be configured.
@@ -971,6 +973,18 @@ definitions:
           - V1
           - V2
         default: V1
+      network_interfaces:
+        description:
+          List of the network interface IDs capable of forwarding packets to
+          the MMDS. Network interface IDs mentioned must be valid at the time
+          of this request. The net device model will reply to HTTP GET requests
+          sent to the MMDS address via the interfaces mentioned. In this
+          case, both ARP requests and TCP segments heading to `ipv4_address`
+          are intercepted by the device model, and do not reach the associated
+          TAP device.
+        type: array
+        items:
+          type: string
       ipv4_address:
         type: string
         format: "169.254.([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-4]).([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -225,11 +225,19 @@ impl Net {
         self.mmds_ns.is_some()
     }
 
-    /// Sets MMDS endpoint IPv4 address, if the device supports MMDS.
-    pub fn set_mmds_ipv4_addr(&mut self, ipv4_addr: Ipv4Addr) {
+    /// Configures the `MmdsNetworkStack` to allow device to forward MMDS requests.
+    /// If the device already supports MMDS, updates the IPv4 address.
+    pub fn configure_mmds_network_stack(&mut self, ipv4_addr: Ipv4Addr) {
         if let Some(mmds_ns) = self.mmds_ns.as_mut() {
             mmds_ns.set_ipv4_addr(ipv4_addr);
+        } else {
+            self.mmds_ns = Some(MmdsNetworkStack::new_with_defaults(Some(ipv4_addr)))
         }
+    }
+
+    /// Disables the `MmdsNetworkStack` to prevent device to forward MMDS requests.
+    pub fn disable_mmds_network_stack(&mut self) {
+        self.mmds_ns = None
     }
 
     /// Provides a reference to the configured RX rate limiter.

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -220,11 +220,6 @@ impl Net {
         self.tap.if_name_as_str().to_string()
     }
 
-    /// Says if this device supports MMDS.
-    pub fn mmds_enabled(&self) -> bool {
-        self.mmds_ns.is_some()
-    }
-
     /// Configures the `MmdsNetworkStack` to allow device to forward MMDS requests.
     /// If the device already supports MMDS, updates the IPv4 address.
     pub fn configure_mmds_network_stack(&mut self, ipv4_addr: Ipv4Addr) {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1273,7 +1273,6 @@ pub mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
-            allow_mmds_requests: true,
         };
 
         let mut cmdline = default_kernel_cmdline();

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -569,7 +569,6 @@ mod tests {
                 guest_mac: None,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
-                allow_mmds_requests: true,
             };
             insert_net_device(
                 &mut vmm,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -564,7 +564,6 @@ mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
-            allow_mmds_requests: true,
         };
         insert_net_device(
             &mut vmm,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -439,7 +439,6 @@ mod tests {
             guest_mac: Some(MacAddr::parse_str("01:23:45:67:89:0a").unwrap()),
             rx_rate_limiter: Some(RateLimiterConfig::default()),
             tx_rate_limiter: Some(RateLimiterConfig::default()),
-            allow_mmds_requests: false,
         }
     }
 
@@ -769,8 +768,7 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif",
-                            "host_dev_name": "hostname8",
-                            "allow_mmds_requests": true
+                            "host_dev_name": "hostname8"
                         }}
                     ],
                     "machine-config": {{
@@ -814,8 +812,7 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif",
-                            "host_dev_name": "hostname9",
-                            "allow_mmds_requests": true
+                            "host_dev_name": "hostname9"
                         }}
                     ],
                     "machine-config": {{

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1155,7 +1155,6 @@ mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
-            allow_mmds_requests: false,
         });
         check_preboot_request(req, |result, vm_res| {
             assert_eq!(result, Ok(VmmData::Empty));
@@ -1168,7 +1167,6 @@ mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
-            allow_mmds_requests: false,
         });
         check_preboot_request_err(
             req,
@@ -1590,7 +1588,6 @@ mod tests {
                 guest_mac: None,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
-                allow_mmds_requests: false,
             }),
             VmmActionError::OperationNotSupportedPostBoot,
         );
@@ -1685,7 +1682,6 @@ mod tests {
             guest_mac: None,
             rx_rate_limiter: None,
             tx_rate_limiter: None,
-            allow_mmds_requests: false,
         });
         verify_load_snap_disallowed_after_boot_resources(req, "InsertNetworkDevice");
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1208,6 +1208,7 @@ mod tests {
         let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
             ipv4_address: None,
             version: MmdsVersion::default(),
+            network_interfaces: Vec::new(),
         });
         check_preboot_request(req, |result, vm_res| {
             assert_eq!(result, Ok(VmmData::Empty));
@@ -1217,6 +1218,7 @@ mod tests {
         let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
             ipv4_address: None,
             version: MmdsVersion::default(),
+            network_interfaces: Vec::new(),
         });
         check_preboot_request_err(
             req,
@@ -1616,6 +1618,7 @@ mod tests {
             VmmAction::SetMmdsConfiguration(MmdsConfig {
                 ipv4_address: None,
                 version: MmdsVersion::default(),
+                network_interfaces: Vec::new(),
             }),
             VmmActionError::OperationNotSupportedPostBoot,
         );
@@ -1702,6 +1705,7 @@ mod tests {
         let req = VmmAction::SetMmdsConfiguration(MmdsConfig {
             ipv4_address: None,
             version: MmdsVersion::default(),
+            network_interfaces: Vec::new(),
         });
         verify_load_snap_disallowed_after_boot_resources(req, "SetMmdsConfiguration");
     }

--- a/src/vmm/src/vmm_config/mmds.rs
+++ b/src/vmm/src/vmm_config/mmds.rs
@@ -14,6 +14,8 @@ pub struct MmdsConfig {
     /// MMDS version.
     #[serde(default)]
     pub version: MmdsVersion,
+    /// Network interfaces that allow forwarding packets to MMDS.
+    pub network_interfaces: Vec<String>,
     /// MMDS IPv4 configured address.
     pub ipv4_address: Option<Ipv4Addr>,
 }
@@ -22,6 +24,11 @@ impl MmdsConfig {
     /// Returns the MMDS version configured.
     pub fn version(&self) -> MmdsVersion {
         self.version
+    }
+
+    /// Returns the network interfaces that accept MMDS requests.
+    pub fn network_interfaces(&self) -> Vec<String> {
+        self.network_interfaces.clone()
     }
 
     /// Returns the MMDS IPv4 address if one was configured.
@@ -34,8 +41,13 @@ impl MmdsConfig {
 /// MMDS configuration related errors.
 #[derive(Debug)]
 pub enum MmdsConfigError {
+    /// The network interfaces list provided is empty.
+    EmptyNetworkIfaceList,
     /// The provided IPv4 address is not link-local valid.
     InvalidIpv4Addr,
+    /// The network interfaces list provided contains IDs that
+    /// does not correspond to any existing network interface.
+    InvalidNetworkInterfaceId,
     /// MMDS version could not be configured.
     MmdsVersion(MmdsVersion, data_store::Error),
 }
@@ -43,8 +55,22 @@ pub enum MmdsConfigError {
 impl Display for MmdsConfigError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
+            MmdsConfigError::EmptyNetworkIfaceList => {
+                write!(
+                    f,
+                    "The list of network interface IDs that allow \
+                    forwarding MMDS requests is empty."
+                )
+            }
             MmdsConfigError::InvalidIpv4Addr => {
                 write!(f, "The MMDS IPv4 address is not link local.")
+            }
+            MmdsConfigError::InvalidNetworkInterfaceId => {
+                write!(
+                    f,
+                    "The list of network interface IDs provided contains at least one ID \
+                    that does not correspond to any existing network interface."
+                )
             }
             MmdsConfigError::MmdsVersion(version, err) => {
                 write!(

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -30,13 +30,6 @@ pub struct NetworkInterfaceConfig {
     pub rx_rate_limiter: Option<RateLimiterConfig>,
     /// Rate Limiter for transmitted packages.
     pub tx_rate_limiter: Option<RateLimiterConfig>,
-    #[serde(default = "default_allow_mmds_requests")]
-    /// If this field is set, the device model will reply to HTTP GET
-    /// requests sent to the MMDS address via this interface. In this case,
-    /// both ARP requests for `169.254.169.254` and TCP segments heading to the
-    /// same address are intercepted by the device model, and do not reach
-    /// the associated TAP device.
-    pub allow_mmds_requests: bool,
 }
 
 impl From<&Net> for NetworkInterfaceConfig {
@@ -49,16 +42,8 @@ impl From<&Net> for NetworkInterfaceConfig {
             guest_mac: net.guest_mac().copied(),
             rx_rate_limiter: rx_rl.into_option(),
             tx_rate_limiter: tx_rl.into_option(),
-            allow_mmds_requests: net.mmds_enabled(),
         }
     }
-}
-
-// Serde does not allow specifying a default value for a field
-// that is not required. The workaround is to specify a function
-// that returns the value.
-fn default_allow_mmds_requests() -> bool {
-    false
 }
 
 /// The data fed into a network iface update request. Currently, only the RX and TX rate limiters
@@ -202,7 +187,7 @@ impl NetBuilder {
             cfg.guest_mac.as_ref(),
             rx_rate_limiter.unwrap_or_default(),
             tx_rate_limiter.unwrap_or_default(),
-            cfg.allow_mmds_requests,
+            false,
         )
         .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
@@ -240,7 +225,6 @@ mod tests {
             guest_mac: Some(MacAddr::parse_str(mac).unwrap()),
             rx_rate_limiter: RateLimiterConfig::default().into_option(),
             tx_rate_limiter: RateLimiterConfig::default().into_option(),
-            allow_mmds_requests: false,
         }
     }
 
@@ -252,7 +236,6 @@ mod tests {
                 guest_mac: self.guest_mac,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
-                allow_mmds_requests: self.allow_mmds_requests,
             }
         }
     }
@@ -383,7 +366,6 @@ mod tests {
             net_if_cfg.guest_mac.unwrap(),
             MacAddr::parse_str(guest_mac).unwrap()
         );
-        assert_eq!(net_if_cfg.allow_mmds_requests, false);
 
         let mut net_builder = NetBuilder::new();
         assert!(net_builder.build(net_if_cfg.clone()).is_ok());

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -124,8 +124,7 @@ class MicrovmBuilder:
             response = vm.network.put(
                 iface_id=iface.dev_name,
                 host_dev_name=iface.tap_name,
-                guest_mac=guest_mac,
-                allow_mmds_requests=True,
+                guest_mac=guest_mac
             )
             assert vm.api_session.is_status_no_content(response.status_code)
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -762,7 +762,6 @@ class Microvm:
             self,
             network_config,
             iface_id,
-            allow_mmds_requests=False,
             tx_rate_limiter=None,
             rx_rate_limiter=None,
             tapname=None
@@ -774,7 +773,6 @@ class Microvm:
         ssh_config dictionary.
         :param network_config: UniqueIPv4Generator instance
         :param iface_id: the interface id for the API request
-        :param allow_mmds_requests: specifies whether requests sent from
         the guest on this interface towards the MMDS address are
         intercepted and processed by the device model.
         :param tx_rate_limiter: limit the tx rate
@@ -795,7 +793,6 @@ class Microvm:
             iface_id=iface_id,
             host_dev_name=tapname,
             guest_mac=guest_mac,
-            allow_mmds_requests=allow_mmds_requests,
             tx_rate_limiter=tx_rate_limiter,
             rx_rate_limiter=rx_rate_limiter
         )

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -706,7 +706,6 @@ class Network():
             iface_id=None,
             host_dev_name=None,
             guest_mac=None,
-            allow_mmds_requests=None,
             rx_rate_limiter=None,
             tx_rate_limiter=None):
         """Create the json for the net specific API request."""
@@ -719,9 +718,6 @@ class Network():
 
         if guest_mac is not None:
             datax['guest_mac'] = guest_mac
-
-        if allow_mmds_requests is not None:
-            datax['allow_mmds_requests'] = allow_mmds_requests
 
         if tx_rate_limiter is not None:
             datax['tx_rate_limiter'] = tx_rate_limiter

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -27,8 +27,5 @@
   "vsock": null,
   "logger": null,
   "metrics": null,
-  "mmds-config": {
-    "version": "V2",
-    "ipv4_address": "169.254.169.250"
-  }
+  "mmds-config": null
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.13}
+    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.04}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.07}
+    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 80.98}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -300,7 +300,7 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
 
 def test_api_mmds_config(test_microvm_with_api):
     """
-   Test /mmds/config PUT scenarios that unit tests can't cover.
+    Test /mmds/config PUT scenarios that unit tests can't cover.
 
     Tests updates on MMDS config before and after attaching a network device.
 
@@ -1366,8 +1366,7 @@ def test_get_full_config(test_microvm_with_api):
         iface_id=iface_id,
         guest_mac=guest_mac,
         host_dev_name=tap1.name,
-        tx_rate_limiter=tx_rl,
-        allow_mmds_requests=True
+        tx_rate_limiter=tx_rl
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     expected_cfg['network-interfaces'] = [{
@@ -1375,8 +1374,7 @@ def test_get_full_config(test_microvm_with_api):
         'host_dev_name': tap1.name,
         'guest_mac': '06:00:00:00:00:01',
         'rx_rate_limiter': None,
-        'tx_rate_limiter': tx_rl,
-        'allow_mmds_requests': True
+        'tx_rate_limiter': tx_rl
     }]
 
     # Update MMDS config.


### PR DESCRIPTION
# Reason for This PR

Provide a cleaner API for allowing MMDS requests on network interfaces. 
Also fixes #2174

## Description of Changes

- Add a `network_interfaces` field that takes a list of the network interface IDs capable of forwarding packets to the MMDS. Network interface IDs mentioned must be valid at the time of this request. The net device model will reply to HTTP GET requests sent to the MMDS address via the interfaces mentioned. In this case, both ARP requests and TCP segments heading to `ipv4_address` are intercepted by the device model, and do not reach the associated TAP device.
- Remove `allow_mmds_requests` from the body of the request that creates network interfaces.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
