### PR TITLE
Use == when comparing with an int literal

### DIFF
--- a/tests/framework/stats/function.py
+++ b/tests/framework/stats/function.py
@@ -135,8 +135,7 @@ class Stddev(Function):
         """Get the stddev."""
         assert isinstance(result, list)
         assert len(result) > 0
-        # pylint: disable=R0123
-        if len(result) is 1:
+        if len(result) == 1:
             return 0
         return stdev(result)
 
@@ -155,9 +154,8 @@ class Percentile(Function, ABC):
 
     def __call__(self, result: List) -> Any:
         """Get the kth percentile of the statistical exercise."""
-        # pylint: disable=R0123
         assert isinstance(result, list)
-        if len(result) is 1:
+        if len(result) == 1:
             return result[0]
 
         length = len(result)


### PR DESCRIPTION
Fixes these warnings when running the tests:

```
framework/stats/function.py:139
  /firecracker/tests/framework/stats/function.py:139: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if len(result) is 1:

framework/stats/function.py:160
  /firecracker/tests/framework/stats/function.py:160: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if len(result) is 1:
```

# Reason for This PR

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Fixes #

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
