### PR TITLE
Simplify ApiServer thread shutdown

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -314,6 +314,19 @@
                 ]
             },
             {
+                "syscall": "tkill",
+                "comment": "Used to signal api thread shutdown",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 64,
+                        "comment": "sigrtmax()"
+                    }
+                ]
+            },
+            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for rate limiting and metrics",
                 "args": [

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -314,6 +314,19 @@
                 ]
             },
             {
+                "syscall": "tkill",
+                "comment": "Used to signal api thread shutdown",
+                "args": [
+                    {
+                        "index": 1,
+                        "type": "dword",
+                        "op": "eq",
+                        "val": 64,
+                        "comment": "sigrtmax()"
+                    }
+                ]
+            },
+            {
                 "syscall": "timerfd_settime",
                 "comment": "Needed for rate limiting and metrics",
                 "args": [

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,13 +1,10 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::prelude::*;
 use std::os::unix::io::AsRawFd;
-use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use api_server::{ApiRequest, ApiResponse, ApiServer};
 use event_manager::{EventOps, Events, MutEventSubscriber, SubscriberOps};
@@ -134,7 +131,6 @@ pub(crate) fn run_with_api(
     // Channels for both directions between Vmm and Api threads.
     let (to_vmm, from_api) = channel();
     let (to_api, from_vmm) = channel();
-    let (socket_ready_sender, socket_ready_receiver) = channel();
 
     let to_vmm_event_fd = api_event_fd
         .try_clone()
@@ -145,33 +141,16 @@ pub(crate) fn run_with_api(
         .expect("Missing seccomp filter for API thread.");
 
     // Start the separate API thread.
-    let api_thread = thread::Builder::new()
-        .name("fc_api".to_owned())
-        .spawn(move || {
-            match ApiServer::new(to_vmm, from_vmm, to_vmm_event_fd).bind_and_run(
-                api_bind_path,
-                process_time_reporter,
-                &api_seccomp_filter,
-                api_payload_limit,
-                socket_ready_sender,
-            ) {
-                Ok(_) => (),
-                Err(api_server::Error::Io(inner)) => match inner.kind() {
-                    std::io::ErrorKind::AddrInUse => panic!(
-                        "Failed to open the API socket: {:?}",
-                        api_server::Error::Io(inner)
-                    ),
-                    _ => panic!(
-                        "Failed to communicate with the API socket: {:?}",
-                        api_server::Error::Io(inner)
-                    ),
-                },
-                Err(eventfd_err @ api_server::Error::Eventfd(_)) => {
-                    panic!("Failed to open the API socket: {:?}", eventfd_err)
-                }
-            }
-        })
-        .expect("API thread spawn failed.");
+    let api_thread = ApiServer::start_threaded(
+        to_vmm,
+        from_vmm,
+        to_vmm_event_fd,
+        api_bind_path,
+        process_time_reporter,
+        api_seccomp_filter,
+        api_payload_limit,
+    )
+    .expect("API thread spawn failed.");
 
     let mut event_manager = EventManager::new().expect("Unable to create EventManager");
     // Create the firecracker metrics object responsible for periodically printing metrics.
@@ -235,27 +214,8 @@ pub(crate) fn run_with_api(
         Err(exit_code) => exit_code,
     };
 
-    // We want to tell the API thread to shut down for a clean exit. But this is after
-    // the Vmm.stop() has been called, so it's a moment of internal finalization (as
-    // opposed to be something the client might call to shut the Vm down).  Since it's
-    // an internal signal implementing it with an HTTP request is probably not the ideal
-    // way to do it...but having another way would involve multiplexing micro-http server
-    // with some other communication mechanism, or enhancing micro-http with exit
-    // conditions.
+    // Stop and wait for the ApiServer thread for a clean exit.
+    api_thread.stop_and_join();
 
-    // We also need to make sure the socket path is ready.
-    // The recv will return an error if the other end has already exited which means
-    // that there is no need for us to send the "shutdown internal".
-    let mut sock;
-    if socket_ready_receiver.recv() == Ok(true) {
-        // "sock" var is declared outside of this "if" scope so that the socket's fd stays
-        // alive until all bytes are sent through; otherwise fd will close before being flushed.
-        sock = UnixStream::connect(bind_path).unwrap();
-        sock.write_all(b"PUT /shutdown-internal HTTP/1.1\r\n\r\n")
-            .unwrap();
-    }
-    // This call to thread::join() should block until the API thread has processed the
-    // shutdown-internal and returns from its function.
-    api_thread.join().unwrap();
     exit_code
 }


### PR DESCRIPTION
## Description of Changes

Replace hacky "/shutdown-internal" HTTP request with clean signal+flag based mechanism.

`SIGRTMAX` noop handler is installed and is used on the API thread to break the internal micro-http `epoll` loop. A simple `AtomicBool` flag is then used to signal the ApiServer it should shut down.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] ~The issue which led to this PR has a clear conclusion.~
- [x] ~This PR follows the solution outlined in the related issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~Any newly added `unsafe` code is properly documented.~
- [x] ~Any API changes follow the [Runbook for Firecracker API changes][2].~
- [x] ~Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
