### PR TITLE
tests: ensure MMDS works as expected when configuring microVM from file

### DIFF
--- a/tests/framework/jailer.py
+++ b/tests/framework/jailer.py
@@ -247,7 +247,7 @@ class JailerContext:
             )
             utils.run_cmd(cmd)
 
-        if self.netns:
+        if self.netns and self.netns not in utils.run_cmd('ip netns list')[1]:
             utils.run_cmd('ip netns add {}'.format(self.netns))
 
     def cleanup(self):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -631,3 +631,27 @@ def is_io_uring_supported():
     return compare_versions(
         get_kernel_version(), MIN_KERNEL_VERSION_FOR_IO_URING
     ) >= 0
+
+
+def generate_mmds_session_token(ssh_connection, ipv4_address, token_ttl):
+    """Generate session token used for MMDS V2 requests."""
+    cmd = 'curl -m 2 -s'
+    cmd += ' -X PUT'
+    cmd += ' -H  "X-metadata-token-ttl-seconds: {}"'.format(token_ttl)
+    cmd += ' http://{}/latest/api/token'.format(ipv4_address)
+    _, stdout, _ = ssh_connection.execute_command(cmd)
+    token = stdout.read()
+
+    return token
+
+
+def generate_mmds_v2_get_request(ipv4_address, token, app_json=True):
+    """Build `GET` request to fetch metadata from MMDS when using V2."""
+    cmd = 'curl -m 2 -s'
+    cmd += ' -X GET'
+    cmd += ' -H  "X-metadata-token: {}"'.format(token)
+    if app_json:
+        cmd += ' -H "Accept: application/json"'
+    cmd += ' http://{}/'.format(ipv4_address)
+
+    return cmd

--- a/tests/framework/vm_config_with_mmdsv1.json
+++ b/tests/framework/vm_config_with_mmdsv1.json
@@ -1,0 +1,40 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "initrd_path": null
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "partuuid": null,
+      "is_read_only": false,
+      "cache_type": "Unsafe",
+      "io_engine": "Sync",
+      "rate_limiter": null
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "track_dirty_pages": false
+  },
+  "balloon": null,
+  "network-interfaces": [
+    {
+      "iface_id": "1",
+      "host_dev_name": "tap0",
+      "guest_mac": "06:00:c0:a8:00:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    }
+  ],
+  "vsock": null,
+  "logger": null,
+  "metrics": null,
+  "mmds-config": {
+    "network_interfaces": ["1"]
+  }
+}

--- a/tests/framework/vm_config_with_mmdsv2.json
+++ b/tests/framework/vm_config_with_mmdsv2.json
@@ -1,0 +1,43 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "initrd_path": null
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "partuuid": null,
+      "is_read_only": false,
+      "cache_type": "Unsafe",
+      "io_engine": "Sync",
+      "rate_limiter": null
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "smt": false,
+    "track_dirty_pages": false
+  },
+  "balloon": null,
+  "network-interfaces": [
+    {
+      "iface_id": "1",
+      "host_dev_name": "tap0",
+      "guest_mac": "06:00:c0:a8:00:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    }
+  ],
+  "vsock": null,
+  "logger": null,
+  "metrics": null,
+  "mmds-config": {
+    "network_interfaces": ["1"],
+    "ipv4_address": "169.254.169.250",
+    "version": "V2"
+  }
+}


### PR DESCRIPTION
Ensure MMDS works as expected (both default and V2) when spawning
microVM from a configuration file.

Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Enhance MMDS tests.

## Description of Changes

Add tests to ensure that MMDS works as expected when configuring microVM from file.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
