### PR TITLE
Fix JSON syntax error in snapshotting docs

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -385,7 +385,7 @@ curl --unix-socket /tmp/firecracker.socket -i \
             "snapshot_path": "./snapshot_file",
             "mem_backend": {
                 "backend_path": "./mem_file",
-                "backend_type": "File",
+                "backend_type": "File"
             },
             "enable_diff_snapshots": true,
             "resume_vm": false


### PR DESCRIPTION
## Description of Changes

Extra comma causes JSON de-serialization to fail.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
