### PR TITLE
Mmds remove speculative address check.

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.94, "AMD": 84.41, "ARM": 84.29}
+    COVERAGE_DICT = {"Intel": 84.99, "AMD": 84.48, "ARM": 84.29}
 else:
-    COVERAGE_DICT = {"Intel": 81.93, "AMD": 81.46, "ARM": 81.25}
+    COVERAGE_DICT = {"Intel": 82.0, "AMD": 81.46, "ARM": 81.25}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

With a special crafted packet the speculative check from the `detour_frame` method could have been bypassed.

Fixes #

## Description of Changes

* Removes the speculative check of address from `detour_frame` method. 
* The address is now checked after the ethertype is verified.
* 

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
