### PR TITLE
tests/test_uffd: revert to correct working dir

### DIFF
--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -68,6 +68,7 @@ def spawn_pf_handler(vm, handler_path, mem_path):
 
     uffd_handler = UffdHandler(handler_name, args)
     real_root = os.open("/", os.O_RDONLY)
+    working_dir = os.getcwd()
 
     os.chroot(vm.chroot())
     os.chdir('/')
@@ -89,6 +90,7 @@ def spawn_pf_handler(vm, handler_path, mem_path):
 
     os.fchdir(real_root)
     os.chroot(".")
+    os.chdir(working_dir)
 
     return uffd_handler
 


### PR DESCRIPTION
# Reason for This PR

`test_custom_seccomp.py` and `test_seccomp.py` are failing when preparing the release archive.

## Description of Changes

`spawn_pf_handler` changes the current working directory to `/`
which causes some tests that are run after this call to fail.
Revert to the correct working directory before exiting from
spawn_pf_handler.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
