### PR TITLE
Fix intermittent fail on AMD when getting cpu count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio_gen",
- "vm-memory 0.1.0",
+ "vm-allocator",
  "vm-memory 0.3.0",
  "vm-superio",
 ]

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -172,37 +172,16 @@ pub fn register_signal_handlers() -> utils::errno::Result<()> {
 mod tests {
     use super::*;
 
-    use libc::{cpu_set_t, syscall};
-    use std::{mem, process, thread};
+    use std::env;
+    use std::{process, thread};
 
+    use libc::syscall;
     use seccompiler::sock_filter;
-
-    // This function is used when running unit tests, so all the unsafes are safe.
-    fn cpu_count() -> usize {
-        let mut cpuset: cpu_set_t = unsafe { mem::zeroed() };
-        unsafe {
-            libc::CPU_ZERO(&mut cpuset);
-        }
-        let ret = unsafe {
-            libc::sched_getaffinity(
-                0,
-                mem::size_of::<cpu_set_t>(),
-                &mut cpuset as *mut cpu_set_t,
-            )
-        };
-        assert_eq!(ret, 0);
-
-        let mut num = 0;
-        for i in 0..libc::CPU_SETSIZE as usize {
-            if unsafe { libc::CPU_ISSET(i, &cpuset) } {
-                num += 1;
-            }
-        }
-        num
-    }
 
     #[test]
     fn test_signal_handler() {
+        let run_with_kcov = env::var("CARGO_WRAPPER").unwrap_or_else(|_| "".to_string()) == *"kcov";
+
         let child = thread::spawn(move || {
             assert!(register_signal_handlers().is_ok());
 
@@ -258,16 +237,12 @@ mod tests {
         });
         assert!(child.join().is_ok());
 
-        // Sanity check.
-        assert!(cpu_count() > 0);
-        // Kcov somehow messes with our handler getting the SIGSYS signal when a bad syscall
-        // is caught, so the following assertion no longer holds. Ideally, we'd have a surefire
-        // way of either preventing this behaviour, or detecting for certain whether this test is
-        // run by kcov or not. The best we could do so far is to look at the perceived number of
-        // available CPUs. Kcov seems to make a single CPU available to the process running the
-        // tests, so we use this as an heuristic to decide if we check the assertion.
-        if cpu_count() > 1 {
-            // The signal handler should let the program continue during unit tests.
+        // SIGSYS, which is raised whenever a bad syscall is caught will be intercepted by kcov on x86_64
+        // and thus not reach Firecracker:
+        // https://github.com/SimonKagstrom/kcov/blob/a8b60c43fb33f56553a2bb20633e3b59a08abae1/src/engines/ptrace.cc#L187
+        // So, we are not checking for the `num_faults` metrics which gets incremented on each bad syscall
+        // if we run with kcov and we are on x86_64.
+        if !(cfg!(target_arch = "x86_64") && run_with_kcov) {
             assert!(METRICS.seccomp.num_faults.fetch() >= 1);
         }
         assert!(METRICS.signals.sigbus.fetch() >= 1);
@@ -276,9 +251,9 @@ mod tests {
         assert!(METRICS.signals.sigxcpu.fetch() >= 1);
         assert!(METRICS.signals.sigpipe.count() >= 1);
         assert!(METRICS.signals.sighup.fetch() >= 1);
-        // Workaround to GitHub issue 2216.
-        #[cfg(not(target_arch = "aarch64"))]
-        assert!(METRICS.signals.sigill.fetch() >= 1);
+        if !(cfg!(target_arch = "aarch64") && run_with_kcov) {
+            assert!(METRICS.signals.sigill.fetch() >= 1);
+        }
     }
 
     fn make_test_seccomp_bpf_filter() -> Vec<sock_filter> {

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.83, "AMD": 84.32, "ARM": 84.06}
+    COVERAGE_DICT = {"Intel": 84.83, "AMD": 84.32, "ARM": 84.00}
 else:
-    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.37, "ARM": 81.05}
+    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.37, "ARM": 81.00}
 
 PROC_MODEL = proc.proc_type()
 
@@ -82,7 +82,8 @@ def test_coverage(test_fc_session_root_path, test_session_tmp_path):
     target = "{}-unknown-linux-musl".format(platform.machine())
 
     cmd = (
-        'RUSTFLAGS="{}" CARGO_TARGET_DIR={} cargo kcov --all '
+        'CARGO_WRAPPER="kcov" RUSTFLAGS="{}" CARGO_TARGET_DIR={} '
+        'cargo kcov --all '
         '--target {} --output {} -- '
         '--exclude-pattern={} '
         '--exclude-region={} --verify'


### PR DESCRIPTION
# Reason for This PR

We have been dealing with intermittent fails for `vmm::signal_handler::test_signal_handler` on AMD.
This happens in the cpu_count() function due. We are computing the number of cpus by getting the affinity mask of current process and then going through CPU_SETSIZE to count the number of cpus that hit the mask. 
Problem is that `libc:musl` has a maximum of CPU_SETSIZE equal 128 and  on AMD the maximum number of CPUS with SMT enabled is 192.

Fixes #2216 

## Description of Changes

The cpu_count was used as an trick for detecting whether or not the unit tests are run under `cargo test` or `cargo kcov` since cargo kcov would make it seem that there is only one CPU online.

We remove this workaround and introduce a environment variable CARGO_WRAPPER that can tell us what is the wrapper currently run by cargo.

While implementing the solution, also found the reason why this happens: https://github.com/firecracker-microvm/firecracker/issues/2216. Comment in code.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
