### PR TITLE
Don't explicitly send FC's PID to the page fault handler

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.44, "ARM": 84.11}
+    COVERAGE_DICT = {"Intel": 84.95, "AMD": 84.44, "ARM": 83.99}
 else:
-    COVERAGE_DICT = {"Intel": 81.98, "AMD": 81.48, "ARM": 81.1}
+    COVERAGE_DICT = {"Intel": 81.98, "AMD": 81.48, "ARM": 80.98}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

The page fault handler process requires FC's PID in order
to be able to notify FC of any crashes/exists. The way
we initially intended to make the handler process aware
of FC's PID was to have FC sent its PID explicitly through
the UDS. But there is a problem with this approach:

Firecracker's PID depends on the way the process was started.
When normally started through the jailer, Firecracker will
see its global PID. However, if using `--new-pid-ns` flag
when running the jailer, the jailer will spawn FC in a new
PID namespace, which would cause Firecracker to not be
aware of its PID and see it as being 1.

Moreover, when not using `--new-pid-ns` flag, we recommend
to the users to spawn the jailer process into a new PID
namespace when starting it.

This is why sending FC's PID from whithin the FC process is
not reliable.

To tackle this, we no longer send FC's PID explicitly,
but advise the page fault handler process to use
`getsockopt` call with `SO_PEERCRED` option in order
to fetch the global Firecracker PID at the moment of
connecting. Per [pid_namespaces man page](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html):

> When a process ID is passed over a UNIX domain socket to a
   process in a different PID namespace (see the description of
   SCM_CREDENTIALS in [unix(7)](https://man7.org/linux/man-pages/man7/unix.7.html)), it is translated into the
   corresponding PID value in the receiving process's PID namespace.


## Description of Changes

Don't explicitly send FC's PID to the page fault handler process.

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] The issue which led to this PR has a clear conclusion.~
- ~[ ] This PR follows the solution outlined in the related issue.~
- [X] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] Any newly added `unsafe` code is properly documented.~
- ~[ ] Any API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
