### PR TITLE
Add and update baselines inside snapshot resume latency CI test

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -15,7 +15,6 @@ from framework.utils import (
     eager_map,
     CpuMap,
     get_firecracker_version_from_toml,
-    compare_versions,
     get_kernel_version,
     is_io_uring_supported,
 )
@@ -92,15 +91,6 @@ def snapshot_create_measurements(vm_type, snapshot_type):
 def snapshot_resume_measurements(vm_type):
     """Define measurements for snapshot resume tests."""
     load_latency = LOAD_LATENCY_BASELINES[platform.machine()][vm_type]
-
-    if is_io_uring_supported():
-        # There is added latency caused by the io_uring syscalls used by the
-        # block device.
-        load_latency["target"] += 115
-    if compare_versions(get_kernel_version(), "5.4.0") > 0:
-        # Host kernels >= 5.4 add an up to ~30ms latency.
-        # See: https://github.com/firecracker-microvm/firecracker/issues/2129
-        load_latency["target"] += 30
 
     latency = types.MeasurementDef.create_measurement(
         "latency",

--- a/tools/devtool
+++ b/tools/devtool
@@ -1334,6 +1334,7 @@ cmd_shell() {
             --ulimit memlock=-1:-1 \
             --security-opt seccomp=unconfined \
             --workdir "$CTR_FC_ROOT_DIR" \
+            -v /boot:/boot \
             ${ramdisk_args} \
             -- \
             bash


### PR DESCRIPTION
# Reason for This PR

We recently went back to using Sync engine by default and that required us to re-gather baselines for the snapshot resume test on all platforms.

This should also solve the intermittent failures that we sometimes get on x86 for this test (i.e test_snapshot_resume_latency).

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
