### PR TITLE
api: fix race in api connecting logic

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.18, "AMD": 84.66, "ARM": 84.23}
+    COVERAGE_DICT = {"Intel": 85.12, "AMD": 84.60, "ARM": 84.17}
 else:
-    COVERAGE_DICT = {"Intel": 82.2, "AMD": 81.68, "ARM": 81.23}
+    COVERAGE_DICT = {"Intel": 82.14, "AMD": 81.62, "ARM": 81.17}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION




# Reason for This PR

We have been observing intermittent failures for
test_start_with_metadata_default_limit. This comes
from a race possibility when the microVM is not
succesfuly built and thus there is no previous
blocking communication between the API thread and
Firecracker.
If that happens, we may run the risk of Firecracker trying
to connect to the socket path to trigger a graceful shutdown
of the API thread before the socket was actually created.

## Tests
This test fixes a possible race condition and thus there is not
a short integration test that could exercise this path (we could add a patch over
the Firecracker binary but this is not quite feasible for the current framework).

The regression can be tested by running:
```
 for i in {0..30}; do pytest -s integration_tests/functional/test_cmd_line_start.py::test_start_with_metadata_default_limit; done
```
Everytime this was run, there was a least a failure.


## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
