### PR TITLE
Cmdline

### DIFF
--- a/src/vmm/src/cmdline.rs
+++ b/src/vmm/src/cmdline.rs
@@ -1,0 +1,163 @@
+// Copyright 2022 Ametros. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::builder::StartMicrovmError;
+use std::result::Result;
+
+// The "unchecked" refers to from_utf8_unchecked(), i.e. bs must be valid UTF-8
+fn trimmed_str_unchecked(bs: &[u8]) -> &str {
+    std::str::from_utf8(bs).unwrap().trim()
+}
+
+// Returns true iff bs is b"--" or starts b"--<space>"
+fn is_delim(bs: &[u8]) -> bool {
+    bs == b"--" || (bs.len() > 2 && bs[0] == b'-' && bs[1] == b'-' && bs[2].is_ascii_whitespace())
+}
+
+// Returns the index of the first ASCII whitespace character in bs
+fn next_space(bs: &[u8]) -> Option<usize> {
+    let mut ret = 0usize;
+    loop {
+        if ret >= bs.len() {
+            break None;
+        }
+        if bs[ret].is_ascii_whitespace() {
+            break Some(ret);
+        }
+
+        ret += 1
+    }
+}
+
+// Splits cmdline on a space-delimited "--". This is complicated by the need to return
+// references into the argument, so can't e.g. split on whitespace and accumulate.
+//
+// Bugs wrt the kernel's command line parser:
+//  - Kernel defines 160 as whitespace, but cmdline is UTF-8, so for now just disallow it.
+//  - Kernel also defines vertical tab (11) as whitespace but it's simpler to disallow that too.
+//  - Kernel permits double-quoted parameter values, e.g foo.bar="blah -- blah"; if those values
+//    contain "--" then we'll erroneously split on that "--".
+pub fn split(cmdline: &str) -> Result<(&str, &str), StartMicrovmError> {
+    let bs = cmdline.as_bytes();
+
+    // Exclude:
+    //  - non-ASCII cmdline
+    //  - cmdline is empty
+    //  - cmdline starts with --, i.e. is "--" or "--<space>"
+    if !cmdline.is_ascii() {
+        Err(StartMicrovmError::KernelCmdline(
+            "Kernel cmdline is not ASCII".to_string(),
+        ))
+    } else if cmdline.is_empty() || cmdline == "--" {
+        Ok(("", ""))
+    } else if is_delim(bs) {
+        Ok(("", trimmed_str_unchecked(&bs[3..])))
+    } else {
+        // Look for the delimiter
+        let mut it = bs;
+        Ok(loop {
+            match next_space(it) {
+                None => break (cmdline, ""),
+                Some(x) if is_delim(&it[x + 1..]) => {
+                    // Safety: bs is 7-bit ASCII
+                    break (
+                        trimmed_str_unchecked(&bs[..bs.len() - it.len() + x]),
+                        trimmed_str_unchecked(&it[x + 3..]),
+                    );
+                }
+                Some(x) => it = &it[x + 1..],
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    #[test]
+    fn test_split() {
+        struct TestCase {
+            cmdline: &'static str,
+            kernel: &'static str,
+            init: &'static str,
+        }
+
+        let test_cases = &[
+            TestCase {
+                cmdline: "",
+                kernel: "",
+                init: "",
+            },
+            TestCase {
+                cmdline: "--",
+                kernel: "",
+                init: "",
+            },
+            TestCase {
+                cmdline: " --",
+                kernel: "",
+                init: "",
+            },
+            TestCase {
+                cmdline: "-- ",
+                kernel: "",
+                init: "",
+            },
+            TestCase {
+                cmdline: "foo",
+                kernel: "foo",
+                init: "",
+            },
+            TestCase {
+                cmdline: "--foo",
+                kernel: "--foo",
+                init: "",
+            },
+            TestCase {
+                cmdline: "foo--",
+                kernel: "foo--",
+                init: "",
+            },
+            TestCase {
+                cmdline: "foo --",
+                kernel: "foo",
+                init: "",
+            },
+            TestCase {
+                cmdline: "-- foo",
+                kernel: "",
+                init: "foo",
+            },
+            TestCase {
+                cmdline: " -- ",
+                kernel: "",
+                init: "",
+            },
+            TestCase {
+                cmdline: "foo -- bar",
+                kernel: "foo",
+                init: "bar",
+            },
+            TestCase {
+                cmdline: "--foo -- bar",
+                kernel: "--foo",
+                init: "bar",
+            },
+            TestCase {
+                cmdline: "foo --bar -- qux",
+                kernel: "foo --bar",
+                init: "qux",
+            },
+            TestCase {
+                cmdline: "foo -- bar -- qux",
+                kernel: "foo",
+                init: "bar -- qux",
+            },
+        ];
+
+        for it in test_cases.iter() {
+            let (kernel, init) = super::split(it.cmdline).unwrap();
+            assert_eq!(kernel, it.kernel);
+            assert_eq!(init, it.init);
+        }
+    }
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -12,6 +12,7 @@
 
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;
+mod cmdline;
 pub(crate) mod device_manager;
 pub mod memory_snapshot;
 /// Save/restore utilities.

--- a/tests/integration_tests/functional/test_kernel_cmdline.py
+++ b/tests/integration_tests/functional/test_kernel_cmdline.py
@@ -23,8 +23,8 @@ def test_init_params(test_microvm_with_api):
     # Ubuntu version from the /etc/issue file.
     vm.basic_config(
         vcpu_count=1,
-        boot_args='console=ttyS0 reboot=k panic=1 pci=off'
-                  ' init=/bin/cat -- /etc/issue',
+        boot_args='console=ttyS0 reboot=k panic=1 --dummy pci=off'
+                  ' init=/bin/cat -- --show-tabs /etc/issue',
     )
 
     vm.start()

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -30,6 +30,13 @@ ALIBABA_COPYRIGHT = (
 ALIBABA_LICENSE = (
     "SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause"
 )
+AMETROS_COPYRIGHT_YEARS = range(2022, datetime.datetime.now().year + 1)
+AMETROS_COPYRIGHT = (
+    "Copyright {} Ametros. All Rights Reserved."
+)
+AMETROS_LICENSE = (
+    "SPDX-License-Identifier: Apache-2.0"
+)
 
 EXCLUDE = ["build", ".kernel"]
 
@@ -37,6 +44,13 @@ EXCLUDE = ["build", ".kernel"]
 def _has_amazon_copyright(string):
     for year in AMAZON_COPYRIGHT_YEARS:
         if AMAZON_COPYRIGHT.format(year) in string:
+            return True
+    return False
+
+
+def _has_ametros_copyright(string):
+    for year in AMETROS_COPYRIGHT_YEARS:
+        if AMETROS_COPYRIGHT.format(year) in string:
             return True
     return False
 
@@ -84,11 +98,18 @@ def _validate_license(filename):
             ALIBABA_COPYRIGHT in copyright_info and
             _look_for_license(file, ALIBABA_LICENSE)
         )
+
+        has_ametros_copyright = (
+            _has_ametros_copyright(copyright_info) and
+            _look_for_license(file, AMETROS_LICENSE)
+        )
+
         return (
             has_amazon_copyright or
             has_chromium_copyright or
             has_tuntap_copyright or
-            has_alibaba_copyright
+            has_alibaba_copyright or
+            has_ametros_copyright
         )
     return True
 


### PR DESCRIPTION
# Reason for This PR

Fixes #3023: FC v0.25.2 and later fails to start VMs with valid kernel command lines containing multiple `--` substrings, and fails to handle correctly kernel command lines containing boot parameters starting with `--`.

## Description of Changes

 - Add a `cmdline` module under `vmm` containing a `split` function that splits kernel command lines into boot parameters and init arguments, more faithfuly following the kernel's handling of `--` substrings.

 - Change `build_microvm_for_boot` to use that function rather than `str::split("--")`.

 - Extended integration_tests/functional/test_kernel_cmdline.py accordingly.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
