### PR TITLE
mmds: compute token's expiry in ms instead of seconds

### DIFF
--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 /// Constant to convert seconds to nanoseconds.
 pub const NANOS_PER_SECOND: u64 = 1_000_000_000;
+/// Constant to convert milliseconds to nanoseconds.
+pub const NANOS_PER_MILLISECOND: u64 = 1_000_000;
 
 /// Wrapper over `libc::clockid_t` to specify Linux Kernel clock source.
 pub enum ClockType {
@@ -160,13 +162,13 @@ pub fn get_time_us(clock_type: ClockType) -> u64 {
     get_time_ns(clock_type) / 1000
 }
 
-/// Returns a timestamp in seconds based on the provided clock type.
+/// Returns a timestamp in milliseconds based on the provided clock type.
 ///
 /// # Arguments
 ///
 /// * `clock_type` - Identifier of the Linux Kernel clock on which to act.
-pub fn get_time_s(clock_type: ClockType) -> u64 {
-    get_time_ns(clock_type) / NANOS_PER_SECOND
+pub fn get_time_ms(clock_type: ClockType) -> u64 {
+    get_time_ns(clock_type) / NANOS_PER_MILLISECOND
 }
 
 /// Converts a timestamp in seconds to an equivalent one in nanoseconds.
@@ -200,7 +202,9 @@ mod tests {
         assert_ne!(get_time_ns(ClockType::Real), 0);
         assert_ne!(get_time_us(ClockType::Real), 0);
         assert!(get_time_ns(ClockType::Real) / 1000 <= get_time_us(ClockType::Real));
-        assert!(get_time_ns(ClockType::Real) / NANOS_PER_SECOND <= get_time_s(ClockType::Real));
+        assert!(
+            get_time_ns(ClockType::Real) / NANOS_PER_MILLISECOND <= get_time_ms(ClockType::Real)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

This commit changes expiration time's unit of measure from seconds
to milliseconds. When computing expiry in seconds, if the request
to create a new token arrives at time X,999 seconds with a ttl=1s,
the token's expiry is computed to be X + 1 and the token ends up
having a lifetime of 0,0001 seconds instead of 1 second.

Computing expiry based on current time in milliseconds instead of
seconds provides greater precision.

## Description of Changes

Compute token's expiration time based on current time in ms instead of seconds and validate token's expiry based on its value in ms.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] Any newly added `unsafe` code is properly documented.
- [X] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
