### PR TITLE
Removed the trailing semi-colon in `unwrap_async_file_engine_or_return`

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -225,7 +225,7 @@ macro_rules! unwrap_async_file_engine_or_return {
                 error!("The block device doesn't use an async IO engine");
                 return;
             }
-        };
+        }
     };
 }
 


### PR DESCRIPTION
# Reason for This PR

issue https://github.com/firecracker-microvm/firecracker/issues/2951

Fixes:
```
warning: trailing semicolon in macro used in expression position
   --> src/devices/src/virtio/block/device.rs:228:10
    |
228 |         };
    |          ^
...
394 |         let engine = unwrap_async_file_engine_or_return!(&mut self.disk.file_engine);
    |                      --------------------------------------------------------------- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `unwrap_async_file_engine_or_return` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Description of Changes

Removed trailing semi-colon.

- [x] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
