### PR TITLE
tests/snapshots: cross kernel test with cpu templates

### DIFF
--- a/tests/integration_tests/functional/test_cmd_line_start.py
+++ b/tests/integration_tests/functional/test_cmd_line_start.py
@@ -20,13 +20,15 @@ from framework import utils_cpuid
 import host_tools.network as net_tools
 
 
-def _configure_vm_from_json(test_microvm, vm_config_file):
+def _configure_vm_from_json(test_microvm, vm_config_file, json_xform=None):
     """
     Configure a microvm using a file sent as command line parameter.
 
     Create resources needed for the configuration of the microvm and
     set as configuration file a copy of the file that was passed as
     parameter to this helper function.
+    Also apply a transformation fuction to the copy of the configuration
+    JSON if specified.
     """
     test_microvm.create_jailed_resource(test_microvm.kernel_file,
                                         create_jail=True)
@@ -40,9 +42,11 @@ def _configure_vm_from_json(test_microvm, vm_config_file):
     vm_config_path = os.path.join(test_microvm.path,
                                   os.path.basename(vm_config_file))
     with open(vm_config_file, encoding='utf-8') as f1:
+        vm_cfg_json = json.load(f1)
+        if json_xform is not None:
+            vm_cfg_json = json_xform(vm_cfg_json)
         with open(vm_config_path, "w", encoding='utf-8') as f2:
-            for line in f1:
-                f2.write(line)
+            json.dump(vm_cfg_json, f2)
     test_microvm.create_jailed_resource(vm_config_path, create_jail=True)
     test_microvm.jailer.extra_args = {'config-file': os.path.basename(
         vm_config_file)}

--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import os
+import re
 import pathlib
 import shutil
 import pytest
@@ -113,8 +114,9 @@ def _test_mmds(vm, mmds_net_iface):
 
 
 @pytest.mark.nonci
+@pytest.mark.parametrize("cpu_template", ["C3", "T2", "None"])
 def test_snap_restore_from_artifacts(bin_cloner_path, bin_vsock_path,
-                                     test_fc_session_root_path):
+                                     test_fc_session_root_path, cpu_template):
     """
     Restore from snapshots obtained with all supported guest kernel versions.
 
@@ -133,8 +135,13 @@ def test_snap_restore_from_artifacts(bin_cloner_path, bin_vsock_path,
     pathlib.Path(Artifact.LOCAL_ARTIFACT_DIR).mkdir(parents=True,
                                                     exist_ok=True)
 
-    # Iterate through all subdirectories in the snapshot root dir.
-    for subdir_name in os.listdir(snapshot_root_dir):
+    # Iterate through all subdirectories based on CPU template
+    # in the snapshot root dir.
+    subdir_filter = r".*_" + re.escape(cpu_template) + r"_guest_snapshot"
+    snap_subdirs = [
+        d for d in os.listdir(snapshot_root_dir) if re.match(subdir_filter, d)
+    ]
+    for subdir_name in snap_subdirs:
         snapshot_dir = os.path.join(snapshot_root_dir, subdir_name)
         assert os.path.isdir(snapshot_dir)
 


### PR DESCRIPTION
# Reason for This PR
These changes allow for better coverage for snap-restore testing and
can be reused to test cross-CPU snap restore compatibility.

## Description of Changes

Extend the functionality of the snapshot artifact creator tool in order
to create snapshots based on CPU templates.
Change the snapshot_restore_cross_kernel test to check restore
capability based on CPU template.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [N/A] The issue which led to this PR has a clear conclusion.
- [N/A] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [N/A] Any newly added `unsafe` code is properly documented.
- [N/A] Any API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
