### PR TITLE
kvm: KVM_CAP_IRQCHIP not needed on ARM

### DIFF
--- a/src/vmm/src/vstate/system.rs
+++ b/src/vmm/src/vstate/system.rs
@@ -78,7 +78,7 @@ impl KvmContext {
 
         #[cfg(target_arch = "aarch64")]
         let capabilities = vec![
-            Irqchip, Ioeventfd, Irqfd, UserMemory, ArmPsci02, DeviceCtrl, MpState, OneReg,
+            Ioeventfd, Irqfd, UserMemory, ArmPsci02, DeviceCtrl, MpState, OneReg,
         ];
 
         // Check that all desired capabilities are supported.


### PR DESCRIPTION
# Reason for This PR

We are using KVM_CREATE_DEVICE to setup the
irqchip on ARM guests and not KVM_CREATE_IRQCHIP. Since
KVM_CAP_IRQCHIP is only mandated by the use of KVM_CREATE_IRQCHIP,
this means that on ARM we do not actually need to check for that
kvm capability.

For a detailed explanation check out kvm doc: https://elixir.bootlin.com/linux/v4.14.266/source/Documentation/virtual/kvm/api.txt#L659.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
