### PR TITLE
CI: Add checks for commit body ending format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,17 @@ testing. Your contribution needs to meet the following standards:
 - Document all your public functions.
 - Add a descriptive message for each commit. Follow
   [commit message best practices](https://github.com/erlang/otp/wiki/writing-good-commit-messages).
+- A good commit message may look like
+
+  ```
+  A descriptive title of 50 characters or fewer
+
+  A concise description where each line is 72 characters or fewer.
+
+  Signed-Off-By <A full name> <A email>
+  Co-Authored-By: <B full name> <B email>
+  ```
+
 - Document your pull requests. Include the reasoning behind each change, and
   the testing done.
 - Acknowledge Firecracker's [Apache 2.0 license](LICENSE) and certify that no

--- a/tests/framework/gitlint_rules.py
+++ b/tests/framework/gitlint_rules.py
@@ -8,20 +8,70 @@ from gitlint.rules import CommitRule, RuleViolation
 # pylint: disable=R0903
 
 
-class SignedOffBy(CommitRule):
-    """Make sure that each commit contains a "Signed-off-by" line."""
+class EndsSigned(CommitRule):
+    """Checks commit message body formatting.
+
+    Makes sure each commit message body ends with
+    1 or more signatures ("Signed-off-by"), followed by
+    0 or more co-authors ("Co-authored-by").
+    """
 
     # The name of the rule.
-    name = "body-requires-signed-off-by"
+    name = "body-requires-signature"
 
     # The unique id of the rule.
     id = "UC2"
 
     def validate(self, commit):
         """Validate user defined gitlint rules."""
-        for line in commit.message.body:
-            if line.startswith("Signed-off-by"):
-                return []
+        # Utilities
+        def rtn(stmt, i):
+            return [RuleViolation(self.id, stmt, None, i)]
 
-        msg = "Body does not contain a 'Signed-off-by' line"
-        return [RuleViolation(self.id, msg, line_nr=1)]
+        co_auth = "Co-authored-by:"
+        sig = "Signed-off-by:"
+
+        message_iter = enumerate(commit.message.body)
+
+        # Checks commit message contains a `sig` string
+        found = False
+        for i, line in message_iter:
+            # We check that no co-authors are declared before signatures.
+            if line.startswith(co_auth):
+                return rtn(f"'{co_auth}' found before '{sig}'", i)
+            if line.startswith(sig):
+                found = True
+                break
+
+        # If no signature was found in the message
+        # (before `message_iter` ended)
+        if not found:
+            return rtn(f"'{sig}' not found in commit message body", None)
+
+        # Checks lines following signature are
+        # either signatures or co-authors
+        for i, line in message_iter:
+            if line.startswith(sig) or not line.strip():
+                continue
+
+            # Once we encounter the first co-author,
+            # we no longer accept signatures
+            if line.startswith(co_auth):
+                break
+
+            return rtn(
+                (f"Non '{co_auth}' or '{sig}' string found "
+                 f"following 1st '{sig}'"),
+                i,
+            )
+
+        # Checks lines following co-author are only additional co-authors.
+        for i, line in message_iter:
+            if not line.startswith(co_auth):
+                return rtn(
+                    f"Non '{co_auth}' string found after 1st '{co_auth}'",
+                    i,
+                )
+
+        # Return no errors
+        return []

--- a/tests/framework/gitlint_rules.py
+++ b/tests/framework/gitlint_rules.py
@@ -23,7 +23,78 @@ class EndsSigned(CommitRule):
     id = "UC2"
 
     def validate(self, commit):
-        """Validate user defined gitlint rules."""
+        r"""Validate user defined gitlint rules.
+
+        >>> from gitlint.tests.base import BaseTestCase
+        >>> from gitlint.rules import RuleViolation
+        ...
+        >>> ends_signed = EndsSigned()
+        ...
+        >>> msg1 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... f"Signed-off-by: name <email@domain>"
+        ... )
+        >>> commit1 = BaseTestCase.gitcommit(msg1)
+        >>> ends_signed.validate(commit1)
+        []
+        >>> msg2 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... f"Signed-off-by: name <email>\n\n"
+        ... f"Co-authored-by: name <email>"
+        ... )
+        >>> commit2 = BaseTestCase.gitcommit(msg2)
+        >>> ends_signed.validate(commit2)
+        []
+        >>> msg3 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... )
+        >>> commit3 = BaseTestCase.gitcommit(msg3)
+        >>> vio3 = ends_signed.validate(commit3)
+        >>> vio_msg3 = (
+        ... f"'Signed-off-by:' not found "
+        ... f"in commit message body"
+        ... )
+        >>> vio3 == [RuleViolation("UC2", vio_msg3)]
+        True
+        >>> msg4 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... f"Signed-off-by: name <email@domain>\n\na sentence"
+        ... )
+        >>> commit4 = BaseTestCase.gitcommit(msg4)
+        >>> vio4 = ends_signed.validate(commit4)
+        >>> vio_msg4 = (
+        ... f"Non 'Co-authored-by:' or 'Signed-off-by:'"
+        ... f" string found following 1st 'Signed-off-by:'"
+        ... )
+        >>> vio4 == [RuleViolation("UC2", vio_msg4, None, 5)]
+        True
+        >>> msg5 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... f"Co-authored-by: name <email@domain>\n\n"
+        ... f"a sentence."
+        ... )
+        >>> commit5 = BaseTestCase.gitcommit(msg5)
+        >>> vio5 = ends_signed.validate(commit5)
+        >>> vio_msg5 = (
+        ... f"'Co-authored-by:' found before 'Signed-off-by:'"
+        ... )
+        >>> vio5 == [RuleViolation("UC2", vio_msg5, None, 3)]
+        True
+        >>> msg6 = (
+        ... f"Title\n\nMessage.\n\n"
+        ... f"Signed-off-by: name <email@domain>\n\n"
+        ... f"Co-authored-by: name <email@domain>\n\n"
+        ... f"a sentence"
+        ... )
+        >>> commit6 = BaseTestCase.gitcommit(msg6)
+        >>> vio6 = ends_signed.validate(commit6)
+        >>> vio_msg6 = (
+        ... f"Non 'Co-authored-by:' string found "
+        ... f"after 1st 'Co-authored-by:'"
+        ... )
+        >>> vio6 == [RuleViolation("UC2", vio_msg6, None, 6)]
+        True
+        """
         # Utilities
         def rtn(stmt, i):
             return [RuleViolation(self.id, stmt, None, i)]


### PR DESCRIPTION
# Reason for This PR
Add checks for commit body ending format, closes #3026 

## Description of Changes

Adds test for commit body ending format
that makes sure body ends with 'Signed-off-by' or 'Co-authored-by'
and no other trailing line

## Examples

``` sh
   1   │ A commit message
   2   │
   3   │ some message
   4   │ some other message
   5   │ Signed-off-by: someone@somewhere.com
```

``` sh
❯ cat gitlint_example_1 | gitlint -C .gitlint --extra-path tests/framework/gitlint_rules.py
```

-----------

``` sh
   1   │ A commit message
```

``` sh
❯ cat gitlint_example_2 | gitlint -C .gitlint --extra-path tests/framework/gitlint_rules.py
1: UC2 Body does not contain a 'Signed-off-by' line
3: B6 Body message is missing
```

-----------

``` sh
   1   │ A commit message
   2   │
   3   │ some other message
   4   │ Signed-off-by: someone@somewhere.com
   5   │ Co-authored-by: someone_else@somewhere_else.com
```

``` sh
❯ cat gitlint_example_3 | gitlint -C .gitlint --extra-path tests/framework/gitlint_rules.py
```
-----------

``` sh
   1   │ A commit message
   2   │
   3   │ Signed-off-by: someone@somewhere.com
   4   │ Co-authored-by: someone_else@somewhere_else.com
   5   │ some other message
```

``` sh
❯ cat gitlint_example_4 | gitlint -C .gitlint --extra-path tests/framework/gitlint_rules.py
2: UC2 Last line in commit message body should be 'Signed-off-by'
```
-----------

``` sh
   1   │ A commit message
   2   │
   3   │ Signed-off-by: someone@somewhere.com
   4   │ Co-authored-by: someone_else@somewhere_else.com
   5   │
   6   │ some other message
```

``` sh
❯ cat gitlint_example_5 | gitlint -C .gitlint --extra-path tests/framework/gitlint_rules.py
3: UC2 Last line in commit message body should be 'Signed-off-by'
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] All added/changed functionality is tested.
