### PR TITLE
Fix signal handler race condition on metrics.write()

### DIFF
--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -11,7 +11,7 @@ use std::process;
 use std::sync::{Arc, Mutex};
 
 use event_manager::SubscriberOps;
-use logger::{error, info, IncMetric, ProcessTimeReporter, LOGGER, METRICS};
+use logger::{error, info, ProcessTimeReporter, StoreMetric, LOGGER, METRICS};
 use mmds::MMDS;
 use seccompiler::BpfThreadMap;
 use snapshot::Snapshot;
@@ -96,7 +96,7 @@ fn main_exitable() -> ExitCode {
             );
         }
 
-        METRICS.vmm.panic_count.inc();
+        METRICS.vmm.panic_count.store(1);
 
         // Write the metrics before aborting.
         if let Err(e) = METRICS.write() {

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -46,8 +46,6 @@ impl PeriodicMetrics {
     }
 
     fn write_metrics(&mut self) {
-        // Please note that, if METRICS has no output file configured yet, it will write to
-        // stdout, so metrics writing will interfere with console output.
         if let Err(e) = METRICS.write() {
             METRICS.logger.missed_metrics_count.inc();
             error!("Failed to write metrics: {}", e);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -31,7 +31,7 @@ from host_tools import proc
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.21}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.10}
+    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.16}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/security/test_custom_seccomp.py
+++ b/tests/integration_tests/security/test_custom_seccomp.py
@@ -205,7 +205,7 @@ def test_failing_filter(test_microvm_with_api):
     for line in lines:
         num_faults += json.loads(line)["seccomp"]["num_faults"]
 
-    assert num_faults == 1
+    assert num_faults >= 1
 
     # assert that the process was killed
     assert not psutil.pid_exists(test_microvm.jailer_clone_pid)


### PR DESCRIPTION
# Reason for This PR

FIxes the root cause of intermittent failure of `test_custom_seccomp.py::test_failing_fiter`
View commit messages.

## Description of Changes

View commit messages.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
