### PR TITLE
Simplify dev-preview logging

### DIFF
--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -11,7 +11,7 @@ use io_uring::{
     Error as IoUringError, IoUring,
 };
 
-use logger::{warn, DEV_PREVIEW_LOG_PREFIX};
+use logger::log_dev_preview_warning;
 use utils::eventfd::EventFd;
 use vm_memory::{mark_dirty_mem, GuestAddress, GuestMemory, GuestMemoryMmap};
 
@@ -66,10 +66,7 @@ impl<T> WrappedUserData<T> {
 
 impl<T> AsyncFileEngine<T> {
     pub fn from_file(file: File) -> Result<AsyncFileEngine<T>, Error> {
-        warn!(
-            "{} {}",
-            DEV_PREVIEW_LOG_PREFIX, "Async file IO is in development preview."
-        );
+        log_dev_preview_warning("Async file IO", Option::None);
 
         let completion_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
         let ring = IoUring::new(

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -20,8 +20,26 @@ pub use crate::metrics::{
 pub use log::Level::*;
 pub use log::*;
 
-/// Prefix to be used in log lines for functions/modules in Firecracker that are not generally available.
-pub const DEV_PREVIEW_LOG_PREFIX: &str = "[DevPreview]";
+pub use log::warn;
+
+/// Prefix to be used in log lines for functions/modules in Firecracker
+/// that are not generally available.
+const DEV_PREVIEW_LOG_PREFIX: &str = "[DevPreview]";
+
+/// Log a standard warning message indicating a given feature name
+/// is in development preview.
+pub fn log_dev_preview_warning(feature_name: &str, msg_opt: Option<String>) {
+    match msg_opt {
+        None => warn!(
+            "{} {} is in development preview.",
+            DEV_PREVIEW_LOG_PREFIX, feature_name
+        ),
+        Some(msg) => warn!(
+            "{} {} is in development preview - {}",
+            DEV_PREVIEW_LOG_PREFIX, feature_name, msg
+        ),
+    }
+}
 
 fn extract_guard<G>(lock_result: LockResult<G>) -> G {
     match lock_result {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -34,7 +34,7 @@ use crate::vmm_config::vsock::{VsockConfigError, VsockDeviceConfig};
 use crate::vmm_config::{self, RateLimiterUpdate};
 use crate::FcExitCode;
 use crate::{builder::StartMicrovmError, EventManager};
-use logger::{error, info, update_metric_with_elapsed_time, warn, DEV_PREVIEW_LOG_PREFIX, METRICS};
+use logger::*;
 use mmds::data_store::{self, Mmds};
 use seccompiler::BpfThreadMap;
 #[cfg(test)]
@@ -514,10 +514,7 @@ impl<'a> PrebootApiController<'a> {
     // On success, this command will end the pre-boot stage and this controller
     // will be replaced by a runtime controller.
     fn load_snapshot(&mut self, load_params: &LoadSnapshotParams) -> ActionResult {
-        warn!(
-            "{} {}",
-            DEV_PREVIEW_LOG_PREFIX, "Restoring snapshots is currently in development preview."
-        );
+        log_dev_preview_warning("Virtual machine snapshots", Option::None);
 
         let load_start_us = utils::time::get_time_us(utils::time::ClockType::Monotonic);
 
@@ -558,11 +555,15 @@ impl<'a> PrebootApiController<'a> {
             VmmActionError::LoadSnapshot(e)
         });
 
-        let elapsed_time_us =
-            update_metric_with_elapsed_time(&METRICS.latencies_us.vmm_load_snapshot, load_start_us);
-        warn!(
-            "{} 'load snapshot' VMM action took {} us.",
-            DEV_PREVIEW_LOG_PREFIX, elapsed_time_us
+        log_dev_preview_warning(
+            "Virtual machine snapshots",
+            Some(format!(
+                "'load snapshot' VMM action took {} us.",
+                update_metric_with_elapsed_time(
+                    &METRICS.latencies_us.vmm_load_snapshot,
+                    load_start_us
+                )
+            )),
         );
 
         result
@@ -716,10 +717,7 @@ impl RuntimeApiController {
     }
 
     fn create_snapshot(&mut self, create_params: &CreateSnapshotParams) -> ActionResult {
-        warn!(
-            "{} {}",
-            DEV_PREVIEW_LOG_PREFIX, "Creating snapshots is currently in development preview."
-        );
+        log_dev_preview_warning("Virtual machine snapshots", None);
 
         if create_params.snapshot_type == SnapshotType::Diff
             && !self.vm_resources.track_dirty_pages()


### PR DESCRIPTION
# Reason for This PR

A point raised in [PR/2976](https://github.com/firecracker-microvm/firecracker/pull/2976) is that it would be better to standardize the log level and message format for dev-preview lines,

## Description of Changes

This PR defines a dev-preview specific macro in the logger crate to standardize the logging and streamline the usage as well.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
