### PR TITLE
Add EPT check to devtool checkenv

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -1807,7 +1807,7 @@ check_L1TF () {
 
 check_swap () {
     (grep -q "swap.img" /proc/swaps ) && \
-    say_warn "WARNING: SWAP enabled"
+    say_warn "WARNING: SWAP ENABLED"
 }
 
 check_SSBD () {
@@ -1828,6 +1828,13 @@ check_SSBD () {
     else
         say_warn "WARNING: SSBD mitigation not supported on this kernel."\
             "View the prod-host-setup.md for more details."
+    fi
+}
+
+check_EPT() {
+    if [ "$arch" = "x86_64" ]; then
+        (grep -q "Y" /sys/module/kvm_intel/parameters/ept) || \
+        say_warn "WARNING: EPT DISABLED. Performance will be affected."
     fi
 }
 
@@ -1864,6 +1871,7 @@ cmd_checkenv() {
     check_SMT
     check_swap
     check_SSBD
+    check_EPT
 }
 
 generate_syscall_table_x86_64() {


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

# Reason for This PR

Running with EPT disabled can affect performance. 

## Description of Changes

Add a warning to `devtool checkenv` when EPT is disabled.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
