### PR TITLE
Persist mmds version in snapshot and make MmdsV2 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@
   reset the `cpu_template` once it was set.
 - Added a `rebase-snap` tool for rebasing a diff snapshot over a base
   snapshot.
+- Mmds version is persisted across snapshot-restore. Snapshot compatibility is
+  preserved bidirectionally, to and from a Firecracker version that does not
+  support persisting the Mmds version. In such cases, the default V1 option is
+  used.
 
 ### Changed
 
 - The API `PATCH` method for `/machine-config` can be now used to change
   `track_dirty_pages` on aarch64.
+- MmdsV2 is now Generally Available.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "firecracker"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api_server",
  "event-manager",
@@ -460,7 +460,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jailer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "libc",
  "regex",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "rebase-snap"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "libc",
  "utils",
@@ -841,7 +841,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seccompiler"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "libc",

--- a/docs/mmds/mmds-user-guide.md
+++ b/docs/mmds/mmds-user-guide.md
@@ -83,7 +83,7 @@ ip route add ${MMDS_IPV4_ADDR} dev ${MMDS_NET_IF}
 ```
 
 MMDS supports two methods to access the contents of the metadata store from the
-guest operating system: `V1` and `V2` (in [developer preview](../RELEASE_POLICY.md)).
+guest operating system: `V1` and `V2`.
 More about the particularities of the two mechanisms can be found in the
 [Retrieving metadata in the guest operating system](#retrieving-metadata-in-the-guest-operating-system)
 section. The MMDS version used can be specified when configuring MMDS, through
@@ -217,7 +217,7 @@ Accessing the contents of the metadata store from the guest operating system
 can be done using one of the following methods:
 
 - `V1`: simple request/response method
-- `V2`: session-oriented method (in [developer preview](../RELEASE_POLICY.md))
+- `V2`: session-oriented method
 
 #### Version 1
 
@@ -271,24 +271,19 @@ curl -s "http://${MMDS_IPV4_ADDR}/${RESOURCE_POINTER_OBJ}" \
 
 After the token expires, it becomes unusable and a new session token must be issued.
 
-##### Developer preview status
+##### Snapshotting considerations
 
-View the [release policy](../RELEASE_POLICY.md) for information about developer
-preview terminology.
+The data store is **not** persisted across snapshots, in order to avoid leaking
+vm-specific information that may need to be reseeded into the data store for
+a new clone.
 
-MMDS `version 2` is not yet suitable for production use. Currently, there is no
-way to configure `V2` after loading a microVM snapshot from file. Even if the
-base microVM snapshotted was customized to use MMDS `V2`, the snapshot clone
-defaults to MMDS `V1`.
+The MMDS version, network stack configuration and IP address used for accessing the
+service are persisted across snapshot-restore.
 
-It is important to note that the network interfaces configured to allow
-forwarding requests to MMDS and the custom IPv4 address are preserved between
-snapshots.
-
-We plan to make MMDS version 2 production ready once we will fully integrate it
-with snapshotting workflows and we will have a mechanism to preserve MMDS version
-configured between snapshots (the same we do for the IPv4 address or network
-interfaces that allow MMDS requests).
+If the targeted snapshot version does not support Mmds Version 2, it will not be
+persisted in the snapshot (the clone will use the default, V1). Similarly, if a
+snapshotted Vm state contains the Mmds version but the Firecracker version used
+for restoring does not support persisting the version, the default will be used.
 
 ### MMDS formats
 

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 1.0.0
+  version: 1.1.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"
@@ -1196,4 +1196,4 @@ definitions:
         description: Path to UNIX domain socket, used to proxy vsock connections.
       vsock_id:
         type: string
-        description: This parameter has been deprecated since v1.0.0.
+        description: This parameter has been deprecated since v1.1.0.

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -90,7 +90,8 @@ impl Persist<'_> for Net {
         .map_err(Error::CreateNet)?;
 
         // We trust the MMIODeviceManager::restore to pass us an MMDS data store reference if
-        // there is at least one net device having the MMDS NS present. Otherwise, return an error.
+        // there is at least one net device having the MMDS NS present and/or the mmds version was
+        // persisted in the snapshot.
         if let Some(mmds_ns) = &state.mmds_ns {
             // We're safe calling unwrap() to discard the error, as MmdsNetworkStack::restore() always
             // returns Ok.

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jailer"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/mmds/src/ns.rs
+++ b/src/mmds/src/ns.rs
@@ -71,7 +71,7 @@ pub struct MmdsNetworkStack {
     // This handles MMDS<->guest interaction at the TCP level.
     pub(crate) tcp_handler: TcpIPv4Handler,
     // Data store reference shared across all MmdsNetworkStack instances.
-    mmds: Arc<Mutex<Mmds>>,
+    pub mmds: Arc<Mutex<Mmds>>,
 }
 
 impl MmdsNetworkStack {

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebase-snap"
-version = "0.1.0"
+version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccompiler"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 build = "../../build.rs"

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -411,8 +411,8 @@ impl VmResources {
         Ok(())
     }
 
-    // Updates MMDS version.
-    fn set_mmds_version(
+    /// Updates MMDS version.
+    pub fn set_mmds_version(
         &mut self,
         version: MmdsVersion,
         instance_id: &str,

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -24,6 +24,8 @@ pub const FC_V0_24_SNAP_VERSION: u16 = 2;
 pub const FC_V0_25_SNAP_VERSION: u16 = 3;
 /// Snap version for Firecracker v1.0
 pub const FC_V1_0_SNAP_VERSION: u16 = 4;
+/// Snap version for Firecracker v1.1
+pub const FC_V1_1_SNAP_VERSION: u16 = 5;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -40,9 +42,12 @@ lazy_static! {
         #[cfg(target_arch = "x86_64")]
         version_map.set_type_version(VcpuState::type_id(), 2);
 
-        // v1.0 state change mappings
+        // v1.0 state change mappings.
         version_map.new_version().set_type_version(QueueState::type_id(), 2);
         version_map.set_type_version(BlockState::type_id(), 3);
+
+        // v1.1 state change mappings.
+        version_map.new_version().set_type_version(DeviceStates::type_id(), 3);
 
         version_map
     };
@@ -57,6 +62,7 @@ lazy_static! {
         mapping.insert(String::from("0.24.0"), FC_V0_24_SNAP_VERSION);
         mapping.insert(String::from("0.25.0"), FC_V0_25_SNAP_VERSION);
         mapping.insert(String::from("1.0.0"), FC_V1_0_SNAP_VERSION);
+        mapping.insert(String::from("1.1.0"), FC_V1_1_SNAP_VERSION);
 
         mapping
     };

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -16,7 +16,7 @@ from framework.utils import compare_versions
 from host_tools.snapshot_helper import merge_memory_bitmaps
 
 
-ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts"
+ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts-alin"
 
 
 class ArtifactType(Enum):

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -714,7 +714,8 @@ class Network():
             host_dev_name=None,
             guest_mac=None,
             rx_rate_limiter=None,
-            tx_rate_limiter=None):
+            tx_rate_limiter=None,
+            allow_mmds_requests=None):
         """Create the json for the net specific API request."""
         datax = {
             'iface_id': iface_id
@@ -731,6 +732,10 @@ class Network():
 
         if rx_rate_limiter is not None:
             datax['rx_rate_limiter'] = rx_rate_limiter
+
+        # Keep this for interacting with older FC versions in snapshot tests.
+        if allow_mmds_requests is not None:
+            datax['allow_mmds_requests'] = allow_mmds_requests
 
         return datax
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -31,7 +31,7 @@ from host_tools import proc
 if utils.is_io_uring_supported():
     COVERAGE_DICT = {"Intel": 85.18, "AMD": 84.66, "ARM": 84.42}
 else:
-    COVERAGE_DICT = {"Intel": 82.2, "AMD": 81.68, "ARM": 81.37}
+    COVERAGE_DICT = {"Intel": 82.2, "AMD": 81.68, "ARM": 81.44}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -15,7 +15,7 @@ import pytest
 from framework import utils
 from framework.artifacts import NetIfaceConfig
 from framework.utils import generate_mmds_session_token, \
-    generate_mmds_v2_get_request
+    generate_mmds_get_request
 from framework import utils_cpuid
 import host_tools.network as net_tools
 
@@ -94,11 +94,7 @@ def _build_cmd_to_fetch_metadata(ssh_connection, version, ipv4_address):
     the `GET` request.
     """
     # Fetch data from MMDS from the guest's side.
-    if version == "V1":
-        cmd = 'curl -s -H "Accept: application/json" '
-        cmd += 'http://{}'.format(ipv4_address)
-
-    else:
+    if version == "V2":
         # If MMDS is configured to version 2, so we need to create
         # the session token first.
         token = generate_mmds_session_token(
@@ -106,9 +102,10 @@ def _build_cmd_to_fetch_metadata(ssh_connection, version, ipv4_address):
             ipv4_address,
             token_ttl=60
         )
-        cmd = generate_mmds_v2_get_request(ipv4_address, token)
+    else:
+        token = None
 
-    return cmd
+    return generate_mmds_get_request(ipv4_address, token)
 
 
 def _get_optional_fields_from_file(vm_config_file):

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "seccompiler"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "libc",

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -22,7 +22,7 @@ from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.matrix import TestMatrix, TestContext
 from framework.utils import generate_mmds_session_token, \
-    generate_mmds_v2_get_request, run_cmd
+    generate_mmds_get_request, run_cmd
 from integration_tests.functional.test_cmd_line_start import \
     _configure_vm_from_json
 import host_tools.network as net_tools  # pylint: disable=import-error
@@ -130,7 +130,7 @@ def validate_mmds(ssh_connection, data_store):
         token_ttl=60
     )
 
-    cmd = generate_mmds_v2_get_request(
+    cmd = generate_mmds_get_request(
         IPV4_ADDRESS,
         token=token
     )

--- a/tools/devtool
+++ b/tools/devtool
@@ -1460,6 +1460,7 @@ cmd_prepare_release() {
     files_to_change=("$swagger"                                 \
                      "$FC_ROOT_DIR/src/firecracker/Cargo.toml"  \
                      "$FC_ROOT_DIR/src/jailer/Cargo.toml"       \
+                     "$FC_ROOT_DIR/src/rebase-snap/Cargo.toml"  \
                      "$FC_ROOT_DIR/src/seccompiler/Cargo.toml")
     say "Updating source files:"
     for file in "${files_to_change[@]}"; do


### PR DESCRIPTION
# Reason for This PR

Previously, there was no way of using MmdsV2 after a snapshot restore.

## Description of Changes

The mmds version is now persisted in the snapshot.
Make Mmds V2 Generally available.
Adds extensive integration tests.

### **Note: The last commit adds a temporary CI folder. I'll remove it once I get a couple of reviews and the PR is close to merge. The folder adds v1.1.0 binaries built from this PR's code**

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
