### PR TITLE
Allow directly writing snapshots on top of existing files

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -327,14 +327,20 @@ fn snapshot_memory_to_file(
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
-        .truncate(true)
         .open(mem_file_path)
         .map_err(|e| MemoryBackingFile("open", e))?;
 
-    // Set the length of the file to the full size of the memory area.
     let mem_size_mib = mem_size_mib(vmm.guest_memory());
-    file.set_len((mem_size_mib * 1024 * 1024) as u64)
-        .map_err(|e| MemoryBackingFile("set_length", e))?;
+    let expected_size = (mem_size_mib * 1024 * 1024) as u64;
+    let file_size = file
+        .metadata()
+        .map_err(|e| MemoryBackingFile("get_metadata", e))?
+        .len();
+    if file_size != expected_size {
+        // Set the length of the file to the full size of the memory area.
+        file.set_len(expected_size)
+            .map_err(|e| MemoryBackingFile("set_length", e))?;
+    }
 
     match snapshot_type {
         SnapshotType::Diff => {


### PR DESCRIPTION
# Reason for This PR

We're exploring diff snapshots, but found out that our underlying filesystem (btrfs) doesn't perform well with the `rebase-snap` tool due to performance issues with finding holes in files (related: https://github.com/firecracker-microvm/firecracker/issues/2948). Initially we tried using another syscall (`fiemap`), but that also was too slow (10s for 4GB). Because of this, we cannot apply diff snapshots quickly on top of a base snapshot.

Instead, we're now taking another approach where we directly save the diff snapshot on top of the base memory. Firecracker already supports this, because it only writes changed blocks. This has worked out well for us, and this might be interesting to merge into upstream.

There's no issue opened for this right now, and it might well be that this change cannot be merged into Firecracker, but if you're interested I'd be happy to make the required changes to make it fit for the repo!

## Description of Changes

Instead of truncating the memory file we write to, we write on top of it.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
