### PR TITLE
[backport][devtool] copy relase artifacts before test run

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -1026,8 +1026,8 @@ cmd_build_release_archive() {
     archive_checksum="$archive_name.sha256.txt"
     release_dir="release-$release_suffix"
 
-    # Run tests, build release binaries and strip them from debug symbols.
-    ( cmd_build --release && cmd_strip && cmd_test ) || die "Aborted."
+    # Build release binaries and strip them from debug symbols.
+    ( cmd_build --release && cmd_strip ) || die "Aborted."
 
     # Create release directory or overwrite if it already exists.
     rm -rf "$release_dir" && mkdir "$release_dir"
@@ -1042,11 +1042,14 @@ cmd_build_release_archive() {
     done
 
     add_swagger_artifact "$release_dir"
-    add_folder_artifact "$release_dir" "test_results" "$release_suffix"
     add_file_artifact "$release_dir" "$seccomp_json" "seccomp-filter-$release_suffix.json"
     for file in "LICENSE" "NOTICE" "THIRD-PARTY"; do
         add_file_artifact "$release_dir" "$file"
     done
+
+    # Run tests to obtain test reports dir.
+    cmd_test || cleanup_release_dir "$release_dir" "Tests failed."
+    add_folder_artifact "$release_dir" "test_results" "$release_suffix"
 
     # Create release archive.
     say "Creating release archive..."
@@ -1055,6 +1058,14 @@ cmd_build_release_archive() {
     say "Calculating checksum for release archive..."
     sha256sum "$archive_name"  | awk '{print $1}' > "$archive_checksum"
     say "Done. Saved checksum in $archive_checksum."
+}
+
+cleanup_release_dir() {
+    release_dir="$1"
+    error_msg="$2"
+
+    rm -rf "$release_dir"
+    die "$error_msg"
 }
 
 check_file_existence() {


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Release artifacts must be copied before test run. These changes have been merged in v0.25 but missed on main.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
