### PR TITLE
Updated PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,10 @@
-# Reason for This PR
+## Changes
 
-`[Author TODO: add issue #.]`
-`[Open the PR after the related issue has a clear conclusion.]`
-`[If there is no issue which states the need for this PR, create one first.]`
-Fixes #
+...
 
-## Description of Changes
+## Reason
 
-`[Author TODO: add description of changes.]`
-
-- [ ] This functionality can be added in [`rust-vmm`][1].
+...
 
 ## License Acceptance
 
@@ -18,18 +13,18 @@ the terms of the Apache 2.0 license.
 
 ## PR Checklist
 
-`[Author TODO: Meet these criteria.]`
-`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`
-
 - [ ] All commits in this PR are signed (`git commit -s`).
-- [ ] The issue which led to this PR has a clear conclusion.
-- [ ] This PR follows the solution outlined in the related issue.
+- [ ] If a specific issue led to this PR, this PR closes the issue.
 - [ ] The description of changes is clear and encompassing.
 - [ ] Any required documentation changes (code and docs) are included in this PR.
-- [ ] Any newly added `unsafe` code is properly documented.
-- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
-- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
+- [ ] New `unsafe` code is documented.
+- [ ] API changes follow the [Runbook for Firecracker API changes][2].
+- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
 - [ ] All added/changed functionality is tested.
+
+---
+
+- [ ] This functionality can be added in [`rust-vmm`][1].
 
 [1]: https://github.com/rust-vmm
 [2]: ../docs/api-change-runbook.md


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

# Reason for This PR

The current PR template is old and rarely followed. An example being that most PRs do not have a preceding issue despite that the PR template prescribes this.

## Description of Changes

Changed the PR template.

- [ ] This functionality can be added in [`rust-vmm`][1].

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any API changes follow the [Runbook for Firecracker API changes][2].
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
