### PR TITLE
Update network latency performance baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -24,7 +24,7 @@
             "m5d.metal": {
                 "cpus": [
                     {
-                        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+                        "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
                         "baselines": {
                             "latency": {
                                 "vmlinux-4.14.bin": {
@@ -32,8 +32,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.245,
-                                                    "delta_percentage": 0.02
+                                                    "target": 0.211,
+                                                    "delta_percentage": 33.1
                                                 }
                                             }
                                         }
@@ -44,8 +44,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.258,
-                                                    "delta_percentage": 0.02
+                                                    "target": 0.23,
+                                                    "delta_percentage": 32.1
                                                 }
                                             }
                                         }
@@ -59,7 +59,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -71,7 +71,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -81,7 +81,7 @@
                         }
                     },
                     {
-                        "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+                        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
                         "baselines": {
                             "latency": {
                                 "vmlinux-4.14.bin": {
@@ -89,8 +89,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.219,
-                                                    "delta_percentage": 0.01
+                                                    "target": 0.247,
+                                                    "delta_percentage": 3.1
                                                 }
                                             }
                                         }
@@ -101,8 +101,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.234,
-                                                    "delta_percentage": 0.01
+                                                    "target": 0.261,
+                                                    "delta_percentage": 3.1
                                                 }
                                             }
                                         }
@@ -116,7 +116,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -128,7 +128,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -151,7 +151,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.032,
-                                                    "delta_percentage": 0.01
+                                                    "delta_percentage": 15.1
                                                 }
                                             }
                                         }
@@ -163,7 +163,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.037,
-                                                    "delta_percentage": 0.01
+                                                    "delta_percentage": 12.1
                                                 }
                                             }
                                         }
@@ -177,7 +177,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -189,7 +189,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -32,8 +32,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.229,
-                                                    "delta_percentage": 0.01
+                                                    "target": 0.228,
+                                                    "delta_percentage": 3.1
                                                 }
                                             }
                                         }
@@ -44,8 +44,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.238,
-                                                    "delta_percentage": 0.01
+                                                    "target": 0.239,
+                                                    "delta_percentage": 2.1
                                                 }
                                             }
                                         }
@@ -59,7 +59,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -71,7 +71,64 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.249,
+                                                    "delta_percentage": 2.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.262,
+                                                    "delta_percentage": 4.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "pkt_loss": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -93,8 +150,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.034,
-                                                    "delta_percentage": 0.01
+                                                    "target": 0.032,
+                                                    "delta_percentage": 15.1
                                                 }
                                             }
                                         }
@@ -106,7 +163,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.036,
-                                                    "delta_percentage": 0.01
+                                                    "delta_percentage": 16.1
                                                 }
                                             }
                                         }
@@ -120,7 +177,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }
@@ -132,7 +189,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "target": 0.0,
-                                                    "delta_percentage": 0
+                                                    "delta_percentage": 0.1
                                                 }
                                             }
                                         }

--- a/tools/parse_baselines/providers/latency.py
+++ b/tools/parse_baselines/providers/latency.py
@@ -3,6 +3,7 @@
 """Implement the DataParser for network latency performance tests."""
 
 import statistics
+import math
 from collections.abc import Iterator
 from typing import List
 from providers.types import DataParser
@@ -11,7 +12,7 @@ from providers.types import DataParser
 # that were not caught while gathering baselines. This provides
 # slightly better reliability, while not affecting regression
 # detection.
-DELTA_EXTRA_MARGIN = 0.01
+DELTA_EXTRA_MARGIN = 0.1
 
 
 # pylint: disable=R0903
@@ -23,14 +24,18 @@ class LatencyDataParser(DataParser):
         """Initialize the data parser."""
         super().__init__(
             data_provider,
-            ["latency/Avg"],
+            ["latency/Avg", "pkt_loss/Avg"],
         )
 
     def calculate_baseline(self, data: List[float]) -> dict:
         """Return the target and delta values, given a list of data points."""
         avg = statistics.mean(data)
         stddev = statistics.stdev(data)
+        if math.isclose(0.0, avg):
+            delta_percentage = 0.0
+        else:
+            delta_percentage = math.ceil(3 * stddev / avg * 100)
         return {
             "target": round(avg, 3),
-            "delta_percentage": round(stddev + DELTA_EXTRA_MARGIN, 2),
+            "delta_percentage": delta_percentage + DELTA_EXTRA_MARGIN,
         }


### PR DESCRIPTION
# Reason for This PR

Latency performance baselines are currently incorrect.

## Description of Changes

Updates network latency performance baselines by adding baselines for all processors we test and adding the `pkt_loss` metric.
Also fix the `LatencyDataParser` in the `parse_baselines` script to correctly calculate the delta percentage.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
