### PR TITLE
api_server: VmmConfig swagger definition to reflect the actual state of the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   for `/machine-config` will reset all optional parameters (`smt`,
   `cpu_template`, `track_dirty_pages`) to their default values if they are
   not specified in the `PUT` request.
+- Fixed incosistency in the swagger definition with the current state of the
+  `/vm/config` endpoint.
 
 ## [1.0.0]
 

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -835,29 +835,29 @@ definitions:
   FullVmConfiguration:
     type: object
     properties:
-      balloon_device:
+      balloon:
         $ref: "#/definitions/Balloon"
-      block_devices:
+      drives:
         type: array
         description: Configurations for all block devices.
         items:
           $ref: "#/definitions/Drive"
-      boot_source:
+      boot-source:
         $ref: "#/definitions/BootSource"
       logger:
         $ref: "#/definitions/Logger"
-      machine_config:
+      machine-config:
         $ref: "#/definitions/MachineConfiguration"
       metrics:
         $ref: "#/definitions/Metrics"
-      mmds_config:
+      mmds-config:
         $ref: "#/definitions/MmdsConfig"
-      net_devices:
+      network-interfaces:
         type: array
         description: Configurations for all net devices.
         items:
           $ref: "#/definitions/NetworkInterface"
-      vsock_device:
+      vsock:
         $ref: "#/definitions/Vsock"
 
   InstanceActionInfo:


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>

# Reason for This PR

Fixes #2963

## Description of Changes

- Change the swagger definition to reflect the current state of the API

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
