### PR TITLE
CI: fix snap incompatibility

### DIFF
--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -693,8 +693,9 @@ def test_mmds_snapshot(bin_cloner_path, version):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
-        # v1.1.0 breaks snapshot compatibility with older versions.
-        min_version="1.1.0",
+        # current snapshot (i.e a machine snapshotted with current build)
+        # is incompatible with any past release due to notification suppression.
+        min_version="1.2.0",
         max_version=get_firecracker_version_from_toml(),
     )
     for firecracker in firecracker_artifacts:

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -91,8 +91,9 @@ def test_restore_old_version(bin_cloner_path):
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
     firecracker_artifacts = artifacts.firecrackers(
-        # v1.1.0 breaks snapshot compatibility with older versions.
-        min_version="1.1.0",
+        # current snapshot (i.e a machine snapshotted with current build)
+        # is incompatible with any past release due to notification suppression.
+        min_version="1.2.0",
         max_version=get_firecracker_version_from_toml(),
     )
     for firecracker in firecracker_artifacts:


### PR DESCRIPTION

# Reason for This PR

Due to notification suppression having been added
after v1.1.0, there is no past release that is snapshot
compatible with current one. 

This is tackling the scenario where past firecracker versions are not able to resume a microVM obtained with the current build.
Since the past firecracker versions cannot be aware of the features subsequent versions will implement, we do not have many options of offering a better compatibility check experience. It would be nice to brainstorm some ideas in that respect.

`[Author TODO: add issue #.]`
`[Open the PR after the related issue has a clear conclusion.]`
`[If there is no issue which states the need for this PR, create one first.]`
Fixes #

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
