### PR TITLE
Update v1.0 release branch with stability and security compliance changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory 0.1.0",
+ "vm-memory 0.3.0",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio_gen",
- "vm-memory 0.1.0",
+ "vm-memory 0.3.0",
  "vm-superio",
 ]
 
@@ -434,7 +434,7 @@ dependencies = [
  "libc",
  "proptest",
  "utils",
- "vm-memory 0.1.0",
+ "vm-memory 0.3.0",
 ]
 
 [[package]]
@@ -1025,7 +1025,7 @@ checksum = "bd986f4fdf949ab2181c7b4fedb03fb0e9de6b0aa788fff247b2608701ce3457"
 
 [[package]]
 name = "vm-memory"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "libc",
  "utils",
@@ -1073,7 +1073,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio_gen",
- "vm-memory 0.1.0",
+ "vm-memory 0.3.0",
  "vm-superio",
 ]
 

--- a/src/vm-memory/Cargo.toml
+++ b/src/vm-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -393,14 +393,14 @@ class ArtifactCollection:
 
         # Filter out binaries with versions older than the `min_version` arg.
         if min_version is not None:
-            return list(filter(
+            firecrackers = list(filter(
                 lambda fc: compare_versions(fc.version, min_version) >= 0,
                 firecrackers
             ))
 
         # Filter out binaries with versions newer than the `max_version` arg.
         if max_version is not None:
-            return list(filter(
+            firecrackers = list(filter(
                 lambda fc: compare_versions(fc.version, max_version) <= 0,
                 firecrackers
             ))

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -655,3 +655,19 @@ def generate_mmds_v2_get_request(ipv4_address, token, app_json=True):
     cmd += ' http://{}/'.format(ipv4_address)
 
     return cmd
+
+
+def sanitize_version_string(fc_version_string):
+    """Clean up a version string from different sources to number only."""
+    clean_version = fc_version_string
+    # Skip the "v" at the start of some version strings
+    if not fc_version_string[0].isnumeric():
+        clean_version = clean_version[1:]
+    # Strip the metadata appended to the tag
+    if clean_version.find('-') > -1:
+        clean_version = clean_version[:clean_version.index('-')]
+    else:
+        # Just strip potential newlines
+        clean_version = clean_version.strip()
+
+    return clean_version

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.07}
+    COVERAGE_DICT = {"Intel": 85.09, "AMD": 84.51, "ARM": 84.00}
 else:
-    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 81.0}
+    COVERAGE_DICT = {"Intel": 82.03, "AMD": 81.5, "ARM": 80.94}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -13,6 +13,7 @@ import time
 import pytest
 
 import framework.utils_cpuid as utils
+import framework.utils as test_utils
 import host_tools.drive as drive_tools
 import host_tools.network as net_tools
 
@@ -1166,8 +1167,15 @@ def test_api_version(test_microvm_with_api):
     assert preboot_response.json() == postboot_response.json()
     # Check that the version is the same as `git describe --dirty`.
     out = subprocess.check_output(['git', 'describe', '--dirty']).decode()
-    # Skip the "v" at the start and the newline at the end.
-    assert out.strip()[1:] == preboot_response.json()['firecracker_version']
+
+    tag_version = test_utils.sanitize_version_string(out)
+    preboot_response_fc_version = test_utils.sanitize_version_string(
+        preboot_response.json()['firecracker_version'])
+
+    # Git tag should match FC API version
+    assert tag_version == preboot_response_fc_version, \
+        "Expected [{}], Actual [{}]".format(
+            preboot_response_fc_version, tag_version)
 
 
 def test_api_vsock(bin_cloner_path):

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -24,20 +24,20 @@ BASELINES = {
         "serialize": {
             "no-crc": {
                 "target": 0.146,  # milliseconds
-                "delta": 0.025  # milliseconds
+                "delta": 0.030  # milliseconds
             },
             "crc": {
-                "target": 0.205,  # milliseconds
-                "delta": 0.025  # milliseconds
+                "target": 0.180,  # milliseconds
+                "delta": 0.030  # milliseconds
             }
         },
         "deserialize": {
             "no-crc": {
-                "target": 0.034,  # milliseconds
+                "target": 0.040,  # milliseconds
                 "delta": 0.015  # milliseconds
             },
             "crc": {
-                "target": 0.042,  # milliseconds
+                "target": 0.050,  # milliseconds
                 "delta": 0.015  # milliseconds
             }
         }
@@ -55,12 +55,12 @@ BASELINES = {
         },
         "deserialize": {
             "no-crc": {
-                "target": 0.037,  # milliseconds
-                "delta": 0.015  # milliseconds
+                "target": 0.050,  # milliseconds
+                "delta": 0.020  # milliseconds
             },
             "crc": {
-                "target": 0.045,  # milliseconds
-                "delta": 0.015  # milliseconds
+                "target": 0.055,  # milliseconds
+                "delta": 0.025  # milliseconds
             }
         }
     },
@@ -106,8 +106,9 @@ def _check_statistics(directory, mean):
     measure = BASELINES[proc_model[0]][bench][attribute]
     low = measure["target"] - measure["delta"]
     high = measure["target"] + measure["delta"]
-    assert low <= mean <= high, "Benchmark result {} has changed!" \
-        .format(directory)
+    assert low <= mean <= high, "Benchmark result {} has changed! " \
+                                "(Low:[{}] Mean:[{}] High:[{}]" \
+        .format(directory, low, mean, high)
 
     return directory, f"{mean} ms", f"{low} <= result <= {high}"
 


### PR DESCRIPTION
# Reason for This PR

Maintenance changes to keep the v1.0 release branch stable and testable. Changes include:

* Bump internal crate vm-memory version to 0.3.0 - [Security advisory](https://rustsec.org/advisories/RUSTSEC-2020-0157) is being flagged for Firecracker due to a conflict between the internal crate and the external crate with the same name,  `vm-memory`. The internal crate's version for the firecracker main branch was bumped in [pr/3011](https://github.com/firecracker-microvm/firecracker/pull/3011). There isn't a security risk any more, but this is being done to resolve the call-out.
* Update test coverage targets.
* Fix test_api integ test that did not sanitize the FC version retrieved by the API.
* Fix FC artifact filter bug, that resulted in trying to restore snapshots with versions later than the branch being tested on.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

