### PR TITLE
virtio-net: add support for notification suppression

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -154,16 +154,16 @@ The Firecracker snapshotting implementation offers support for snapshot versioni
   Firecracker release `v` might drop the possibility to save snapshots at any
   versions older than `v`.
 
-  For example Firecracker v1.0 adds support for some additional virtio features
-  (e.g. notification suppression). These features lead the guest drivers to
-  behave in a very specific way and as a consequence the Firecracker devices
-  have to respond accordingly. As a result, the snapshots that are created
-  while these features are in use will not be backwards compatible with
+  For example Firecracker v1.0 and v1.1 adds support for some additional virtio
+  features (e.g. notification suppression). These features lead the guest
+  drivers to behave in a very specific way and as a consequence the Firecracker
+  devices have to respond accordingly. As a result, the snapshots that are
+  created while these features are in use will not be backwards compatible with
   previous versions of Firecracker since the devices that come with these older
   versions do not behave in a way that’s compatible with the snapshotted guest
   drivers.
 
-  The list of versions that break snapshot backwards compatibility: `1.0`
+  The list of versions that break snapshot backwards compatibility: `1.0`, `1.1`
 - Loading snapshots from older versions (being able to load a snapshot created
   by any Firecracker version in the `[N, N + o]` interval, in a Firecracker
   version `N+o`).

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -22,6 +22,14 @@ pub use self::device::Net;
 pub use self::event_handler::*;
 pub use tap::Error as TapError;
 
+/// Enum representing the Net device queue types
+pub enum NetQueue {
+    /// The RX queue
+    Rx,
+    /// The TX queue
+    Tx,
+}
+
 #[derive(Debug)]
 pub enum Error {
     /// Open tap device failed.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.82, "AMD": 84.32, "ARM": 83.91}
+    COVERAGE_DICT = {"Intel": 84.89, "AMD": 84.38, "ARM": 84.06}
 else:
-    COVERAGE_DICT = {"Intel": 81.86, "AMD": 81.36, "ARM": 80.90}
+    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.43, "ARM": 81.05}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -824,8 +824,8 @@ def test_mmds_snapshot(bin_cloner_path,  version):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
-        # v1.0.0 breaks snapshot compatibility with older versions.
-        min_version="1.0.0",
+        # v1.1.0 breaks snapshot compatibility with older versions.
+        min_version="1.1.0",
         max_version=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         vm_instance = vm_builder.build_vm_nano(

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -89,8 +89,8 @@ def test_restore_old_version(bin_cloner_path):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
-        # v1.0.0 breaks snapshot compatibility with older versions.
-        min_version="1.0.0",
+        # v1.1.0 breaks snapshot compatibility with older versions.
+        min_version="1.1.0",
         max_version=get_firecracker_version_from_toml())
     for firecracker in firecracker_artifacts:
         firecracker.download()

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -198,12 +198,26 @@ def test_create_with_newer_virtio_features(bin_cloner_path):
                "with older versions of Firecracker: notification suppression" \
                in response.text
 
-        # It should work when we target a version >= 1.0.0
-        response = test_microvm.snapshot.create(
-            mem_file_path="/snapshot/vm.mem",
-            snapshot_path="/snapshot/vm.vmstate",
-            version="1.0.0"
-        )
-        assert test_microvm.api_session.is_status_no_content(
-            response.status_code
-        )
+    # We try to create a snapshot for target version 1.0.0. This should
+    # fail because in 1.0.0 we do not support notification suppression for Net.
+    response = test_microvm.snapshot.create(
+        mem_file_path="/snapshot/vm.mem",
+        snapshot_path="/snapshot/vm.vmstate",
+        version="1.0.0"
+    )
+    assert test_microvm.api_session.is_status_bad_request(
+        response.status_code
+    )
+    assert "The virtio devices use a features that is incompatible " \
+           "with older versions of Firecracker: notification suppression" \
+           in response.text
+
+    # It should work when we target a version >= 1.1.0
+    response = test_microvm.snapshot.create(
+        mem_file_path="/snapshot/vm.mem",
+        snapshot_path="/snapshot/vm.vmstate",
+        version="1.1.0"
+    )
+    assert test_microvm.api_session.is_status_no_content(
+        response.status_code
+    )


### PR DESCRIPTION
# Reason for This PR

Integrate notification suppression for the VirtIO net device (see issues: #2478, #2636) using functionality added for the 
equivalent block device feature (#2658).

## Description of Changes

Here I mainly used the machinery introduced by @serban300 for the corresponding block device feature. I ran a number of tests to evaluate performance impact.

My experimental setup is the following:
* I 'm using an `c5d.metal` instance
* I am using 48 cores to avoid using hyper-threading
* Each microVM has 5 vcpus and 4GB of memory (so that each microVM has 7 threads in total)
* I launch from 1-12 microVMs pinning them in cores and forcing them to allocate memory from the corresponding NUMA node, i.e. 6 microVMs fill up the available cores. Data points with more than 6 microVMs represent overcommit scenarios.
* Each microVM is running an `iperf3` server
* On the host side I launch an `iperf3` client (which I pin in a core not occupied by a microVM thread) per microVM and launch one TX and one RX experiment.

In the following table I show the percentage increase of bandwidth (RX and TX) when using notification over the current main.

| #VMs | RX (% increase) | TX (% increase) |
|---|---|---|
|1|98.53|98.53|
|2|98.48|98.48|
|3|97.64|97.64|
|4|100.59|100.59|
|5|100.78|100.78|
|6|99.04|99.04|
|7|97.83|97.83|
|8|98.92|98.92|
|9|99.52|99.52|
|10|98.64|98.64|
|11|99.83|99.83|
|12|100.00|100.00|

We see that the current implementation does not actually provide any performance boost. My current best guess is that
due to the fact that our virtio-net implementation already consumes as many Descriptor heads from the virtqueue as possible before raising a trigger, suppressing notification does not really make a difference.

Trying to dive a bit deeper, I also compared the `net` metrics of the two implementations:

| metric | notification_suppression / main (%) |
|---|---|
|tx_packets_count|100.71|
|no_rx_avail_buffer|112.94|
|rx_queue_event_count|101.77|
|rx_packets_count|102.58|
|rx_tap_event_count|117.18|
|tx_queue_event_count|100.65|
|no_tx_avail_buffer|0.45|
|tx_count|100.71|
|tx_bytes_count|100.71|
|rx_bytes_count|102.59|
|rx_count|102.58|

An interesting result from this table is that whereas notification suppression almost eliminates `no_tx_avail_buffer` events, the corresponding RX path events (`no_rx_avail_buffer`) actually increase by ~13%.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
