### PR TITLE
tests/snap: make balloon checks more reliable

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -35,14 +35,14 @@ def _test_balloon(microvm, ssh_connection):
 
     # Check memory usage.
     first_reading = get_stable_rss_mem_by_pid(firecracker_pid)
-    # Dirty 60MB of pages.
-    make_guest_dirty_memory(ssh_connection, amount=(60 * MB_TO_PAGES))
+    # Dirty 300MB of pages.
+    make_guest_dirty_memory(ssh_connection, amount=(300 * MB_TO_PAGES))
     # Check memory usage again.
     second_reading = get_stable_rss_mem_by_pid(firecracker_pid)
     assert second_reading > first_reading
 
-    # Inflate the balloon.
-    response = microvm.balloon.patch(amount_mib=40)
+    # Inflate the balloon. Get back 200MB.
+    response = microvm.balloon.patch(amount_mib=200)
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     third_reading = get_stable_rss_mem_by_pid(firecracker_pid)


### PR DESCRIPTION
# Reason for This PR

Tentative fix for the intermittent failure of tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py in the CI.

## Description of Changes

When checking the functionality of the balloon device, we use an application to fault in some memory inside the guest, then try to reclaim some memory back using the balloon.

Make the balloon check function fault in and reclaim a more significant amount of memory such that the test does not get affected by other processes in the guest that are maybe using memory temporarily.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
