### PR TITLE
arch/x86_64: save additional MSRs

### DIFF
--- a/src/arch/src/x86_64/msr.rs
+++ b/src/arch/src/x86_64/msr.rs
@@ -50,6 +50,8 @@ const MSR_KVM_SYSTEM_TIME_NEW: u32 = 0x4b56_4d01;
 const MSR_KVM_ASYNC_PF_EN: u32 = 0x4b56_4d02;
 const MSR_KVM_STEAL_TIME: u32 = 0x4b56_4d03;
 const MSR_KVM_PV_EOI_EN: u32 = 0x4b56_4d04;
+const MSR_KVM_POLL_CONTROL: u32 = 0x4b56_4d05;
+const MSR_KVM_ASYNC_PF_INT: u32 = 0x4b56_4d06;
 
 /// Taken from arch/x86/include/asm/msr-index.h
 const MSR_IA32_SPEC_CTRL: u32 = 0x0000_0048;
@@ -167,6 +169,10 @@ static ALLOWED_MSR_RANGES: &[MsrRange] = &[
     SINGLE_MSR!(MSR_GS_BASE),
     SINGLE_MSR!(MSR_KERNEL_GS_BASE),
     SINGLE_MSR!(MSR_TSC_AUX),
+    SINGLE_MSR!(MSR_MISC_FEATURE_ENABLES),
+    SINGLE_MSR!(MSR_K7_HWCR),
+    SINGLE_MSR!(MSR_KVM_POLL_CONTROL),
+    SINGLE_MSR!(MSR_KVM_ASYNC_PF_INT),
 ];
 
 /// Specifies whether a particular MSR should be included in vcpu serialization.


### PR DESCRIPTION
# Reason for This PR

Some Guest writtable MSRs are not saved in the snapshot which means that when the snapshot is resumed, software that was using those MSRs may not work properly.

## Description of Changes

Allow saving these additional guest writable MSRs to preserve
functionality after snapshot and resume:
* `MSR_MISC_FEATURE_ENABLES` to preserve CPUID fault
* `MSR_K7_HWCR` to preserve value written
* `MSR_KVM_POLL_CONTROL` to preserve HLT polling request
* `MSR_KVM_ASYNC_PF_INT` to preserve ASYNC PF interrupt vector

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
