### PR TITLE
Add tool to create snapshot artifacts for VMs built from config file

### DIFF
--- a/tools/create_snapshot_artifact/complex_vm_config.json
+++ b/tools/create_snapshot_artifact/complex_vm_config.json
@@ -1,0 +1,70 @@
+{
+  "boot-source": {
+    "kernel_image_path": "vmlinux.bin",
+    "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+    "initrd_path": null
+  },
+  "drives": [
+    {
+      "drive_id": "rootfs",
+      "path_on_host": "ubuntu-18.04.ext4",
+      "is_root_device": true,
+      "partuuid": null,
+      "is_read_only": false,
+      "cache_type": "Unsafe",
+      "io_engine": "Sync",
+      "rate_limiter": null
+    }
+  ],
+  "machine-config": {
+    "vcpu_count": 2,
+    "mem_size_mib": 1024,
+    "track_dirty_pages": true
+  },
+  "balloon": {
+    "amount_mib": 0,
+    "deflate_on_oom": true,
+    "stats_polling_interval_s": 1
+  },
+  "network-interfaces": [
+    {
+      "iface_id": "1",
+      "host_dev_name": "tap0",
+      "guest_mac": "06:00:c0:a8:00:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    },
+    {
+      "iface_id": "2",
+      "host_dev_name": "tap1",
+      "guest_mac": "06:00:c0:a8:01:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    },
+    {
+      "iface_id": "3",
+      "host_dev_name": "tap2",
+      "guest_mac": "06:00:c0:a8:02:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    },
+    {
+      "iface_id": "4",
+      "host_dev_name": "tap3",
+      "guest_mac": "06:00:c0:a8:03:02",
+      "rx_rate_limiter": null,
+      "tx_rate_limiter": null
+    }
+  ],
+  "vsock": {
+    "guest_cid": 3,
+    "uds_path": "/v.sock",
+    "vsock_id": "vsock0"
+  },
+  "logger": null,
+  "metrics": null,
+  "mmds-config": {
+    "version": "V2",
+    "network_interfaces": ["4"]
+  }
+}

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -1,0 +1,305 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Script used to generate snapshots of microVMs."""
+
+import json
+import os
+import re
+import shutil
+import tempfile
+import sys
+
+# Hack to be able to import testing framework functions.
+sys.path.append(os.path.join(os.getcwd(), 'tests'))  # noqa: E402
+
+# pylint: disable=wrong-import-position
+from conftest import _test_images_s3_bucket, _gcc_compile, init_microvm
+from framework.artifacts import NetIfaceConfig, ArtifactCollection, ArtifactSet
+from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
+from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
+from framework.matrix import TestMatrix, TestContext
+from framework.utils import generate_mmds_session_token, \
+    generate_mmds_v2_get_request, run_cmd
+from integration_tests.functional.test_cmd_line_start import \
+    _configure_vm_from_json
+import host_tools.network as net_tools  # pylint: disable=import-error
+
+DEST_KERNEL_NAME = "vmlinux.bin"
+ROOTFS_KEY = "ubuntu-18.04"
+
+# Define 4 net device configurations.
+net_ifaces = [NetIfaceConfig(),
+              NetIfaceConfig(host_ip="192.168.1.1",
+                             guest_ip="192.168.1.2",
+                             tap_name="tap1",
+                             dev_name="eth1"),
+              NetIfaceConfig(host_ip="192.168.2.1",
+                             guest_ip="192.168.2.2",
+                             tap_name="tap2",
+                             dev_name="eth2"),
+              NetIfaceConfig(host_ip="192.168.3.1",
+                             guest_ip="192.168.3.2",
+                             tap_name="tap3",
+                             dev_name="eth3")]
+
+# Allow routing requests to MMDS through eth3.
+net_iface_for_mmds = net_ifaces[3]
+# Default IPv4 address to route MMDS requests.
+IPV4_ADDRESS = '169.254.169.254'
+# Path to the VM configuration file.
+VM_CONFIG_FILE = "tools/create_snapshot_artifact/complex_vm_config.json"
+# Root directory for the snapshot artifacts.
+SNAPSHOT_ARTIFACTS_ROOT_DIR = "snapshot_artifacts"
+
+
+def compile_file(file_name, dest_path, bin_name):
+    """
+    Compile source file using gcc.
+
+    The resulted executable is placed at `/dest_path/bin_name`.
+    """
+    host_tools_path = os.path.join(os.getcwd(), 'tests/host_tools')
+
+    source_file_path = os.path.join(host_tools_path, file_name)
+    bin_file_path = os.path.join(dest_path, bin_name)
+    _gcc_compile(source_file_path, bin_file_path)
+
+    return bin_file_path
+
+
+def populate_mmds(microvm, data_store):
+    """Populate MMDS contents with json data provided."""
+    # MMDS should be empty.
+    response = microvm.mmds.get()
+    assert microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == {}
+
+    # Populate MMDS with data.
+    response = microvm.mmds.put(json=data_store)
+    assert microvm.api_session.is_status_no_content(response.status_code)
+
+    # Ensure data is persistent inside the data store.
+    response = microvm.mmds.get()
+    assert microvm.api_session.is_status_ok(response.status_code)
+    assert response.json() == data_store
+
+
+def setup_vm(context):
+    """Init microVM using context provided."""
+    root_path = context.custom['session_root_path']
+    bin_cloner_path = context.custom['bin_cloner_path']
+
+    print(
+        f"Creating snapshot of microVM with kernel {context.kernel.name()}"
+        f" and disk {context.disk.name()}."
+    )
+
+    vm = init_microvm(root_path, bin_cloner_path)
+
+    # Change kernel name to match the one in the config file.
+    kernel_full_path = os.path.join(vm.path, DEST_KERNEL_NAME)
+    shutil.copyfile(context.kernel.local_path(), kernel_full_path)
+    vm.kernel_file = kernel_full_path
+
+    rootfs_full_path = os.path.join(vm.path, context.disk.name())
+    shutil.copyfile(context.disk.local_path(), rootfs_full_path)
+    vm.rootfs_file = rootfs_full_path
+
+    return vm
+
+
+def configure_network_interfaces(microvm):
+    """Create network namespace and tap device for network interfaces."""
+    # Create network namespace.
+    run_cmd(f"ip netns add {microvm.jailer.netns}")
+
+    for net_iface in net_ifaces:
+        _tap = microvm.create_tap_and_ssh_config(
+            net_iface.host_ip,
+            net_iface.guest_ip,
+            net_iface.netmask,
+            net_iface.tap_name
+        )
+
+
+def validate_mmds(ssh_connection, data_store):
+    """Validate that MMDS contents fetched from the guest."""
+    # Configure interface to route MMDS requests
+    cmd = 'ip route add {} dev {}'.format(
+        IPV4_ADDRESS,
+        net_iface_for_mmds.dev_name
+    )
+    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    assert stdout.read() == stderr.read() == ''
+
+    # Fetch metadata to ensure MMDS is accessible.
+    token = generate_mmds_session_token(
+        ssh_connection,
+        IPV4_ADDRESS,
+        token_ttl=60
+    )
+
+    cmd = generate_mmds_v2_get_request(
+        IPV4_ADDRESS,
+        token=token
+    )
+    _, stdout, _ = ssh_connection.execute_command(cmd)
+    assert json.load(stdout) == data_store
+
+
+def copy_snapshot_artifacts(snapshot, rootfs, kernel, ssh_key):
+    """Copy snapshot artifacts to dedicated snapshot directory."""
+    # Create snapshot artifacts directory specific for the kernel version used.
+    guest_kernel_version = re.search(
+        'vmlinux-(.*).bin',
+        os.path.basename(kernel)
+    )
+    snapshot_artifacts_dir = os.path.join(
+        SNAPSHOT_ARTIFACTS_ROOT_DIR,
+        f"{guest_kernel_version.group(1)}_guest_snapshot"
+    )
+    os.mkdir(snapshot_artifacts_dir)
+
+    # Copy snapshot artifacts.
+    # Memory file.
+    mem_file_path = os.path.join(snapshot_artifacts_dir, "vm.mem")
+    shutil.copyfile(snapshot.mem, mem_file_path)
+    # MicroVM state file.
+    vmstate_file_path = os.path.join(snapshot_artifacts_dir, "vm.vmstate")
+    shutil.copyfile(snapshot.vmstate, vmstate_file_path)
+    # Ssh key file.
+    ssh_key_file_path = os.path.join(snapshot_artifacts_dir,
+                                     f"{ROOTFS_KEY}.id_rsa")
+    shutil.copyfile(ssh_key.local_path(), ssh_key_file_path)
+    # Rootfs file.
+    disk_file_path = os.path.join(snapshot_artifacts_dir, f"{ROOTFS_KEY}.ext4")
+    shutil.copyfile(rootfs, disk_file_path)
+
+    print("Copied snapshot memory file, vmstate file, disk and "
+          "ssh key to: {}.".format(snapshot_artifacts_dir))
+
+
+def main():
+    """
+    Run the main logic.
+
+    Create snapshot artifacts from complex microVMs with all Firecracker's
+    functionality enabled. The kernels are parametrized to include all guest
+    supported versions.
+
+    Artifacts are saved in the following format:
+    snapshot_artifacts
+        |
+        -> <guest_kernel_supported_0>_guest_snapshot
+            |
+            -> vm.mem
+            -> vm.vmstate
+            -> ubuntu-18.04.id_rsa
+            -> ubuntu-18.04.ext4
+        -> <guest_kernel_supported_1>_guest_snapshot
+            |
+            ...
+    """
+    # Create directory dedicated to store snapshot artifacts for
+    # each guest kernel version.
+    shutil.rmtree(SNAPSHOT_ARTIFACTS_ROOT_DIR, ignore_errors=True)
+    os.mkdir(SNAPSHOT_ARTIFACTS_ROOT_DIR)
+
+    root_path = tempfile.mkdtemp(
+        prefix=MicrovmBuilder.ROOT_PREFIX,
+        dir=f"{DEFAULT_TEST_SESSION_ROOT_PATH}")
+
+    # Compile new-pid cloner helper.
+    bin_cloner_path = compile_file(
+        file_name='newpid_cloner.c',
+        bin_name='newpid_cloner',
+        dest_path=root_path
+    )
+
+    # Fetch kernel and rootfs artifacts from S3 bucket.
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    kernel_artifacts = ArtifactSet(artifacts.kernels())
+    disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
+
+    # Create a test context.
+    test_context = TestContext()
+    test_context.custom = {
+        'bin_cloner_path': bin_cloner_path,
+        'session_root_path': root_path
+    }
+
+    # Create the test matrix.
+    test_matrix = TestMatrix(context=test_context,
+                             artifact_sets=[
+                                 kernel_artifacts,
+                                 disk_artifacts
+                             ])
+
+    test_matrix.run_test(create_snapshots)
+
+
+def create_snapshots(context):
+    """Snapshot microVM built from vm configuration file."""
+    vm = setup_vm(context)
+
+    # Get ssh key from read-only artifact.
+    ssh_key = context.disk.ssh_key()
+    ssh_key.download(vm.path)
+    vm.ssh_config['ssh_key_path'] = ssh_key.local_path()
+    os.chmod(vm.ssh_config['ssh_key_path'], 0o400)
+
+    _configure_vm_from_json(vm, VM_CONFIG_FILE)
+    configure_network_interfaces(vm)
+    vm.spawn()
+
+    # Ensure the microVM has started.
+    response = vm.machine_cfg.get()
+    assert vm.api_session.is_status_ok(response.status_code)
+    assert vm.state == "Running"
+
+    # Populate MMDS.
+    data_store = {
+        'latest': {
+            'meta-data': {
+                'ami-id': 'ami-12345678',
+                'reservation-id': 'r-fea54097',
+                'local-hostname': 'ip-10-251-50-12.ec2.internal',
+                'public-hostname': 'ec2-203-0-113-25.compute-1.amazonaws.com'
+            }
+        }
+    }
+    populate_mmds(vm, data_store)
+
+    # Iterate and validate connectivity on all ifaces after boot.
+    for iface in net_ifaces:
+        vm.ssh_config['hostname'] = iface.guest_ip
+        ssh_connection = net_tools.SSHConnection(vm.ssh_config)
+        exit_code, _, _ = ssh_connection.execute_command("sync")
+        assert exit_code == 0
+
+    # Validate MMDS.
+    validate_mmds(ssh_connection, data_store)
+
+    # Create a snapshot builder from a microVM.
+    snapshot_builder = SnapshotBuilder(vm)
+
+    # Snapshot the microVM.
+    snapshot = snapshot_builder.create(
+        [vm.rootfs_file],
+        ssh_key,
+        SnapshotType.DIFF,
+        net_ifaces=net_ifaces
+    )
+
+    copy_snapshot_artifacts(
+        snapshot,
+        vm.rootfs_file,
+        context.kernel.name(),
+        ssh_key
+    )
+
+    vm.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/devtool
+++ b/tools/devtool
@@ -692,6 +692,10 @@ cmd_help() {
     echo "        Run a continuous integration test run that executes the integration tests and"
     echo "        checks that the release process works."
     echo ""
+    echo "    create_snapshot_artifacts"
+    echo "        Runs a tool that generates snapshot artifacts for supported kernel versions."
+    echo "        Snapshot mem and state files are saved under \`snapshot_artifacts/\` directory"
+    echo ""
     echo "    distclean"
     echo "        Clean up the build tree and remove the docker container."
     echo ""
@@ -1330,6 +1334,33 @@ cmd_shell() {
     if [[ $ramdisk = true ]]; then
         umount_ramdisk
     fi
+
+    return $ret
+}
+
+
+cmd_create_snapshot_artifacts() {
+    privileged=true
+
+    # Make sure we have what we need to continue.
+    ensure_devctr
+    ensure_build_dir
+
+    say "Creating snapshot artifacts ..."
+    run_devctr \
+        --privileged \
+        --ulimit nofile=4096:4096 \
+        --ulimit memlock=-1:-1 \
+        --security-opt seccomp=unconfined \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        ${ramdisk_args} \
+        -- \
+        python3 tools/create_snapshot_artifact/main.py
+    ret=$?
+
+    # Running as root may have created some root-owned files under the build
+    # dir. Let's fix that.
+    cmd_fix_perms
 
     return $ret
 }


### PR DESCRIPTION
# Reason for This PR

Add `create_snapshot_artifacts` devtool command that creates snapshot artifacts for microVMs built from config file.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] The issue which led to this PR has a clear conclusion.~
- ~[ ] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] Any newly added `unsafe` code is properly documented.~
- ~[ ] Any API changes follow the [Runbook for Firecracker API changes][2].~
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
