### PR TITLE
docs(prod-host-setup): Fix `tc qdisc` reference

### DIFF
--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -204,7 +204,7 @@ configuring rate limiters for the network interface as explained within
 [Network Interface documentation](api_requests/patch-network-interface.md),
 or by using one of the tools presented below:
 
-- `tc qdisk` - manipulate traffic control settings by configuring filters.
+- `tc qdisc` - manipulate traffic control settings by configuring filters.
 
 When traffic enters a classful qdisc, the filters are consulted and the
 packet is enqueued into one of the classes within. Besides


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# Reason for This PR
Correct `tc` usage example in production setup guide

## Description of Changes

Fix `tc qdisk` -> `tc qdisc` in `docs/prod-host-setup.md`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
