### PR TITLE
Updated devctr-image.md

### DIFF
--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -29,6 +29,14 @@ registry. The Firecracker CI suite must also be updated to use the new image.
    | docker login --username AWS --password-stdin public.ecr.aws
     ```
 
+   For non-TTY devices, although not recommended a less secure approach can be
+   used:
+
+   ```bash
+   docker login --username AWS --password \
+   $(aws ecr-public get-login-password) public.ecr.aws
+   ```
+
 1. Navigate to the Firecracker directory. Verify that you have the latest
    container image locally.
 


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

# Reason for This PR

The currently suggested approach for logging into AWS for docker does not work with non-TTY devices.

## Description of Changes

Added approach which working alternative.

- [x] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The issue which led to this PR has a clear conclusion.
- [x] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
