### PR TITLE
Set RDA bit in serial after restore

### DIFF
--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -29,6 +29,12 @@ use utils::epoll::EventSet;
 /// Trait that composes the `std::io::Read` and `std::os::unix::io::AsRawFd` traits.
 pub trait ReadableFd: io::Read + AsRawFd {}
 
+// Received Data Available interrupt - for letting the driver know that
+// there is some pending data to be processed.
+pub const IER_RDA_BIT: u8 = 0b0000_0001;
+// Received Data Available interrupt offset
+pub const IER_RDA_OFFSET: u8 = 1;
+
 #[derive(Debug)]
 pub enum RawIOError {
     Serial(SerialError<io::Error>),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -528,6 +528,8 @@ pub fn build_microvm_from_snapshot(
         MMIODeviceManager::restore(mmio_ctor_args, &microvm_state.device_states)
             .map_err(MicrovmStateError::RestoreDevices)
             .map_err(RestoreMicrovmState)?;
+    vmm.emulate_serial_init()
+        .map_err(StartMicrovmError::Internal)?;
 
     // Move vcpus to their own threads and start their state machine in the 'Paused' state.
     vmm.start_vcpus(

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -89,11 +89,11 @@ class MicrovmBuilder:
               fc_binary=None,
               jailer_binary=None,
               use_ramdisk=False,
-              smt=None):
+              smt=None, daemonize=True):
         """Build a fresh microvm."""
         vm = init_microvm(self.root_path, self.bin_cloner_path,
                           fc_binary, jailer_binary)
-
+        vm.jailer.daemonize = daemonize
         # Start firecracker.
         vm.spawn(use_ramdisk=use_ramdisk)
 
@@ -173,10 +173,12 @@ class MicrovmBuilder:
                             # Enable incremental snapshot capability.
                             diff_snapshots=False,
                             use_ramdisk=False,
-                            fc_binary=None, jailer_binary=None):
+                            fc_binary=None, jailer_binary=None,
+                            daemonize=True):
         """Build a microvm from a snapshot artifact."""
         vm = init_microvm(self.root_path, self.bin_cloner_path,
                           fc_binary, jailer_binary,)
+        vm.jailer.daemonize = daemonize
         vm.spawn(log_level='Error', use_ramdisk=use_ramdisk)
         vm.api_session.untime()
 
@@ -227,7 +229,8 @@ class MicrovmBuilder:
     def build_from_artifacts(self, config,
                              kernel, disks, cpu_template,
                              net_ifaces=None, diff_snapshots=False,
-                             fc_binary=None, jailer_binary=None):
+                             fc_binary=None, jailer_binary=None,
+                             daemonize=True):
         """Spawns a new Firecracker and applies specified config."""
         artifacts = ArtifactCollection(_test_images_s3_bucket())
         # Pick the first artifact in the set.
@@ -253,10 +256,11 @@ class MicrovmBuilder:
                           diff_snapshots=diff_snapshots,
                           cpu_template=cpu_template,
                           fc_binary=fc_binary,
-                          jailer_binary=jailer_binary)
+                          jailer_binary=jailer_binary,
+                          daemonize=daemonize)
 
     def build_vm_nano(self, fc_binary=None, jailer_binary=None,
-                      net_ifaces=None, diff_snapshots=False):
+                      net_ifaces=None, diff_snapshots=False, daemonize=True):
         """Create a clean VM in an initial state."""
         return self.build_from_artifacts("2vcpu_256mb",
                                          "vmlinux-4.14",
@@ -265,7 +269,8 @@ class MicrovmBuilder:
                                          net_ifaces=net_ifaces,
                                          diff_snapshots=diff_snapshots,
                                          fc_binary=fc_binary,
-                                         jailer_binary=jailer_binary)
+                                         jailer_binary=jailer_binary,
+                                         daemonize=daemonize)
 
     def build_vm_micro(self, fc_binary=None, jailer_binary=None,
                        net_ifaces=None, diff_snapshots=False):

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.04}
+    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 83.98}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 80.98}
+    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 80.91}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR
 After resuming from snapshot, the console is unresponsive.

## Description of Changes

* Set the RDA bit on serial after restore to kick the dive
* Added integration test for console functionality after restore

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
