### PR TITLE
tests/snapshots: remove test_restore_no_tsc

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -130,62 +130,6 @@ def test_restore_old_version(bin_cloner_path):
     platform.machine() != "x86_64",
     reason="TSC is x86_64 specific."
 )
-def test_restore_no_tsc(bin_cloner_path):
-    """
-    Test scenario: restore a snapshot without TSC in current version.
-
-    @type: functional
-    """
-    logger = logging.getLogger("no_tsc_snapshot")
-    builder = MicrovmBuilder(bin_cloner_path)
-
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch the v0.24.0 firecracker binary as that one does not have
-    # the TSC frequency in the snapshot file.
-    firecracker_artifacts = artifacts.firecrackers(
-        keyword="v0.24.0"
-    )
-    firecracker = firecracker_artifacts[0]
-    firecracker.download()
-    jailer = firecracker.jailer()
-    jailer.download()
-    diff_snapshots = True
-
-    # Create a snapshot.
-    snapshot = create_snapshot_helper(
-        builder,
-        logger,
-        drives=scratch_drives,
-        ifaces=net_ifaces,
-        fc_binary=firecracker.local_path(),
-        jailer_binary=jailer.local_path(),
-        diff_snapshots=diff_snapshots,
-        balloon=True
-    )
-
-    # Resume microvm using current build of FC/Jailer.
-    # The resume should be successful because the CPU model
-    # in the snapshot state is the same as this host's.
-    microvm, _ = builder.build_from_snapshot(
-        snapshot,
-        resume=True,
-        diff_snapshots=False
-    )
-    validate_all_devices(
-        logger,
-        microvm,
-        net_ifaces,
-        scratch_drives,
-        diff_snapshots
-    )
-    logger.debug("========== Firecracker restore snapshot log ==========")
-    logger.debug(microvm.log_data)
-
-
-@pytest.mark.skipif(
-    platform.machine() != "x86_64",
-    reason="TSC is x86_64 specific."
-)
 def test_save_tsc_old_version(bin_cloner_path):
     """
     Test TSC warning message when saving old snapshot.


### PR DESCRIPTION
# Reason for This PR

This test does 2 things:
  * Create a snapshot using Firecracker v0.24
  * Restore that snapshot using the current build

Firecracker v0.24 is used here because the snapshot file does not
contain the TSC frequency. We do want to allow resume on the same
processor type without any TSC adjustment but since Firecracker
v0.24 is not supported anymore we need a different type of test to
do this validation.

## Description of Changes

Removed this test and added an issue to track the addition of a new type of test here: https://github.com/firecracker-microvm/firecracker/issues/2985

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
