### PR TITLE
mmds: don't initialise data store unless used

### DIFF
--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -54,6 +54,25 @@ pub fn default_net() -> Net {
     net
 }
 
+pub fn default_net_no_mmds() -> Net {
+    let next_tap = NEXT_INDEX.fetch_add(1, Ordering::SeqCst);
+    let tap_dev_name = format!("net-device{}", next_tap);
+
+    let guest_mac = default_guest_mac();
+
+    let net = Net::new_with_tap(
+        format!("net-device{}", next_tap),
+        tap_dev_name,
+        Some(&guest_mac),
+        RateLimiter::default(),
+        RateLimiter::default(),
+    )
+    .unwrap();
+    enable(&net.tap);
+
+    net
+}
+
 pub enum ReadTapMock {
     Failure,
     MockFrame(Vec<u8>),


### PR DESCRIPTION
# Reason for This PR

The mmds data store is initialised to a default even if
it is never used.

## Description of Changes

With this PR, the mmds data store is created on demand. View commit message for more info.
Also adapts unit tests.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
