### PR TITLE
mmds: deprecate V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - The API `PATCH` method for `/machine-config` can be now used to change
   `track_dirty_pages` on aarch64.
 - MmdsV2 is now Generally Available.
+- MmdsV1 is now deprecated and will be removed in Firecracker v2.0.0.
+  Use MmdsV2 instead.
 
 ### Fixed
 

--- a/docs/mmds/mmds-user-guide.md
+++ b/docs/mmds/mmds-user-guide.md
@@ -88,8 +88,8 @@ More about the particularities of the two mechanisms can be found in the
 [Retrieving metadata in the guest operating system](#retrieving-metadata-in-the-guest-operating-system)
 section. The MMDS version used can be specified when configuring MMDS, through
 the `version` field of the HTTP `PUT` request to `/mmds/config` resource.
-Accepted values are `V1` and `V2` and the default MMDS version used in case the
-`version` field is missing is [Version 1](#version-1).
+Accepted values are `V1`(deprecated) and `V2` and the default MMDS version used
+in case the `version` field is missing is [Version 1](#version-1-deprecated).
 
 ```bash
 MMDS_IPV4_ADDR=169.254.170.2
@@ -216,10 +216,13 @@ Output:
 Accessing the contents of the metadata store from the guest operating system
 can be done using one of the following methods:
 
-- `V1`: simple request/response method
+- `V1`: simple request/response method (deprecated)
 - `V2`: session-oriented method
 
-#### Version 1
+#### Version 1 (Deprecated)
+
+**Version 1 is deprecated and will be removed in the next major version change.
+Version 2 should be used instead.**
 
 To retrieve existing MMDS metadata using MMDS version 1, an HTTP `GET`
 request must be issued. The requested resource can be referenced by its

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -663,13 +663,15 @@ def generate_mmds_get_request(ipv4_address, token=None, app_json=True):
     return cmd
 
 
-def configure_mmds(test_microvm, iface_ids, version, ipv4_address=None,
+def configure_mmds(test_microvm, iface_ids, version=None, ipv4_address=None,
                    fc_version=None):
     """Configure mmds service."""
     mmds_config = {
-        'version': version,
         'network_interfaces': iface_ids
     }
+
+    if version is not None:
+        mmds_config['version'] = version
 
     # For versions prior to v1.0.0, the mmds config only contains
     # the ipv4_address.
@@ -682,3 +684,5 @@ def configure_mmds(test_microvm, iface_ids, version, ipv4_address=None,
 
     response = test_microvm.mmds.put_config(json=mmds_config)
     assert test_microvm.api_session.is_status_no_content(response.status_code)
+
+    return response


### PR DESCRIPTION
## Description of Changes

Deprecates MmdsV1

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
