### PR TITLE
Using tagged enum variants for exit codes

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -172,7 +172,7 @@ impl ApiServer {
     ) -> Result<()> {
         let mut server = HttpServer::new(path).unwrap_or_else(|e| {
             error!("Error creating the HTTP server: {}", e);
-            std::process::exit(vmm::FC_EXIT_CODE_GENERIC_ERROR);
+            std::process::exit(vmm::FcExitCode::GenericError as i32);
         });
         // Announce main thread that the socket path was created.
         // As per the doc, "A send operation can only fail if the receiving end of a channel is disconnected".

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -18,7 +18,7 @@ use vmm::{
     resources::VmResources,
     rpc_interface::{PrebootApiController, RuntimeApiController, VmmAction},
     vmm_config::instance_info::InstanceInfo,
-    EventManager, ExitCode, Vmm,
+    EventManager, FcExitCode, Vmm,
 };
 
 struct ApiServerAdapter {
@@ -38,7 +38,7 @@ impl ApiServerAdapter {
         vm_resources: VmResources,
         vmm: Arc<Mutex<Vmm>>,
         event_manager: &mut EventManager,
-    ) -> ExitCode {
+    ) -> FcExitCode {
         let api_adapter = Arc::new(Mutex::new(Self {
             api_event_fd,
             from_api,
@@ -126,7 +126,7 @@ pub(crate) fn run_with_api(
     api_payload_limit: usize,
     mmds_size_limit: usize,
     metadata_json: Option<&str>,
-) -> ExitCode {
+) -> FcExitCode {
     // FD to notify of API events. This is a blocking eventfd by design.
     // It is used in the config/pre-boot loop which is a simple blocking loop
     // which only consumes API events.

--- a/src/vmm/benches/main.rs
+++ b/src/vmm/benches/main.rs
@@ -20,7 +20,7 @@ use vmm::utilities::mock_resources::NOISY_KERNEL_IMAGE;
 use vmm::utilities::test_utils::create_vmm;
 use vmm::version_map::VERSION_MAP;
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, SnapshotType};
-use vmm::{persist, FC_EXIT_CODE_OK};
+use vmm::{persist, FcExitCode};
 
 #[inline]
 pub fn bench_restore_snapshot(
@@ -83,7 +83,7 @@ fn create_microvm_state(is_diff: bool) -> MicrovmState {
         persist::create_snapshot(&mut locked_vmm, &snapshot_params, VERSION_MAP.clone()).unwrap();
     }
 
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 
     // Deserialize the microVM state from `snapshot_file`.
     let snapshot_path = snapshot_file.as_path().to_path_buf();

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -32,8 +32,8 @@ use crate::vmm_config::net::{
 use crate::vmm_config::snapshot::{CreateSnapshotParams, LoadSnapshotParams, SnapshotType};
 use crate::vmm_config::vsock::{VsockConfigError, VsockDeviceConfig};
 use crate::vmm_config::{self, RateLimiterUpdate};
+use crate::FcExitCode;
 use crate::{builder::StartMicrovmError, warn, EventManager};
-use crate::{ExitCode, FC_EXIT_CODE_BAD_CONFIGURATION};
 use logger::{error, info, update_metric_with_elapsed_time, METRICS};
 use mmds::data_store::{self, Mmds};
 use seccompiler::BpfThreadMap;
@@ -282,7 +282,7 @@ pub struct PrebootApiController<'a> {
     boot_path: bool,
     // Some PrebootApiRequest errors are irrecoverable and Firecracker
     // should cleanly teardown if they occur.
-    fatal_error: Option<ExitCode>,
+    fatal_error: Option<FcExitCode>,
 }
 
 impl MmdsRequestHandler for PrebootApiController<'_> {
@@ -325,7 +325,7 @@ impl<'a> PrebootApiController<'a> {
         boot_timer_enabled: bool,
         mmds_size_limit: usize,
         metadata_json: Option<&str>,
-    ) -> result::Result<(VmResources, Arc<Mutex<Vmm>>), ExitCode>
+    ) -> result::Result<(VmResources, Arc<Mutex<Vmm>>), FcExitCode>
     where
         F: Fn() -> VmmAction,
         G: Fn(ActionResult),
@@ -350,7 +350,7 @@ impl<'a> PrebootApiController<'a> {
                 )
                 .map_err(|err| {
                     error!("Populating MMDS from file failed: {:?}", err);
-                    crate::FC_EXIT_CODE_GENERIC_ERROR
+                    crate::FcExitCode::GenericError
                 })?;
 
             info!("Successfully added metadata to mmds from file");
@@ -549,7 +549,7 @@ impl<'a> PrebootApiController<'a> {
         })
         .map_err(|e| {
             // The process is too dirty to recover at this point.
-            self.fatal_error = Some(FC_EXIT_CODE_BAD_CONFIGURATION);
+            self.fatal_error = Some(FcExitCode::BadConfiguration);
             VmmActionError::LoadSnapshot(e)
         });
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use vmm::resources::VmResources;
 use vmm::seccomp_filters::{get_filters, SeccompConfig};
 use vmm::version_map::VERSION_MAP;
 use vmm::vmm_config::snapshot::{CreateSnapshotParams, SnapshotType};
-use vmm::{EventManager, FC_EXIT_CODE_OK};
+use vmm::{EventManager, FcExitCode};
 
 use vmm::utilities::mock_devices::MockSerialInput;
 use vmm::utilities::mock_resources::{MockVmResources, NOISY_KERNEL_IMAGE};
@@ -61,11 +61,11 @@ fn test_build_microvm() {
     #[cfg(target_arch = "x86_64")]
     _evmgr.run_with_timeout(500).unwrap();
     #[cfg(target_arch = "aarch64")]
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 
     assert_eq!(
         vmm.lock().unwrap().shutdown_exit_code(),
-        Some(FC_EXIT_CODE_OK)
+        Some(FcExitCode::Ok)
     );
 }
 
@@ -81,7 +81,7 @@ fn test_pause_resume_microvm() {
     // `Paused` state).
     assert!(vmm.lock().unwrap().pause_vm().is_ok());
     assert!(vmm.lock().unwrap().resume_vm().is_ok());
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn test_dirty_bitmap_error() {
         format!("{:?}", vmm.lock().unwrap().get_dirty_bitmap().err()),
         "Some(DirtyBitmap(Error(2)))"
     );
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn test_dirty_bitmap_success() {
         })
         .sum();
     assert!(num_dirty_pages > 0);
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn test_disallow_snapshots_without_pausing() {
     // It is now allowed.
     vmm.lock().unwrap().save_state().unwrap();
     // Stop.
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
 fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
@@ -170,7 +170,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
         persist::create_snapshot(&mut locked_vmm, &snapshot_params, VERSION_MAP.clone()).unwrap();
     }
 
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 
     // Check that we can deserialize the microVM state from `snapshot_file`.
     let snapshot_path = snapshot_file.as_path().to_path_buf();
@@ -239,7 +239,7 @@ fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
     )
     .unwrap();
     // For now we're happy we got this far, we don't test what the guest is actually doing.
-    vmm.lock().unwrap().stop(FC_EXIT_CODE_OK);
+    vmm.lock().unwrap().stop(FcExitCode::Ok);
 }
 
 #[test]


### PR DESCRIPTION
# Reason for This PR

See issue https://github.com/firecracker-microvm/firecracker/issues/2954

## Description of Changes

Using an enum with tagged variants instead of multiple constants to define exit codes.
```rust
/// Vmm exit-code type.
#[derive(PartialEq,Clone,Copy,Debug)]
enum FcExitCode {
    /// Success exit code.
    Ok = 0,
    /// Generic error exit code.
    CodeGenericError = 1,
    /// Generic exit code for an error considered not possible to occur if the program logic is sound.
    UnexpectedError = 2,
    /// Firecracker was shut down after intercepting a restricted system call.
    BadSyscall = 148,
    /// Firecracker was shut down after intercepting `SIGBUS`.
    SIGBUS = 149,
    /// Firecracker was shut down after intercepting `SIGSEGV`.
    SIGSEGV = 150,
    /// Firecracker was shut down after intercepting `SIGXFSZ`.
    SIGXFSZ = 151,
    /// Firecracker was shut down after intercepting `SIGXCPU`.
    SIGXCPU = 154,
    /// Firecracker was shut down after intercepting `SIGPIPE`.
    SIGPIPE = 155,
    /// Firecracker was shut down after intercepting `SIGHUP`.
    SIGHUP = 156,
    /// Firecracker was shut down after intercepting `SIGILL`.
    SIGILL = 157,
    /// Bad configuration for microvm's resources, when using a single json.
    BadConfiguration = 152,
    /// Command line arguments parsing error.
    ArgParsing = 153,
}
```
I was unsure how to properly name some of the variants, notably the full uppercase variants like `SIGBUS` especially as they trigger the [`upper_case_acronyms`](https://rust-lang.github.io/rust-clippy/master/#upper_case_acronyms) clippy lint. However given they are almost always written in this uppercase form I decided they should be defined in uppercase and to simply disable this clippy lint on the enum.

- [x] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
