### PR TITLE
Clarify FC panic error message when missing user ACL for KVM device

### DIFF
--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -27,7 +27,11 @@ pub(crate) fn parse_put_net(
         METRICS.put_api_requests.network_fails.inc();
         return Err(Error::Generic(
             StatusCode::BadRequest,
-            "The id from the path does not match the id from the body!".to_string(),
+            format!(
+                "The id from the path [{}] does not match the id from the body [{}]!",
+                id,
+                netif.iface_id.as_str()
+            ),
         ));
     }
     Ok(ParsedRequest::new_sync(VmmAction::InsertNetworkDevice(
@@ -56,7 +60,11 @@ pub(crate) fn parse_patch_net(
         METRICS.patch_api_requests.network_count.inc();
         return Err(Error::Generic(
             StatusCode::BadRequest,
-            "The id from the path does not match the id from the body!".to_string(),
+            format!(
+                "The id from the path [{}] does not match the id from the body [{}]!",
+                id,
+                netif.iface_id.as_str()
+            ),
         ));
     }
     Ok(ParsedRequest::new_sync(VmmAction::UpdateNetworkInterface(

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.89, "AMD": 84.38, "ARM": 83.96}
+    COVERAGE_DICT = {"Intel": 84.82, "AMD": 84.32, "ARM": 83.91}
 else:
-    COVERAGE_DICT = {"Intel": 81.94, "AMD": 81.43, "ARM": 80.96}
+    COVERAGE_DICT = {"Intel": 81.86, "AMD": 81.36, "ARM": 80.90}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

[Issue #2908](https://github.com/firecracker-microvm/firecracker/issues/2908) shows an example where configuring a network tap for a microVM run by a user without access to KVM will cause the firecracker process to close and returns an error that is quite vague.

Some potential options: 
1) Validate the user's access to the `/dev/kvm` device prior to attempting to fulfill the `InstanceStart` request. This would leave the firecracker process running and the API call could be re-attempted after configuring the file's ACL.
1) Add some detail to the error logged in response to the failed initialization of the `/dev/kvm` device.

Unfortunately the first option would likely require a system call which be executed for every `InstanceStart` API call (or possibly on the firecracker process' launch). The value of not having to restart the process to accommodate a configuration issue does not seem to warrant slowing down the launch process.

## Description of Changes

### Before
```
$ firecracker  --api-sock /tmp/firecracker.socket
2022-05-02T14:00:53.524156161 [anonymous-instance:main:ERROR:src/firecracker/src/main.rs:90] Firecracker panicked at 'Error creating the Kvm object: Error(13)', src/vmm/src/vstate/system.rs:53:30
Aborted
```

### After
```
$ firecracker --api-sock /tmp/firecracker.socket
2022-05-05T12:41:34.181549756 [anonymous-instance:main:ERROR:src/firecracker/src/main.rs:90] Firecracker panicked at 'Error creating KVM object. [Permission denied (os error 13)]
Make sure the user launching the firecracker process is configured on the /dev/kvm file's ACL.', src/vmm/src/vstate/system.rs:69:13
./launch-fc-process.sh: line 6: 36845 Aborted                 /home/ec2-user/workspace/fc-mattschlebusch/build/cargo_target/x86_64-unknown-linux-musl/debug/firecracker --api-sock /tmp/firecracker.socket
[ec2-user@ip-172-31-15-233 fc-sandbox]$ ./launch-fc-process.sh 
+ rm -rf /tmp/firecracker.socket
+ /home/ec2-user/workspace/fc-mattschlebusch/build/cargo_target/x86_64-unknown-linux-musl/debug/firecracker --api-sock /tmp/firecracker.socket
2022-05-05T12:52:20.941678838 [anonymous-instance:fc_api:ERROR:src/api_server/src/parsed_request.rs:192] Received Error. Status code: 400 Bad Request. Message: Internal error while starting microVM: Failed to validate KVM support: Error creating KVM object. [Permission denied (os error 13)]
Make sure the user launching the firecracker process is configured on the /dev/kvm file's ACL.

```
(Take note that the firecracker process does not terminate)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
