### PR TITLE
api: rename `ht_enabled` to `smt`, make it optional and forbid setting it to True on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,10 @@
   interfaces. Specifying interfaces that allow forwarding requests to MMDS is done
   by adding the network interface's ID to the `network_interfaces` field of PUT
   `/mmds/config` request's body.
-- Configuring `ht_enabled: true` on aarch64 via the API is forbidden.
-- `ht_enabled` field is now optional on PUT `/machine-config`, defaulting to
+- Renamed `/machine-config` `ht_enabled` to `smt`.
+- `smt` field is now optional on PUT `/machine-config`, defaulting to
   `false`.
+- Configuring `smt: true` on aarch64 via the API is forbidden.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
   interfaces. Specifying interfaces that allow forwarding requests to MMDS is done
   by adding the network interface's ID to the `network_interfaces` field of PUT
   `/mmds/config` request's body.
+- Configuring `ht_enabled: true` on aarch64 via the API is forbidden.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
   by adding the network interface's ID to the `network_interfaces` field of PUT
   `/mmds/config` request's body.
 - Configuring `ht_enabled: true` on aarch64 via the API is forbidden.
+- `ht_enabled` field is now optional on PUT `/machine-config`, defaulting to
+  `false`.
 
 ### Fixed
 

--- a/docs/device-api.md
+++ b/docs/device-api.md
@@ -65,7 +65,7 @@ specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 |                            | show_level            |    O     |       O        |      O       |       O       |      O       |
 |                            | show_log_origin       |    O     |       O        |      O       |       O       |      O       |
 | `MachineConfiguration`     | cpu_template          |    O     |       O        |      O       |       O       |      O       |
-|                            | ht_enabled            |    O     |       O        |      O       |       O       |      O       |
+|                            | smt                   |    O     |       O        |      O       |       O       |      O       |
 |                            | mem_size_mib          |    O     |       O        |      O       |       O       |      O       |
 |                            | track_dirty_pages     |    O     |       O        |      O       |       O       |      O       |
 |                            | vcpu_count            |    O     |       O        |      O       |       O       |      O       |
@@ -112,7 +112,7 @@ specification: [firecracker.yaml](./../src/api_server/swagger/firecracker.yaml).
 |                        | state             |    O     |       O        |      O       |     O      |      O       |
 |                        | vmm_version       |    O     |       O        |      O       |     O      |      O       |
 | `MachineConfiguration` | cpu_template      |    O     |       O        |      O       |     O      |      O       |
-|                        | ht_enabled        |    O     |       O        |      O       |     O      |      O       |
+|                        | smt               |    O     |       O        |      O       |     O      |      O       |
 |                        | mem_size_mib      |    O     |       O        |      O       |     O      |      O       |
 |                        | track_dirty_pages |    O     |       O        |      O       |     O      |      O       |
 |                        | vcpu_count        |    O     |       O        |      O       |     O      |      O       |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,8 +216,7 @@ curl --unix-socket /tmp/firecracker.socket -i  \
   -H 'Content-Type: application/json'      \
   -d '{
       "vcpu_count": 2,
-      "mem_size_mib": 1024,
-      "ht_enabled": false
+      "mem_size_mib": 1024
   }'
 ```
 

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -333,7 +333,7 @@ curl --unix-socket /tmp/firecracker.socket -i  \
     -d '{
             "vcpu_count": 2,
             "mem_size_mib": 1024,
-            "ht_enabled": false,
+            "smt": false,
             "track_dirty_pages": true
     }'
 ```

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -788,8 +788,7 @@ pub(crate) mod tests {
         let mut connection = HttpConnection::new(receiver);
         let body = "{ \
             \"vcpu_count\": 0, \
-            \"mem_size_mib\": 0, \
-            \"ht_enabled\": false \
+            \"mem_size_mib\": 0 \
         }";
         sender
             .write_all(http_request("PUT", "/machine-config", Some(&body)).as_bytes())
@@ -1009,8 +1008,7 @@ pub(crate) mod tests {
         let mut connection = HttpConnection::new(receiver);
         let body = "{ \
             \"vcpu_count\": 0, \
-            \"mem_size_mib\": 0, \
-            \"ht_enabled\": false \
+            \"mem_size_mib\": 0 \
         }";
         sender
             .write_all(http_request("PATCH", "/machine-config", Some(&body)).as_bytes())

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -789,7 +789,7 @@ pub(crate) mod tests {
         let body = "{ \
             \"vcpu_count\": 0, \
             \"mem_size_mib\": 0, \
-            \"ht_enabled\": true \
+            \"ht_enabled\": false \
         }";
         sender
             .write_all(http_request("PUT", "/machine-config", Some(&body)).as_bytes())
@@ -1010,7 +1010,7 @@ pub(crate) mod tests {
         let body = "{ \
             \"vcpu_count\": 0, \
             \"mem_size_mib\": 0, \
-            \"ht_enabled\": true \
+            \"ht_enabled\": false \
         }";
         sender
             .write_all(http_request("PATCH", "/machine-config", Some(&body)).as_bytes())
@@ -1021,7 +1021,7 @@ pub(crate) mod tests {
         let body = "{ \
             \"vcpu_count\": 0, \
             \"mem_size_mib\": 0, \
-            \"ht_enabled\": true, \
+            \"ht_enabled\": false, \
             \"cpu_template\": \"C3\" \
         }";
         sender

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -1019,7 +1019,7 @@ pub(crate) mod tests {
         let body = "{ \
             \"vcpu_count\": 0, \
             \"mem_size_mib\": 0, \
-            \"ht_enabled\": false, \
+            \"smt\": false, \
             \"cpu_template\": \"C3\" \
         }";
         sender

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -285,7 +285,7 @@ paths:
       description:
         Gets the machine configuration of the VM. When called before the PUT operation, it
         will return the default values for the vCPU count (=1), memory size (=128 MiB).
-        By default Hyperthreading is disabled and there is no CPU Template.
+        By default SMT is disabled and there is no CPU Template.
       operationId: getMachineConfiguration
       responses:
         200:
@@ -302,7 +302,7 @@ paths:
       description:
         Updates the Virtual Machine Configuration with the specified input.
         Firecracker starts with default values for vCPU count (=1) and memory size (=128 MiB).
-        With Hyperthreading enabled, the vCPU count is restricted to be 1 or an even number,
+        With SMT enabled, the vCPU count is restricted to be 1 or an even number,
         otherwise there are no restrictions regarding the vCPU count.
         If any of the parameters has an incorrect value, the whole update fails.
       operationId: putMachineConfiguration
@@ -925,7 +925,7 @@ definitions:
   MachineConfiguration:
     type: object
     description:
-      Describes the number of vCPUs, memory size, Hyperthreading capabilities and
+      Describes the number of vCPUs, memory size, SMT capabilities and
       the CPU template.
     required:
       - mem_size_mib
@@ -933,9 +933,10 @@ definitions:
     properties:
       cpu_template:
         $ref: "#/definitions/CpuTemplate"
-      ht_enabled:
+      smt:
         type: boolean
-        description: Flag for enabling/disabling Hyperthreading. x86-only.
+        description: Flag for enabling/disabling simultaneous multithreading. Can be enabled only on x86.
+        default: false
       mem_size_mib:
         type: integer
         description: Memory size of VM

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -928,7 +928,6 @@ definitions:
       Describes the number of vCPUs, memory size, Hyperthreading capabilities and
       the CPU template.
     required:
-      - ht_enabled
       - mem_size_mib
       - vcpu_count
     properties:

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -774,6 +774,7 @@ definitions:
     description:
       The CPU Template defines a set of flags to be disabled from the microvm so that
       the features exposed to the guest are the same as in the selected instance type.
+      Works only on Intel.
     enum:
       - C3
       - T2
@@ -935,7 +936,7 @@ definitions:
         $ref: "#/definitions/CpuTemplate"
       ht_enabled:
         type: boolean
-        description: Flag for enabling/disabling Hyperthreading
+        description: Flag for enabling/disabling Hyperthreading. x86-only.
       mem_size_mib:
         type: integer
         description: Memory size of VM

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -252,10 +252,10 @@ mod tests {
         assert_eq!(entry.ecx.read_bit(ecx::TOPOEXT_INDEX), true);
     }
 
-    fn check_update_amd_features_entry(cpu_count: u8, ht_enabled: bool) {
+    fn check_update_amd_features_entry(cpu_count: u8, smt: bool) {
         use crate::cpu_leaf::leaf_0x80000008::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, smt).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -282,13 +282,13 @@ mod tests {
     fn check_update_extended_apic_id_entry(
         cpu_id: u8,
         cpu_count: u8,
-        ht_enabled: bool,
+        smt: bool,
         expected_core_id: u32,
         expected_threads_per_core: u32,
     ) {
         use crate::cpu_leaf::leaf_0x8000001e::*;
 
-        let vm_spec = VmSpec::new(cpu_id, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(cpu_id, cpu_count, smt).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -174,13 +174,13 @@ mod tests {
 
     fn check_update_cache_parameters_entry(
         cpu_count: u8,
-        ht_enabled: bool,
+        smt: bool,
         cache_level: u32,
         expected_max_cpus_per_core: u32,
     ) {
         use crate::cpu_leaf::leaf_cache_parameters::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, smt).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -162,13 +162,13 @@ mod tests {
 
     fn check_update_deterministic_cache_entry(
         cpu_count: u8,
-        ht_enabled: bool,
+        smt: bool,
         cache_level: u32,
         expected_max_cores_per_package: u32,
     ) {
         use crate::cpu_leaf::leaf_0x4::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, smt).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,
@@ -192,7 +192,7 @@ mod tests {
 
     fn check_update_extended_topology_entry(
         cpu_count: u8,
-        ht_enabled: bool,
+        smt: bool,
         index: u32,
         expected_apicid: u32,
         expected_num_logical_processors: u32,
@@ -200,7 +200,7 @@ mod tests {
     ) {
         use crate::cpu_leaf::leaf_0xb::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, smt).expect("Error creating vm_spec");
         let mut entry = &mut kvm_cpuid_entry2 {
             function: 0x0,
             index,

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -30,14 +30,14 @@ pub struct VmSpec {
 impl VmSpec {
     /// Creates a new instance of VmSpec with the specified parameters
     /// The brand string is deduced from the vendor_id
-    pub fn new(cpu_index: u8, cpu_count: u8, ht_enabled: bool) -> Result<VmSpec, Error> {
+    pub fn new(cpu_index: u8, cpu_count: u8, smt: bool) -> Result<VmSpec, Error> {
         let cpu_vendor_id = get_vendor_id_from_host().map_err(Error::InternalError)?;
 
         Ok(VmSpec {
             cpu_vendor_id,
             cpu_index,
             cpu_count,
-            cpu_bits: (cpu_count > 1 && ht_enabled) as u8,
+            cpu_bits: (cpu_count > 1 && smt) as u8,
             brand_string: BrandString::from_vendor_id(&cpu_vendor_id),
         })
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -176,7 +176,7 @@ impl VmResources {
         // supplied by the user.
         VcpuConfig {
             vcpu_count: self.vm_config().vcpu_count.unwrap(),
-            ht_enabled: self.vm_config().ht_enabled.unwrap(),
+            smt: self.vm_config().smt.unwrap(),
             cpu_template: self.vm_config().cpu_template,
         }
     }
@@ -222,23 +222,23 @@ impl VmResources {
             return Err(VmConfigError::IncompatibleBalloonSize);
         }
 
-        let ht_enabled = machine_config
-            .ht_enabled
-            .unwrap_or_else(|| self.vm_config.ht_enabled.unwrap());
+        let smt = machine_config
+            .smt
+            .unwrap_or_else(|| self.vm_config.smt.unwrap());
 
         let vcpu_count_value = machine_config
             .vcpu_count
             .unwrap_or_else(|| self.vm_config.vcpu_count.unwrap());
 
-        // If hyperthreading is enabled or is to be enabled in this call
+        // If SMT is enabled or is to be enabled in this call
         // only allow vcpu count to be 1 or even.
-        if ht_enabled && vcpu_count_value > 1 && vcpu_count_value % 2 == 1 {
+        if smt && vcpu_count_value > 1 && vcpu_count_value % 2 == 1 {
             return Err(VmConfigError::InvalidVcpuCount);
         }
 
         // Update all the fields that have a new value.
         self.vm_config.vcpu_count = Some(vcpu_count_value);
-        self.vm_config.ht_enabled = Some(ht_enabled);
+        self.vm_config.smt = Some(smt);
         self.vm_config.track_dirty_pages = machine_config.track_dirty_pages;
 
         if machine_config.mem_size_mib.is_some() {
@@ -772,7 +772,7 @@ mod tests {
                     "machine-config": {{
                         "vcpu_count": 2,
                         "mem_size_mib": 1024,
-                        "ht_enabled": false
+                        "smt": false
                     }},
                     "mmds-config": {{
                         "version": "V2",
@@ -816,7 +816,7 @@ mod tests {
                     "machine-config": {{
                         "vcpu_count": 2,
                         "mem_size_mib": 1024,
-                        "ht_enabled": false
+                        "smt": false
                     }},
                     "mmds-config": {{
                         "network_interfaces": ["netif"]
@@ -833,7 +833,7 @@ mod tests {
         let vm_resources = default_vm_resources();
         let expected_vcpu_config = VcpuConfig {
             vcpu_count: vm_resources.vm_config().vcpu_count.unwrap(),
-            ht_enabled: vm_resources.vm_config().ht_enabled.unwrap(),
+            smt: vm_resources.vm_config().smt.unwrap(),
             cpu_template: vm_resources.vm_config().cpu_template,
         };
 
@@ -855,7 +855,7 @@ mod tests {
         let mut aux_vm_config = VmConfig {
             vcpu_count: Some(32),
             mem_size_mib: Some(512),
-            ht_enabled: Some(true),
+            smt: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
             track_dirty_pages: false,
         };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -609,8 +609,7 @@ mod tests {
                     ],
                     "machine-config": {{
                         "vcpu_count": 0,
-                        "mem_size_mib": 1024,
-                        "ht_enabled": false
+                        "mem_size_mib": 1024
                     }}
             }}"#,
             kernel_file.as_path().to_str().unwrap(),
@@ -639,8 +638,7 @@ mod tests {
                     ],
                     "machine-config": {{
                         "vcpu_count": 2,
-                        "mem_size_mib": 0,
-                        "ht_enabled": false
+                        "mem_size_mib": 0
                     }}
             }}"#,
             kernel_file.as_path().to_str().unwrap(),

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -89,8 +89,8 @@ pub type Result<T> = result::Result<T, Error>;
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,
-    /// Enable hyperthreading in the CPUID configuration.
-    pub ht_enabled: bool,
+    /// Enable simultaneous multithreading in the CPUID configuration.
+    pub smt: bool,
     /// CPUID template to use.
     pub cpu_template: Option<CpuFeaturesTemplate>,
 }
@@ -911,7 +911,7 @@ mod tests {
         {
             let vcpu_config = VcpuConfig {
                 vcpu_count: 1,
-                ht_enabled: false,
+                smt: false,
                 cpu_template: None,
             };
             vcpu.kvm_vcpu

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -198,7 +198,7 @@ impl KvmVcpu {
         vcpu_config: &VcpuConfig,
         mut cpuid: CpuId,
     ) -> Result<()> {
-        let cpuid_vm_spec = VmSpec::new(self.index, vcpu_config.vcpu_count, vcpu_config.ht_enabled)
+        let cpuid_vm_spec = VmSpec::new(self.index, vcpu_config.vcpu_count, vcpu_config.smt)
             .map_err(Error::CpuId)?;
 
         filter_cpuid(&mut cpuid, &cpuid_vm_spec).map_err(|e| {
@@ -504,7 +504,7 @@ mod tests {
 
         let mut vcpu_config = VcpuConfig {
             vcpu_count: 1,
-            ht_enabled: false,
+            smt: false,
             cpu_template: None,
         };
 

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -88,7 +88,8 @@ class MicrovmBuilder:
               cpu_template=None,
               fc_binary=None,
               jailer_binary=None,
-              use_ramdisk=False):
+              use_ramdisk=False,
+              smt=None):
         """Build a fresh microvm."""
         vm = init_microvm(self.root_path, self.bin_cloner_path,
                           fc_binary, jailer_binary)
@@ -152,7 +153,7 @@ class MicrovmBuilder:
         response = vm.machine_cfg.put(
             vcpu_count=int(microvm_config['vcpu_count']),
             mem_size_mib=int(microvm_config['mem_size_mib']),
-            ht_enabled=microvm_config['ht_enabled'],
+            smt=smt,
             track_dirty_pages=diff_snapshots,
             cpu_template=cpu_template,
         )

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -152,7 +152,7 @@ class MicrovmBuilder:
         response = vm.machine_cfg.put(
             vcpu_count=int(microvm_config['vcpu_count']),
             mem_size_mib=int(microvm_config['mem_size_mib']),
-            ht_enabled=bool(microvm_config['ht_enabled']),
+            ht_enabled=microvm_config['ht_enabled'],
             track_dirty_pages=diff_snapshots,
             cpu_template=cpu_template,
         )

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -634,7 +634,7 @@ class Microvm:
     def basic_config(
         self,
         vcpu_count: int = 2,
-        ht_enabled: bool = False,
+        ht_enabled: bool = None,
         mem_size_mib: int = 256,
         add_root_device: bool = True,
         boot_args: str = None,

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -507,16 +507,17 @@ class Microvm:
         self.desc_inst = DescribeInstance(self._api_socket, self._api_session)
         self.full_cfg = FullConfig(self._api_socket, self._api_session)
         self.logger = Logger(self._api_socket, self._api_session)
+        self.version = InstanceVersion(
+            self._api_socket, self._fc_binary_path, self._api_session)
         self.machine_cfg = MachineConfigure(
             self._api_socket,
-            self._api_session
+            self._api_session,
+            self.firecracker_version
         )
         self.metrics = Metrics(self._api_socket, self._api_session)
         self.mmds = MMDS(self._api_socket, self._api_session)
         self.network = Network(self._api_socket, self._api_session)
         self.snapshot = SnapshotHelper(self._api_socket, self._api_session)
-        self.version = InstanceVersion(
-            self._api_socket, self._fc_binary_path, self._api_session)
         self.drive = Drive(self._api_socket, self._api_session,
                            self.firecracker_version)
         self.vm = Vm(self._api_socket, self._api_session)
@@ -634,7 +635,7 @@ class Microvm:
     def basic_config(
         self,
         vcpu_count: int = 2,
-        ht_enabled: bool = None,
+        smt: bool = None,
         mem_size_mib: int = 256,
         add_root_device: bool = True,
         boot_args: str = None,
@@ -655,7 +656,7 @@ class Microvm:
         """
         response = self.machine_cfg.put(
             vcpu_count=vcpu_count,
-            ht_enabled=ht_enabled,
+            smt=smt,
             mem_size_mib=mem_size_mib,
             track_dirty_pages=track_dirty_pages
         )

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -563,13 +563,18 @@ class MachineConfigure():
 
     MACHINE_CFG_RESOURCE = 'machine-config'
 
-    def __init__(self, api_usocket_full_name, api_session):
+    def __init__(
+            self,
+            api_usocket_full_name,
+            api_session,
+            firecracker_version):
         """Specify the information needed for sending API requests."""
         url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
         api_url = API_USOCKET_URL_PREFIX + url_encoded_path + '/'
 
         self._machine_cfg_url = api_url + self.MACHINE_CFG_RESOURCE
         self._api_session = api_session
+        self._firecracker_version = firecracker_version
         self._datax = {}
 
     @property
@@ -602,11 +607,11 @@ class MachineConfigure():
             self._machine_cfg_url
         )
 
-    @staticmethod
     def create_json(
+            self,
             vcpu_count=None,
             mem_size_mib=None,
-            ht_enabled=None,
+            smt=None,
             cpu_template=None,
             track_dirty_pages=None):
         """Compose the json associated to this type of API request."""
@@ -617,8 +622,10 @@ class MachineConfigure():
         if mem_size_mib is not None:
             datax['mem_size_mib'] = mem_size_mib
 
-        if ht_enabled is not None:
-            datax['ht_enabled'] = ht_enabled
+        if compare_versions(self._firecracker_version, "0.25.0") <= 0:
+            datax['ht_enabled'] = False if smt is None else smt
+        elif smt is not None:
+            datax['smt'] = smt
 
         if cpu_template is not None:
             datax['cpu_template'] = cpu_template

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -19,7 +19,7 @@
   "machine-config": {
     "vcpu_count": 2,
     "mem_size_mib": 1024,
-    "ht_enabled": false,
+    "smt": false,
     "track_dirty_pages": false
   },
   "balloon": null,

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -165,7 +165,6 @@ def test_cpu_template(test_microvm_with_api, network_config, cpu_template):
     response = test_microvm.machine_cfg.put(
         vcpu_count=1,
         mem_size_mib=256,
-        ht_enabled=False,
         cpu_template=cpu_template,
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -55,7 +55,7 @@ def test_cpuid(test_microvm_with_api, network_config, num_vcpus, htt):
     """
     vm = test_microvm_with_api
     vm.spawn()
-    vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)
+    vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     _tap, _, _ = vm.ssh_network_config(network_config, '1')
     vm.start()
     _check_cpuid_x86(vm, num_vcpus, "true" if num_vcpus > 1 else "false")

--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -199,7 +199,6 @@ def test_api_requests_logs(test_microvm_with_api):
     # Check that a Put request on /machine-config is logged.
     response = microvm.machine_cfg.put(
         vcpu_count=4,
-        ht_enabled=False,
         mem_size_mib=128
     )
     assert microvm.api_session.is_status_no_content(response.status_code)

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -152,6 +152,8 @@ def test_cache_topology(test_microvm_with_api, network_config, num_vcpus, htt):
 
     @type: functional
     """
+    if htt and PLATFORM == 'aarch64':
+        pytest.skip("HyperThreading is configurable only on x86.")
     vm = test_microvm_with_api
     vm.spawn()
     vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -130,7 +130,7 @@ def test_cpu_topology(test_microvm_with_api, network_config, num_vcpus, htt):
     """
     vm = test_microvm_with_api
     vm.spawn()
-    vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)
+    vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     _tap, _, _ = vm.ssh_network_config(network_config, '1')
     vm.start()
 
@@ -153,10 +153,10 @@ def test_cache_topology(test_microvm_with_api, network_config, num_vcpus, htt):
     @type: functional
     """
     if htt and PLATFORM == 'aarch64':
-        pytest.skip("HyperThreading is configurable only on x86.")
+        pytest.skip("SMT is configurable only on x86.")
     vm = test_microvm_with_api
     vm.spawn()
-    vm.basic_config(vcpu_count=num_vcpus, ht_enabled=htt)
+    vm.basic_config(vcpu_count=num_vcpus, smt=htt)
     _tap, _, _ = vm.ssh_network_config(network_config, '1')
     vm.start()
     if PLATFORM == "x86_64":

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -133,7 +133,6 @@ def get_snap_restore_latency(
     response = basevm.machine_cfg.put(
         vcpu_count=vcpus,
         mem_size_mib=mem_size,
-        ht_enabled=False
     )
     assert basevm.api_session.is_status_no_content(response.status_code)
 


### PR DESCRIPTION
# Reason for This PR

We plan on renaming/removing ht_enabled in a future release and this is a first step towards this without introducing a breaking change in this release.
Also, making it required did not make sense for ARM, where it actually does nothing if configured. Added an error for when it's configured as True on ARM.

## Description of Changes

View commits

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
