### PR TITLE
Better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
 name = "api_server"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "libc",
  "logger",
  "micro_http",
@@ -58,6 +59,7 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "arch_gen",
+ "derive_more",
  "device_tree",
  "kvm-bindings",
  "kvm-ioctls",
@@ -236,6 +238,7 @@ dependencies = [
 name = "cpuid"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "kvm-bindings",
  "kvm-ioctls",
  "utils",
@@ -359,6 +362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "device_tree"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +382,7 @@ checksum = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 name = "devices"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "dumbo",
  "event-manager",
  "io_uring",
@@ -393,6 +408,7 @@ name = "dumbo"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "derive_more",
  "logger",
  "micro_http",
  "serde_json",
@@ -488,6 +504,7 @@ dependencies = [
 name = "io_uring"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "libc",
  "proptest",
  "utils",
@@ -650,6 +667,7 @@ dependencies = [
  "aes-gcm",
  "base64",
  "bincode",
+ "derive_more",
  "dumbo",
  "logger",
  "micro_http",
@@ -959,6 +977,7 @@ name = "seccompiler"
 version = "1.1.0"
 dependencies = [
  "bincode",
+ "derive_more",
  "libc",
  "serde",
  "serde_json",
@@ -1150,6 +1169,7 @@ dependencies = [
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "libc",
  "net_gen",
  "serde",
@@ -1243,6 +1263,7 @@ dependencies = [
  "arch",
  "cpuid",
  "criterion",
+ "derive_more",
  "devices",
  "event-manager",
  "kvm-bindings",

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -10,6 +10,7 @@ libc = ">=0.2.39"
 serde = { version = ">=1.0.27", features = ["derive"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 logger = { path = "../logger" }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -170,8 +170,8 @@ impl ApiServer {
         api_payload_limit: usize,
         socket_ready: mpsc::Sender<bool>,
     ) -> Result<()> {
-        let mut server = HttpServer::new(path).unwrap_or_else(|e| {
-            error!("Error creating the HTTP server: {}", e);
+        let mut server = HttpServer::new(path).unwrap_or_else(|err| {
+            error!("Error creating the HTTP server: {}", err);
             std::process::exit(vmm::FcExitCode::GenericError as i32);
         });
         // Announce main thread that the socket path was created.
@@ -191,10 +191,10 @@ impl ApiServer {
         // Load seccomp filters on the API thread.
         // Execution panics if filters cannot be loaded, use --no-seccomp if skipping filters
         // altogether is the desired behaviour.
-        if let Err(e) = seccompiler::apply_filter(seccomp_filter) {
+        if let Err(err) = seccompiler::apply_filter(seccomp_filter) {
             panic!(
                 "Failed to set the requested seccomp filters on the API thread: {}",
-                e
+                err
             );
         }
 
@@ -203,9 +203,9 @@ impl ApiServer {
         loop {
             let request_vec = match server.requests() {
                 Ok(vec) => vec,
-                Err(e) => {
+                Err(err) => {
                     // print request error, but keep server running
-                    error!("API Server error on retrieving incoming request: {}", e);
+                    error!("API Server error on retrieving incoming request: {}", err);
                     continue;
                 }
             };
@@ -219,8 +219,8 @@ impl ApiServer {
                             self.handle_request(request, request_processing_start_us)
                         }),
                     )
-                    .or_else(|e| {
-                        error!("API Server encountered an error on response: {}", e);
+                    .or_else(|err| {
+                        error!("API Server encountered an error on response: {}", err);
                         Ok(())
                     })?;
 
@@ -262,9 +262,9 @@ impl ApiServer {
                 }
                 response
             }
-            Err(e) => {
-                error!("{}", e);
-                e.into()
+            Err(err) => {
+                error!("{}", err);
+                err.into()
             }
         }
     }
@@ -343,28 +343,28 @@ mod tests {
 
     #[test]
     fn test_error_messages() {
-        let e = Error::Io(io::Error::from_raw_os_error(0));
+        let err = Error::Io(io::Error::from_raw_os_error(0));
         assert_eq!(
-            format!("{}", e),
+            format!("{}", err),
             format!("IO error: {}", io::Error::from_raw_os_error(0))
         );
-        let e = Error::Eventfd(io::Error::from_raw_os_error(0));
+        let err = Error::Eventfd(io::Error::from_raw_os_error(0));
         assert_eq!(
-            format!("{}", e),
+            format!("{}", err),
             format!("EventFd error: {}", io::Error::from_raw_os_error(0))
         );
     }
 
     #[test]
     fn test_error_debug() {
-        let e = Error::Io(io::Error::from_raw_os_error(0));
+        let err = Error::Io(io::Error::from_raw_os_error(0));
         assert_eq!(
-            format!("{:?}", e),
+            format!("{:?}", err),
             format!("IO error: {}", io::Error::from_raw_os_error(0))
         );
-        let e = Error::Eventfd(io::Error::from_raw_os_error(0));
+        let err = Error::Eventfd(io::Error::from_raw_os_error(0));
         assert_eq!(
-            format!("{:?}", e),
+            format!("{:?}", err),
             format!("EventFd error: {}", io::Error::from_raw_os_error(0))
         );
     }

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -255,7 +255,7 @@ pub(crate) fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) enum Error {
     // A generic error, with a given status code and message to be turned into a fault message.
     Generic(StatusCode, String),

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -284,10 +284,10 @@ impl std::fmt::Display for Error {
                 std::str::from_utf8(method.raw()).expect("Cannot convert from UTF-8"),
                 path
             ),
-            Error::SerdeJson(ref e) => write!(
+            Error::SerdeJson(ref err) => write!(
                 f,
                 "An error occurred when deserializing the json body of a request: {}.",
-                e
+                err
             ),
         }
     }
@@ -295,9 +295,9 @@ impl std::fmt::Display for Error {
 
 // It's convenient to turn errors into HTTP responses directly.
 impl From<Error> for Response {
-    fn from(e: Error) -> Self {
-        let msg = ApiServer::json_fault_message(format!("{}", e));
-        match e {
+    fn from(err: Error) -> Self {
+        let msg = ApiServer::json_fault_message(format!("{}", err));
+        match err {
             Error::Generic(status, _) => ApiServer::json_response(status, msg),
             Error::EmptyID
             | Error::InvalidID

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -30,9 +30,9 @@ struct ActionBody {
 
 pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.actions_count.inc();
-    let action_body = serde_json::from_slice::<ActionBody>(body.raw()).map_err(|e| {
+    let action_body = serde_json::from_slice::<ActionBody>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.actions_fails.inc();
-        e
+        err
     })?;
 
     match action_body.action_type {

--- a/src/api_server/src/request/actions.rs
+++ b/src/api_server/src/request/actions.rs
@@ -32,7 +32,7 @@ pub(crate) fn parse_put_actions(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.actions_count.inc();
     let action_body = serde_json::from_slice::<ActionBody>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.actions_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
 
     match action_body.action_type {

--- a/src/api_server/src/request/balloon.rs
+++ b/src/api_server/src/request/balloon.rs
@@ -25,7 +25,7 @@ pub(crate) fn parse_get_balloon(path_second_token: Option<&&str>) -> Result<Pars
 
 pub(crate) fn parse_put_balloon(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::SetBalloonDevice(
-        serde_json::from_slice::<BalloonDeviceConfig>(body.raw()).map_err(Error::SerdeJson)?,
+        serde_json::from_slice::<BalloonDeviceConfig>(body.raw())?,
     )))
 }
 
@@ -36,8 +36,7 @@ pub(crate) fn parse_patch_balloon(
     match path_second_token {
         Some(config_path) => match *config_path {
             "statistics" => Ok(ParsedRequest::new_sync(VmmAction::UpdateBalloonStatistics(
-                serde_json::from_slice::<BalloonUpdateStatsConfig>(body.raw())
-                    .map_err(Error::SerdeJson)?,
+                serde_json::from_slice::<BalloonUpdateStatsConfig>(body.raw())?,
             ))),
             _ => Err(Error::Generic(
                 StatusCode::BadRequest,
@@ -45,7 +44,7 @@ pub(crate) fn parse_patch_balloon(
             )),
         },
         None => Ok(ParsedRequest::new_sync(VmmAction::UpdateBalloon(
-            serde_json::from_slice::<BalloonUpdateConfig>(body.raw()).map_err(Error::SerdeJson)?,
+            serde_json::from_slice::<BalloonUpdateConfig>(body.raw())?,
         ))),
     }
 }

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -11,9 +11,9 @@ use crate::request::Body;
 pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.boot_source_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
-        serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|e| {
+        serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|err| {
             METRICS.put_api_requests.boot_source_fails.inc();
-            e
+            err
         })?,
     )))
 }

--- a/src/api_server/src/request/boot_source.rs
+++ b/src/api_server/src/request/boot_source.rs
@@ -13,7 +13,7 @@ pub(crate) fn parse_put_boot_source(body: &Body) -> Result<ParsedRequest, Error>
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureBootSource(
         serde_json::from_slice::<BootSourceConfig>(body.raw()).map_err(|e| {
             METRICS.put_api_requests.boot_source_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?,
     )))
 }

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -22,7 +22,7 @@ pub(crate) fn parse_put_drive(
 
     let device_cfg = serde_json::from_slice::<BlockDeviceConfig>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.drive_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
 
     if id != device_cfg.drive_id {
@@ -53,7 +53,7 @@ pub(crate) fn parse_patch_drive(
     let block_device_update_cfg: BlockDeviceUpdateConfig =
         serde_json::from_slice::<BlockDeviceUpdateConfig>(body.raw()).map_err(|e| {
             METRICS.patch_api_requests.drive_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?;
 
     if id != block_device_update_cfg.drive_id {

--- a/src/api_server/src/request/drive.rs
+++ b/src/api_server/src/request/drive.rs
@@ -20,9 +20,9 @@ pub(crate) fn parse_put_drive(
         return Err(Error::EmptyID);
     };
 
-    let device_cfg = serde_json::from_slice::<BlockDeviceConfig>(body.raw()).map_err(|e| {
+    let device_cfg = serde_json::from_slice::<BlockDeviceConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.drive_fails.inc();
-        e
+        err
     })?;
 
     if id != device_cfg.drive_id {
@@ -51,9 +51,9 @@ pub(crate) fn parse_patch_drive(
     };
 
     let block_device_update_cfg: BlockDeviceUpdateConfig =
-        serde_json::from_slice::<BlockDeviceUpdateConfig>(body.raw()).map_err(|e| {
+        serde_json::from_slice::<BlockDeviceUpdateConfig>(body.raw()).map_err(|err| {
             METRICS.patch_api_requests.drive_fails.inc();
-            e
+            err
         })?;
 
     if id != block_device_update_cfg.drive_id {

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -11,9 +11,9 @@ use crate::request::Body;
 pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.logger_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureLogger(
-        serde_json::from_slice::<LoggerConfig>(body.raw()).map_err(|e| {
+        serde_json::from_slice::<LoggerConfig>(body.raw()).map_err(|err| {
             METRICS.put_api_requests.logger_fails.inc();
-            e
+            err
         })?,
     )))
 }

--- a/src/api_server/src/request/logger.rs
+++ b/src/api_server/src/request/logger.rs
@@ -13,7 +13,7 @@ pub(crate) fn parse_put_logger(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureLogger(
         serde_json::from_slice::<LoggerConfig>(body.raw()).map_err(|e| {
             METRICS.put_api_requests.logger_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?,
     )))
 }

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -17,7 +17,7 @@ pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Err
     METRICS.put_api_requests.machine_cfg_count.inc();
     let vm_config = serde_json::from_slice::<VmConfig>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.machine_cfg_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
 
     let vm_config = VmUpdateConfig::from(vm_config);
@@ -31,7 +31,7 @@ pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, E
     METRICS.patch_api_requests.machine_cfg_count.inc();
     let vm_config = serde_json::from_slice::<VmUpdateConfig>(body.raw()).map_err(|e| {
         METRICS.patch_api_requests.machine_cfg_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
 
     if vm_config.is_empty() {

--- a/src/api_server/src/request/machine_configuration.rs
+++ b/src/api_server/src/request/machine_configuration.rs
@@ -15,9 +15,9 @@ pub(crate) fn parse_get_machine_config() -> Result<ParsedRequest, Error> {
 
 pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.machine_cfg_count.inc();
-    let vm_config = serde_json::from_slice::<VmConfig>(body.raw()).map_err(|e| {
+    let vm_config = serde_json::from_slice::<VmConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.machine_cfg_fails.inc();
-        e
+        err
     })?;
 
     let vm_config = VmUpdateConfig::from(vm_config);
@@ -29,9 +29,9 @@ pub(crate) fn parse_put_machine_config(body: &Body) -> Result<ParsedRequest, Err
 
 pub(crate) fn parse_patch_machine_config(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.machine_cfg_count.inc();
-    let vm_config = serde_json::from_slice::<VmUpdateConfig>(body.raw()).map_err(|e| {
+    let vm_config = serde_json::from_slice::<VmUpdateConfig>(body.raw()).map_err(|err| {
         METRICS.patch_api_requests.machine_cfg_fails.inc();
-        e
+        err
     })?;
 
     if vm_config.is_empty() {

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -13,7 +13,7 @@ pub(crate) fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureMetrics(
         serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|e| {
             METRICS.put_api_requests.metrics_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?,
     )))
 }

--- a/src/api_server/src/request/metrics.rs
+++ b/src/api_server/src/request/metrics.rs
@@ -11,9 +11,9 @@ use crate::request::Body;
 pub(crate) fn parse_put_metrics(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.metrics_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::ConfigureMetrics(
-        serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|e| {
+        serde_json::from_slice::<MetricsConfig>(body.raw()).map_err(|err| {
             METRICS.put_api_requests.metrics_fails.inc();
-            e
+            err
         })?,
     )))
 }

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -16,9 +16,9 @@ pub(crate) fn parse_get_mmds() -> Result<ParsedRequest, Error> {
 }
 
 fn parse_put_mmds_config(body: &Body) -> Result<ParsedRequest, Error> {
-    let config: MmdsConfig = serde_json::from_slice(body.raw()).map_err(|e| {
+    let config: MmdsConfig = serde_json::from_slice(body.raw()).map_err(|err| {
         METRICS.put_api_requests.mmds_fails.inc();
-        e
+        err
     })?;
     // Construct the `ParsedRequest` object.
     let version = config.version;
@@ -42,9 +42,9 @@ pub(crate) fn parse_put_mmds(
     METRICS.put_api_requests.mmds_count.inc();
     match path_second_token {
         None => Ok(ParsedRequest::new_sync(VmmAction::PutMMDS(
-            serde_json::from_slice(body.raw()).map_err(|e| {
+            serde_json::from_slice(body.raw()).map_err(|err| {
                 METRICS.put_api_requests.mmds_fails.inc();
-                e
+                err
             })?,
         ))),
         Some(&"config") => parse_put_mmds_config(body),
@@ -61,9 +61,9 @@ pub(crate) fn parse_put_mmds(
 pub(crate) fn parse_patch_mmds(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.patch_api_requests.mmds_count.inc();
     Ok(ParsedRequest::new_sync(VmmAction::PatchMMDS(
-        serde_json::from_slice(body.raw()).map_err(|e| {
+        serde_json::from_slice(body.raw()).map_err(|err| {
             METRICS.patch_api_requests.mmds_fails.inc();
-            e
+            err
         })?,
     )))
 }

--- a/src/api_server/src/request/mmds.rs
+++ b/src/api_server/src/request/mmds.rs
@@ -18,7 +18,7 @@ pub(crate) fn parse_get_mmds() -> Result<ParsedRequest, Error> {
 fn parse_put_mmds_config(body: &Body) -> Result<ParsedRequest, Error> {
     let config: MmdsConfig = serde_json::from_slice(body.raw()).map_err(|e| {
         METRICS.put_api_requests.mmds_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
     // Construct the `ParsedRequest` object.
     let version = config.version;
@@ -44,7 +44,7 @@ pub(crate) fn parse_put_mmds(
         None => Ok(ParsedRequest::new_sync(VmmAction::PutMMDS(
             serde_json::from_slice(body.raw()).map_err(|e| {
                 METRICS.put_api_requests.mmds_fails.inc();
-                Error::SerdeJson(e)
+                e
             })?,
         ))),
         Some(&"config") => parse_put_mmds_config(body),
@@ -63,7 +63,7 @@ pub(crate) fn parse_patch_mmds(body: &Body) -> Result<ParsedRequest, Error> {
     Ok(ParsedRequest::new_sync(VmmAction::PatchMMDS(
         serde_json::from_slice(body.raw()).map_err(|e| {
             METRICS.patch_api_requests.mmds_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?,
     )))
 }

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -20,9 +20,9 @@ pub(crate) fn parse_put_net(
         return Err(Error::EmptyID);
     };
 
-    let netif = serde_json::from_slice::<NetworkInterfaceConfig>(body.raw()).map_err(|e| {
+    let netif = serde_json::from_slice::<NetworkInterfaceConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.network_fails.inc();
-        e
+        err
     })?;
     if id != netif.iface_id.as_str() {
         METRICS.put_api_requests.network_fails.inc();
@@ -53,9 +53,9 @@ pub(crate) fn parse_patch_net(
     };
 
     let netif =
-        serde_json::from_slice::<NetworkInterfaceUpdateConfig>(body.raw()).map_err(|e| {
+        serde_json::from_slice::<NetworkInterfaceUpdateConfig>(body.raw()).map_err(|err| {
             METRICS.patch_api_requests.network_fails.inc();
-            e
+            err
         })?;
     if id != netif.iface_id {
         METRICS.patch_api_requests.network_count.inc();

--- a/src/api_server/src/request/net.rs
+++ b/src/api_server/src/request/net.rs
@@ -22,7 +22,7 @@ pub(crate) fn parse_put_net(
 
     let netif = serde_json::from_slice::<NetworkInterfaceConfig>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.network_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
     if id != netif.iface_id.as_str() {
         METRICS.put_api_requests.network_fails.inc();
@@ -55,7 +55,7 @@ pub(crate) fn parse_patch_net(
     let netif =
         serde_json::from_slice::<NetworkInterfaceUpdateConfig>(body.raw()).map_err(|e| {
             METRICS.patch_api_requests.network_fails.inc();
-            Error::SerdeJson(e)
+            e
         })?;
     if id != netif.iface_id {
         METRICS.patch_api_requests.network_count.inc();

--- a/src/api_server/src/request/snapshot.rs
+++ b/src/api_server/src/request/snapshot.rs
@@ -29,8 +29,7 @@ pub(crate) fn parse_put_snapshot(
     match request_type_from_path {
         Some(&request_type) => match request_type {
             "create" => Ok(ParsedRequest::new_sync(VmmAction::CreateSnapshot(
-                serde_json::from_slice::<CreateSnapshotParams>(body.raw())
-                    .map_err(Error::SerdeJson)?,
+                serde_json::from_slice::<CreateSnapshotParams>(body.raw())?,
             ))),
             "load" => parse_put_snapshot_load(body),
             _ => Err(Error::InvalidPathMethod(
@@ -46,7 +45,7 @@ pub(crate) fn parse_put_snapshot(
 }
 
 pub(crate) fn parse_patch_vm_state(body: &Body) -> Result<ParsedRequest, Error> {
-    let vm = serde_json::from_slice::<Vm>(body.raw()).map_err(Error::SerdeJson)?;
+    let vm = serde_json::from_slice::<Vm>(body.raw())?;
 
     match vm.state {
         VmState::Paused => Ok(ParsedRequest::new_sync(VmmAction::Pause)),
@@ -55,8 +54,7 @@ pub(crate) fn parse_patch_vm_state(body: &Body) -> Result<ParsedRequest, Error> 
 }
 
 fn parse_put_snapshot_load(body: &Body) -> Result<ParsedRequest, Error> {
-    let snapshot_config =
-        serde_json::from_slice::<LoadSnapshotConfig>(body.raw()).map_err(Error::SerdeJson)?;
+    let snapshot_config = serde_json::from_slice::<LoadSnapshotConfig>(body.raw())?;
 
     match (&snapshot_config.mem_backend, &snapshot_config.mem_file_path) {
         // Ensure `mem_file_path` and `mem_backend` fields are not present at the same time.

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -12,7 +12,7 @@ pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.vsock_count.inc();
     let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(|e| {
         METRICS.put_api_requests.vsock_fails.inc();
-        Error::SerdeJson(e)
+        e
     })?;
 
     // Check for the presence of deprecated `vsock_id` field.

--- a/src/api_server/src/request/vsock.rs
+++ b/src/api_server/src/request/vsock.rs
@@ -10,9 +10,9 @@ use crate::request::Body;
 
 pub(crate) fn parse_put_vsock(body: &Body) -> Result<ParsedRequest, Error> {
     METRICS.put_api_requests.vsock_count.inc();
-    let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(|e| {
+    let vsock_cfg = serde_json::from_slice::<VsockDeviceConfig>(body.raw()).map_err(|err| {
         METRICS.put_api_requests.vsock_fails.inc();
-        e
+        err
     })?;
 
     // Check for the presence of deprecated `vsock_id` field.

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -13,6 +13,7 @@ linux-loader = ">=0.4.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 vm-fdt = "0.1.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 arch_gen = { path = "../arch_gen" }
 logger = { path = "../logger" }

--- a/src/arch/src/aarch64/cache_info.rs
+++ b/src/arch/src/aarch64/cache_info.rs
@@ -79,19 +79,22 @@ impl CacheEntry {
             Ok(level) => {
                 cache.level = level
                     .parse::<u8>()
-                    .map_err(|e| Error::InvalidCacheAttr("level".to_string(), e.to_string()))?;
+                    .map_err(|err| Error::InvalidCacheAttr("level".to_string(), err.to_string()))?;
             }
-            Err(e) => {
+            Err(err) => {
                 // If we cannot read the cache level even for the first level of cache, we will
                 // stop processing anymore cache info and log an error.
-                warn!("Could not read cache level for index {}: {}", index, e);
+                warn!("Could not read cache level for index {}: {}", index, err);
                 return Err(Error::MissingCacheConfig);
             }
         }
         match store.get_by_key(index, "type") {
             Ok(cache_type) => cache.type_ = CacheType::try_from(&cache_type)?,
-            Err(e) => {
-                warn!("Could not read type for cache level {}: {}", cache.level, e);
+            Err(err) => {
+                warn!(
+                    "Could not read type for cache level {}: {}",
+                    cache.level, err
+                );
                 return Err(Error::MissingCacheConfig);
             }
         }
@@ -104,8 +107,8 @@ impl CacheEntry {
         }
 
         if let Ok(coherency_line_size) = store.get_by_key(index, "coherency_line_size") {
-            cache.line_size = Some(coherency_line_size.parse::<u16>().map_err(|e| {
-                Error::InvalidCacheAttr("coherency_line_size".to_string(), e.to_string())
+            cache.line_size = Some(coherency_line_size.parse::<u16>().map_err(|err| {
+                Error::InvalidCacheAttr("coherency_line_size".to_string(), err.to_string())
             })?);
         } else {
             err_str += "coherency line size";
@@ -120,8 +123,8 @@ impl CacheEntry {
         }
 
         if let Ok(number_of_sets) = store.get_by_key(index, "number_of_sets") {
-            cache.number_of_sets = Some(number_of_sets.parse::<u16>().map_err(|e| {
-                Error::InvalidCacheAttr("number_of_sets".to_string(), e.to_string())
+            cache.number_of_sets = Some(number_of_sets.parse::<u16>().map_err(|err| {
+                Error::InvalidCacheAttr("number_of_sets".to_string(), err.to_string())
             })?);
         } else {
             err_str += "number of sets";
@@ -236,11 +239,11 @@ fn to_bytes(cache_size_pretty: &mut String) -> Result<usize> {
     match cache_size_pretty.pop() {
         Some('K') => Ok(cache_size_pretty
             .parse::<usize>()
-            .map_err(|e| Error::InvalidCacheAttr("size".to_string(), e.to_string()))?
+            .map_err(|err| Error::InvalidCacheAttr("size".to_string(), err.to_string()))?
             * 1024),
         Some('M') => Ok(cache_size_pretty
             .parse::<usize>()
-            .map_err(|e| Error::InvalidCacheAttr("size".to_string(), e.to_string()))?
+            .map_err(|err| Error::InvalidCacheAttr("size".to_string(), err.to_string()))?
             * 1024
             * 1024),
         Some(letter) => {
@@ -272,7 +275,7 @@ fn mask_str2bit_count(mask_str: &str) -> Result<u16> {
             s_zero_free = "0";
         }
         bit_count += u32::from_str_radix(s_zero_free, 16)
-            .map_err(|e| Error::InvalidCacheAttr("shared_cpu_map".to_string(), e.to_string()))?
+            .map_err(|err| Error::InvalidCacheAttr("shared_cpu_map".to_string(), err.to_string()))?
             .count_ones() as u16;
     }
     if bit_count == 0 {
@@ -326,7 +329,7 @@ pub(crate) fn read_cache_config(
                     logged_missing_attr = true;
                 }
             }
-            Err(e) => return Err(e),
+            Err(err) => return Err(err),
         }
     }
     Ok(())
@@ -414,8 +417,8 @@ mod tests {
         assert!(to_bytes(&mut "64M".to_string()).is_ok());
 
         match to_bytes(&mut "64KK".to_string()) {
-            Err(e) => assert_eq!(
-                format!("{}", e),
+            Err(err) => assert_eq!(
+                format!("{}", err),
                 "Invalid cache configuration found for size: invalid digit found in string"
             ),
             _ => panic!("This should be an error!"),

--- a/src/arch/src/aarch64/cache_info.rs
+++ b/src/arch/src/aarch64/cache_info.rs
@@ -10,7 +10,7 @@ use logger::warn;
 // Based on https://elixir.free-electrons.com/linux/v4.9.62/source/arch/arm64/kernel/cacheinfo.c#L29.
 const MAX_CACHE_LEVEL: u8 = 7;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) enum Error {
     FailedToReadCacheInfo(io::Error),
     InvalidCacheAttr(String, String),
@@ -228,7 +228,7 @@ impl CacheType {
 }
 
 fn readln_special<T: AsRef<Path>>(file_path: &T) -> Result<String> {
-    let line = fs::read_to_string(file_path).map_err(Error::FailedToReadCacheInfo)?;
+    let line = fs::read_to_string(file_path)?;
     Ok(line.trim_end().to_string())
 }
 

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -52,18 +52,12 @@ pub trait DeviceInfoForFDT {
 }
 
 /// Errors thrown while configuring the Flattened Device Tree for aarch64.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     CreateFdt(VmFdtError),
     ReadCacheInfo(String),
     /// Failure in writing FDT in memory.
     WriteFdtToMemory(GuestMemoryError),
-}
-
-impl From<VmFdtError> for Error {
-    fn from(e: VmFdtError) -> Self {
-        Error::CreateFdt(e)
-    }
 }
 
 type Result<T> = result::Result<T, Error>;
@@ -111,9 +105,7 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildHasher
 
     // Write FDT to memory.
     let fdt_address = GuestAddress(get_fdt_addr(&guest_mem));
-    guest_mem
-        .write_slice(fdt_final.as_slice(), fdt_address)
-        .map_err(Error::WriteFdtToMemory)?;
+    guest_mem.write_slice(fdt_final.as_slice(), fdt_address)?;
     Ok(fdt_final)
 }
 

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -118,7 +118,7 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, vcpu_mpidr: &[u64]) -> Result<()> {
     let mut non_l1_caches: Vec<CacheEntry> = Vec::new();
     // We use sysfs for extracting the cache information.
     read_cache_config(&mut l1_caches, &mut non_l1_caches)
-        .map_err(|e| Error::ReadCacheInfo(e.to_string()))?;
+        .map_err(|err| Error::ReadCacheInfo(err.to_string()))?;
 
     // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/arm/cpus.yaml.
     let cpus = fdt.begin_node("cpus")?;

--- a/src/arch/src/aarch64/gic/gicv3/mod.rs
+++ b/src/arch/src/aarch64/gic/gicv3/mod.rs
@@ -137,7 +137,7 @@ fn save_pending_tables(fd: &DeviceFd) -> Result<()> {
         flags: 0,
     };
     fd.set_device_attr(&init_gic_attr)
-        .map_err(|e| Error::DeviceAttribute(e, true, kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL))
+        .map_err(|err| Error::DeviceAttribute(err, true, kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL))
 }
 
 #[cfg(test)]

--- a/src/arch/src/aarch64/gic/mod.rs
+++ b/src/arch/src/aarch64/gic/mod.rs
@@ -101,7 +101,7 @@ pub trait GICDevice {
             addr,
         };
         fd.set_device_attr(&attr)
-            .map_err(|e| Error::DeviceAttribute(e, true, group))?;
+            .map_err(|err| Error::DeviceAttribute(err, true, group))?;
 
         Ok(())
     }

--- a/src/arch/src/aarch64/gic/regs.rs
+++ b/src/arch/src/aarch64/gic/regs.rs
@@ -110,7 +110,7 @@ pub(crate) trait VgicRegEngine {
         for offset in reg.iter::<Self::RegChunk>() {
             let mut val = Self::RegChunk::default();
             fd.get_device_attr(&mut Self::kvm_device_attr(offset, &mut val, mpidr))
-                .map_err(|e| Error::DeviceAttribute(e, false, Self::group()))?;
+                .map_err(|err| Error::DeviceAttribute(err, false, Self::group()))?;
             data.push(val);
         }
 
@@ -145,7 +145,7 @@ pub(crate) trait VgicRegEngine {
     {
         for (offset, val) in reg.iter::<Self::RegChunk>().zip(&data.chunks) {
             fd.set_device_attr(&Self::kvm_device_attr(offset, &mut val.clone(), mpidr))
-                .map_err(|e| Error::DeviceAttribute(e, true, Self::group()))?;
+                .map_err(|err| Error::DeviceAttribute(err, true, Self::group()))?;
         }
 
         Ok(())

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -21,7 +21,7 @@ use self::gic::GICDevice;
 use crate::DeviceType;
 
 /// Errors thrown while configuring aarch64 system.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     /// Failed to create a Flattened Device Tree for this aarch64 microVM.
     SetupFDT(fdt::Error),
@@ -67,8 +67,7 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::Build
         device_info,
         gic_device,
         initrd,
-    )
-    .map_err(Error::SetupFDT)?;
+    )?;
     Ok(())
 }
 

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -43,15 +43,19 @@ impl fmt::Display for Error {
         use self::Error::*;
 
         match *self {
-            GetCoreRegister(ref e, ref desc) => write!(f, "Failed to get {} register: {}", desc, e),
-            GetMP(ref e) => write!(f, "Failed to get multiprocessor state: {}", e),
-            GetRegList(ref e) => write!(f, "Failed to retrieve list of registers: {}", e),
-            GetSysRegister(ref e) => write!(f, "Failed to get system register: {}", e),
-            SetCoreRegister(ref e, ref desc) => write!(f, "Failed to set {} register: {}", desc, e),
-            SetMP(ref e) => write!(f, "Failed to set multiprocessor state: {}", e),
-            SetRegister(ref e) => write!(f, "Failed to set register: {}", e),
-            GetMidrEl1(ref e) => write!(f, "{}", e),
-            FamError(ref e) => write!(f, "Failed FamStructWrapper operation: {:?}", e),
+            GetCoreRegister(ref err, ref desc) => {
+                write!(f, "Failed to get {} register: {}", desc, err)
+            }
+            GetMP(ref err) => write!(f, "Failed to get multiprocessor state: {}", err),
+            GetRegList(ref err) => write!(f, "Failed to retrieve list of registers: {}", err),
+            GetSysRegister(ref err) => write!(f, "Failed to get system register: {}", err),
+            SetCoreRegister(ref err, ref desc) => {
+                write!(f, "Failed to set {} register: {}", desc, err)
+            }
+            SetMP(ref err) => write!(f, "Failed to set multiprocessor state: {}", err),
+            SetRegister(ref err) => write!(f, "Failed to set register: {}", err),
+            GetMidrEl1(ref err) => write!(f, "{}", err),
+            FamError(ref err) => write!(f, "Failed FamStructWrapper operation: {:?}", err),
         }
     }
 }
@@ -172,15 +176,18 @@ pub fn get_manufacturer_id_from_host() -> Result<u32> {
     let midr_el1_path =
         &PathBuf::from("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1".to_string());
 
-    let midr_el1 = fs::read_to_string(midr_el1_path).map_err(|e| {
+    let midr_el1 = fs::read_to_string(midr_el1_path).map_err(|err| {
         Error::GetMidrEl1(format!(
             "Failed to get MIDR_EL1 from host path: {}",
-            e.to_string()
+            err.to_string()
         ))
     })?;
     let midr_el1_trimmed = midr_el1.trim_end().trim_start_matches("0x");
-    let manufacturer_id = u32::from_str_radix(midr_el1_trimmed, 16).map_err(|e| {
-        Error::GetMidrEl1(format!("Invalid MIDR_EL1 found on host: {}", e.to_string()))
+    let manufacturer_id = u32::from_str_radix(midr_el1_trimmed, 16).map_err(|err| {
+        Error::GetMidrEl1(format!(
+            "Invalid MIDR_EL1 found on host: {}",
+            err.to_string()
+        ))
     })?;
 
     Ok(manufacturer_id >> 24)
@@ -208,14 +215,14 @@ pub fn setup_boot_regs(
         arm64_core_reg_id!(KVM_REG_SIZE_U64, pstate),
         PSTATE_FAULT_BITS_64,
     )
-    .map_err(|e| Error::SetCoreRegister(e, "processor state".to_string()))?;
+    .map_err(|err| Error::SetCoreRegister(err, "processor state".to_string()))?;
 
     // Other vCPUs are powered off initially awaiting PSCI wakeup.
     if cpu_id == 0 {
         // Setting the PC (Processor Counter) to the current program address (kernel address).
         let pc = offset__of!(user_pt_regs, pc) + kreg_off;
         vcpu.set_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, pc), boot_ip as u64)
-            .map_err(|e| Error::SetCoreRegister(e, "program counter".to_string()))?;
+            .map_err(|err| Error::SetCoreRegister(err, "program counter".to_string()))?;
 
         // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
         // "The device tree blob (dtb) must be placed on an 8-byte boundary and must
@@ -226,7 +233,7 @@ pub fn setup_boot_regs(
             arm64_core_reg_id!(KVM_REG_SIZE_U64, regs0),
             get_fdt_addr(mem) as u64,
         )
-        .map_err(|e| Error::SetCoreRegister(e, "X0".to_string()))?;
+        .map_err(|err| Error::SetCoreRegister(err, "X0".to_string()))?;
     }
     Ok(())
 }
@@ -278,7 +285,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
             id,
             addr: vcpu
                 .get_one_reg(id)
-                .map_err(|e| Error::GetCoreRegister(e, format!("X{}", i)))?,
+                .map_err(|err| Error::GetCoreRegister(err, format!("X{}", i)))?,
         });
         off += std::mem::size_of::<u64>();
     }
@@ -291,7 +298,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "stack pointer".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "stack pointer".to_string()))?,
     });
 
     // Second one, the program counter.
@@ -301,7 +308,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "program counter".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "program counter".to_string()))?,
     });
 
     // Next is the processor state.
@@ -311,7 +318,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "processor state".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "processor state".to_string()))?,
     });
 
     // The stack pointer associated with EL1.
@@ -321,7 +328,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "SP_EL1".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "SP_EL1".to_string()))?,
     });
 
     // Exception Link Register for EL1, when taking an exception to EL1, this register
@@ -332,7 +339,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "ELR_EL1".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "ELR_EL1".to_string()))?,
     });
 
     // Saved Program Status Registers, there are 5 of them used in the kernel.
@@ -343,7 +350,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
             id,
             addr: vcpu
                 .get_one_reg(id)
-                .map_err(|e| Error::GetCoreRegister(e, format!("SPSR{}", i)))?,
+                .map_err(|err| Error::GetCoreRegister(err, format!("SPSR{}", i)))?,
         });
         off += std::mem::size_of::<u64>();
     }
@@ -357,7 +364,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
             id,
             addr: vcpu
                 .get_one_reg(id)
-                .map_err(|e| Error::GetCoreRegister(e, format!("FP_VREG{}", i)))?,
+                .map_err(|err| Error::GetCoreRegister(err, format!("FP_VREG{}", i)))?,
         });
         off += mem::size_of::<u128>();
     }
@@ -369,7 +376,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "FPSR".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "FPSR".to_string()))?,
     });
 
     // Floating-point Control Register.
@@ -379,7 +386,7 @@ pub fn save_core_registers(vcpu: &VcpuFd, state: &mut Vec<kvm_one_reg>) -> Resul
         id,
         addr: vcpu
             .get_one_reg(id)
-            .map_err(|e| Error::GetCoreRegister(e, "FPCR".to_string()))?,
+            .map_err(|err| Error::GetCoreRegister(err, "FPCR".to_string()))?,
     });
 
     Ok(())

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -27,7 +27,7 @@ use crate::InitrdConfig;
 const E820_RAM: u32 = 1;
 
 /// Errors thrown while configuring x86_64 system.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, derive_more::From)]
 pub enum Error {
     /// Invalid e820 setup params.
     E820Configuration,
@@ -114,7 +114,7 @@ pub fn configure_system(
     let himem_start = GuestAddress(layout::HIMEM_START);
 
     // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
+    mptable::setup_mptable(guest_mem, num_cpus)?;
 
     let mut params = boot_params::default();
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -8,5 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 utils = { path = "../utils"}

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -69,15 +69,13 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
 /// Extracts the CPU vendor id from leaf 0x0.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn get_vendor_id_from_host() -> Result<[u8; 12], Error> {
-    match get_cpuid(0, 0) {
-        Ok(vendor_entry) => {
-            let bytes: [u8; 12] = unsafe {
-                std::mem::transmute([vendor_entry.ebx, vendor_entry.edx, vendor_entry.ecx])
-            };
-            Ok(bytes)
-        }
-        Err(err) => Err(err),
-    }
+    get_cpuid(0, 0).map(|vendor_entry| unsafe {
+        std::mem::transmute::<[u32; 3], [u8; 12]>([
+            vendor_entry.ebx,
+            vendor_entry.edx,
+            vendor_entry.ecx,
+        ])
+    })
 }
 
 /// Extracts the CPU vendor id from leaf 0x0.

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -76,7 +76,7 @@ pub fn get_vendor_id_from_host() -> Result<[u8; 12], Error> {
             };
             Ok(bytes)
         }
-        Err(e) => Err(e),
+        Err(err) => Err(err),
     }
 }
 

--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -10,7 +10,7 @@ use crate::common::{get_vendor_id_from_host, VENDOR_ID_INTEL};
 use crate::transformer::Error;
 
 pub fn validate_vendor_id() -> Result<(), Error> {
-    let vendor_id = get_vendor_id_from_host().map_err(Error::InternalError)?;
+    let vendor_id = get_vendor_id_from_host()?;
     if &vendor_id != VENDOR_ID_INTEL {
         return Err(Error::InvalidVendor);
     }

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -6,7 +6,6 @@ use kvm_bindings::{kvm_cpuid_entry2, CpuId};
 use super::*;
 use crate::bit_helper::BitHelper;
 use crate::common::get_cpuid;
-use crate::transformer::Error::FamError;
 
 // constants for setting the fields of kvm_cpuid2 structures
 // CPUID bits in ebx, ecx, and edx.
@@ -115,18 +114,16 @@ pub fn use_host_cpuid_function(
             break;
         }
 
-        cpuid
-            .push(kvm_cpuid_entry2 {
-                function,
-                index: count,
-                flags: 0,
-                eax: entry.eax,
-                ebx: entry.ebx,
-                ecx: entry.ecx,
-                edx: entry.edx,
-                padding: [0, 0, 0],
-            })
-            .map_err(FamError)?;
+        cpuid.push(kvm_cpuid_entry2 {
+            function,
+            index: count,
+            flags: 0,
+            eax: entry.eax,
+            ebx: entry.ebx,
+            ecx: entry.ecx,
+            edx: entry.edx,
+            padding: [0, 0, 0],
+        })?;
 
         count += 1;
     }

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -30,7 +30,7 @@ impl VmSpec {
     /// Creates a new instance of VmSpec with the specified parameters
     /// The brand string is deduced from the vendor_id
     pub fn new(cpu_index: u8, cpu_count: u8, smt: bool) -> Result<VmSpec, Error> {
-        let cpu_vendor_id = get_vendor_id_from_host().map_err(Error::InternalError)?;
+        let cpu_vendor_id = get_vendor_id_from_host()?;
 
         Ok(VmSpec {
             cpu_vendor_id,
@@ -53,7 +53,7 @@ impl VmSpec {
 }
 
 /// Errors associated with processing the CPUID leaves.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, derive_more::From)]
 pub enum Error {
     /// A FamStructWrapper operation has failed
     FamError(utils::fam::Error),

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -12,6 +12,7 @@ timerfd = ">=1.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 vm-superio = ">=0.4.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }

--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -143,7 +143,7 @@ impl I8042Device {
 
         match self.trigger_kbd_interrupt() {
             Ok(_) | Err(Error::KbdInterruptDisabled) => Ok(()),
-            Err(e) => Err(e),
+            Err(err) => Err(err),
         }
     }
 
@@ -246,8 +246,8 @@ impl BusDevice for I8042Device {
                 // The guest wants to assert the CPU reset line. We handle that by triggering
                 // our exit event fd. Meaning Firecracker will be exiting as soon as the VMM
                 // thread wakes up to handle this event.
-                if let Err(e) = self.reset_evt.write(1) {
-                    error!("Failed to trigger i8042 reset event: {:?}", e);
+                if let Err(err) = self.reset_evt.write(1) {
+                    error!("Failed to trigger i8042 reset event: {:?}", err);
                     METRICS.i8042.error_count.inc();
                 }
                 METRICS.i8042.reset_count.inc();

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -106,10 +106,10 @@ impl<W: Write> SerialWrapper<EventFdTrigger, SerialEventsWrapper, W> {
         }
         match ops.add(Events::new(&input_fd, EventSet::IN)) {
             Err(event_manager::Error::FdAlreadyRegistered) => (),
-            Err(e) => {
+            Err(err) => {
                 error!(
                     "Could not register the serial input to the event manager: {:?}",
-                    e
+                    err
                 );
             }
             Ok(()) => {
@@ -214,8 +214,8 @@ impl<W: std::io::Write> MutEventSubscriber
                     warn!("Detached the serial input due to peer close/error.");
                 }
             }
-            Err(e) => {
-                match e.raw_os_error() {
+            Err(err) => {
+                match err.raw_os_error() {
                     Some(errno) if errno == libc::ENOBUFS => {
                         unregister_source(ops, &input_fd);
                     }
@@ -245,12 +245,12 @@ impl<W: std::io::Write> MutEventSubscriber
             let serial_fd = self.serial_input_fd();
             let buf_ready_evt = self.buffer_ready_evt_fd();
             if serial_fd != -1 {
-                if let Err(e) = ops.add(Events::new(&serial_fd, EventSet::IN)) {
-                    warn!("Failed to register serial input fd: {}", e);
+                if let Err(err) = ops.add(Events::new(&serial_fd, EventSet::IN)) {
+                    warn!("Failed to register serial input fd: {}", err);
                 }
             }
-            if let Err(e) = ops.add(Events::new(&buf_ready_evt, EventSet::IN)) {
-                warn!("Failed to register serial buffer ready event: {}", e);
+            if let Err(err) = ops.add(Events::new(&buf_ready_evt, EventSet::IN)) {
+                warn!("Failed to register serial buffer ready event: {}", err);
             }
         }
     }
@@ -272,9 +272,9 @@ impl<W: Write + Send + 'static> BusDevice
             self.serial.events().metrics.missed_write_count.inc();
             return;
         }
-        if let Err(e) = self.serial.write(offset as u8, data[0]) {
+        if let Err(err) = self.serial.write(offset as u8, data[0]) {
             // Counter incremented for any handle_write() error.
-            error!("Failed the write to serial: {:?}", e);
+            error!("Failed the write to serial: {:?}", err);
             self.serial.events().metrics.error_count.inc();
         }
     }

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -305,12 +305,12 @@ impl Balloon {
                 let guest_addr =
                     GuestAddress((page_frame_number as u64) << VIRTIO_BALLOON_PFN_SHIFT);
 
-                if let Err(e) = remove_range(
+                if let Err(err) = remove_range(
                     mem,
                     (guest_addr, u64::from(range_len) << VIRTIO_BALLOON_PFN_SHIFT),
                     self.restored,
                 ) {
-                    error!("Error removing memory range: {:?}", e);
+                    error!("Error removing memory range: {:?}", err);
                 }
             }
         }
@@ -383,9 +383,9 @@ impl Balloon {
     }
 
     pub(crate) fn signal_used_queue(&self) -> Result<(), BalloonError> {
-        self.irq_trigger.trigger_irq(IrqType::Vring).map_err(|e| {
+        self.irq_trigger.trigger_irq(IrqType::Vring).map_err(|err| {
             METRICS.balloon.event_fails.inc();
-            BalloonError::InterruptError(e)
+            BalloonError::InterruptError(err)
         })
     }
 

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -13,36 +13,36 @@ use crate::virtio::{VirtioDevice, DEFLATE_INDEX, INFLATE_INDEX, STATS_INDEX};
 
 impl Balloon {
     fn register_runtime_events(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.queue_evts[INFLATE_INDEX], EventSet::IN)) {
-            error!("Failed to register inflate queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_evts[INFLATE_INDEX], EventSet::IN)) {
+            error!("Failed to register inflate queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.queue_evts[DEFLATE_INDEX], EventSet::IN)) {
-            error!("Failed to register deflate queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_evts[DEFLATE_INDEX], EventSet::IN)) {
+            error!("Failed to register deflate queue event: {}", err);
         }
         if self.stats_enabled() {
-            if let Err(e) = ops.add(Events::new(&self.queue_evts[STATS_INDEX], EventSet::IN)) {
-                error!("Failed to register stats queue event: {}", e);
+            if let Err(err) = ops.add(Events::new(&self.queue_evts[STATS_INDEX], EventSet::IN)) {
+                error!("Failed to register stats queue event: {}", err);
             }
-            if let Err(e) = ops.add(Events::new(&self.stats_timer, EventSet::IN)) {
-                error!("Failed to register stats timerfd event: {}", e);
+            if let Err(err) = ops.add(Events::new(&self.stats_timer, EventSet::IN)) {
+                error!("Failed to register stats timerfd event: {}", err);
             }
         }
     }
 
     fn register_activate_event(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to register activate event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to register activate event: {}", err);
         }
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
         debug!("balloon: activate event");
-        if let Err(e) = self.activate_evt.read() {
-            error!("Failed to consume balloon activate event: {:?}", e);
+        if let Err(err) = self.activate_evt.read() {
+            error!("Failed to consume balloon activate event: {:?}", err);
         }
         self.register_runtime_events(ops);
-        if let Err(e) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to un-register activate event: {}", e);
+        if let Err(err) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to un-register activate event: {}", err);
         }
     }
 }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -434,14 +434,13 @@ impl Block {
 
         if let Err(err) = engine.completion_evt().read() {
             error!("Failed to get async completion event: {:?}", err);
-            return;
-        }
+        } else {
+            self.process_async_completion_queue();
 
-        self.process_async_completion_queue();
-
-        if self.is_io_engine_throttled {
-            self.is_io_engine_throttled = false;
-            self.process_queue(0);
+            if self.is_io_engine_throttled {
+                self.is_io_engine_throttled = false;
+                self.process_queue(0);
+            }
         }
     }
 

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -12,33 +12,33 @@ use crate::virtio::VirtioDevice;
 
 impl Block {
     fn register_runtime_events(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.queue_evts[0], EventSet::IN)) {
-            error!("Failed to register queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_evts[0], EventSet::IN)) {
+            error!("Failed to register queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.rate_limiter, EventSet::IN)) {
-            error!("Failed to register ratelimiter event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.rate_limiter, EventSet::IN)) {
+            error!("Failed to register ratelimiter event: {}", err);
         }
         if let FileEngine::Async(engine) = self.disk.file_engine() {
-            if let Err(e) = ops.add(Events::new(engine.completion_evt(), EventSet::IN)) {
-                error!("Failed to register IO engine completion event: {}", e);
+            if let Err(err) = ops.add(Events::new(engine.completion_evt(), EventSet::IN)) {
+                error!("Failed to register IO engine completion event: {}", err);
             }
         }
     }
 
     fn register_activate_event(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to register activate event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to register activate event: {}", err);
         }
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
         debug!("block: activate event");
-        if let Err(e) = self.activate_evt.read() {
-            error!("Failed to consume block activate event: {:?}", e);
+        if let Err(err) = self.activate_evt.read() {
+            error!("Failed to consume block activate event: {:?}", err);
         }
         self.register_runtime_events(ops);
-        if let Err(e) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to un-register activate event: {}", e);
+        if let Err(err) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to un-register activate event: {}", err);
         }
     }
 }

--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -108,10 +108,10 @@ impl<T> AsyncFileEngine<T> {
     ) -> Result<(), UserDataError<T, Error>> {
         let buf = match mem.get_slice(addr, count as usize) {
             Ok(slice) => slice.as_ptr(),
-            Err(e) => {
+            Err(err) => {
                 return Err(UserDataError {
                     user_data,
-                    error: Error::GuestMemory(e),
+                    error: Error::GuestMemory(err),
                 });
             }
         };
@@ -145,10 +145,10 @@ impl<T> AsyncFileEngine<T> {
     ) -> Result<(), UserDataError<T, Error>> {
         let buf = match mem.get_slice(addr, count as usize) {
             Ok(slice) => slice.as_ptr(),
-            Err(e) => {
+            Err(err) => {
                 return Err(UserDataError {
                     user_data,
-                    error: Error::GuestMemory(e),
+                    error: Error::GuestMemory(err),
                 });
             }
         };

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -34,8 +34,8 @@ pub enum Error {
 
 impl Error {
     pub fn is_throttling_err(&self) -> bool {
-        if let Error::Async(async_io::Error::IoUring(e)) = self {
-            return e.is_throttling_err();
+        if let Error::Async(async_io::Error::IoUring(err)) = self {
+            return err.is_throttling_err();
         }
         false
     }
@@ -89,17 +89,17 @@ impl<T> FileEngine<T> {
             FileEngine::Async(engine) => {
                 match engine.push_read(offset, mem, addr, count, user_data) {
                     Ok(_) => Ok(FileEngineOk::Submitted),
-                    Err(e) => Err(UserDataError {
-                        user_data: e.user_data,
-                        error: Error::Async(e.error),
+                    Err(err) => Err(UserDataError {
+                        user_data: err.user_data,
+                        error: Error::Async(err.error),
                     }),
                 }
             }
             FileEngine::Sync(engine) => match engine.read(offset, mem, addr, count) {
                 Ok(count) => Ok(FileEngineOk::Executed(UserDataOk { user_data, count })),
-                Err(e) => Err(UserDataError {
+                Err(err) => Err(UserDataError {
                     user_data,
-                    error: Error::Sync(e),
+                    error: Error::Sync(err),
                 }),
             },
         }
@@ -117,17 +117,17 @@ impl<T> FileEngine<T> {
             FileEngine::Async(engine) => {
                 match engine.push_write(offset, mem, addr, count, user_data) {
                     Ok(_) => Ok(FileEngineOk::Submitted),
-                    Err(e) => Err(UserDataError {
-                        user_data: e.user_data,
-                        error: Error::Async(e.error),
+                    Err(err) => Err(UserDataError {
+                        user_data: err.user_data,
+                        error: Error::Async(err.error),
                     }),
                 }
             }
             FileEngine::Sync(engine) => match engine.write(offset, mem, addr, count) {
                 Ok(count) => Ok(FileEngineOk::Executed(UserDataOk { user_data, count })),
-                Err(e) => Err(UserDataError {
+                Err(err) => Err(UserDataError {
                     user_data,
-                    error: Error::Sync(e),
+                    error: Error::Sync(err),
                 }),
             },
         }
@@ -137,9 +137,9 @@ impl<T> FileEngine<T> {
         match self {
             FileEngine::Async(engine) => match engine.push_flush(user_data) {
                 Ok(_) => Ok(FileEngineOk::Submitted),
-                Err(e) => Err(UserDataError {
-                    user_data: e.user_data,
-                    error: Error::Async(e.error),
+                Err(err) => Err(UserDataError {
+                    user_data: err.user_data,
+                    error: Error::Async(err.error),
                 }),
             },
             FileEngine::Sync(engine) => match engine.flush() {
@@ -147,9 +147,9 @@ impl<T> FileEngine<T> {
                     user_data,
                     count: 0,
                 })),
-                Err(e) => Err(UserDataError {
+                Err(err) => Err(UserDataError {
                     user_data,
-                    error: Error::Sync(e),
+                    error: Error::Sync(err),
                 }),
             },
         }
@@ -195,8 +195,8 @@ pub mod tests {
                     user_data: _,
                     error: $($pattern)+,
                 }) => (),
-                ref e => {
-                    println!("expected `{}` but got `{:?}`", stringify!($($pattern)+), e);
+                ref err => {
+                    println!("expected `{}` but got `{:?}`", stringify!($($pattern)+), err);
                     assert!(false)
                 }
             }

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -34,10 +34,10 @@ pub enum Error {
 
 impl Error {
     pub fn is_throttling_err(&self) -> bool {
-        if let Error::Async(async_io::Error::IoUring(err)) = self {
-            return err.is_throttling_err();
+        match self {
+            Error::Async(async_io::Error::IoUring(err)) => err.is_throttling_err(),
+            _ => false,
         }
-        false
     }
 }
 

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -21,7 +21,7 @@ use super::{io as block_io, Error, SECTOR_SHIFT};
 use crate::virtio::block::device::DiskProperties;
 use crate::virtio::SECTOR_SIZE;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum IoErr {
     GetId(GuestMemoryError),
     PartialTransfer { completed: u32, expected: u32 },

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -66,9 +66,9 @@ impl IrqTrigger {
         };
         self.irq_status.fetch_or(irq as usize, Ordering::SeqCst);
 
-        self.irq_evt.write(1).map_err(|e| {
-            error!("Failed to send irq to the guest: {:?}", e);
-            e
+        self.irq_evt.write(1).map_err(|err| {
+            error!("Failed to send irq to the guest: {:?}", err);
+            err
         })?;
 
         Ok(())

--- a/src/devices/src/virtio/net/event_handler.rs
+++ b/src/devices/src/virtio/net/event_handler.rs
@@ -12,40 +12,40 @@ use crate::virtio::{VirtioDevice, RX_INDEX, TX_INDEX};
 
 impl Net {
     fn register_runtime_events(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.queue_evts[RX_INDEX], EventSet::IN)) {
-            error!("Failed to register rx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_evts[RX_INDEX], EventSet::IN)) {
+            error!("Failed to register rx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.queue_evts[TX_INDEX], EventSet::IN)) {
-            error!("Failed to register tx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_evts[TX_INDEX], EventSet::IN)) {
+            error!("Failed to register tx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.rx_rate_limiter, EventSet::IN)) {
-            error!("Failed to register rx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.rx_rate_limiter, EventSet::IN)) {
+            error!("Failed to register rx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.tx_rate_limiter, EventSet::IN)) {
-            error!("Failed to register tx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.tx_rate_limiter, EventSet::IN)) {
+            error!("Failed to register tx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(
+        if let Err(err) = ops.add(Events::new(
             &self.tap,
             EventSet::IN | EventSet::EDGE_TRIGGERED,
         )) {
-            error!("Failed to register tap event: {}", e);
+            error!("Failed to register tap event: {}", err);
         }
     }
 
     fn register_activate_event(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to register activate event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to register activate event: {}", err);
         }
     }
 
     fn process_activate_event(&self, ops: &mut EventOps) {
         debug!("net: activate event");
-        if let Err(e) = self.activate_evt.read() {
-            error!("Failed to consume net activate event: {:?}", e);
+        if let Err(err) = self.activate_evt.read() {
+            error!("Failed to consume net activate event: {:?}", err);
         }
         self.register_runtime_events(ops);
-        if let Err(e) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to un-register activate event: {}", e);
+        if let Err(err) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to un-register activate event: {}", err);
         }
     }
 }

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -40,10 +40,10 @@ impl fmt::Display for QueueError {
 
         match &*self {
             DescIndexOutOfBounds(val) => write!(f, "Descriptor index out of bounds: {}", val),
-            UsedRing(e) => write!(
+            UsedRing(err) => write!(
                 f,
                 "Failed to write value into the virtio queue used ring: {}",
-                e
+                err
             ),
         }
     }

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -26,7 +26,7 @@ pub(super) const VIRTQ_DESC_F_WRITE: u16 = 0x2;
 // The Virtio Spec 1.0 defines the alignment of VirtIO descriptor is 16 bytes,
 // which fulfills the explicit constraint of GuestMemoryMmap::read_obj_from_addr().
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum QueueError {
     /// Descriptor index out of bounds.
     DescIndexOutOfBounds(u16),
@@ -401,12 +401,10 @@ impl Queue {
         let next_used = u64::from(self.next_used.0 % self.actual_size());
         let used_elem = used_ring.unchecked_add(4 + next_used * 8);
 
-        mem.write_obj(u32::from(desc_index), used_elem)
-            .map_err(QueueError::UsedRing)?;
+        mem.write_obj(u32::from(desc_index), used_elem)?;
 
         let len_addr = used_elem.unchecked_add(4);
-        mem.write_obj(len as u32, len_addr)
-            .map_err(QueueError::UsedRing)?;
+        mem.write_obj(len as u32, len_addr)?;
 
         self.num_added += Wrapping(1);
         self.next_used += Wrapping(1);

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -608,17 +608,17 @@ where
         // The TX buffer is empty, so we can try to write straight to the host stream.
         let written = match pkt.write_from_offset_to(mem, 0, &mut self.stream, len) {
             Ok(cnt) => cnt,
-            Err(VsockError::GuestMemoryMmap(GuestMemoryError::IOError(e)))
-                if e.kind() == ErrorKind::WouldBlock =>
+            Err(VsockError::GuestMemoryMmap(GuestMemoryError::IOError(err)))
+                if err.kind() == ErrorKind::WouldBlock =>
             {
                 // Absorb any would-block errors, since we can always try again later.
                 0
             }
-            Err(e) => {
+            Err(err) => {
                 // We don't know how to handle any other write error, so we'll send it up
                 // the call chain.
                 METRICS.vsock.tx_write_fails.inc();
-                return Err(e);
+                return Err(err);
             }
         };
         // Move the "forwarded bytes" counter ahead by how much we were able to send out.

--- a/src/devices/src/virtio/vsock/csm/mod.rs
+++ b/src/devices/src/virtio/vsock/csm/mod.rs
@@ -39,15 +39,15 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::TxBufFull => write!(f, "Attempted to push data to a full TX buffer"),
-            Self::TxBufFlush(e) => write!(
+            Self::TxBufFlush(err) => write!(
                 f,
                 "An I/O error occurred, when attempting to flush the connection TX buffer: {}",
-                e
+                err
             ),
-            Self::StreamWrite(e) => write!(
+            Self::StreamWrite(err) => write!(
                 f,
                 "An I/O error occurred, when attempting to write data to the host-side stream: {}",
-                e
+                err
             ),
         }
     }

--- a/src/devices/src/virtio/vsock/csm/txbuf.rs
+++ b/src/devices/src/virtio/vsock/csm/txbuf.rs
@@ -137,7 +137,7 @@ impl Write for TxBuf {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.push(buf)
             .map(|()| buf.len())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -252,9 +252,9 @@ mod tests {
         }
 
         match txbuf.write(&[1, 2]) {
-            Err(e) => {
+            Err(err) => {
                 assert_eq!(
-                    format!("{}", e),
+                    format!("{}", err),
                     "Attempted to push data to a full TX buffer"
                 );
             }

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -48,8 +48,8 @@ where
         }
 
         let mut raise_irq = false;
-        if let Err(e) = self.queue_events[RXQ_INDEX].read() {
-            error!("Failed to get vsock rx queue event: {:?}", e);
+        if let Err(err) = self.queue_events[RXQ_INDEX].read() {
+            error!("Failed to get vsock rx queue event: {:?}", err);
             METRICS.vsock.rx_queue_event_fails.inc();
         } else if self.backend.has_pending_rx() {
             raise_irq |= self.process_rx();
@@ -68,8 +68,8 @@ where
         }
 
         let mut raise_irq = false;
-        if let Err(e) = self.queue_events[TXQ_INDEX].read() {
-            error!("Failed to get vsock tx queue event: {:?}", e);
+        if let Err(err) = self.queue_events[TXQ_INDEX].read() {
+            error!("Failed to get vsock tx queue event: {:?}", err);
             METRICS.vsock.tx_queue_event_fails.inc();
         } else {
             raise_irq |= self.process_tx();
@@ -93,8 +93,8 @@ where
             return false;
         }
 
-        if let Err(e) = self.queue_events[EVQ_INDEX].read() {
-            error!("Failed to consume vsock evq event: {:?}", e);
+        if let Err(err) = self.queue_events[EVQ_INDEX].read() {
+            error!("Failed to consume vsock evq event: {:?}", err);
             METRICS.vsock.ev_queue_event_fails.inc();
         }
         false
@@ -117,34 +117,34 @@ where
     }
 
     fn register_runtime_events(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.queue_events[RXQ_INDEX], EventSet::IN)) {
-            error!("Failed to register rx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_events[RXQ_INDEX], EventSet::IN)) {
+            error!("Failed to register rx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.queue_events[TXQ_INDEX], EventSet::IN)) {
-            error!("Failed to register tx queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_events[TXQ_INDEX], EventSet::IN)) {
+            error!("Failed to register tx queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.queue_events[EVQ_INDEX], EventSet::IN)) {
-            error!("Failed to register ev queue event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.queue_events[EVQ_INDEX], EventSet::IN)) {
+            error!("Failed to register ev queue event: {}", err);
         }
-        if let Err(e) = ops.add(Events::new(&self.backend, self.backend.get_polled_evset())) {
-            error!("Failed to register vsock backend event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.backend, self.backend.get_polled_evset())) {
+            error!("Failed to register vsock backend event: {}", err);
         }
     }
 
     fn register_activate_event(&self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to register activate event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to register activate event: {}", err);
         }
     }
 
     fn handle_activate_event(&self, ops: &mut EventOps) {
         debug!("vsock: activate event");
-        if let Err(e) = self.activate_evt.read() {
-            error!("Failed to consume net activate event: {:?}", e);
+        if let Err(err) = self.activate_evt.read() {
+            error!("Failed to consume net activate event: {:?}", err);
         }
         self.register_runtime_events(ops);
-        if let Err(e) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
-            error!("Failed to un-register activate event: {}", e);
+        if let Err(err) = ops.remove(Events::new(&self.activate_evt, EventSet::IN)) {
+            error!("Failed to un-register activate event: {}", err);
         }
     }
 }

--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -75,7 +75,7 @@ impl VsockChannel for TestBackend {
                 self.rx_ok_cnt += 1;
                 Ok(())
             }
-            Some(e) => Err(e),
+            Some(err) => Err(err),
         }
     }
 
@@ -85,7 +85,7 @@ impl VsockChannel for TestBackend {
                 self.tx_ok_cnt += 1;
                 Ok(())
             }
-            Some(e) => Err(e),
+            Some(err) => Err(err),
         }
     }
 

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -290,8 +290,8 @@ impl VsockEpollListener for VsockMuxer {
                     );
                 }
             }
-            Err(e) => {
-                warn!("vsock: failed to consume muxer epoll event: {}", e);
+            Err(err) => {
+                warn!("vsock: failed to consume muxer epoll event: {}", err);
                 METRICS.vsock.muxer_event_fails.inc();
             }
         }

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 bitflags = ">=1.0.4"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 logger = { path = "../logger" }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -97,6 +97,7 @@ pub enum RecvError {
 }
 
 /// Describes errors which may occur when a connection attempts to write a segment.
+#[derive(derive_more::From)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum WriteNextError {
     /// The connection cannot write the segment because it has been previously reset.
@@ -751,8 +752,7 @@ impl Connection {
                 .checked_sub(mss_reserved)
                 .ok_or(WriteNextError::MssRemaining)?,
             payload,
-        )
-        .map_err(WriteNextError::TcpSegment)?;
+        )?;
 
         if flags_after_ns.intersects(TcpFlags::ACK) {
             self.pending_ack = false;

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -518,13 +518,13 @@ mod tests {
         h: &mut TcpIPv4Handler,
         buf: &'a mut [u8],
     ) -> Result<(Option<IPv4Packet<'a, &'a mut [u8]>>, WriteEvent), WriteNextError> {
-        h.write_next_packet(buf).map(|(o, e)| {
+        h.write_next_packet(buf).map(|(o, err)| {
             (
                 o.map(move |len| {
                     let len = len.get();
                     IPv4Packet::from_bytes(buf.split_at_mut(len).0, true).unwrap()
                 }),
-                e,
+                err,
             )
         })
     }
@@ -535,8 +535,8 @@ mod tests {
         expected_event: WriteEvent,
     ) -> TcpSegment<'a, &'a mut [u8]> {
         let (segment_start, segment_end) = {
-            let (o, e) = write_next(h, buf).unwrap();
-            assert_eq!(e, expected_event);
+            let (o, event) = write_next(h, buf).unwrap();
+            assert_eq!(event, expected_event);
             let p = o.unwrap();
             (p.header_len(), p.len())
         };

--- a/src/dumbo/src/tcp/handler.rs
+++ b/src/dumbo/src/tcp/handler.rs
@@ -56,6 +56,7 @@ pub enum WriteEvent {
 ///
 /// [`receive_packet`]: struct.TcpIPv4Handler.html#method.receive_packet
 /// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
+#[derive(derive_more::From)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum RecvError {
     /// The inner segment has an invalid destination port.
@@ -69,7 +70,7 @@ pub enum RecvError {
 ///
 /// [`write_next_packet`]: struct.TcpIPv4Handler.html#method.write_next_packet
 /// [`TcpIPv4Handler`]: struct.TcpIPv4Handler.html
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Debug, PartialEq, derive_more::From)]
 pub enum WriteNextError {
     /// There was an error while writing the contents of the IPv4 packet.
     IPv4Packet(IPv4PacketError),
@@ -212,8 +213,7 @@ impl TcpIPv4Handler {
         // TODO: We skip verifying the checksum, just in case the device model relies on offloading
         // checksum computation from the guest to some other entity. Clear this up at some point!
         // (Issue #520)
-        let segment =
-            TcpSegment::from_bytes(packet.payload(), None).map_err(RecvError::TcpSegment)?;
+        let segment = TcpSegment::from_bytes(packet.payload(), None)?;
 
         if segment.destination_port() != self.local_port {
             return Err(RecvError::InvalidPort);
@@ -388,8 +388,7 @@ impl TcpIPv4Handler {
 
         // Write an incomplete Ipv4 packet and complete it afterwards with missing information.
         let mut packet =
-            IPv4Packet::write_header(buf, PROTOCOL_TCP, Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST)
-                .map_err(WriteNextError::IPv4Packet)?;
+            IPv4Packet::write_header(buf, PROTOCOL_TCP, Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST)?;
 
         // We set mss_used to 0, because we don't add any IP options.
         // TODO: Maybe get this nicely from packet at some point.
@@ -409,8 +408,7 @@ impl TcpIPv4Handler {
                 None,
                 0,
                 None,
-            )
-            .map_err(WriteNextError::TcpSegment)?
+            )?
             .finalize(
                 self.local_port,
                 tuple.remote_port,

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -108,8 +108,8 @@ impl MutEventSubscriber for ApiServerAdapter {
     }
 
     fn init(&mut self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.api_event_fd, EventSet::IN)) {
-            error!("Failed to register activate event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.api_event_fd, EventSet::IN)) {
+            error!("Failed to register activate event: {}", err);
         }
     }
 }

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -68,8 +68,8 @@ fn main_exitable() -> FcExitCode {
         .configure(Some(DEFAULT_INSTANCE_ID.to_string()))
         .expect("Failed to register logger");
 
-    if let Err(e) = register_signal_handlers() {
-        error!("Failed to register signal handlers: {}", e);
+    if let Err(err) = register_signal_handlers() {
+        error!("Failed to register signal handlers: {}", err);
         return vmm::FcExitCode::GenericError;
     }
 
@@ -87,18 +87,18 @@ fn main_exitable() -> FcExitCode {
         // origin of the panic, including the payload passed to panic! and the source code location
         // from which the panic originated.
         error!("Firecracker {}", info);
-        if let Err(e) = stdin.lock().set_canon_mode() {
+        if let Err(err) = stdin.lock().set_canon_mode() {
             error!(
                 "Failure while trying to reset stdin to canonical mode: {}",
-                e
+                err
             );
         }
 
         METRICS.vmm.panic_count.store(1);
 
         // Write the metrics before aborting.
-        if let Err(e) = METRICS.write() {
-            error!("Failed to write metrics while panicking: {}", e);
+        if let Err(err) = METRICS.write() {
+            error!("Failed to write metrics while panicking: {}", err);
         }
     }));
 
@@ -271,11 +271,11 @@ fn main_exitable() -> FcExitCode {
         let level = arguments.single_value("level").unwrap().to_owned();
         let logger_level = match LoggerLevel::from_string(level) {
             Ok(level) => level,
-            Err(e) => {
+            Err(err) => {
                 return generic_error_exit(&format!(
                     "Invalid value for logger level: {}.Possible values: [Error, Warning, Info, \
                      Debug]",
-                    e
+                    err
                 ));
             }
         };
@@ -288,8 +288,8 @@ fn main_exitable() -> FcExitCode {
             show_level,
             show_log_origin,
         );
-        if let Err(e) = init_logger(logger_config, &instance_info) {
-            return generic_error_exit(&format!("Could not initialize logger:: {}", e));
+        if let Err(err) = init_logger(logger_config, &instance_info) {
+            return generic_error_exit(&format!("Could not initialize logger:: {}", err));
         };
     }
 
@@ -300,8 +300,8 @@ fn main_exitable() -> FcExitCode {
     .and_then(get_filters)
     {
         Ok(filters) => filters,
-        Err(e) => {
-            return generic_error_exit(&format!("Seccomp error: {}", e));
+        Err(err) => {
+            return generic_error_exit(&format!("Seccomp error: {}", err));
         }
     };
 

--- a/src/firecracker/src/metrics.rs
+++ b/src/firecracker/src/metrics.rs
@@ -46,9 +46,9 @@ impl PeriodicMetrics {
     }
 
     fn write_metrics(&mut self) {
-        if let Err(e) = METRICS.write() {
+        if let Err(err) = METRICS.write() {
             METRICS.logger.missed_metrics_count.inc();
-            error!("Failed to write metrics: {}", e);
+            error!("Failed to write metrics: {}", err);
         }
 
         #[cfg(test)]
@@ -84,8 +84,8 @@ impl MutEventSubscriber for PeriodicMetrics {
     }
 
     fn init(&mut self, ops: &mut EventOps) {
-        if let Err(e) = ops.add(Events::new(&self.write_metrics_event_fd, EventSet::IN)) {
-            error!("Failed to register metrics event: {}", e);
+        if let Err(err) = ops.add(Events::new(&self.write_metrics_event_fd, EventSet::IN)) {
+            error!("Failed to register metrics event: {}", err);
         }
     }
 }

--- a/src/io_uring/Cargo.toml
+++ b/src/io_uring/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 libc = ">=0.2.103"
 utils = { path = "../utils" }
 vm-memory = { path="../vm-memory" }
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 [dev-dependencies]
 proptest = { version = ">=1.0.0", default-features = false, features = ["std"] }

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -12,7 +12,7 @@ use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;
 use crate::operation::Cqe;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 /// CQueue Error.
 pub enum Error {
     /// Error mapping the ring.
@@ -47,13 +47,10 @@ impl CompletionQueue {
         // To this we add an offset as per the io_uring specifications.
         let ring_size = (params.cq_off.cqes as usize)
             + (params.cq_entries as usize) * std::mem::size_of::<bindings::io_uring_cqe>();
-        let cqes = mmap(ring_size, io_uring_fd, bindings::IORING_OFF_CQ_RING.into())
-            .map_err(Error::Mmap)?;
+        let cqes = mmap(ring_size, io_uring_fd, bindings::IORING_OFF_CQ_RING.into())?;
 
         let ring = cqes.as_volatile_slice();
-        let ring_mask = ring
-            .read_obj(offsets.ring_mask as usize)
-            .map_err(Error::VolatileMemory)?;
+        let ring_mask = ring.read_obj(offsets.ring_mask as usize)?;
 
         Ok(Self {
             // safe because it's an u32 offset
@@ -82,22 +79,17 @@ impl CompletionQueue {
         let ring = self.cqes.as_volatile_slice();
         // get the head & tail
         let head = self.unmasked_head.0 & self.ring_mask;
-        let unmasked_tail = ring
-            .load::<u32>(self.tail_off, Ordering::Acquire)
-            .map_err(Error::VolatileMemory)?;
+        let unmasked_tail = ring.load::<u32>(self.tail_off, Ordering::Acquire)?;
 
         // validate that we have smth to fetch
         if Wrapping(unmasked_tail) - self.unmasked_head > Wrapping(0) {
-            let cqe: bindings::io_uring_cqe = ring
-                .read_obj(
-                    self.cqes_off + (head as usize) * std::mem::size_of::<bindings::io_uring_cqe>(),
-                )
-                .map_err(Error::VolatileMemory)?;
+            let cqe: bindings::io_uring_cqe = ring.read_obj(
+                self.cqes_off + (head as usize) * std::mem::size_of::<bindings::io_uring_cqe>(),
+            )?;
 
             // increase the head
             self.unmasked_head += Wrapping(1u32);
-            ring.store(self.unmasked_head.0, self.head_off, Ordering::Release)
-                .map_err(Error::VolatileMemory)?;
+            ring.store(self.unmasked_head.0, self.head_off, Ordering::Release)?;
 
             Ok(Some(Cqe::new(cqe)))
         } else {

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -15,7 +15,7 @@ use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;
 use crate::operation::Sqe;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 /// SQueue Error.
 pub enum Error {
     /// The queue is full.
@@ -59,18 +59,12 @@ impl SubmissionQueue {
 
         // since we don't need the extra layer of indirection, we can simply map the index array
         // to be array[i] = i;
-        let sq_array = ring_slice
-            .offset(params.sq_off.array as usize)
-            .map_err(Error::VolatileMemory)?;
+        let sq_array = ring_slice.offset(params.sq_off.array as usize)?;
         for i in 0..params.sq_entries {
-            sq_array
-                .write_obj(i, mem::size_of::<u32>() * (i as usize))
-                .map_err(Error::VolatileMemory)?;
+            sq_array.write_obj(i, mem::size_of::<u32>() * (i as usize))?;
         }
 
-        let ring_mask = ring_slice
-            .read_obj(params.sq_off.ring_mask as usize)
-            .map_err(Error::VolatileMemory)?;
+        let ring_mask = ring_slice.read_obj(params.sq_off.ring_mask as usize)?;
 
         Ok(Self {
             io_uring_fd,
@@ -148,8 +142,7 @@ impl SubmissionQueue {
                 std::ptr::null() as *const libc::sigset_t,
             )
         } as libc::c_int)
-        .into_result()
-        .map_err(Error::Submit)?
+        .into_result()?
         // It's safe to convert to u32 since the syscall didn't return an error.
         as u32;
 
@@ -173,8 +166,7 @@ impl SubmissionQueue {
             sqe_ring_size,
             io_uring_fd,
             bindings::IORING_OFF_SQ_RING.into(),
-        )
-        .map_err(Error::Mmap)?;
+        )?;
 
         // map the SQEs.
         let sqes_array_size =
@@ -184,8 +176,7 @@ impl SubmissionQueue {
             sqes_array_size,
             io_uring_fd,
             bindings::IORING_OFF_SQES.into(),
-        )
-        .map_err(Error::Mmap)?;
+        )?;
 
         Ok((sqe_ring, sqes))
     }
@@ -193,9 +184,7 @@ impl SubmissionQueue {
     pub(crate) fn pending(&self) -> Result<u32, Error> {
         let ring_slice = self.ring.as_volatile_slice();
         // get the sqe head
-        let unmasked_head = ring_slice
-            .load::<u32>(self.head_off, Ordering::Acquire)
-            .map_err(Error::VolatileMemory)?;
+        let unmasked_head = ring_slice.load::<u32>(self.head_off, Ordering::Acquire)?;
 
         Ok((self.unmasked_tail - Wrapping(unmasked_head)).0)
     }

--- a/src/io_uring/tests/integration_tests.rs
+++ b/src/io_uring/tests/integration_tests.rs
@@ -29,7 +29,7 @@ fn test_ring_new() {
     // Invalid entries count: 0.
     assert!(matches!(
         IoUring::new(0, vec![], vec![], None),
-        Err(Error::Setup(e)) if e.kind() == std::io::ErrorKind::InvalidInput
+        Err(Error::Setup(err)) if err.kind() == std::io::ErrorKind::InvalidInput
     ));
     // Try to register too many files.
     let dummy_file = TempFile::new().unwrap().into_file();
@@ -106,7 +106,7 @@ fn test_restrictions() {
         assert_eq!(ring.submit_and_wait_all().unwrap(), 1);
         assert!(
             matches!(unsafe{ring.pop::<u8>().unwrap().unwrap().result()},
-            Err(e) if e.kind() == std::io::ErrorKind::Other)
+            Err(err) if err.kind() == std::io::ErrorKind::Other)
         );
     }
 }

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -121,7 +121,7 @@ impl Env {
             .single_value("exec-file")
             .ok_or_else(|| Error::ArgumentParsing(MissingValue("exec-file".to_string())))?;
         let exec_file_path = canonicalize(&exec_file)
-            .map_err(|e| Error::Canonicalize(PathBuf::from(&exec_file), e))?;
+            .map_err(|err| Error::Canonicalize(PathBuf::from(&exec_file), err))?;
 
         if !exec_file_path.is_file() {
             return Err(Error::NotAFile(exec_file_path));
@@ -135,7 +135,7 @@ impl Env {
             .single_value("chroot-base-dir")
             .ok_or_else(|| Error::ArgumentParsing(MissingValue("chroot-base-dir".to_string())))?;
         let mut chroot_dir = canonicalize(&chroot_base)
-            .map_err(|e| Error::Canonicalize(PathBuf::from(&chroot_base), e))?;
+            .map_err(|err| Error::Canonicalize(PathBuf::from(&chroot_base), err))?;
 
         if !chroot_dir.is_dir() {
             return Err(Error::NotADirectory(chroot_dir));
@@ -300,10 +300,10 @@ impl Env {
             .write(true)
             .create_new(true)
             .open(pid_file_path.clone())
-            .map_err(|e| Error::FileOpen(pid_file_path.clone(), e))?;
+            .map_err(|err| Error::FileOpen(pid_file_path.clone(), err))?;
 
         // Write PID to file.
-        write!(pid_file, "{}", pid).map_err(|e| Error::Write(pid_file_path, e))
+        write!(pid_file, "{}", pid).map_err(|err| Error::Write(pid_file_path, err))
     }
 
     fn mknod_and_own_dev(
@@ -327,9 +327,9 @@ impl Env {
             )
         })
         .into_empty_result()
-        .map_err(|e| {
+        .map_err(|err| {
             Error::MknodDev(
-                e,
+                err,
                 std::str::from_utf8(dev_path_str).expect("Cannot convert from UTF-8"),
             )
         })?;
@@ -337,7 +337,7 @@ impl Env {
         SyscallReturnCode(unsafe { libc::chown(dev_path.as_ptr(), self.uid(), self.gid()) })
             .into_empty_result()
             // Safe to unwrap as we provided valid file names.
-            .map_err(|e| Error::ChangeFileOwner(PathBuf::from(dev_path.to_str().unwrap()), e))
+            .map_err(|err| Error::ChangeFileOwner(PathBuf::from(dev_path.to_str().unwrap()), err))
     }
 
     fn setup_jailed_folder(&self, folder: &[u8]) -> Result<()> {
@@ -346,9 +346,9 @@ impl Env {
         // Safe to unwrap as the byte sequence is UTF-8 validated above.
         let path = folder_cstr.to_str().unwrap();
         let path_buf = PathBuf::from(path);
-        fs::create_dir_all(path).map_err(|e| Error::CreateDir(path_buf.clone(), e))?;
+        fs::create_dir_all(path).map_err(|err| Error::CreateDir(path_buf.clone(), err))?;
         fs::set_permissions(path, Permissions::from_mode(FOLDER_PERMISSIONS))
-            .map_err(|e| Error::Chmod(path_buf.clone(), e))?;
+            .map_err(|err| Error::Chmod(path_buf.clone(), err))?;
 
         #[cfg(target_arch = "x86_64")]
         let folder_bytes_ptr = folder.as_ptr() as *const i8;
@@ -356,7 +356,7 @@ impl Env {
         let folder_bytes_ptr = folder.as_ptr();
         SyscallReturnCode(unsafe { libc::chown(folder_bytes_ptr, self.uid(), self.gid()) })
             .into_empty_result()
-            .map_err(|e| Error::ChangeFileOwner(path_buf, e))
+            .map_err(|err| Error::ChangeFileOwner(path_buf, err))
     }
 
     fn copy_exec_to_chroot(&mut self) -> Result<OsString> {
@@ -373,8 +373,9 @@ impl Env {
 
         // TODO: hard link instead of copy? This would save up disk space, but hard linking is
         // not always possible :(
-        fs::copy(&self.exec_file_path, &self.chroot_dir)
-            .map_err(|e| Error::Copy(self.exec_file_path.clone(), self.chroot_dir.clone(), e))?;
+        fs::copy(&self.exec_file_path, &self.chroot_dir).map_err(|err| {
+            Error::Copy(self.exec_file_path.clone(), self.chroot_dir.clone(), err)
+        })?;
 
         // Pop exec_file_name.
         self.chroot_dir.pop();
@@ -385,7 +386,7 @@ impl Env {
         // Not used `as_raw_fd` as it will create a dangling fd (object will be freed immediately)
         // instead used `into_raw_fd` which provides underlying fd ownership to caller.
         let netns_fd = File::open(path)
-            .map_err(|e| Error::FileOpen(PathBuf::from(path), e))?
+            .map_err(|err| Error::FileOpen(PathBuf::from(path), err))?
             .into_raw_fd();
 
         // Safe because we are passing valid parameters.
@@ -437,7 +438,7 @@ impl Env {
         let jailer_cache_dir =
             Path::new(self.chroot_dir()).join("sys/devices/system/cpu/cpu0/cache/");
         fs::create_dir_all(&jailer_cache_dir)
-            .map_err(|e| Error::CreateDir(jailer_cache_dir.to_owned(), e))?;
+            .map_err(|err| Error::CreateDir(jailer_cache_dir.to_owned(), err))?;
 
         for index in 0..(MAX_CACHE_LEVEL + 1) {
             let index_folder = format!("index{}", index);
@@ -452,7 +453,7 @@ impl Env {
             // We now create the destination folder in the jailer.
             let jailer_path = jailer_cache_dir.join(&index_folder);
             fs::create_dir_all(&jailer_path)
-                .map_err(|e| Error::CreateDir(jailer_path.to_owned(), e))?;
+                .map_err(|err| Error::CreateDir(jailer_path.to_owned(), err))?;
 
             // We now read the contents of the current directory and copy the files we are
             // interested in to the destination path.
@@ -469,7 +470,7 @@ impl Env {
                     libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid())
                 })
                 .into_empty_result()
-                .map_err(|e| Error::ChangeFileOwner(jailer_cache_file.to_owned(), e))?;
+                .map_err(|err| Error::ChangeFileOwner(jailer_cache_file.to_owned(), err))?;
             }
         }
         Ok(())
@@ -484,7 +485,7 @@ impl Env {
         let jailer_midr_el1_directory =
             Path::new(self.chroot_dir()).join("sys/devices/system/cpu/cpu0/regs/identification/");
         fs::create_dir_all(&jailer_midr_el1_directory)
-            .map_err(|e| Error::CreateDir(jailer_midr_el1_directory.to_owned(), e))?;
+            .map_err(|err| Error::CreateDir(jailer_midr_el1_directory.to_owned(), err))?;
 
         let host_midr_el1_file = PathBuf::from(format!("{}/midr_el1", HOST_MIDR_EL1_INFO));
         let jailer_midr_el1_file = jailer_midr_el1_directory.join("midr_el1");
@@ -497,7 +498,7 @@ impl Env {
         let dest_path_cstr = to_cstring(&jailer_midr_el1_file)?;
         SyscallReturnCode(unsafe { libc::chown(dest_path_cstr.as_ptr(), self.uid(), self.gid()) })
             .into_empty_result()
-            .map_err(|e| Error::ChangeFileOwner(jailer_midr_el1_file.to_owned(), e))?;
+            .map_err(|err| Error::ChangeFileOwner(jailer_midr_el1_file.to_owned(), err))?;
 
         Ok(())
     }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -326,12 +326,12 @@ where
     V: ::std::fmt::Display,
 {
     fs::write(file_path, format!("{}\n", value))
-        .map_err(|e| Error::Write(PathBuf::from(file_path.as_ref()), e))
+        .map_err(|err| Error::Write(PathBuf::from(file_path.as_ref()), err))
 }
 
 pub fn readln_special<T: AsRef<Path>>(file_path: &T) -> Result<String> {
     let mut line = fs::read_to_string(file_path)
-        .map_err(|e| Error::ReadToString(PathBuf::from(file_path.as_ref()), e))?;
+        .map_err(|err| Error::ReadToString(PathBuf::from(file_path.as_ref()), err))?;
 
     // Remove the newline character at the end (if any).
     line.pop();
@@ -381,7 +381,7 @@ pub fn to_cstring<T: AsRef<Path>>(path: T) -> Result<CString> {
         .to_path_buf()
         .into_os_string()
         .into_string()
-        .map_err(|e| Error::OsStringParsing(path.as_ref().to_path_buf(), e))?;
+        .map_err(|err| Error::OsStringParsing(path.as_ref().to_path_buf(), err))?;
     CString::new(path_str).map_err(Error::CStringParsing)
 }
 
@@ -422,7 +422,7 @@ fn main() {
     )
     .and_then(|env| {
         fs::create_dir_all(env.chroot_dir())
-            .map_err(|e| Error::CreateDir(env.chroot_dir().to_owned(), e))?;
+            .map_err(|err| Error::CreateDir(env.chroot_dir().to_owned(), err))?;
         env.run()
     })
     .unwrap_or_else(|err| panic!("Jailer error: {}", err));

--- a/src/logger/src/logger.rs
+++ b/src/logger/src/logger.rs
@@ -25,8 +25,8 @@
 //! use logger::{error, warn, LOGGER};
 //!
 //! // Optionally do an initial configuration for the logger.
-//! if let Err(e) = LOGGER.deref().configure(Some("MY-INSTANCE".to_string())) {
-//!     println!("Could not configure the log subsystem: {}", e);
+//! if let Err(err) = LOGGER.deref().configure(Some("MY-INSTANCE".to_string())) {
+//!     println!("Could not configure the log subsystem: {}", err);
 //!     return;
 //! }
 //! warn!("this is a warning");
@@ -400,7 +400,7 @@ pub enum LoggerError {
 impl fmt::Display for LoggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
-            LoggerError::Init(ref e) => format!("Logger initialization failure: {}", e),
+            LoggerError::Init(ref err) => format!("Logger initialization failure: {}", err),
         };
         write!(f, "{}", printable)
     }

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -169,8 +169,8 @@ impl<T: Serialize> Metrics<T> {
                         );
                     }
                 }
-                Err(e) => {
-                    return Err(MetricsError::Serde(e.to_string()));
+                Err(err) => {
+                    return Err(MetricsError::Serde(err.to_string()));
                 }
             }
         }
@@ -204,12 +204,12 @@ pub enum MetricsError {
 impl fmt::Display for MetricsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
-            MetricsError::NeverInitialized(ref e) => e.to_string(),
+            MetricsError::NeverInitialized(ref err) => err.to_string(),
             MetricsError::AlreadyInitialized => {
                 "Reinitialization of metrics not allowed.".to_string()
             }
-            MetricsError::Serde(ref e) => e.to_string(),
-            MetricsError::Write(ref e) => format!("Failed to write metrics: {}", e),
+            MetricsError::Serde(ref err) => err.to_string(),
+            MetricsError::Write(ref err) => format!("Failed to write metrics: {}", err),
         };
         write!(f, "{}", printable)
     }

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -156,10 +156,10 @@ impl<T: Serialize> Metrics<T> {
                         // flushes automatically whenever a newline is
                         // detected (and we always end with a newline the
                         // current write).
-                        return guard
+                        guard
                             .write_all(&(format!("{}\n", msg)).as_bytes())
                             .map_err(MetricsError::Write)
-                            .map(|_| true);
+                            .map(|_| true)
                     } else {
                         // We have not incremented `missed_metrics_count` as there is no way to push
                         // metrics if destination lock got poisoned.
@@ -169,14 +169,13 @@ impl<T: Serialize> Metrics<T> {
                         );
                     }
                 }
-                Err(err) => {
-                    return Err(MetricsError::Serde(err.to_string()));
-                }
+                Err(err) => Err(MetricsError::Serde(err.to_string())),
             }
+        } else {
+            // If the metrics are not initialized, no error is thrown but we do let the user know
+            // that metrics were not written.
+            Ok(false)
         }
-        // If the metrics are not initialized, no error is thrown but we do let the user know that
-        // metrics were not written.
-        Ok(false)
     }
 }
 

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -46,7 +46,7 @@ pub enum OutputFormat {
     Imds,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     DataStoreLimitExceeded,
     NotFound,
@@ -107,8 +107,7 @@ impl Mmds {
             }
             MmdsVersion::V2 => {
                 if self.token_authority.is_none() {
-                    self.token_authority =
-                        Some(TokenAuthority::new().map_err(Error::TokenAuthority)?);
+                    self.token_authority = Some(TokenAuthority::new()?);
                 }
                 Ok(())
             }

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -216,7 +216,7 @@ fn respond_to_get_request_unchecked(mmds: &Mmds, request: Request) -> Response {
             StatusCode::OK,
             Body::new(response_body),
         ),
-        Err(e) => match e {
+        Err(err) => match err {
             MmdsError::NotFound => {
                 let error_msg = Error::ResourceNotFound(String::from(uri)).to_string();
                 build_response(
@@ -228,12 +228,12 @@ fn respond_to_get_request_unchecked(mmds: &Mmds, request: Request) -> Response {
             MmdsError::UnsupportedValueType => build_response(
                 request.http_version(),
                 StatusCode::NotImplemented,
-                Body::new(e.to_string()),
+                Body::new(err.to_string()),
             ),
             MmdsError::DataStoreLimitExceeded => build_response(
                 request.http_version(),
                 StatusCode::PayloadTooLarge,
-                Body::new(e.to_string()),
+                Body::new(err.to_string()),
             ),
             _ => unreachable!(),
         },

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -44,10 +44,10 @@ fn build_arg_parser<'a>() -> ArgParser<'a> {
 }
 
 fn extract_args<'a>(arg_parser: &'a mut ArgParser<'a>) -> &'a Arguments<'a> {
-    arg_parser.parse_from_cmdline().unwrap_or_else(|e| {
+    arg_parser.parse_from_cmdline().unwrap_or_else(|err| {
         panic!(
             "Arguments parsing error: {} \n\nFor more information try --help.",
-            e
+            err
         );
     });
 
@@ -120,10 +120,10 @@ fn main() {
     let mut arg_parser = build_arg_parser();
     let args = extract_args(&mut arg_parser);
     let (mut base_file, mut diff_file) =
-        parse_args(args).unwrap_or_else(|e| panic!("Error parsing the cmd line args: {:?}", e));
+        parse_args(args).unwrap_or_else(|err| panic!("Error parsing the cmd line args: {:?}", err));
 
     rebase(&mut base_file, &mut diff_file)
-        .unwrap_or_else(|e| panic!("Error merging the files: {:?}", e));
+        .unwrap_or_else(|err| panic!("Error merging the files: {:?}", err));
 }
 
 #[cfg(test)]
@@ -139,8 +139,8 @@ mod tests {
         ($expression:expr, $($pattern:tt)+) => {
             match $expression {
                 Err($($pattern)+) => (),
-                ref e =>  {
-                    println!("expected `{}` but got `{:?}`", stringify!($($pattern)+), e);
+                ref err =>  {
+                    println!("expected `{}` but got `{:?}`", stringify!($($pattern)+), err);
                     assert!(false)
                 }
             }

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -17,5 +17,6 @@ bincode = "1.2.1"
 libc = ">=0.2.39"
 serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 utils = { path = "../utils" }

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -34,7 +34,7 @@ use crate::syscall_table::SyscallTable;
 type Result<T> = result::Result<T, Error>;
 
 /// Errors compiling Filters into BPF.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, derive_more::From)]
 pub(crate) enum Error {
     /// Filter and default actions are equal.
     IdenticalActions,
@@ -197,17 +197,10 @@ impl Compiler {
             if is_basic {
                 bpf_map.insert(
                     thread_name,
-                    self.make_basic_seccomp_filter(filter)?
-                        .try_into()
-                        .map_err(Error::SeccompFilter)?,
+                    self.make_basic_seccomp_filter(filter)?.try_into()?,
                 );
             } else {
-                bpf_map.insert(
-                    thread_name,
-                    self.make_seccomp_filter(filter)?
-                        .try_into()
-                        .map_err(Error::SeccompFilter)?,
-                );
+                bpf_map.insert(thread_name, self.make_seccomp_filter(filter)?.try_into()?);
             }
         }
         Ok(bpf_map)

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -55,7 +55,7 @@ const SECCOMPILER_VERSION: &str = env!("FIRECRACKER_VERSION");
 const DEFAULT_OUTPUT_FILENAME: &str = "seccomp_binary_filter.out";
 const EXIT_CODE_ERROR: i32 = 1;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 enum Error {
     Bincode(BincodeError),
     FileOpen(PathBuf, io::Error),
@@ -131,11 +131,7 @@ fn get_argument_values(arguments: &ArgumentsBag) -> Result<Arguments> {
     if arch_string.is_none() {
         return Err(Error::MissingTargetArch);
     }
-    let target_arch: TargetArch = arch_string
-        .unwrap()
-        .as_str()
-        .try_into()
-        .map_err(Error::Arch)?;
+    let target_arch: TargetArch = arch_string.unwrap().as_str().try_into()?;
 
     let input_file = arguments.single_value("input-file");
     if input_file.is_none() {
@@ -171,9 +167,7 @@ fn compile(args: &Arguments) -> Result<()> {
     let compiler = Compiler::new(args.target_arch);
 
     // transform the IR into a Map of BPFPrograms
-    let bpf_data: HashMap<String, BpfProgram> = compiler
-        .compile_blob(filters.0, args.is_basic)
-        .map_err(Error::FileFormat)?;
+    let bpf_data: HashMap<String, BpfProgram> = compiler.compile_blob(filters.0, args.is_basic)?;
 
     // serialize the BPF programs & output them to a file
     let output_file = File::create(&args.output_file)

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 libc = ">=0.2.39"
 serde = { version = ">=1.0.27", features = ["derive"] }
 vmm-sys-util = ">=0.8.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 net_gen = { path = "../net_gen" }
 

--- a/src/utils/src/kernel_version.rs
+++ b/src/utils/src/kernel_version.rs
@@ -6,7 +6,7 @@ use std::result::Result;
 
 use libc::{uname, utsname};
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     Uname(IoError),
     InvalidUtf8(std::string::FromUtf8Error),
@@ -46,10 +46,9 @@ impl KernelVersion {
             return Err(Error::Uname(IoError::last_os_error()));
         }
 
-        Self::parse(
-            String::from_utf8(name.release.iter().map(|c| *c as u8).collect())
-                .map_err(Error::InvalidUtf8)?,
-        )
+        Self::parse(String::from_utf8(
+            name.release.iter().map(|c| *c as u8).collect(),
+        )?)
     }
 
     fn parse(release: String) -> Result<Self, Error> {
@@ -65,9 +64,9 @@ impl KernelVersion {
         }
 
         Ok(Self {
-            major: major.parse().map_err(Error::InvalidInt)?,
-            minor: minor.parse().map_err(Error::InvalidInt)?,
-            patch: patch.parse().map_err(Error::InvalidInt)?,
+            major: major.parse()?,
+            minor: minor.parse()?,
+            patch: patch.parse()?,
         })
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -19,6 +19,7 @@ versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 vm-superio = ">=0.4.0"
 vm-allocator = "0.1.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -62,11 +62,13 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::BusError(e) => write!(f, "failed to perform bus operation: {}", e),
-            Error::Cmdline(e) => write!(f, "unable to add device to kernel command line: {}", e),
-            Error::EventFd(e) => write!(f, "failed to create or clone event descriptor: {}", e),
+            Error::BusError(err) => write!(f, "failed to perform bus operation: {}", err),
+            Error::Cmdline(err) => {
+                write!(f, "unable to add device to kernel command line: {}", err)
+            }
+            Error::EventFd(err) => write!(f, "failed to create or clone event descriptor: {}", err),
             Error::IncorrectDeviceType => write!(f, "incorrect device type"),
-            Error::InternalDeviceError(e) => write!(f, "device error: {}", e),
+            Error::InternalDeviceError(err) => write!(f, "device error: {}", err),
             Error::InvalidInput => write!(f, "invalid configuration"),
             Error::RegisterIoEvent(e) => write!(f, "failed to register IO event: {}", e),
             Error::RegisterIrqFd(e) => write!(f, "failed to register irqfd: {}", e),
@@ -655,21 +657,21 @@ mod tests {
 
     #[test]
     fn test_error_debug_display() {
-        let check_fmt_err = |e: Error| {
+        let check_fmt_err = |err: Error| {
             // Use an exhaustive 'match' to make sure we cover all error variants.
             // When adding a new variant here, don't forget to also call this function with it.
-            let msg = match e {
-                Error::BusError(_) => format!("{}{:?}", e, e),
-                Error::Cmdline(_) => format!("{}{:?}", e, e),
-                Error::DeviceNotFound => format!("{}{:?}", e, e),
-                Error::EventFd(_) => format!("{}{:?}", e, e),
-                Error::IncorrectDeviceType => format!("{}{:?}", e, e),
-                Error::InternalDeviceError(_) => format!("{}{:?}", e, e),
-                Error::InvalidInput => format!("{}{:?}", e, e),
-                Error::RegisterIoEvent(_) => format!("{}{:?}", e, e),
-                Error::RegisterIrqFd(_) => format!("{}{:?}", e, e),
-                Error::UpdateFailed => format!("{}{:?}", e, e),
-                Error::AllocatorError(_) => format!("{}{:?}", e, e),
+            let msg = match err {
+                Error::BusError(_) => format!("{}{:?}", err, err),
+                Error::Cmdline(_) => format!("{}{:?}", err, err),
+                Error::DeviceNotFound => format!("{}{:?}", err, err),
+                Error::EventFd(_) => format!("{}{:?}", err, err),
+                Error::IncorrectDeviceType => format!("{}{:?}", err, err),
+                Error::InternalDeviceError(_) => format!("{}{:?}", err, err),
+                Error::InvalidInput => format!("{}{:?}", err, err),
+                Error::RegisterIoEvent(_) => format!("{}{:?}", err, err),
+                Error::RegisterIrqFd(_) => format!("{}{:?}", err, err),
+                Error::UpdateFailed => format!("{}{:?}", err, err),
+                Error::AllocatorError(_) => format!("{}{:?}", err, err),
             };
             assert!(!msg.is_empty());
         };

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -301,8 +301,8 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                     // Send Transport event to reset connections if device
                     // is activated.
                     if vsock.is_activated() {
-                        vsock.send_transport_reset_event().unwrap_or_else(|e| {
-                            error!("Failed to send reset transport event: {:?}", e);
+                        vsock.send_transport_reset_event().unwrap_or_else(|err| {
+                            error!("Failed to send reset transport event: {:?}", err);
                         });
                     }
 

--- a/src/vmm/src/memory_snapshot.rs
+++ b/src/vmm/src/memory_snapshot.rs
@@ -64,7 +64,7 @@ where
 }
 
 /// Errors associated with dumping guest memory to file.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     /// Cannot access file.
     FileHandle(std::io::Error),
@@ -124,7 +124,7 @@ impl SnapshotMemory for GuestMemoryMmap {
         dirty_bitmap: &DirtyBitmap,
     ) -> std::result::Result<(), Error> {
         let mut writer_offset = 0;
-        let page_size = get_page_size().map_err(Error::PageSize)?;
+        let page_size = get_page_size()?;
 
         self.iter()
             .enumerate()
@@ -188,10 +188,7 @@ impl SnapshotMemory for GuestMemoryMmap {
         let mut regions = vec![];
         for region in state.regions.iter() {
             let f = match file {
-                Some(f) => Some(FileOffset::new(
-                    f.try_clone().map_err(Error::FileHandle)?,
-                    region.offset,
-                )),
+                Some(f) => Some(FileOffset::new(f.try_clone()?, region.offset)),
                 None => None,
             };
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -55,17 +55,17 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::BalloonDevice(e) => write!(f, "Balloon device error: {}", e),
-            Error::BlockDevice(e) => write!(f, "Block device error: {}", e),
-            Error::BootSource(e) => write!(f, "Boot source error: {}", e),
-            Error::InvalidJson(e) => write!(f, "Invalid JSON: {}", e),
-            Error::Logger(e) => write!(f, "Logger error: {}", e),
-            Error::Metrics(e) => write!(f, "Metrics error: {}", e),
-            Error::Mmds(e) => write!(f, "MMDS error: {}", e),
-            Error::MmdsConfig(e) => write!(f, "MMDS config error: {}", e),
-            Error::NetDevice(e) => write!(f, "Network device error: {}", e),
-            Error::VmConfig(e) => write!(f, "VM config error: {}", e),
-            Error::VsockDevice(e) => write!(f, "Vsock device error: {}", e),
+            Error::BalloonDevice(err) => write!(f, "Balloon device error: {}", err),
+            Error::BlockDevice(err) => write!(f, "Block device error: {}", err),
+            Error::BootSource(err) => write!(f, "Boot source error: {}", err),
+            Error::InvalidJson(err) => write!(f, "Invalid JSON: {}", err),
+            Error::Logger(err) => write!(f, "Logger error: {}", err),
+            Error::Metrics(err) => write!(f, "Metrics error: {}", err),
+            Error::Mmds(err) => write!(f, "MMDS error: {}", err),
+            Error::MmdsConfig(err) => write!(f, "MMDS config error: {}", err),
+            Error::NetDevice(err) => write!(f, "Network device error: {}", err),
+            Error::VmConfig(err) => write!(f, "VM config error: {}", err),
+            Error::VsockDevice(err) => write!(f, "Vsock device error: {}", err),
         }
     }
 }
@@ -409,7 +409,7 @@ impl VmResources {
         let mut mmds_guard = self.locked_mmds_or_default();
         mmds_guard
             .set_version(version)
-            .map_err(|e| MmdsConfigError::MmdsVersion(version, e))?;
+            .map_err(|err| MmdsConfigError::MmdsVersion(version, err))?;
         mmds_guard.set_aad(instance_id);
 
         Ok(())

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -254,11 +254,11 @@ trait MmdsRequestHandler {
         self.mmds()
             .patch_data(value)
             .map(|()| VmmData::Empty)
-            .map_err(|e| match e {
+            .map_err(|err| match err {
                 data_store::Error::DataStoreLimitExceeded => {
                     VmmActionError::MmdsLimitExceeded(data_store::Error::DataStoreLimitExceeded)
                 }
-                _ => VmmActionError::Mmds(e),
+                _ => VmmActionError::Mmds(err),
             })
     }
 
@@ -266,11 +266,11 @@ trait MmdsRequestHandler {
         self.mmds()
             .put_data(value)
             .map(|()| VmmData::Empty)
-            .map_err(|e| match e {
+            .map_err(|err| match err {
                 data_store::Error::DataStoreLimitExceeded => {
                     VmmActionError::MmdsLimitExceeded(data_store::Error::DataStoreLimitExceeded)
                 }
-                _ => VmmActionError::Mmds(e),
+                _ => VmmActionError::Mmds(err),
             })
     }
 }
@@ -557,10 +557,10 @@ impl<'a> PrebootApiController<'a> {
             })
             .map_err(LoadSnapshotError::ResumeMicroVm)
         })
-        .map_err(|e| {
+        .map_err(|err| {
             // The process is too dirty to recover at this point.
             self.fatal_error = Some(FcExitCode::BadConfiguration);
-            VmmActionError::LoadSnapshot(e)
+            VmmActionError::LoadSnapshot(err)
         });
 
         log_dev_preview_warning(
@@ -604,14 +604,14 @@ impl RuntimeApiController {
                 .expect("Poisoned lock")
                 .balloon_config()
                 .map(|state| VmmData::BalloonConfig(BalloonDeviceConfig::from(state)))
-                .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
+                .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             GetBalloonStats => self
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
                 .latest_balloon_stats()
                 .map(VmmData::BalloonStats)
-                .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
+                .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             GetFullVmConfig => Ok(VmmData::FullVmConfig((&self.vm_resources).into())),
             GetMMDS => self.get_mmds(),
             GetVmMachineConfig => Ok(VmmData::MachineConfiguration(
@@ -635,14 +635,14 @@ impl RuntimeApiController {
                 .expect("Poisoned lock")
                 .update_balloon_config(balloon_update.amount_mib)
                 .map(|_| VmmData::Empty)
-                .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
+                .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             UpdateBalloonStatistics(balloon_stats_update) => self
                 .vmm
                 .lock()
                 .expect("Poisoned lock")
                 .update_balloon_stats_config(balloon_stats_update.stats_polling_interval_s)
                 .map(|_| VmmData::Empty)
-                .map_err(|e| VmmActionError::BalloonConfig(BalloonConfigError::from(e))),
+                .map_err(|err| VmmActionError::BalloonConfig(BalloonConfigError::from(err))),
             UpdateBlockDevice(new_cfg) => self.update_block_device(new_cfg),
             UpdateNetworkInterface(netif_update) => self.update_net_rate_limiters(netif_update),
 
@@ -966,7 +966,7 @@ mod tests {
             let mut mmds_guard = self.locked_mmds_or_default();
             mmds_guard
                 .set_version(mmds_config.version)
-                .map_err(|e| MmdsConfigError::MmdsVersion(mmds_config.version, e))?;
+                .map_err(|err| MmdsConfigError::MmdsVersion(mmds_config.version, err))?;
             Ok(())
         }
 

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -21,8 +21,8 @@ const SYS_SECCOMP_CODE: i32 = 1;
 #[inline]
 fn exit_with_code(exit_code: FcExitCode) {
     // Write the metrics before exiting.
-    if let Err(e) = METRICS.write() {
-        error!("Failed to write metrics while stopping: {}", e);
+    if let Err(err) = METRICS.write() {
+        error!("Failed to write metrics while stopping: {}", err);
     }
     // Safe because we're terminating the process anyway.
     unsafe { libc::_exit(exit_code as i32) };

--- a/src/vmm/src/vmm_config/balloon.rs
+++ b/src/vmm/src/vmm_config/balloon.rs
@@ -43,11 +43,11 @@ impl fmt::Display for BalloonConfigError {
             InvalidStatsUpdate => write!(f, "Cannot enable/disable the statistics after boot."),
             TooManyPagesRequested => write!(f, "Amount of pages requested is too large."),
             StatsNotFound => write!(f, "Statistics for the balloon device are not enabled"),
-            CreateFailure(e) => write!(f, "Error creating the balloon device: {:?}", e),
-            UpdateFailure(e) => write!(
+            CreateFailure(err) => write!(f, "Error creating the balloon device: {:?}", err),
+            UpdateFailure(err) => write!(
                 f,
                 "Error updating the balloon device configuration: {:?}",
-                e
+                err
             ),
         }
     }

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -56,14 +56,14 @@ impl Display for BootSourceConfigError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use self::BootSourceConfigError::*;
         match *self {
-            InvalidKernelPath(ref e) => write!(f, "The kernel file cannot be opened: {}", e),
-            InvalidInitrdPath(ref e) => write!(
+            InvalidKernelPath(ref err) => write!(f, "The kernel file cannot be opened: {}", err),
+            InvalidInitrdPath(ref err) => write!(
                 f,
                 "The initrd file cannot be opened due to invalid path or invalid permissions. {}",
-                e,
+                err,
             ),
-            InvalidKernelCommandLine(ref e) => {
-                write!(f, "The kernel command line is invalid: {}", e.as_str())
+            InvalidKernelCommandLine(ref err) => {
+                write!(f, "The kernel command line is invalid: {}", err.as_str())
             }
         }
     }
@@ -101,7 +101,7 @@ impl BootConfig {
         };
         cmdline
             .insert_str(boot_args)
-            .map_err(|e| InvalidKernelCommandLine(e.to_string()))?;
+            .map_err(|err| InvalidKernelCommandLine(err.to_string()))?;
 
         Ok(BootConfig {
             cmdline,

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -44,15 +44,15 @@ impl Display for DriveError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::DriveError::*;
         match self {
-            CreateBlockDevice(e) => write!(f, "Unable to create the block device {:?}", e),
-            BlockDeviceUpdateFailed(e) => write!(f, "The update operation failed: {}", e),
-            CreateRateLimiter(e) => write!(f, "Cannot create RateLimiter: {}", e),
-            DeviceUpdate(e) => write!(f, "Error during drive update (patch): {}", e),
+            CreateBlockDevice(err) => write!(f, "Unable to create the block device {:?}", err),
+            BlockDeviceUpdateFailed(err) => write!(f, "The update operation failed: {}", err),
+            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {}", err),
+            DeviceUpdate(err) => write!(f, "Error during drive update (patch): {}", err),
             InvalidBlockDevicePath(path) => write!(f, "Invalid block device path: {}", path),
-            OpenBlockDevice(e) => write!(
+            OpenBlockDevice(err) => write!(
                 f,
                 "Cannot open block device. Invalid permission/path: {}",
-                e
+                err
             ),
             RootBlockDeviceAlreadyAdded => write!(f, "A root block device already exists!"),
         }

--- a/src/vmm/src/vmm_config/logger.rs
+++ b/src/vmm/src/vmm_config/logger.rs
@@ -138,7 +138,7 @@ pub fn init_logger(
 
     let writer = FcLineWriter::new(
         open_file_nonblock(&logger_cfg.log_path)
-            .map_err(|e| LoggerConfigError::InitializationFailure(e.to_string()))?,
+            .map_err(|err| LoggerConfigError::InitializationFailure(err.to_string()))?,
     );
     LOGGER
         .init(
@@ -148,7 +148,7 @@ pub fn init_logger(
             ),
             Box::new(writer),
         )
-        .map_err(|e| LoggerConfigError::InitializationFailure(e.to_string()))
+        .map_err(|err| LoggerConfigError::InitializationFailure(err.to_string()))
 }
 
 #[cfg(test)]

--- a/src/vmm/src/vmm_config/metrics.rs
+++ b/src/vmm/src/vmm_config/metrics.rs
@@ -37,11 +37,11 @@ impl Display for MetricsConfigError {
 pub fn init_metrics(metrics_cfg: MetricsConfig) -> std::result::Result<(), MetricsConfigError> {
     let writer = FcLineWriter::new(
         open_file_nonblock(&metrics_cfg.metrics_path)
-            .map_err(|e| MetricsConfigError::InitializationFailure(e.to_string()))?,
+            .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))?,
     );
     METRICS
         .init(Box::new(writer))
-        .map_err(|e| MetricsConfigError::InitializationFailure(e.to_string()))
+        .map_err(|err| MetricsConfigError::InitializationFailure(err.to_string()))
 }
 
 #[cfg(test)]

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -79,18 +79,18 @@ impl fmt::Display for NetworkInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::NetworkInterfaceError::*;
         match self {
-            CreateNetworkDevice(e) => write!(f, "Could not create Network Device: {:?}", e),
-            CreateRateLimiter(e) => write!(f, "Cannot create RateLimiter: {}", e),
+            CreateNetworkDevice(err) => write!(f, "Could not create Network Device: {:?}", err),
+            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {}", err),
             GuestMacAddressInUse(mac_addr) => write!(
                 f,
                 "{}",
                 format!("The guest MAC address {} is already in use.", mac_addr)
             ),
-            DeviceUpdate(e) => write!(f, "Error during interface update (patch): {}", e),
-            OpenTap(e) => {
+            DeviceUpdate(err) => write!(f, "Error during interface update (patch): {}", err),
+            OpenTap(err) => {
                 // We are propagating the Tap Error. This error can contain
                 // imbricated quotes which would result in an invalid json.
-                let mut tap_err = format!("{:?}", e);
+                let mut tap_err = format!("{:?}", err);
                 tap_err = tap_err.replace("\"", "");
 
                 write!(

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -61,7 +61,7 @@ pub struct NetworkInterfaceUpdateConfig {
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum NetworkInterfaceError {
     /// Could not create Network Device.
     CreateNetworkDevice(devices::virtio::net::Error),
@@ -176,13 +176,11 @@ impl NetBuilder {
         let rx_rate_limiter = cfg
             .rx_rate_limiter
             .map(super::RateLimiterConfig::try_into)
-            .transpose()
-            .map_err(NetworkInterfaceError::CreateRateLimiter)?;
+            .transpose()?;
         let tx_rate_limiter = cfg
             .tx_rate_limiter
             .map(super::RateLimiterConfig::try_into)
-            .transpose()
-            .map_err(NetworkInterfaceError::CreateRateLimiter)?;
+            .transpose()?;
 
         // Create and return the Net device
         devices::virtio::net::Net::new_with_tap(

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -23,10 +23,10 @@ impl fmt::Display for VsockConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::VsockConfigError::*;
         match *self {
-            CreateVsockBackend(ref e) => {
-                write!(f, "Cannot create backend for vsock device: {:?}", e)
+            CreateVsockBackend(ref err) => {
+                write!(f, "Cannot create backend for vsock device: {:?}", err)
             }
-            CreateVsockDevice(ref e) => write!(f, "Cannot create vsock device: {:?}", e),
+            CreateVsockDevice(ref err) => write!(f, "Cannot create vsock device: {:?}", err),
         }
     }
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 type MutexVsockUnix = Arc<Mutex<Vsock<VsockUnixBackend>>>;
 
 /// Errors associated with `NetworkInterfaceConfig`.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum VsockConfigError {
     /// Failed to create the backend for the vsock device.
     CreateVsockBackend(VsockUnixBackendError),
@@ -94,9 +94,7 @@ impl VsockBuilder {
     pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<()> {
         // Make sure to drop the old one and remove the socket before creating a new one.
         if let Some(existing) = self.inner.take() {
-            std::fs::remove_file(existing.uds_path)
-                .map_err(VsockUnixBackendError::UnixBind)
-                .map_err(VsockConfigError::CreateVsockBackend)?;
+            std::fs::remove_file(existing.uds_path).map_err(VsockUnixBackendError::UnixBind)?;
         }
         self.inner = Some(VsockAndUnixPath {
             uds_path: cfg.uds_path.clone(),
@@ -112,8 +110,7 @@ impl VsockBuilder {
 
     /// Creates a Vsock device from a VsockDeviceConfig.
     pub fn create_unixsock_vsock(cfg: VsockDeviceConfig) -> Result<Vsock<VsockUnixBackend>> {
-        let backend = VsockUnixBackend::new(u64::from(cfg.guest_cid), cfg.uds_path)
-            .map_err(VsockConfigError::CreateVsockBackend)?;
+        let backend = VsockUnixBackend::new(u64::from(cfg.guest_cid), cfg.uds_path)?;
 
         Vsock::new(u64::from(cfg.guest_cid), backend).map_err(VsockConfigError::CreateVsockDevice)
     }

--- a/src/vmm/src/vstate/system.rs
+++ b/src/vmm/src/vstate/system.rs
@@ -12,7 +12,7 @@ use kvm_bindings::KVM_API_VERSION;
 use kvm_ioctls::{Error as KvmIoctlsError, Kvm};
 
 /// Errors associated with the wrappers over KVM ioctls.
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub enum Error {
     /// The host kernel reports an invalid KVM API version.
     KvmApiVersion(i32),
@@ -62,7 +62,7 @@ pub struct KvmContext {
 impl KvmContext {
     pub fn new() -> Result<Self> {
         use kvm_ioctls::Cap::*;
-        let kvm = Kvm::new().map_err(Error::KvmInit)?;
+        let kvm = Kvm::new()?;
 
         // Check that KVM has the correct version.
         if kvm.get_api_version() != KVM_API_VERSION as i32 {

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -39,14 +39,20 @@ impl Display for Error {
         use self::Error::*;
 
         match self {
-            ConfigureRegisters(e) => {
-                write!(f, "Error configuring the general purpose registers: {}", e)
+            ConfigureRegisters(err) => {
+                write!(
+                    f,
+                    "Error configuring the general purpose registers: {}",
+                    err
+                )
             }
-            CreateFd(e) => write!(f, "Error in opening the VCPU file descriptor: {}", e),
-            GetPreferredTarget(e) => write!(f, "Error retrieving the vcpu preferred target: {}", e),
-            Init(e) => write!(f, "Error initializing the vcpu: {}", e),
-            RestoreState(e) => write!(f, "Failed to restore the state of the vcpu: {}", e),
-            SaveState(e) => write!(f, "Failed to save the state of the vcpu: {}", e),
+            CreateFd(err) => write!(f, "Error in opening the VCPU file descriptor: {}", err),
+            GetPreferredTarget(err) => {
+                write!(f, "Error retrieving the vcpu preferred target: {}", err)
+            }
+            Init(err) => write!(f, "Error initializing the vcpu: {}", err),
+            RestoreState(err) => write!(f, "Failed to restore the state of the vcpu: {}", err),
+            SaveState(err) => write!(f, "Failed to save the state of the vcpu: {}", err),
         }
     }
 }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -101,49 +101,51 @@ impl Display for Error {
         use self::Error::*;
 
         match self {
-            CpuId(e) => write!(f, "Cpuid error: {:?}", e),
-            LocalIntConfiguration(e) => write!(
+            CpuId(err) => write!(f, "Cpuid error: {:?}", err),
+            LocalIntConfiguration(err) => write!(
                 f,
                 "Cannot set the local interruption due to bad configuration: {:?}",
-                e
+                err
             ),
-            VcpuFd(e) => write!(f, "Cannot open the VCPU file descriptor: {}", e),
-            MSRSConfiguration(e) => write!(f, "Error configuring the MSR registers: {:?}", e),
-            REGSConfiguration(e) => write!(
+            VcpuFd(err) => write!(f, "Cannot open the VCPU file descriptor: {}", err),
+            MSRSConfiguration(err) => write!(f, "Error configuring the MSR registers: {:?}", err),
+            REGSConfiguration(err) => write!(
                 f,
                 "Error configuring the general purpose registers: {:?}",
-                e
+                err
             ),
-            SREGSConfiguration(e) => write!(f, "Error configuring the special registers: {:?}", e),
-            FamError(e) => write!(f, "Failed FamStructWrapper operation: {:?}", e),
-            FPUConfiguration(e) => write!(
+            SREGSConfiguration(err) => {
+                write!(f, "Error configuring the special registers: {:?}", err)
+            }
+            FamError(err) => write!(f, "Failed FamStructWrapper operation: {:?}", err),
+            FPUConfiguration(err) => write!(
                 f,
                 "Error configuring the floating point related registers: {:?}",
-                e
+                err
             ),
-            VcpuGetDebugRegs(e) => write!(f, "Failed to get KVM vcpu debug regs: {}", e),
-            VcpuGetLapic(e) => write!(f, "Failed to get KVM vcpu lapic: {}", e),
-            VcpuGetMpState(e) => write!(f, "Failed to get KVM vcpu mp state: {}", e),
-            VcpuGetMsrs(e) => write!(f, "Failed to get KVM vcpu msrs: {}", e),
+            VcpuGetDebugRegs(err) => write!(f, "Failed to get KVM vcpu debug regs: {}", err),
+            VcpuGetLapic(err) => write!(f, "Failed to get KVM vcpu lapic: {}", err),
+            VcpuGetMpState(err) => write!(f, "Failed to get KVM vcpu mp state: {}", err),
+            VcpuGetMsrs(err) => write!(f, "Failed to get KVM vcpu msrs: {}", err),
             VcpuGetMSRSIncomplete => write!(f, "Unexpected number of MSRS reported by the kernel"),
-            VcpuGetRegs(e) => write!(f, "Failed to get KVM vcpu regs: {}", e),
-            VcpuGetSregs(e) => write!(f, "Failed to get KVM vcpu sregs: {}", e),
-            VcpuGetVcpuEvents(e) => write!(f, "Failed to get KVM vcpu event: {}", e),
-            VcpuGetXcrs(e) => write!(f, "Failed to get KVM vcpu xcrs: {}", e),
-            VcpuGetXsave(e) => write!(f, "Failed to get KVM vcpu xsave: {}", e),
-            VcpuGetCpuid(e) => write!(f, "Failed to get KVM vcpu cpuid: {}", e),
-            VcpuGetTSC(e) => write!(f, "Failed to get KVM TSC frequency: {}", e),
-            VcpuSetCpuid(e) => write!(f, "Failed to set KVM vcpu cpuid: {}", e),
-            VcpuSetDebugRegs(e) => write!(f, "Failed to set KVM vcpu debug regs: {}", e),
-            VcpuSetLapic(e) => write!(f, "Failed to set KVM vcpu lapic: {}", e),
-            VcpuSetMpState(e) => write!(f, "Failed to set KVM vcpu mp state: {}", e),
-            VcpuSetMsrs(e) => write!(f, "Failed to set KVM vcpu msrs: {}", e),
-            VcpuSetRegs(e) => write!(f, "Failed to set KVM vcpu regs: {}", e),
-            VcpuSetSregs(e) => write!(f, "Failed to set KVM vcpu sregs: {}", e),
-            VcpuSetVcpuEvents(e) => write!(f, "Failed to set KVM vcpu event: {}", e),
-            VcpuSetXcrs(e) => write!(f, "Failed to set KVM vcpu xcrs: {}", e),
-            VcpuSetXsave(e) => write!(f, "Failed to set KVM vcpu xsave: {}", e),
-            VcpuSetTSC(e) => write!(f, "Failed to set KVM TSC frequency: {}", e),
+            VcpuGetRegs(err) => write!(f, "Failed to get KVM vcpu regs: {}", err),
+            VcpuGetSregs(err) => write!(f, "Failed to get KVM vcpu sregs: {}", err),
+            VcpuGetVcpuEvents(err) => write!(f, "Failed to get KVM vcpu event: {}", err),
+            VcpuGetXcrs(err) => write!(f, "Failed to get KVM vcpu xcrs: {}", err),
+            VcpuGetXsave(err) => write!(f, "Failed to get KVM vcpu xsave: {}", err),
+            VcpuGetCpuid(err) => write!(f, "Failed to get KVM vcpu cpuid: {}", err),
+            VcpuGetTSC(err) => write!(f, "Failed to get KVM TSC frequency: {}", err),
+            VcpuSetCpuid(err) => write!(f, "Failed to set KVM vcpu cpuid: {}", err),
+            VcpuSetDebugRegs(err) => write!(f, "Failed to set KVM vcpu debug regs: {}", err),
+            VcpuSetLapic(err) => write!(f, "Failed to set KVM vcpu lapic: {}", err),
+            VcpuSetMpState(err) => write!(f, "Failed to set KVM vcpu mp state: {}", err),
+            VcpuSetMsrs(err) => write!(f, "Failed to set KVM vcpu msrs: {}", err),
+            VcpuSetRegs(err) => write!(f, "Failed to set KVM vcpu regs: {}", err),
+            VcpuSetSregs(err) => write!(f, "Failed to set KVM vcpu sregs: {}", err),
+            VcpuSetVcpuEvents(err) => write!(f, "Failed to set KVM vcpu event: {}", err),
+            VcpuSetXcrs(err) => write!(f, "Failed to set KVM vcpu xcrs: {}", err),
+            VcpuSetXsave(err) => write!(f, "Failed to set KVM vcpu xsave: {}", err),
+            VcpuSetTSC(err) => write!(f, "Failed to set KVM TSC frequency: {}", err),
         }
     }
 }
@@ -198,13 +200,13 @@ impl KvmVcpu {
         let cpuid_vm_spec = VmSpec::new(self.index, vcpu_config.vcpu_count, vcpu_config.smt)
             .map_err(Error::CpuId)?;
 
-        filter_cpuid(&mut cpuid, &cpuid_vm_spec).map_err(|e| {
+        filter_cpuid(&mut cpuid, &cpuid_vm_spec).map_err(|err| {
             METRICS.vcpu.filter_cpuid.inc();
             error!(
                 "Failure in configuring CPUID for vcpu {}: {:?}",
-                self.index, e
+                self.index, err
             );
-            Error::CpuId(e)
+            Error::CpuId(err)
         })?;
 
         match vcpu_config.cpu_template {

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -71,32 +71,36 @@ impl Display for Error {
 
         match self {
             #[cfg(target_arch = "x86_64")]
-            GuestMSRs(e) => write!(f, "Retrieving supported guest MSRs fails: {:?}", e),
+            GuestMSRs(err) => write!(f, "Retrieving supported guest MSRs fails: {:?}", err),
             #[cfg(target_arch = "aarch64")]
-            VmCreateGIC(e) => write!(f, "Error creating the global interrupt controller: {:?}", e),
-            VmFd(e) => write!(f, "Cannot open the VM file descriptor: {}", e),
-            VmSetup(e) => write!(f, "Cannot configure the microvm: {}", e),
+            VmCreateGIC(err) => write!(
+                f,
+                "Error creating the global interrupt controller: {:?}",
+                err
+            ),
+            VmFd(err) => write!(f, "Cannot open the VM file descriptor: {}", err),
+            VmSetup(err) => write!(f, "Cannot configure the microvm: {}", err),
             NotEnoughMemorySlots => write!(
                 f,
                 "The number of configured slots is bigger than the maximum reported by KVM"
             ),
-            SetUserMemoryRegion(e) => write!(f, "Cannot set the memory regions: {}", e),
+            SetUserMemoryRegion(err) => write!(f, "Cannot set the memory regions: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmGetPit2(e) => write!(f, "Failed to get KVM vm pit state: {}", e),
+            VmGetPit2(err) => write!(f, "Failed to get KVM vm pit state: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmGetClock(e) => write!(f, "Failed to get KVM vm clock: {}", e),
+            VmGetClock(err) => write!(f, "Failed to get KVM vm clock: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmGetIrqChip(e) => write!(f, "Failed to get KVM vm irqchip: {}", e),
+            VmGetIrqChip(err) => write!(f, "Failed to get KVM vm irqchip: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmSetPit2(e) => write!(f, "Failed to set KVM vm pit state: {}", e),
+            VmSetPit2(err) => write!(f, "Failed to set KVM vm pit state: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmSetClock(e) => write!(f, "Failed to set KVM vm clock: {}", e),
+            VmSetClock(err) => write!(f, "Failed to set KVM vm clock: {}", err),
             #[cfg(target_arch = "x86_64")]
-            VmSetIrqChip(e) => write!(f, "Failed to set KVM vm irqchip: {}", e),
+            VmSetIrqChip(err) => write!(f, "Failed to set KVM vm irqchip: {}", err),
             #[cfg(target_arch = "aarch64")]
-            SaveGic(e) => write!(f, "Failed to save the VM's GIC state: {:?}", e),
+            SaveGic(err) => write!(f, "Failed to save the VM's GIC state: {:?}", err),
             #[cfg(target_arch = "aarch64")]
-            RestoreGic(e) => write!(f, "Failed to restore the VM's GIC state: {:?}", e),
+            RestoreGic(err) => write!(f, "Failed to restore the VM's GIC state: {:?}", err),
         }
     }
 }

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -127,7 +127,7 @@ fn test_disallow_snapshots_without_pausing() {
     // Verify saving state while running is not allowed.
     // Can't do unwrap_err() because MicrovmState doesn't impl Debug.
     match vmm.lock().unwrap().save_state() {
-        Err(e) => assert!(format!("{:?}", e).contains("NotAllowed")),
+        Err(err) => assert!(format!("{:?}", err).contains("NotAllowed")),
         Ok(_) => panic!("Should not be allowed."),
     };
 

--- a/tests/framework/dependencies.txt
+++ b/tests/framework/dependencies.txt
@@ -19,6 +19,7 @@
  'cpuid v0.1.0 (/firecracker/src/cpuid)',
  'crc64 v1.0.0',
  'ctr v0.8.0',
+ 'derive_more v0.99.17 (proc-macro)',
  'devices v0.1.0 (/firecracker/src/devices)',
  'dumbo v0.1.0 (/firecracker/src/dumbo)',
  'event-manager v0.2.1',

--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -70,6 +70,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +334,7 @@ dependencies = [
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "libc",
  "net_gen",
  "serde",

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.83, "AMD": 84.32, "ARM": 84.00}
+    COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.26, "ARM": 83.86}
 else:
-    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.37, "ARM": 81.00}
+    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.37, "ARM": 80.95}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -31,6 +31,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +86,7 @@ name = "seccompiler"
 version = "1.1.0"
 dependencies = [
  "bincode",
+ "derive_more",
  "libc",
  "serde",
  "serde_json",
@@ -133,6 +145,7 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 name = "utils"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "libc",
  "net_gen",
  "serde",


### PR DESCRIPTION
# Reason for This PR

1. Error propagation features excessive usage of `map_err` to wrap types before returning them.
    Some error types implement some `From` implementations, but most don't.
2. Usage of the `e` identifier is ambiguous, internally inconsistent (`e` and `err` can both be found in the code base) and externally inconsistent with typical Rust patterns (where `err` is typically used for `impl Error` types).

## Description of Changes

1. Used [`derive_more::from`](https://jeltef.github.io/derive_more/derive_more/from.html) to create many more `From` implementations for error types to allow cleaner error propagation.
   I have taken a conservative approach here only using these implementations when they can be the most simple, this leaves `map_err` still being used extensively throughout the code base. In many of these remaining instances `map_err` is used for clarity with errors where multiple variants contain the same type/s or where error variants contain multiple types.
2. Disambiguated the `e` identifier:
    - Types that implemented `Error` now use the identifier `err`, inline with the standard library and general approach
    - `Endpoint` types now use the identifier `endpoint`
    - `WriteEvent` types now use the identifier `event`

Added [`derive_more`](https://crates.io/crates/derive_more) as a dependency. It is a small (~55kb) and widely used (~17m downloads) library in the Rust ecosystem for minimizing code duplication by deriving simple implementations. Here I also restrict this further by disabling default features and only including the feature for the [`derive_more::from`](https://jeltef.github.io/derive_more/derive_more/from.html) macro.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
