### PR TITLE
CI: remove Async default device configuration

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -533,9 +533,7 @@ class Microvm:
         self.mmds = MMDS(self._api_socket, self._api_session)
         self.network = Network(self._api_socket, self._api_session)
         self.snapshot = SnapshotHelper(self._api_socket, self._api_session)
-        self.drive = Drive(
-            self._api_socket, self._api_session, self.firecracker_version
-        )
+        self.drive = Drive(self._api_socket, self._api_session)
         self.vm = Vm(self._api_socket, self._api_session)
         self.vsock = Vsock(self._api_socket, self._api_session)
 

--- a/tests/framework/resources.py
+++ b/tests/framework/resources.py
@@ -5,7 +5,7 @@
 import urllib
 import re
 
-from framework.utils import compare_versions, is_io_uring_supported, run_cmd
+from framework.utils import compare_versions, run_cmd
 from framework.defs import API_USOCKET_URL_PREFIX
 
 
@@ -164,27 +164,16 @@ class Drive:
 
     DRIVE_CFG_RESOURCE = "drives"
 
-    def __init__(self, api_usocket_full_name, api_session, firecracker_version):
+    def __init__(self, api_usocket_full_name, api_session):
         """Specify the information needed for sending API requests."""
         url_encoded_path = urllib.parse.quote_plus(api_usocket_full_name)
         api_url = API_USOCKET_URL_PREFIX + url_encoded_path + "/"
 
         self._drive_cfg_url = api_url + self.DRIVE_CFG_RESOURCE
         self._api_session = api_session
-        self._firecracker_version = firecracker_version
 
     def put(self, **args):
         """Attach a block device or update the details of a previous one."""
-        # Default the io engine to Async on kernels > 5.10 so that we
-        # make sure to exercise both Sync and Async behaviour in the CI.
-        # Also check the FC version to make sure that it has support for
-        # configurable io_engine.
-        if (
-            is_io_uring_supported()
-            and compare_versions(self._firecracker_version, "0.25.0") > 0
-            and ("io_engine" not in args or args["io_engine"] is None)
-        ):
-            args["io_engine"] = "Async"
 
         datax = self.create_json(**args)
 


### PR DESCRIPTION



# Reason for This PR

We are right now defaulting to use Async (io_uring)
for any test that does not explicitly sets a device engine.

That can lead to regressions (performance or otherwise) getting
obfuscated for the Sync engine (which is actually the only drive
engine that is currently GA).

### OBS

I will post an ulterior PR with the peformance numbers updated for the snapshot and boottime tests since I think it is important to also have those numbers when testing with both Async and Sync.

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
