### PR TITLE
Enhanced code coverage error message

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -116,26 +116,29 @@ def test_coverage(test_fc_session_root_path, test_session_tmp_path):
     print("Thus, coverage is: {:.2f}%".format(coverage))
 
     coverage_low_msg = (
-        'Current code coverage ({:.2f}%) is below the target ({}%).'
-        .format(coverage, coverage_target_pct)
+        'Current code coverage ({:.2f}%) is >{:.2f}% below the target ({}%).'
+        .format(coverage, COVERAGE_MAX_DELTA, coverage_target_pct)
     )
 
-    min_coverage = coverage_target_pct - COVERAGE_MAX_DELTA
-    assert coverage >= min_coverage, coverage_low_msg
+    assert coverage >= coverage_target_pct - COVERAGE_MAX_DELTA, \
+        coverage_low_msg
 
     # Get the name of the variable that needs updating.
     namespace = globals()
-    cov_target_name = [name for name in namespace if namespace[name]
-                       is COVERAGE_DICT][0]
+    cov_target_name = \
+        [name for name in namespace if namespace[name] is COVERAGE_DICT][0]
 
     coverage_high_msg = (
-        'Current code coverage ({:.2f}%) is above the target ({}%).\n'
-        'Please update the value of {}.'
-        .format(coverage, coverage_target_pct, cov_target_name)
+        'Current code coverage ({:.2f}%) is >{:.2f}% above the target ({}%).\n'
+        'Please update the value of {}.'.format(
+            coverage, COVERAGE_MAX_DELTA, coverage_target_pct, cov_target_name
+        )
     )
 
-    assert coverage - coverage_target_pct <= COVERAGE_MAX_DELTA,\
-        coverage_high_msg
+    assert \
+        coverage <= coverage_target_pct + COVERAGE_MAX_DELTA, coverage_high_msg
 
-    return f"{coverage}%", \
+    return (
+        f"{coverage}%",
         f"{coverage_target_pct}% +/- {COVERAGE_MAX_DELTA * 100}%"
+    )


### PR DESCRIPTION
# Reason for This PR

Current code coverage error message is slightly inaccurate e.g.
```
E   AssertionError: Current code coverage (83.77%) is below the target (84.06%).
E   assert 83.76920450665756 >= 84.01
```
We are asserting we are not below `84.01` (`>= 84.01`) while the error message tells us we are asserting we are not below `84.06` (`>= 84.06`).

(same applies with above the target)

## Description of Changes

Enhanced error message to give:
```
E   AssertionError: Current code coverage (83.77%) is >0.05% below the target (84.06%).
E   assert 83.76920450665756 >= 84.01
```

(applied same change with above the target)

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
