### PR TITLE
tests: remove cfg's that forbid runs on aarch64

### DIFF
--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -708,8 +708,6 @@ mod tests {
         .unwrap();
         let mut vm = builder::setup_kvm_vm(&guest_mem, false).unwrap();
 
-        #[cfg(target_arch = "x86_64")]
-        // Only used for x86_64 part of the test.
         let mem_clone = guest_mem.clone();
 
         #[cfg(target_arch = "x86_64")]
@@ -744,27 +742,25 @@ mod tests {
             .get_device(DeviceType::Virtio(type_id), &id)
             .is_none());
 
-        #[cfg(target_arch = "x86_64")]
-        {
-            let dummy2 = Arc::new(Mutex::new(DummyDevice::new()));
-            let id2 = String::from("foo2");
-            device_manager
-                .register_virtio_test_device(vm.fd(), mem_clone, dummy2, &mut cmdline, &id2)
-                .unwrap();
+        let dummy2 = Arc::new(Mutex::new(DummyDevice::new()));
+        let id2 = String::from("foo2");
+        device_manager
+            .register_virtio_test_device(vm.fd(), mem_clone, dummy2, &mut cmdline, &id2)
+            .unwrap();
 
-            let mut count = 0;
-            let _: Result<()> = device_manager.for_each_device(|devtype, devid, _, _| {
-                assert_eq!(*devtype, DeviceType::Virtio(type_id));
-                match devid.as_str() {
-                    "foo" => count += 1,
-                    "foo2" => count += 2,
-                    _ => unreachable!(),
-                };
-                Ok(())
-            });
-            assert_eq!(count, 3);
-            assert_eq!(device_manager.used_irqs_count(), 2);
-        }
+        let mut count = 0;
+        let _: Result<()> = device_manager.for_each_device(|devtype, devid, _, _| {
+            assert_eq!(*devtype, DeviceType::Virtio(type_id));
+            match devid.as_str() {
+                "foo" => count += 1,
+                "foo2" => count += 2,
+                _ => unreachable!(),
+            };
+            Ok(())
+        });
+        assert_eq!(count, 3);
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(device_manager.used_irqs_count(), 2);
     }
 
     #[test]

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1233,7 +1233,6 @@ mod tests {
         );
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_preboot_load_snapshot() {
         let mut vm_resources = MockVmRes::default();

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.94, "AMD": 84.41, "ARM": 84.04}
+    COVERAGE_DICT = {"Intel": 84.94, "AMD": 84.41, "ARM": 84.29}
 else:
-    COVERAGE_DICT = {"Intel": 81.93, "AMD": 81.46, "ARM": 80.99}
+    COVERAGE_DICT = {"Intel": 81.93, "AMD": 81.46, "ARM": 81.25}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

There were some leftover cfgs in tests that made them not run on arm.

## Description of Changes

Removed the cfgs to increase code coverage

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
