### PR TITLE
Add --metrics-path option

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,3 +3,7 @@ line-length=50
 
 [body-max-line-length]
 line-length=72
+
+[ignore-body-lines]
+# Ignore HTTP reference links
+regex=^\[.+\]: http.+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   making it safe to snapshot uVMs running on a newer host CPU (Cascade Lake)
   and restore on a host that has a Skylake CPU.
 
+- Added a new CLI option `--metrics-path PATH`. It accepts a file parameter
+  where metrics will be sent to.
+
 ### Fixed
 
 - Make the `T2` template more robust by explicitly disabling additional

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,11 @@
 # Firecracker Metrics Configuration
 
-For the metrics capability, Firecracker uses a single Metrics system.
-This system can be configured by sending a `PUT` API Request to the
-`/metrics` path.
+For the metrics capability, Firecracker uses a single Metrics system. This
+system can be configured either by: a) sending a `PUT` API Request to the
+`/metrics` path: or b) using the `--metrics-path` CLI option.
+
+Note the metrics configuration is **not** part of the guest configuration and is
+not restored from a snapshot.
 
 ## Prerequisites
 
@@ -17,7 +20,15 @@ mkfifo metrics.fifo
 touch metrics.file
 ```
 
-## Configuring the system
+## Configuring the system via CLI
+
+When launching Firecracker, use the CLI option to set the metrics file.
+
+```bash
+./firecracker --metrics-path metrics.fifo
+```
+
+## Configuring the system via API
 
 You can configure the Metrics system by sending the following API command:
 

--- a/src/api_server/swagger/firecracker.yaml
+++ b/src/api_server/swagger/firecracker.yaml
@@ -366,7 +366,7 @@ paths:
         204:
           description: Metrics system created.
         400:
-          description: Metrics system cannot be initialized due to bad input.
+          description: Metrics system cannot be initialized due to bad input request or metrics system already initialized.
           schema:
             $ref: "#/definitions/Error"
         default:

--- a/src/logger/src/metrics.rs
+++ b/src/logger/src/metrics.rs
@@ -9,7 +9,7 @@
 //! which we are capturing specific metrics.
 //!
 //! ## JSON example with metrics:
-//! ```bash
+//! ```json
 //! {
 //!  "utc_timestamp_ms": 1541591155180,
 //!  "api_server": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Pytest fixtures and redefined-outer-name don't mix well. Disable it.
+# pylint:disable=redefined-outer-name
+
 """Imported by pytest at the start of every test session.
 
 # Fixture Goals
@@ -178,8 +182,6 @@ class JsonFileDumper(ResultsDumperInterface):
 
 def init_microvm(root_path, bin_cloner_path, fc_binary=None, jailer_binary=None):
     """Auxiliary function for instantiating a microvm and setting it up."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     microvm_id = str(uuid.uuid4())
 
     # Update permissions for custom binaries.
@@ -255,8 +257,6 @@ def test_fc_session_root_path():
 @pytest.fixture
 def test_session_tmp_path(test_fc_session_root_path):
     """Yield a random temporary directory. Destroyed on teardown."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
 
     tmp_path = tempfile.mkdtemp(prefix=test_fc_session_root_path)
     yield tmp_path
@@ -285,8 +285,6 @@ def bin_cloner_path(test_fc_session_root_path):
     It's necessary because Python doesn't interface well with the `clone()`
     syscall directly.
     """
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     cloner_bin_path = os.path.join(test_fc_session_root_path, "newpid_cloner")
     _gcc_compile("host_tools/newpid_cloner.c", cloner_bin_path)
     yield cloner_bin_path
@@ -295,8 +293,6 @@ def bin_cloner_path(test_fc_session_root_path):
 @pytest.fixture(scope="session")
 def bin_vsock_path(test_fc_session_root_path):
     """Build a simple vsock client/server application."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     vsock_helper_bin_path = os.path.join(test_fc_session_root_path, "vsock_helper")
     _gcc_compile("host_tools/vsock_helper.c", vsock_helper_bin_path)
     yield vsock_helper_bin_path
@@ -305,7 +301,6 @@ def bin_vsock_path(test_fc_session_root_path):
 @pytest.fixture(scope="session")
 def change_net_config_space_bin(test_fc_session_root_path):
     """Build a binary that changes the MMIO config space."""
-    # pylint: disable=redefined-outer-name
     change_net_config_space_bin = os.path.join(
         test_fc_session_root_path, "change_net_config_space"
     )
@@ -327,8 +322,6 @@ def bin_seccomp_paths(test_fc_session_root_path):
     * a jailed binary that follows the seccomp rules;
     * a jailed binary that breaks the seccomp rules.
     """
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     seccomp_build_path = os.path.join(
         test_fc_session_root_path, build_tools.CARGO_RELEASE_REL_PATH
     )
@@ -367,8 +360,6 @@ def bin_seccomp_paths(test_fc_session_root_path):
 @pytest.fixture(scope="session")
 def uffd_handler_paths(test_fc_session_root_path):
     """Build UFFD handler binaries."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     uffd_build_path = os.path.join(
         test_fc_session_root_path, build_tools.CARGO_RELEASE_REL_PATH
     )
@@ -402,9 +393,6 @@ def uffd_handler_paths(test_fc_session_root_path):
 @pytest.fixture()
 def microvm(test_fc_session_root_path, bin_cloner_path):
     """Instantiate a microvm."""
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
-
     # Make sure the necessary binaries are there before instantiating the
     # microvm.
     vm = init_microvm(test_fc_session_root_path, bin_cloner_path)
@@ -455,8 +443,6 @@ def test_microvm_any(request, microvm):
     test cases for each test that depends on this fixture, each receiving a
     microvm instance with a different microvm image.
     """
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
 
     MICROVM_S3_FETCHER.init_vm_resources(request.param, microvm)
     yield microvm
@@ -471,8 +457,6 @@ def test_multiple_microvms(test_fc_session_root_path, context, bin_cloner_path):
     of the guest image used to spawn a microvm and the number of microvms
     to spawn.
     """
-    # pylint: disable=redefined-outer-name
-    # The fixture pattern causes a pylint false positive for that rule.
     microvms = []
     (microvm_resources, how_many) = context
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,6 +413,29 @@ def microvm(test_fc_session_root_path, bin_cloner_path):
     shutil.rmtree(os.path.join(test_fc_session_root_path, vm.id))
 
 
+@pytest.fixture()
+def microvm_factory(tmp_path, bin_cloner_path):
+    """Fixture to create microvms simply.
+
+    By using tmp_path, the last 3 runs are kept. This may be a problem when
+    running large number of tests, but it's very handy for debugging.
+    """
+
+    class MicroVMFactory:
+        """MicroVM factory"""
+
+        def __init__(self, tmp_path, bin_cloner):
+            self.tmp_path = tmp_path
+            self.bin_cloner_path = bin_cloner
+
+        def build(self):
+            """Build a fresh microvm."""
+            vm = init_microvm(self.tmp_path, self.bin_cloner_path)
+            return vm
+
+    yield MicroVMFactory(tmp_path, bin_cloner_path)
+
+
 @pytest.fixture
 def network_config():
     """Yield a UniqueIPv4Generator."""

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -18,6 +18,7 @@ import select
 import shutil
 import time
 import weakref
+from pathlib import Path
 
 from threading import Lock
 from retry import retry
@@ -508,6 +509,7 @@ class Microvm:
         log_file="log_fifo",
         log_level="Info",
         use_ramdisk=False,
+        metrics_path=None,
     ):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
@@ -546,6 +548,11 @@ class Microvm:
             # to `Info` to also have the boot time printed in fifo.
             self.jailer.extra_args.update({"log-path": log_file, "level": log_level})
             self.start_console_logger(log_fifo)
+
+        if metrics_path is not None:
+            self.create_jailed_resource(metrics_path, create_jail=True)
+            metrics_path = Path(metrics_path)
+            self.jailer.extra_args.update({"metrics-path": metrics_path.name})
 
         if self.metadata_file:
             if os.path.exists(self.metadata_file):

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.11, "ARM": 83.86}
+    COVERAGE_DICT = {"Intel": 84.77, "AMD": 84.11, "ARM": 83.78}
 else:
-    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.25, "ARM": 80.95}
+    COVERAGE_DICT = {"Intel": 81.89, "AMD": 81.25, "ARM": 80.86}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/style/test_python.py
+++ b/tests/integration_tests/style/test_python.py
@@ -12,4 +12,4 @@ def test_python_style():
     @type: style
     """
     # Runs command
-    utils.run_cmd("black . --check")
+    utils.run_cmd("black . --check --diff")


### PR DESCRIPTION
Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

# Reason for This PR

Metrics configuration are not saved in the snapshot since these are host related deployments settings. This means that after resuming, the only way to re-configure the metrics through an API call.
This can be costly for some customers since it will add up to the resume latency.

## Description of Changes

Add a CLI option to configure metrics

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

<!--- `[Author TODO: Meet these criteria.]` --->
<!--- `[Reviewer TODO: Verify that these criteria are met. Request changes if not]` --->

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The issue which led to this PR has a clear conclusion.
- [X] This PR follows the solution outlined in the related issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [X] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [X] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
