### PR TITLE
cpu templates: add T2S templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add a new CPU template called `T2S`. This exposes the same CPUID as `T2`
+  to the Guest and also overwrites the `ARCH_CAPABILITIES` MSR to expose a
+  reduced set of capabilities. With regards to hardware vulnerabilities
+  and mitigations, the Guest vCPU will apear to look like a Skylake CPU,
+  making it safe to snapshot uVMs running on a newer host CPU (Cascade Lake)
+  and restore on a host that has a Skylake CPU.
+
+### Fixed
+
+- Make the `T2` template more robust by explicitly disabling additional
+  CPUID flags that should be off but were missed initially or that were
+  not available in the spec when the template was created.
+
 ## [1.1.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "arch_gen",
+ "bitflags",
  "derive_more",
  "device_tree",
  "kvm-bindings",
@@ -238,6 +239,7 @@ dependencies = [
 name = "cpuid"
 version = "0.1.0"
 dependencies = [
+ "arch",
  "derive_more",
  "kvm-bindings",
  "kvm-ioctls",

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The **API endpoint** can be used to:
 - Configure the microvm by:
   - Setting the number of vCPUs (the default is 1).
   - Setting the memory size (the default is 128 MiB).
-  - [x86_64 only] Choosing a CPU template (currently, C3 and T2 are available).
+  - [x86_64 only] Choosing a CPU template (currently, C3, T2 and T2S are available).
 - Add one or more network interfaces to the microVM.
 - Add one or more read-write or read-only disks to the microVM, each represented
   by a file-backed block device.

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -782,6 +782,7 @@ definitions:
     enum:
       - C3
       - T2
+      - T2S
       - None
     default: "None"
 

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -14,6 +14,7 @@ versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 vm-fdt = "0.1.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
+bitflags = ">=1.0.4"
 
 arch_gen = { path = "../arch_gen" }
 logger = { path = "../logger" }

--- a/src/arch/src/x86_64/msr.rs
+++ b/src/arch/src/x86_64/msr.rs
@@ -5,6 +5,7 @@
 use std::result;
 
 use arch_gen::x86::msr_index::*;
+use bitflags::bitflags;
 use kvm_bindings::{kvm_msr_entry, MsrList, Msrs};
 use kvm_ioctls::{Kvm, VcpuFd};
 
@@ -54,8 +55,73 @@ const MSR_KVM_POLL_CONTROL: u32 = 0x4b56_4d05;
 const MSR_KVM_ASYNC_PF_INT: u32 = 0x4b56_4d06;
 
 /// Taken from arch/x86/include/asm/msr-index.h
-const MSR_IA32_SPEC_CTRL: u32 = 0x0000_0048;
+/// Spectre mitigations control MSR
+pub const MSR_IA32_SPEC_CTRL: u32 = 0x0000_0048;
+/// Architecture capabilities MSR
+pub const MSR_IA32_ARCH_CAPABILITIES: u32 = 0x0000_010a;
+
 const MSR_IA32_PRED_CMD: u32 = 0x0000_0049;
+
+bitflags! {
+    /// Feature flags enumerated in the IA32_ARCH_CAPABILITIES MSR.
+    /// See https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/cpuid-enumeration-and-architectural-msrs.html
+    #[derive(Default)]
+    #[repr(C)]
+    pub struct ArchCapaMSRFlags: u64 {
+        /// The processor is not susceptible to Rogue Data Cache Load (RDCL).
+        const RDCL_NO               = 1 << 0;
+        /// The processor supports enhanced Indirect Branch Restriction Speculation (IBRS)
+        const IBRS_ALL              = 1 << 1;
+        /// The processor supports RSB Alternate. Alternative branch predictors may be used by RET instructions
+        /// when the RSB is empty. Software using retpoline may be affected by this behavior.
+        const RSBA                  = 1 << 2;
+        /// A value of 1 indicates the hypervisor need not flush the L1D on VM entry.
+        const SKIP_L1DFL_VMENTRY    = 1 << 3;
+        /// Processor is not susceptible to Speculative Store Bypass (SSB).
+        const SSB_NO                = 1 << 4;
+        /// Processor is not susceptible to Microarchitectural Data Sampling (MDS).
+        const MDS_NO                = 1 << 5;
+        /// The processor is not susceptible to a machine check error due to modifying the size of a code page
+        /// without TLB invalidation.
+        const IF_PSCHANGE_MC_NO     = 1 << 6;
+        /// The processor supports RTM_DISABLE and TSX_CPUID_CLEAR.
+        const TSX_CTRL              = 1 << 7;
+        /// Processor is not susceptible to Intel® Transactional Synchronization Extensions
+        /// (Intel® TSX) Asynchronous Abort (TAA).
+        const TAA_NO                = 1 << 8;
+        // Bit 9 is reserved
+        /// Processor supports IA32_MISC_PACKAGE_CTRLS MSR.
+        const MISC_PACKAGE_CTRLS    = 1 << 10;
+        /// Processor supports setting and reading IA32_MISC_PACKAGE_CTLS[0] (ENERGY_FILTERING_ENABLE) bit.
+        const ENERGY_FILTERING_CTL  = 1 << 11;
+        /// The processor supports data operand independent timing mode.
+        const DOITM                 = 1 << 12;
+        /// The processor is not affected by either the Shared Buffers Data Read (SBDR) vulnerability or the
+        /// Sideband Stale Data Propagator (SSDP).
+        const SBDR_SSDP_NO          = 1 << 13;
+        /// The processor is not affected by the Fill Buffer Stale Data Propagator (FBSDP).
+        const FBSDP_NO              = 1 << 14;
+        /// The processor is not affected by vulnerabilities involving the Primary Stale Data Propagator (PSDP).
+        const PSDP_NO               = 1 << 15;
+        // Bit 16 is reserved
+        /// The processor will overwrite fill buffer values as part of MD_CLEAR operations with the VERW instruction.
+        /// On these processors, L1D_FLUSH does not overwrite fill buffer values.
+        const FB_CLEAR              = 1 << 17;
+        /// The processor supports read and write to the IA32_MCU_OPT_CTRL MSR (MSR 123H) and to the FB_CLEAR_DIS bit
+        /// in that MSR (bit position 3).
+        const FB_CLEAR_CTRL         = 1 << 18;
+        /// A value of 1 indicates processor may have the RRSBA alternate prediction behavior,
+        /// if not disabled by RRSBA_DIS_U or RRSBA_DIS_S.
+        const RRSBA                 = 1 << 19;
+        /// A value of 1 indicates BHI_NO branch prediction behavior,
+        /// regardless of the value of IA32_SPEC_CTRL[BHI_DIS_S] MSR bit.
+        const BHI_NO                = 1 << 20;
+        // Bits 21:22 are reserved
+        /// If set, the IA32_OVERCLOCKING STATUS MSR exists.
+        const OVERCLOCKING_STATUS   = 1 << 23;
+        // Bits 24:63 are reserved
+    }
+}
 
 // Creates a MsrRange of one msr given as argument.
 macro_rules! SINGLE_MSR {
@@ -188,8 +254,8 @@ pub fn msr_should_serialize(index: u32) -> bool {
     ALLOWED_MSR_RANGES.iter().any(|range| range.contains(index))
 }
 
-// Creates and populates required MSR entries for booting Linux on X86_64.
-fn create_boot_msr_entries() -> Vec<kvm_msr_entry> {
+/// Creates and populates required MSR entries for booting Linux on X86_64.
+pub fn create_boot_msr_entries() -> Vec<kvm_msr_entry> {
     let msr_entry_default = |msr| kvm_msr_entry {
         index: msr,
         data: 0x0,
@@ -221,9 +287,8 @@ fn create_boot_msr_entries() -> Vec<kvm_msr_entry> {
 /// # Arguments
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-pub fn setup_msrs(vcpu: &VcpuFd) -> Result<()> {
-    let entry_vec = create_boot_msr_entries();
-    let msrs = Msrs::from_entries(&entry_vec).map_err(Error::FamError)?;
+pub fn set_msrs(vcpu: &VcpuFd, msr_entries: &[kvm_msr_entry]) -> Result<()> {
+    let msrs = Msrs::from_entries(&msr_entries).map_err(Error::FamError)?;
     vcpu.set_msrs(&msrs)
         .map_err(Error::SetModelSpecificRegisters)
         .and_then(|msrs_written| {
@@ -272,7 +337,8 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        setup_msrs(&vcpu).unwrap();
+        let msr_boot_entries = create_boot_msr_entries();
+        set_msrs(&vcpu, &msr_boot_entries).unwrap();
 
         // This test will check against the last MSR entry configured (the tenth one).
         // See create_msr_entries() for details.

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -11,3 +11,4 @@ kvm-ioctls = ">=0.9.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 utils = { path = "../utils"}
+arch = { path = "../arch" }

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -37,7 +37,9 @@ pub mod leaf_0x1 {
         // Virtual Machine Extensions
         pub const VMX_BITINDEX: u32 = 5;
         // 6 = SMX (Safer Mode Extensions)
+        pub const SMX_BITINDEX: u32 = 6;
         // 7 = EIST (Enhanced Intel SpeedStep® technology)
+        pub const EIST_BITINDEX: u32 = 7;
         // TM2 = Thermal Monitor 2
         pub const TM2_BITINDEX: u32 = 8;
         // CNXT_ID = L1 Context ID (L1 data cache can be set to adaptive/shared mode)
@@ -50,6 +52,7 @@ pub mod leaf_0x1 {
         // PDCM = Perfmon and Debug Capability
         pub const PDCM_BITINDEX: u32 = 15;
         // 18 = DCA Direct Cache Access (prefetch data from a memory mapped device)
+        pub const DCA_BITINDEX: u32 = 18;
         pub const MOVBE_BITINDEX: u32 = 22;
         pub const TSC_DEADLINE_TIMER_BITINDEX: u32 = 24;
         pub const OSXSAVE_BITINDEX: u32 = 27;
@@ -59,11 +62,13 @@ pub mod leaf_0x1 {
 
     pub mod edx {
         pub const PSN_BITINDEX: u32 = 18; // Processor Serial Number
+        pub const SSE42_BITINDEX: u32 = 20; // SSE 4.2
         pub const DS_BITINDEX: u32 = 21; // Debug Store.
         pub const ACPI_BITINDEX: u32 = 22; // Thermal Monitor and Software Controlled Clock Facilities.
         pub const SS_BITINDEX: u32 = 27; // Self Snoop
         pub const HTT_BITINDEX: u32 = 28; // Max APIC IDs reserved field is valid
         pub const TM_BITINDEX: u32 = 29; // Thermal Monitor.
+        pub const IA64_BITINDEX: u32 = 30; // IA64 processor emulating x86
         pub const PBE_BITINDEX: u32 = 31; // Pending Break Enable.
     }
 }
@@ -126,6 +131,7 @@ pub mod leaf_0x7 {
             // Intel® Resource Director Technology (Intel® RDT) Monitoring
             pub const RDT_M_BITINDEX: u32 = 12;
             // 13 = Deprecates FPU CS and FPU DS values if 1
+            pub const FPU_CS_DS_DEPRECATE_BITINDEX: u32 = 13;
             // Memory Protection Extensions
             pub const MPX_BITINDEX: u32 = 14;
             // RDT = Intel® Resource Director Technology
@@ -139,8 +145,8 @@ pub mod leaf_0x7 {
             // 20 = SMAP (Supervisor-Mode Access Prevention)
             // AVX512IFMA = AVX-512 Integer Fused Multiply-Add Instructions
             pub const AVX512IFMA_BITINDEX: u32 = 21;
-            // 21 = PCOMMIT intruction
-            // 22 reserved
+            // 22 = PCOMMIT intruction
+            pub const PCOMMIT_BITINDEX: u32 = 22;
             // CLFLUSHOPT (flushing multiple cache lines in parallel within a single logical
             // processor)
             pub const CLFLUSHOPT_BITINDEX: u32 = 23;

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -19,7 +19,7 @@ use crate::common::*;
 pub mod bit_helper;
 
 mod template;
-pub use crate::template::intel::{c3, t2};
+pub use crate::template::intel::{c3, t2, t2s};
 
 mod cpu_leaf;
 

--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -5,6 +5,9 @@
 pub mod c3;
 /// Follows a T2 template in setting up the CPUID.
 pub mod t2;
+/// Follows a T2 template for setting up the CPUID with additional MSRs
+/// that are speciffic to an Intel Skylake CPU.
+pub mod t2s;
 
 use crate::common::{get_vendor_id_from_host, VENDOR_ID_INTEL};
 use crate::transformer::Error;

--- a/src/cpuid/src/template/intel/t2.rs
+++ b/src/cpuid/src/template/intel/t2.rs
@@ -8,7 +8,10 @@ use crate::cpu_leaf::*;
 use crate::template::intel::validate_vendor_id;
 use crate::transformer::*;
 
-fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) -> Result<(), Error> {
+pub(crate) fn update_feature_info_entry(
+    entry: &mut kvm_cpuid_entry2,
+    _vm_spec: &VmSpec,
+) -> Result<(), Error> {
     use crate::cpu_leaf::leaf_0x1::*;
 
     entry
@@ -33,26 +36,31 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         .write_bit(ecx::MONITOR_BITINDEX, false)
         .write_bit(ecx::DS_CPL_SHIFT, false)
         .write_bit(ecx::VMX_BITINDEX, false)
+        .write_bit(ecx::SMX_BITINDEX, false)
+        .write_bit(ecx::EIST_BITINDEX, false)
         .write_bit(ecx::TM2_BITINDEX, false)
         .write_bit(ecx::CNXT_ID_BITINDEX, false)
         .write_bit(ecx::SDBG_BITINDEX, false)
         .write_bit(ecx::XTPR_UPDATE_BITINDEX, false)
         .write_bit(ecx::PDCM_BITINDEX, false)
+        .write_bit(ecx::DCA_BITINDEX, false)
         .write_bit(ecx::OSXSAVE_BITINDEX, false);
 
     entry
         .edx
         .write_bit(edx::PSN_BITINDEX, false)
+        .write_bit(edx::SSE42_BITINDEX, false)
         .write_bit(edx::DS_BITINDEX, false)
         .write_bit(edx::ACPI_BITINDEX, false)
         .write_bit(edx::SS_BITINDEX, false)
         .write_bit(edx::TM_BITINDEX, false)
+        .write_bit(edx::IA64_BITINDEX, false)
         .write_bit(edx::PBE_BITINDEX, false);
 
     Ok(())
 }
 
-fn update_structured_extended_entry(
+pub(crate) fn update_structured_extended_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
@@ -66,6 +74,7 @@ fn update_structured_extended_entry(
             .write_bit(ebx::FPDP_BITINDEX, false)
             .write_bit(ebx::RTM_BITINDEX, false)
             .write_bit(ebx::RDT_M_BITINDEX, false)
+            .write_bit(ebx::FPU_CS_DS_DEPRECATE_BITINDEX, false)
             .write_bit(ebx::RDT_A_BITINDEX, false)
             .write_bit(ebx::MPX_BITINDEX, false)
             .write_bit(ebx::AVX512F_BITINDEX, false)
@@ -73,6 +82,7 @@ fn update_structured_extended_entry(
             .write_bit(ebx::RDSEED_BITINDEX, false)
             .write_bit(ebx::ADX_BITINDEX, false)
             .write_bit(ebx::AVX512IFMA_BITINDEX, false)
+            .write_bit(ebx::PCOMMIT_BITINDEX, false)
             .write_bit(ebx::CLFLUSHOPT_BITINDEX, false)
             .write_bit(ebx::CLWB_BITINDEX, false)
             .write_bit(ebx::PT_BITINDEX, false)
@@ -104,7 +114,7 @@ fn update_structured_extended_entry(
     Ok(())
 }
 
-fn update_xsave_features_entry(
+pub(crate) fn update_xsave_features_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {
@@ -139,7 +149,7 @@ fn update_xsave_features_entry(
     Ok(())
 }
 
-fn update_extended_feature_info_entry(
+pub(crate) fn update_extended_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
     _vm_spec: &VmSpec,
 ) -> Result<(), Error> {

--- a/src/cpuid/src/template/intel/t2s.rs
+++ b/src/cpuid/src/template/intel/t2s.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use arch::x86_64::msr::{ArchCapaMSRFlags, MSR_IA32_ARCH_CAPABILITIES};
+use kvm_bindings::{kvm_cpuid_entry2, kvm_msr_entry, CpuId};
+
+use crate::cpu_leaf::*;
+use crate::template::intel::validate_vendor_id;
+use crate::transformer::*;
+
+/// Sets up the cpuid entries for a given VCPU following a T2S template.
+struct T2SCpuidTransformer {}
+
+impl CpuidTransformer for T2SCpuidTransformer {
+    fn entry_transformer_fn(&self, entry: &mut kvm_cpuid_entry2) -> Option<EntryTransformerFn> {
+        match entry.function {
+            leaf_0x1::LEAF_NUM => Some(crate::t2::update_feature_info_entry),
+            leaf_0x7::LEAF_NUM => Some(crate::t2::update_structured_extended_entry),
+            leaf_0xd::LEAF_NUM => Some(crate::t2::update_xsave_features_entry),
+            leaf_0x80000001::LEAF_NUM => Some(crate::t2::update_extended_feature_info_entry),
+            _ => None,
+        }
+    }
+}
+
+/// Sets up the cpuid entries for a given VCPU following a T2S template.
+pub fn set_cpuid_entries(kvm_cpuid: &mut CpuId, vm_spec: &VmSpec) -> Result<(), Error> {
+    validate_vendor_id()?;
+    T2SCpuidTransformer {}.process_cpuid(kvm_cpuid, vm_spec)
+}
+
+/// Add the MSR entries speciffic to this T2S template.
+pub fn update_msr_entries(msr_entries: &mut Vec<kvm_msr_entry>) {
+    let capabilities = ArchCapaMSRFlags::RSBA
+        | ArchCapaMSRFlags::SKIP_L1DFL_VMENTRY
+        | ArchCapaMSRFlags::IF_PSCHANGE_MC_NO
+        | ArchCapaMSRFlags::MISC_PACKAGE_CTRLS
+        | ArchCapaMSRFlags::ENERGY_FILTERING_CTL;
+    msr_entries.push(kvm_msr_entry {
+        index: MSR_IA32_ARCH_CAPABILITIES,
+        data: capabilities.bits(),
+        ..Default::default()
+    });
+}
+
+static EXTRA_MSR_ENTRIES: &[u32] = &[MSR_IA32_ARCH_CAPABILITIES];
+
+/// Return a list of MSRs speciffic to this T2S template.
+pub fn msr_entries_to_save() -> &'static [u32] {
+    EXTRA_MSR_ENTRIES
+}

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -242,6 +242,8 @@ pub enum CpuFeaturesTemplate {
     C3,
     /// T2 Template.
     T2,
+    /// T2S Template.
+    T2S,
     /// No CPU template is used.
     None,
 }
@@ -258,6 +260,7 @@ impl fmt::Display for CpuFeaturesTemplate {
         match self {
             CpuFeaturesTemplate::C3 => write!(f, "C3"),
             CpuFeaturesTemplate::T2 => write!(f, "T2"),
+            CpuFeaturesTemplate::T2S => write!(f, "T2S"),
             CpuFeaturesTemplate::None => write!(f, "None"),
         }
     }
@@ -277,6 +280,7 @@ mod tests {
     fn test_display_cpu_features_template() {
         assert_eq!(CpuFeaturesTemplate::C3.to_string(), "C3".to_string());
         assert_eq!(CpuFeaturesTemplate::T2.to_string(), "T2".to_string());
+        assert_eq!(CpuFeaturesTemplate::T2S.to_string(), "T2S".to_string());
     }
 
     #[test]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.26, "ARM": 83.86}
+    COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.11, "ARM": 83.86}
 else:
-    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.37, "ARM": 80.95}
+    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.25, "ARM": 80.95}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
# Reason for This PR

Fix Guest CPU consistency issues when snapshotting and resuming uVMs across hosts with different CPUs.

## Description of Changes

The T2 template lets KVM populate the ARCH_CAPABILITIES MSR by using a
copy of the Host information. We sometimes want to force the information
contained in that MSR in order to make it look like a less capable
processor WRT speculative execution vulnerabilities and mitigations.
This is helpful when we want to snapshot a uVM on a newer processor and
resume on an older processor.
In this case, the software should use only the capabilities that are
available in both the newer and older host.

Create a new CPU template called T2S which is similar to the T2 template
but also sets additional information in the ARCH_CAPABILITIES MSR.
We basically set the MSR to expose to the guest a CPU that has the
security capabilities of a Skylake CPU, regardless of the host.
Also set some bits that were missing from the T2 CPUID config.

Adding the MSR information to the cpuid crate is not ideal based on
the current implementation. In the end the whole cpuid crate should
be refactored to remove the templates implementation into another crate.
The assumption that CPUID is the only place where information about the
processor is stored proves to be false so we need to extend the templates
to include at least the MSRs.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
