### PR TITLE
fix(CONTRIBUTING.md): Signed-off-by instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,8 @@ Your contribution needs to meet the following standards:
 
   A concise description where each line is 72 characters or fewer.
 
-  Signed-Off-By <A full name> <A email>
-  Co-Authored-By: <B full name> <B email>
+  Signed-off-by: <A full name> <A email>
+  Co-authored-by: <B full name> <B email>
   ```
 
 - Document your pull requests. Include the reasoning behind each change, and


### PR DESCRIPTION
And Co-authored-by casing too since `gitline_rules.py` performs a case-sensitive check

Signed-off-by: Aaron O'Mullan <aaron.omullan@gmail.com>