### PR TITLE
rate_limiter: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,6 @@ dependencies = [
 name = "rate_limiter"
 version = "0.1.0"
 dependencies = [
- "libc",
  "logger",
  "snapshot",
  "timerfd",

--- a/src/rate_limiter/Cargo.toml
+++ b/src/rate_limiter/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-libc = ">=0.2.39"
 timerfd = ">=1.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"


### PR DESCRIPTION
# Reason for This PR

The rate_limiter has no dependencies on the libc.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>

## Description of Changes

Remove the libc dependence.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

