### PR TITLE
test_snap_restore_cross_kern: use cpu_template only on intel

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -16,6 +16,7 @@ from framework.defs import FC_WORKSPACE_DIR, DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.utils_vsock import check_vsock_device
 from framework.utils import generate_mmds_session_token, \
     generate_mmds_get_request
+from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from integration_tests.functional.test_mmds import _populate_data_store
 from integration_tests.functional.test_snapshot_basic import \
     _guest_run_fio_iteration
@@ -122,7 +123,9 @@ def _test_mmds(vm, mmds_net_iface):
 
 
 @pytest.mark.nonci
-@pytest.mark.parametrize("cpu_template", ["C3", "T2", "None"])
+@pytest.mark.parametrize("cpu_template",
+                         ["C3", "T2", "None"]
+                         if get_cpu_vendor() == CpuVendor.INTEL else ["None"])
 def test_snap_restore_from_artifacts(bin_cloner_path, bin_vsock_path,
                                      test_fc_session_root_path, cpu_template):
     """

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -23,6 +23,7 @@ from framework.defs import DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.matrix import TestMatrix, TestContext
 from framework.utils import generate_mmds_session_token, \
     generate_mmds_get_request, run_cmd
+from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from integration_tests.functional.test_cmd_line_start import \
     _configure_vm_from_json
 import host_tools.network as net_tools  # pylint: disable=import-error
@@ -212,7 +213,9 @@ def main():
     kernel_artifacts = ArtifactSet(artifacts.kernels())
     disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
 
-    cpu_templates = ["C3", "T2", "None"]
+    cpu_templates = ["None"]
+    if get_cpu_vendor() == CpuVendor.INTEL:
+        cpu_templates.extend(["C3", "T2"])
 
     for cpu_template in cpu_templates:
         # Create a test context.


### PR DESCRIPTION
# Reason for This PR

Cpu templates can only be used on Intel. Fix this logic so that we may run the test on other cpus as well

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
