### PR TITLE
refactor: use slab for user_data instead of box

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1501,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "slab",
  "smallvec",
  "thiserror",
  "timerfd",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -37,6 +37,7 @@ bincode = "1.2.1"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 log-instrument = { path = "../log-instrument", optional = true }
 crc64 = "2.0.0"
+slab = "0.4.7"
 
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 use std::fs::File;
-use std::marker::PhantomData;
 use std::os::fd::RawFd;
 use std::os::unix::io::AsRawFd;
 
@@ -39,7 +38,6 @@ pub struct AsyncFileEngine<T> {
     file: File,
     ring: IoUring<WrappedUserData<T>>,
     completion_evt: EventFd,
-    phantom: PhantomData<T>,
 }
 
 #[derive(Debug)]
@@ -103,7 +101,6 @@ impl<T: Debug> AsyncFileEngine<T> {
             file,
             ring,
             completion_evt,
-            phantom: PhantomData,
         })
     }
 

--- a/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
@@ -37,7 +37,7 @@ pub enum AsyncIoError {
 #[derive(Debug)]
 pub struct AsyncFileEngine<T> {
     file: File,
-    ring: IoUring,
+    ring: IoUring<WrappedUserData<T>>,
     completion_evt: EventFd,
     phantom: PhantomData<T>,
 }
@@ -73,7 +73,10 @@ impl<T: Debug> WrappedUserData<T> {
 }
 
 impl<T: Debug> AsyncFileEngine<T> {
-    fn new_ring(file: &File, completion_fd: RawFd) -> Result<IoUring, io_uring::IoUringError> {
+    fn new_ring(
+        file: &File,
+        completion_fd: RawFd,
+    ) -> Result<IoUring<WrappedUserData<T>>, io_uring::IoUringError> {
         IoUring::new(
             u32::from(IO_URING_NUM_ENTRIES),
             vec![file],
@@ -142,21 +145,18 @@ impl<T: Debug> AsyncFileEngine<T> {
 
         let wrapped_user_data = WrappedUserData::new_with_dirty_tracking(addr, user_data);
 
-        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
-        // with this same `user_data`, so that the value will not be leaked.
-        unsafe {
-            self.ring.push(Operation::read(
+        self.ring
+            .push(Operation::read(
                 0,
                 buf as usize,
                 count,
                 offset,
                 wrapped_user_data,
             ))
-        }
-        .map_err(|err_tuple| UserDataError {
-            user_data: err_tuple.1.user_data,
-            error: AsyncIoError::IoUring(err_tuple.0),
-        })
+            .map_err(|err_tuple| UserDataError {
+                user_data: err_tuple.1.user_data,
+                error: AsyncIoError::IoUring(err_tuple.0),
+            })
     }
 
     pub fn push_write(
@@ -179,34 +179,29 @@ impl<T: Debug> AsyncFileEngine<T> {
 
         let wrapped_user_data = WrappedUserData::new(user_data);
 
-        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
-        // with this same `user_data`, so that the value will not be leaked.
-        unsafe {
-            self.ring.push(Operation::write(
+        self.ring
+            .push(Operation::write(
                 0,
                 buf as usize,
                 count,
                 offset,
                 wrapped_user_data,
             ))
-        }
-        .map_err(|err_tuple| UserDataError {
-            user_data: err_tuple.1.user_data,
-            error: AsyncIoError::IoUring(err_tuple.0),
-        })
+            .map_err(|err_tuple| UserDataError {
+                user_data: err_tuple.1.user_data,
+                error: AsyncIoError::IoUring(err_tuple.0),
+            })
     }
 
     pub fn push_flush(&mut self, user_data: T) -> Result<(), UserDataError<T, AsyncIoError>> {
         let wrapped_user_data = WrappedUserData::new(user_data);
 
-        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
-        // with this same `user_data`, so that the value will not be leaked.
-        unsafe { self.ring.push(Operation::fsync(0, wrapped_user_data)) }.map_err(|err_tuple| {
-            UserDataError {
+        self.ring
+            .push(Operation::fsync(0, wrapped_user_data))
+            .map_err(|err_tuple| UserDataError {
                 user_data: err_tuple.1.user_data,
                 error: AsyncIoError::IoUring(err_tuple.0),
-            }
-        })
+            })
     }
 
     pub fn kick_submission_queue(&mut self) -> Result<(), AsyncIoError> {
@@ -242,11 +237,7 @@ impl<T: Debug> AsyncFileEngine<T> {
     }
 
     fn do_pop(&mut self) -> Result<Option<Cqe<WrappedUserData<T>>>, AsyncIoError> {
-        // SAFETY: We trust that the host kernel did not touch the operation's `user_data` field.
-        // The `T` type is the same one used for `push`ing and since the kernel made this entry
-        // available in the completion queue, we now have full ownership of it.
-
-        unsafe { self.ring.pop::<WrappedUserData<T>>() }.map_err(AsyncIoError::IoUring)
+        self.ring.pop().map_err(AsyncIoError::IoUring)
     }
 
     pub fn pop(&mut self, mem: &GuestMemoryMmap) -> Result<Option<Cqe<T>>, AsyncIoError> {

--- a/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
+++ b/src/vmm/src/devices/virtio/virtio_block/io/async_io.rs
@@ -150,9 +150,9 @@ impl<T: Debug> AsyncFileEngine<T> {
                 offset,
                 wrapped_user_data,
             ))
-            .map_err(|err_tuple| UserDataError {
-                user_data: err_tuple.1.user_data,
-                error: AsyncIoError::IoUring(err_tuple.0),
+            .map_err(|(io_uring_error, data)| UserDataError {
+                user_data: data.user_data,
+                error: AsyncIoError::IoUring(io_uring_error),
             })
     }
 
@@ -184,9 +184,9 @@ impl<T: Debug> AsyncFileEngine<T> {
                 offset,
                 wrapped_user_data,
             ))
-            .map_err(|err_tuple| UserDataError {
-                user_data: err_tuple.1.user_data,
-                error: AsyncIoError::IoUring(err_tuple.0),
+            .map_err(|(io_uring_error, data)| UserDataError {
+                user_data: data.user_data,
+                error: AsyncIoError::IoUring(io_uring_error),
             })
     }
 
@@ -195,9 +195,9 @@ impl<T: Debug> AsyncFileEngine<T> {
 
         self.ring
             .push(Operation::fsync(0, wrapped_user_data))
-            .map_err(|err_tuple| UserDataError {
-                user_data: err_tuple.1.user_data,
-                error: AsyncIoError::IoUring(err_tuple.0),
+            .map_err(|(io_uring_error, data)| UserDataError {
+                user_data: data.user_data,
+                error: AsyncIoError::IoUring(io_uring_error),
             })
     }
 

--- a/src/vmm/src/io_uring/mod.rs
+++ b/src/vmm/src/io_uring/mod.rs
@@ -169,11 +169,11 @@ impl<T: Debug> IoUring<T> {
         // validate that we actually did register fds
         let fd = op.fd();
         match self.registered_fds_count {
-            0 => Err((IoUringError::NoRegisteredFds, op.user_data())),
-            len if fd >= len => Err((IoUringError::InvalidFixedFd(fd), op.user_data())),
+            0 => Err((IoUringError::NoRegisteredFds, op.user_data)),
+            len if fd >= len => Err((IoUringError::InvalidFixedFd(fd), op.user_data)),
             _ => {
                 if self.num_ops >= self.cqueue.count() {
-                    return Err((IoUringError::FullCQueue, op.user_data()));
+                    return Err((IoUringError::FullCQueue, op.user_data));
                 }
                 self.squeue
                     .push(op.into_sqe(&mut self.slab))
@@ -186,14 +186,14 @@ impl<T: Debug> IoUring<T> {
                         (
                             IoUringError::SQueue(sqe_err),
                             // We don't use slab.try_remove here for 2 reasons:
-                            // 1. user_data was insertde in slab with step `op.into_sqe` just
+                            // 1. user_data was inserted in slab with step `op.into_sqe` just
                             //    before the push op so the user_data key should be valid and if
                             //    key is valid then `slab.remove()` will not fail.
                             // 2. If we use `slab.try_remove()` we'll have to find a way to return
                             //    a default value for the generic type T which is difficult because
                             //    it expands to more crates which don't make it easy to define a
                             //    default/clone type for type T.
-                            // So beleiving that `slab.remove` won't fail we don't use
+                            // So believing that `slab.remove` won't fail we don't use
                             // the `slab.try_remove` method.
                             #[allow(clippy::cast_possible_truncation)]
                             self.slab.remove(user_data_key as usize),

--- a/src/vmm/src/io_uring/mod.rs
+++ b/src/vmm/src/io_uring/mod.rs
@@ -78,7 +78,7 @@ impl IoUringError {
 
 /// Main object representing an io_uring instance.
 #[derive(Debug)]
-pub struct IoUring {
+pub struct IoUring<T> {
     registered_fds_count: u32,
     squeue: SubmissionQueue,
     cqueue: CompletionQueue,
@@ -91,9 +91,10 @@ pub struct IoUring {
     // The total number of ops. These includes the ops on the submission queue, the in-flight ops
     // and the ops that are in the CQ, but haven't been popped yet.
     num_ops: u32,
+    slab: slab::Slab<T>,
 }
 
-impl IoUring {
+impl<T: Debug> IoUring<T> {
     /// Create a new instance.
     ///
     /// # Arguments
@@ -136,6 +137,8 @@ impl IoUring {
 
         let squeue = SubmissionQueue::new(fd, &params).map_err(IoUringError::SQueue)?;
         let cqueue = CompletionQueue::new(fd, &params).map_err(IoUringError::CQueue)?;
+        let slab =
+            slab::Slab::with_capacity(params.sq_entries as usize + params.cq_entries as usize);
 
         let mut instance = Self {
             squeue,
@@ -143,6 +146,7 @@ impl IoUring {
             fd: file,
             registered_fds_count: 0,
             num_ops: 0,
+            slab,
         };
 
         instance.check_operations()?;
@@ -161,11 +165,7 @@ impl IoUring {
     }
 
     /// Push an [`Operation`](operation/struct.Operation.html) onto the submission queue.
-    ///
-    /// # Safety
-    /// Unsafe because we pass a raw user_data pointer to the kernel.
-    /// It's up to the caller to make sure that this value is ever freed (not leaked).
-    pub unsafe fn push<T: Debug>(&mut self, op: Operation<T>) -> Result<(), (IoUringError, T)> {
+    pub fn push(&mut self, op: Operation<T>) -> Result<(), (IoUringError, T)> {
         // validate that we actually did register fds
         let fd = op.fd();
         match self.registered_fds_count {
@@ -176,14 +176,28 @@ impl IoUring {
                     return Err((IoUringError::FullCQueue, op.user_data()));
                 }
                 self.squeue
-                    .push(op.into_sqe())
+                    .push(op.into_sqe(&mut self.slab))
                     .map(|res| {
                         // This is safe since self.num_ops < IORING_MAX_CQ_ENTRIES (65536)
                         self.num_ops += 1;
                         res
                     })
-                    .map_err(|err_tuple: (SQueueError, T)| -> (IoUringError, T) {
-                        (IoUringError::SQueue(err_tuple.0), err_tuple.1)
+                    .map_err(|(sqe_err, user_data_key)| -> (IoUringError, T) {
+                        (
+                            IoUringError::SQueue(sqe_err),
+                            // We don't use slab.try_remove here for 2 reasons:
+                            // 1. user_data was insertde in slab with step `op.into_sqe` just
+                            //    before the push op so the user_data key should be valid and if
+                            //    key is valid then `slab.remove()` will not fail.
+                            // 2. If we use `slab.try_remove()` we'll have to find a way to return
+                            //    a default value for the generic type T which is difficult because
+                            //    it expands to more crates which don't make it easy to define a
+                            //    default/clone type for type T.
+                            // So beleiving that `slab.remove` won't fail we don't use
+                            // the `slab.try_remove` method.
+                            #[allow(clippy::cast_possible_truncation)]
+                            self.slab.remove(user_data_key as usize),
+                        )
                     })
             }
         }
@@ -191,14 +205,9 @@ impl IoUring {
 
     /// Pop a completed entry off the completion queue. Returns `Ok(None)` if there are no entries.
     /// The type `T` must be the same as the `user_data` type used for `push`-ing the operation.
-    ///
-    /// # Safety
-    /// Unsafe because we reconstruct the `user_data` from a raw pointer passed by the kernel.
-    /// It's up to the caller to make sure that `T` is the correct type of the `user_data`, that
-    /// the raw pointer is valid and that we have full ownership of that address.
-    pub unsafe fn pop<T: Debug>(&mut self) -> Result<Option<Cqe<T>>, IoUringError> {
+    pub fn pop(&mut self) -> Result<Option<Cqe<T>>, IoUringError> {
         self.cqueue
-            .pop()
+            .pop(&mut self.slab)
             .map(|maybe_cqe| {
                 maybe_cqe.map(|cqe| {
                     // This is safe since the pop-ed CQEs have been previously pushed. However
@@ -391,8 +400,8 @@ mod tests {
     use super::*;
     use crate::vstate::memory::{Bytes, MmapRegion};
 
-    fn drain_cqueue(ring: &mut IoUring) {
-        while let Some(entry) = unsafe { ring.pop::<u32>().unwrap() } {
+    fn drain_cqueue(ring: &mut IoUring<u32>) {
+        while let Some(entry) = ring.pop().unwrap() {
             entry.result().unwrap();
 
             // Assert that there were no partial writes.
@@ -581,9 +590,7 @@ mod tests {
                             ring.submit_and_wait_all().unwrap();
                             drain_cqueue(&mut ring);
                         }
-                        unsafe {
-                            ring.push(operation).unwrap();
-                        }
+                        ring.push(operation).unwrap();
                     }
 
                     // Submit any left async ops and wait.

--- a/src/vmm/src/io_uring/operation/cqe.rs
+++ b/src/vmm/src/io_uring/operation/cqe.rs
@@ -13,22 +13,13 @@ unsafe impl ByteValued for io_uring_cqe {}
 #[derive(Debug)]
 pub struct Cqe<T> {
     res: i32,
-    user_data: Box<T>,
+    user_data: T,
 }
 
 impl<T: Debug> Cqe<T> {
-    /// Construct a [`Cqe`] object from a raw `io_uring_cqe`.
-    ///
-    /// # Safety
-    /// Unsafe because we assume full ownership of the inner.user_data address.
-    /// We assume that it points to a valid address created with a `Box<T>`,
-    /// with the correct type `T`, and that ownership of that address is passed
-    /// to this function.
-    pub(crate) unsafe fn new(inner: io_uring_cqe) -> Self {
-        Self {
-            res: inner.res,
-            user_data: Box::from_raw(inner.user_data as *mut T),
-        }
+    /// Construct a Cqe object from a raw `io_uring_cqe`.
+    pub(crate) fn new(res: i32, user_data: T) -> Self {
+        Self { res, user_data }
     }
 
     /// Return the number of bytes successfully transferred by this operation.
@@ -51,13 +42,13 @@ impl<T: Debug> Cqe<T> {
     pub fn map_user_data<U: Debug, F: FnOnce(T) -> U>(self, op: F) -> Cqe<U> {
         Cqe {
             res: self.res,
-            user_data: Box::new(op(self.user_data())),
+            user_data: op(self.user_data()),
         }
     }
 
     /// Consume the object and return the user_data.
     pub fn user_data(self) -> T {
-        *self.user_data
+        self.user_data
     }
 }
 
@@ -69,15 +60,8 @@ mod tests {
     fn test_result() {
         // Check that `result()` returns an `Error` when `res` is negative.
         {
-            let user_data = Box::new(10u8);
-
-            let cqe: Cqe<u8> = unsafe {
-                Cqe::new(io_uring_cqe {
-                    user_data: Box::into_raw(user_data) as u64,
-                    res: -22,
-                    flags: 0,
-                })
-            };
+            let user_data = 10_u8;
+            let cqe: Cqe<u8> = Cqe::new(-22, user_data);
 
             assert_eq!(
                 cqe.result().unwrap_err().kind(),
@@ -87,15 +71,8 @@ mod tests {
 
         // Check that `result()` returns Ok() when `res` is positive.
         {
-            let user_data = Box::new(10u8);
-
-            let cqe: Cqe<u8> = unsafe {
-                Cqe::new(io_uring_cqe {
-                    user_data: Box::into_raw(user_data) as u64,
-                    res: 128,
-                    flags: 0,
-                })
-            };
+            let user_data = 10_u8;
+            let cqe: Cqe<u8> = Cqe::new(128, user_data);
 
             assert_eq!(cqe.result().unwrap(), 128);
         }
@@ -103,16 +80,18 @@ mod tests {
 
     #[test]
     fn test_user_data() {
-        let user_data = Box::new(10u8);
-
-        let cqe: Cqe<u8> = unsafe {
-            Cqe::new(io_uring_cqe {
-                user_data: Box::into_raw(user_data) as u64,
-                res: 0,
-                flags: 0,
-            })
-        };
+        let user_data = 10_u8;
+        let cqe: Cqe<u8> = Cqe::new(0, user_data);
 
         assert_eq!(cqe.user_data(), 10);
+    }
+
+    #[test]
+    fn test_map_user_data() {
+        let user_data = 10_u8;
+        let cqe: Cqe<u8> = Cqe::new(0, user_data);
+        let cqe = cqe.map_user_data(|x| x + 1);
+
+        assert_eq!(cqe.user_data(), 11);
     }
 }

--- a/src/vmm/src/io_uring/operation/cqe.rs
+++ b/src/vmm/src/io_uring/operation/cqe.rs
@@ -17,8 +17,8 @@ pub struct Cqe<T> {
 }
 
 impl<T: Debug> Cqe<T> {
-    /// Construct a Cqe object from a raw `io_uring_cqe`.
-    pub(crate) fn new(res: i32, user_data: T) -> Self {
+    /// Construct a Cqe object.
+    pub fn new(res: i32, user_data: T) -> Self {
         Self { res, user_data }
     }
 

--- a/src/vmm/src/io_uring/operation/mod.rs
+++ b/src/vmm/src/io_uring/operation/mod.rs
@@ -51,7 +51,7 @@ pub struct Operation<T> {
     pub(crate) len: Option<u32>,
     flags: u8,
     pub(crate) offset: Option<u64>,
-    user_data: Box<T>,
+    user_data: T,
 }
 
 // Needed for proptesting.
@@ -83,7 +83,7 @@ impl<T: Debug> Operation<T> {
             len: Some(len),
             flags: 0,
             offset: Some(offset),
-            user_data: Box::new(user_data),
+            user_data,
         }
     }
 
@@ -96,7 +96,7 @@ impl<T: Debug> Operation<T> {
             len: Some(len),
             flags: 0,
             offset: Some(offset),
-            user_data: Box::new(user_data),
+            user_data,
         }
     }
 
@@ -109,7 +109,7 @@ impl<T: Debug> Operation<T> {
             len: None,
             flags: 0,
             offset: None,
-            user_data: Box::new(user_data),
+            user_data,
         }
     }
 
@@ -119,7 +119,7 @@ impl<T: Debug> Operation<T> {
 
     /// Consumes the operation and returns the associated `user_data`.
     pub fn user_data(self) -> T {
-        *self.user_data
+        self.user_data
     }
 
     // Needed for proptesting.
@@ -129,13 +129,11 @@ impl<T: Debug> Operation<T> {
     }
 
     /// Transform the operation into an `Sqe`.
-    ///
-    /// # Safety
-    /// Unsafe because we turn the Boxed user_data into a raw pointer contained in the sqe.
-    /// It's up to the caller to make sure that this value is freed (not leaked).
-    pub(crate) unsafe fn into_sqe(self) -> Sqe {
+    /// Note: remember remove user_data from slab or it will leak.
+    pub(crate) fn into_sqe(self, slab: &mut slab::Slab<T>) -> Sqe {
+        // SAFETY:
         // Safe because all-zero value is valid. The sqe is made up of integers and raw pointers.
-        let mut inner: io_uring_sqe = std::mem::zeroed();
+        let mut inner: io_uring_sqe = unsafe { std::mem::zeroed() };
 
         inner.opcode = self.opcode as u8;
         inner.fd = i32::try_from(self.fd).unwrap();
@@ -153,7 +151,7 @@ impl<T: Debug> Operation<T> {
         if let Some(offset) = self.offset {
             inner.__bindgen_anon_1.off = offset;
         }
-        inner.user_data = Box::into_raw(self.user_data) as u64;
+        inner.user_data = slab.insert(self.user_data) as u64;
 
         Sqe::new(inner)
     }

--- a/src/vmm/src/io_uring/operation/mod.rs
+++ b/src/vmm/src/io_uring/operation/mod.rs
@@ -51,7 +51,7 @@ pub struct Operation<T> {
     pub(crate) len: Option<u32>,
     flags: u8,
     pub(crate) offset: Option<u64>,
-    user_data: T,
+    pub(crate) user_data: T,
 }
 
 // Needed for proptesting.
@@ -115,11 +115,6 @@ impl<T: Debug> Operation<T> {
 
     pub(crate) fn fd(&self) -> FixedFd {
         self.fd
-    }
-
-    /// Consumes the operation and returns the associated `user_data`.
-    pub fn user_data(self) -> T {
-        self.user_data
     }
 
     // Needed for proptesting.

--- a/src/vmm/src/io_uring/operation/sqe.rs
+++ b/src/vmm/src/io_uring/operation/sqe.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{self, Debug};
+use std::fmt::{self};
 
 use crate::io_uring::bindings::io_uring_sqe;
 use crate::vstate::memory::ByteValued;
@@ -24,13 +24,9 @@ impl Sqe {
         Self(inner)
     }
 
-    /// Consume the sqe and return the `user_data`.
-    ///
-    /// # Safety
-    /// Safe only if you guarantee that this is a valid pointer to some memory
-    /// where there is a value of type `T` created from a [`Box<T>`].
-    pub(crate) unsafe fn user_data<T: Debug>(self) -> T {
-        *Box::from_raw(self.0.user_data as *mut T)
+    /// Return the `user_data`.
+    pub(crate) fn user_data(&self) -> u64 {
+        self.0.user_data
     }
 }
 
@@ -40,12 +36,11 @@ mod tests {
     use super::*;
     #[test]
     fn test_user_data() {
-        let user_data = Box::new(10u8);
+        let user_data = 10_u64;
         let mut inner: io_uring_sqe = unsafe { std::mem::zeroed() };
-        inner.user_data = Box::into_raw(user_data) as u64;
+        inner.user_data = user_data;
 
         let sqe: Sqe = Sqe::new(inner);
-
-        assert_eq!(unsafe { sqe.user_data::<u8>() }, 10);
+        assert_eq!(sqe.user_data(), 10);
     }
 }

--- a/src/vmm/src/io_uring/operation/sqe.rs
+++ b/src/vmm/src/io_uring/operation/sqe.rs
@@ -24,7 +24,7 @@ impl Sqe {
         Self(inner)
     }
 
-    /// Return the `user_data`.
+    /// Return the key to the `user_data` stored in slab.
     pub(crate) fn user_data(&self) -> u64 {
         self.0.user_data
     }

--- a/src/vmm/src/io_uring/queue/completion.rs
+++ b/src/vmm/src/io_uring/queue/completion.rs
@@ -20,6 +20,8 @@ pub enum CQueueError {
     Mmap(#[from] MmapError),
     /// Error reading/writing volatile memory: {0}
     VolatileMemory(#[from] VolatileMemoryError),
+    /// Error in removing data from the slab
+    SlabRemoveFailed,
 }
 
 #[derive(Debug)]
@@ -73,11 +75,10 @@ impl CompletionQueue {
         self.count
     }
 
-    /// # Safety
-    /// Unsafe because we reconstruct the `user_data` from a raw pointer passed by the kernel.
-    /// It's up to the caller to make sure that `T` is the correct type of the `user_data`, that
-    /// the raw pointer is valid and that we have full ownership of that address.
-    pub(crate) unsafe fn pop<T: Debug>(&mut self) -> Result<Option<Cqe<T>>, CQueueError> {
+    pub(crate) fn pop<T: Debug>(
+        &mut self,
+        slab: &mut slab::Slab<T>,
+    ) -> Result<Option<Cqe<T>>, CQueueError> {
         let ring = self.cqes.as_volatile_slice();
         // get the head & tail
         let head = self.unmasked_head.0 & self.ring_mask;
@@ -93,7 +94,13 @@ impl CompletionQueue {
             self.unmasked_head += Wrapping(1u32);
             ring.store(self.unmasked_head.0, self.head_off, Ordering::Release)?;
 
-            Ok(Some(Cqe::new(cqe)))
+            let res = cqe.res;
+            #[allow(clippy::cast_possible_truncation)]
+            let index = cqe.user_data as usize;
+            match slab.try_remove(index) {
+                Some(user_data) => Ok(Some(Cqe::new(res, user_data))),
+                None => Err(CQueueError::SlabRemoveFailed),
+            }
         } else {
             Ok(None)
         }

--- a/src/vmm/src/io_uring/queue/submission.rs
+++ b/src/vmm/src/io_uring/queue/submission.rs
@@ -82,10 +82,7 @@ impl SubmissionQueue {
         })
     }
 
-    /// # Safety
-    /// Unsafe because we pass a raw `user_data` pointer to the kernel.
-    /// It's up to the caller to make sure that this value is ever freed (not leaked).
-    pub(crate) unsafe fn push<T: Debug>(&mut self, sqe: Sqe) -> Result<(), (SQueueError, T)> {
+    pub(crate) fn push(&mut self, sqe: Sqe) -> Result<(), (SQueueError, u64)> {
         let ring_slice = self.ring.as_volatile_slice();
 
         // get the sqe tail


### PR DESCRIPTION
1. use slab for user_data instead of boxto avoid unsafe code.
2. move generic type from push/pop to IoUring struct
  Put generic type on push and pop may cause developers misuse it since current user_data is a pointer, and the type should be the same. Since we always use the same user_data type for an IoUring instance, I move the generic to the IoUring struct.

Signed-off-by: ihciah <ihciah@gmail.com>

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
