### PR TITLE
Machine config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The API `PATCH` methods for `machine-config` can now be used to reset
+  the `cpu_template` to `"None"`. Until this change there was no way to
+  reset the `cpu_template` once it was set.
+
+### Changed
+
+- The API `PATCH` method for `/machine-config` can be now used to change
+  `track_dirty_pages` on aarch64.
+
+### Fixed
+
+- Fixed inconsistency that allowed the start of a microVM from a JSON file
+  without specifying the `vcpu_count` and `mem_size_mib` parameters for
+  `machine-config` although they are mandatory when configuring via the API.
+  Now these fields are mandatory when specifying `machine-config` in the JSON
+  file and when using the `PUT` request on `/machine-config`.
+- Fixed inconsistency that allowed a user to specify the `cpu_template`
+  parameter and set `smt` to `True` in `machine-config` when starting from a
+  JSON file on aarch64 even though they are not permitted when using `PUT` or
+  `PATCH` in the API. Now Firecracker will return an error on aarch64 if `smt`
+  is set to `True` or if `cpu_template` is specified.
+- Fixed inconsistent behaviour of the `PUT` method for `/machine-config` that
+  would reset the `track_dirty_pages` parameter to `false` if it was not
+  specified in the JSON body of the request, but left the `cpu_template`
+  parameter intact if it was not present in the request. Now a `PUT` request
+  for `/machine-config` will reset all optional parameters (`smt`,
+  `cpu_template`, `track_dirty_pages`) to their default values if they are
+  not specified in the `PUT` request.
+
 ## [1.0.0]
 
 ### Added

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -787,8 +787,8 @@ pub(crate) mod tests {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
         let body = "{ \
-            \"vcpu_count\": 0, \
-            \"mem_size_mib\": 0 \
+            \"vcpu_count\": 1, \
+            \"mem_size_mib\": 1 \
         }";
         sender
             .write_all(http_request("PUT", "/machine-config", Some(&body)).as_bytes())
@@ -1007,8 +1007,8 @@ pub(crate) mod tests {
         let (mut sender, receiver) = UnixStream::pair().unwrap();
         let mut connection = HttpConnection::new(receiver);
         let body = "{ \
-            \"vcpu_count\": 0, \
-            \"mem_size_mib\": 0 \
+            \"vcpu_count\": 1, \
+            \"mem_size_mib\": 1 \
         }";
         sender
             .write_all(http_request("PATCH", "/machine-config", Some(&body)).as_bytes())
@@ -1017,8 +1017,8 @@ pub(crate) mod tests {
         let req = connection.pop_parsed_request().unwrap();
         assert!(ParsedRequest::try_from_request(&req).is_ok());
         let body = "{ \
-            \"vcpu_count\": 0, \
-            \"mem_size_mib\": 0, \
+            \"vcpu_count\": 1, \
+            \"mem_size_mib\": 1, \
             \"smt\": false, \
             \"cpu_template\": \"C3\" \
         }";

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -302,9 +302,12 @@ paths:
       description:
         Updates the Virtual Machine Configuration with the specified input.
         Firecracker starts with default values for vCPU count (=1) and memory size (=128 MiB).
-        With SMT enabled, the vCPU count is restricted to be 1 or an even number,
+        The vCPU count is restricted to the [1, 32] range.
+        With SMT enabled, the vCPU count is required to be either 1 or an even number in the range.
         otherwise there are no restrictions regarding the vCPU count.
         If any of the parameters has an incorrect value, the whole update fails.
+        All parameters that are optional and are not specified are set to their default values
+        (smt = false, track_dirty_pages = false, cpu_template = None).
       operationId: putMachineConfiguration
       parameters:
         - name: body
@@ -778,6 +781,8 @@ definitions:
     enum:
       - C3
       - T2
+      - None
+    default: "None"
 
   Drive:
     type: object
@@ -947,6 +952,7 @@ definitions:
           snapshots can be created. These belong to diff snapshots, which contain, besides
           the microVM state, only the memory dirtied since a previous snapshot. Full snapshots
           each contain a full copy of the guest memory.
+        default: false
       vcpu_count:
         type: integer
         minimum: 1

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -324,13 +324,8 @@ pub fn build_microvm_for_boot(
     let boot_config = vm_resources.boot_source().ok_or(MissingKernelConfig)?;
 
     let track_dirty_pages = vm_resources.track_dirty_pages();
-    let guest_memory = create_guest_memory(
-        vm_resources
-            .vm_config()
-            .mem_size_mib
-            .ok_or(MissingMemSizeConfig)?,
-        track_dirty_pages,
-    )?;
+    let guest_memory =
+        create_guest_memory(vm_resources.vm_config().mem_size_mib, track_dirty_pages)?;
     let vcpu_config = vm_resources.vcpu_config();
     let entry_addr = load_kernel(boot_config, &guest_memory)?;
     let initrd = load_initrd_from_config(boot_config, &guest_memory)?;

--- a/src/vmm/src/utilities/mock_resources/mod.rs
+++ b/src/vmm/src/utilities/mock_resources/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use crate::resources::VmResources;
 use crate::vmm_config::boot_source::BootSourceConfig;
-use crate::vmm_config::machine_config::VmConfig;
+use crate::vmm_config::machine_config::{VmConfig, VmUpdateConfig};
 
 pub const DEFAULT_BOOT_ARGS: &str = "reboot=k panic=1 pci=off";
 #[cfg(target_arch = "x86_64")]
@@ -78,7 +78,8 @@ impl MockVmResources {
     }
 
     pub fn with_vm_config(mut self, vm_config: VmConfig) -> Self {
-        self.0.set_vm_config(&vm_config).unwrap();
+        let machine_config = VmUpdateConfig::from(vm_config);
+        self.0.update_vm_config(&machine_config).unwrap();
         self
     }
 }

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -92,7 +92,7 @@ pub struct VcpuConfig {
     /// Enable simultaneous multithreading in the CPUID configuration.
     pub smt: bool,
     /// CPUID template to use.
-    pub cpu_template: Option<CpuFeaturesTemplate>,
+    pub cpu_template: CpuFeaturesTemplate,
 }
 
 // Using this for easier explicit type-casting to help IDEs interpret the code.
@@ -912,7 +912,7 @@ mod tests {
             let vcpu_config = VcpuConfig {
                 vcpu_count: 1,
                 smt: false,
-                cpu_template: None,
+                cpu_template: CpuFeaturesTemplate::None,
             };
             vcpu.kvm_vcpu
                 .configure(

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -620,6 +620,16 @@ class Microvm:
         assert message in self.log_data
 
     @retry(delay=0.1, tries=5)
+    def check_any_log_message(self, messages):
+        """Wait until any message in `messages` appears in logging output."""
+        for message in messages:
+            if message in self.log_data:
+                return
+        raise AssertionError(
+            f"`{messages}` were not found in this log: {self.log_data}"
+        )
+
+    @retry(delay=0.1, tries=5)
     def find_log_message(self, regex):
         """Wait until `regex` appears in logging output and return it."""
         reg_res = re.findall(regex, self.log_data)

--- a/tests/framework/vm_config_cpu_template_C3.json
+++ b/tests/framework/vm_config_cpu_template_C3.json
@@ -1,0 +1,19 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "is_read_only": false
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "cpu_template": "C3"
+  }
+}

--- a/tests/framework/vm_config_missing_mem_size_mib.json
+++ b/tests/framework/vm_config_missing_mem_size_mib.json
@@ -1,0 +1,19 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "is_read_only": false
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "smt": false,
+    "track_dirty_pages": false
+  }
+}

--- a/tests/framework/vm_config_missing_vcpu_count.json
+++ b/tests/framework/vm_config_missing_vcpu_count.json
@@ -1,0 +1,19 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "is_read_only": false
+    }
+  ],
+  "machine-config": {
+    "mem_size_mib": 1024,
+    "smt": false,
+    "track_dirty_pages": false
+  }
+}

--- a/tests/framework/vm_config_smt_true.json
+++ b/tests/framework/vm_config_smt_true.json
@@ -1,0 +1,19 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off"
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "bionic.rootfs.ext4",
+      "is_root_device": true,
+      "is_read_only": false
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "smt": true
+  }
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.21}
+    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.60, "ARM": 84.14}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.16}
+    COVERAGE_DICT = {"Intel": 82.10, "AMD": 81.58, "ARM": 81.10}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fixes several issues with machine_config:
- The following fields on machine-config: `vcpu_count` and `mem_size_mib` are mandatory when configuring via the API but optional when configuring from a JSON file.
- The CPU template and `smt` can be configured on ARM as well when starting from a JSON config. It only returns an error when using the API for config.
- If a machine_config PUT request is issued without the `track_dirty_pages` and the `cpu_template` parameters set, track_dirty_pages would be set to false but the cpu_template would remain unchanged.
- There is no way to reset the cpu_template through PUT or PATCH once it has been set with either of these methods.
- Patching track_dirty_pages was not allowed on aarch64 even though it is a pre-boot request.

## Description of Changes

This patch splits the actual machine configuration in 2 structs: one used for keeping the actual configured values and one used only for updates.
Since Firecracker starts with default values for the machine configuration, all changes (either PUT or PATCH) are unified through an update path.
Having 2 distinct structs allows for validation of parameters early in the deserialization of the structs, and eliminates the need for handling unwraps for the parameters in the VMM.
Since the parameters are validated in the deserializer, we can use the same code for PUT, PATCH and starting from a json file.

Also added more details in the swagger file to better explain the behaviour of PUT.

This change requires a minor version upgrade.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
