### PR TITLE
Update docs to provide better clarity of supported features

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -18,8 +18,8 @@ Firecracker virtual machine manager (VMM).
 
 1. Firecracker can safely run workloads from different customers on the same
    machine.
-1. Customers can create microVMs with any combination of vCPU and memory to
-   match their application requirements.
+1. Customers can create microVMs with any combination of vCPU (up to 32)
+   and memory to match their application requirements.
 1. Firecracker microVMs can oversubscribe host CPU and memory. The degree of
    oversubscription is controlled by customers, who may factor in workload
    correlation and load in order to ensure smooth host system operation.

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -82,10 +82,10 @@ for Firecracker processes that are unresponsive, and kills them, by SIGKILL.
 
 ## Jailer Configuration
 
-For assuring secure isolation in production deployments, Firecracker should
-must be started using the `jailer` binary that's part of each Firecracker
-release, or executed under process constraints equal or more restrictive than
-those in the jailer. For more about Firecracker sandboxing please see
+For assuring secure isolation in production deployments, Firecracker should be
+started using the `jailer` binary that's part of each Firecracker release, or
+executed under process constraints equal or more restrictive than those in the jailer.
+For more about Firecracker sandboxing please see
 [Firecracker design](design.md)
 
 The Jailer process applies
@@ -127,7 +127,7 @@ Here are some recommendations on how to limit the process's resources:
 
 - Jailer's `resource-limit` provides control on the disk usage through:
   - `fsize` - limits the size in bytes for files created by the process
-  - `no-file` - specifies a value one greater than the maximum file
+  - `no-file` - specifies a value greater than the maximum file
     descriptor number that can be opened by the process. If not specified,
     it defaults to 4096.
 


### PR DESCRIPTION
Signed-off-by: Marco Cali <xmarcalx@amazon.co.uk>

# Reason for This PR

Modify the documentation to include explicitly the max number of vCPU supported and other minor grammatical changes.

Fixes #3059

## Description of Changes

Updated the "Features" section of the design.md file to state the max vCPU number. 

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist
- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
