### PR TITLE
MMDS: Make header parsing case-insensitive

### DIFF
--- a/docs/mmds/mmds-user-guide.md
+++ b/docs/mmds/mmds-user-guide.md
@@ -249,7 +249,7 @@ The session must start with an HTTP `PUT` request that generates the session tok
 In order to be successful, the request must respect the following constraints:
 
 - must be directed towards `/latest/api/token` path
-- must contain a `X-ametadata-token-ttl-seconds` header specifying the token lifetime
+- must contain a `X-metadata-token-ttl-seconds` header specifying the token lifetime
   in seconds. The value cannot be lower than 1 or greater than 21600 (6 hours).
 - must not contain a `X-Forwarded-For` header.
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -42,7 +42,7 @@ impl fmt::Display for Error {
             ),
             Error::NoTtlProvided => write!(
                 f,
-                "Token time to live value not found. Use `X-metadata-token-ttl_seconds` \
+                "Token time to live value not found. Use `X-metadata-token-ttl-seconds` \
                 header to specify the token's lifetime."
             ),
             Error::ResourceNotFound(ref uri) => {
@@ -708,7 +708,7 @@ mod tests {
 
         assert_eq!(
             Error::NoTtlProvided.to_string(),
-            "Token time to live value not found. Use `X-metadata-token-ttl_seconds` \
+            "Token time to live value not found. Use `X-metadata-token-ttl-seconds` \
             header to specify the token's lifetime."
         );
 

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -960,7 +960,7 @@ def test_mmds_v2_negative(test_microvm_with_api, network_config):
     # Check `PUT` request fails when token TTL is not provided.
     cmd = f'curl -m 2 -s -X PUT http://{DEFAULT_IPV4}/latest/api/token'
     expected = "Token time to live value not found. Use " \
-               "`X-metadata-token-ttl_seconds` header to specify " \
+               "`X-metadata-token-ttl-seconds` header to specify " \
                "the token's lifetime."
     _run_guest_cmd(ssh_connection, cmd, expected)
 


### PR DESCRIPTION
# Reason for This PR

The MMDS API requires the `X` to be uppercased in header names (e.g. `X-metadata-token`). According to the HTTP1 spec, headers should be ignorant of capitalisation, and because of this libraries like `hyper` automatically lowercase all header names. Because of this, some HTTP clients cannot send requests to the MMDS API.

## Description of Changes

Make the header parsing for MMDS ignorant to casing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
