### PR TITLE
Snapshot-ga: Generate a MAC address if unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,19 @@
 
 - Added a new CLI option `--metrics-path PATH`. It accepts a file parameter
   where metrics will be sent to.
+- A MAC address is generated if one is not explicitly specified while adding
+  network interfaces. This address can be obtained as part of the GET
+  `/vm/config`.
 
 ### Fixed
 
 - Make the `T2` template more robust by explicitly disabling additional
   CPUID flags that should be off but were missed initially or that were
   not available in the spec when the template was created.
+- When MAC address was left unspecified, GET `/vm/config` would report the
+  interface MAC address incorrectly as `null`, and post snapshot restore as
+  `00:00:00:00:00:00`. It now correctly reports the code generated MAC address
+  when queried in both cases.
 
 ## [1.1.0]
 

--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -76,6 +76,10 @@ to your configuration file like this:
 Alternatively, if you are using firectl, add
 --tap-device=tap0/AA:FC:00:00:00:01` to your command line.
 
+*Note:* When `guest_mac` is not explicitely specified, a MAC address is generated
+and assigned to the network interface. This address is included in the result of
+GET `/vm/config`.
+
 ## In The Guest
 
 Once you have booted the guest, bring up networking within the guest:

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -298,7 +298,7 @@ pub fn default_guest_memory() -> GuestMemoryMmap {
 }
 
 pub fn set_mac(net: &mut Net, mac: MacAddr) {
-    net.guest_mac = Some(mac);
+    net.guest_mac = mac;
     net.config_space.guest_mac.copy_from_slice(mac.get_bytes());
 }
 

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -28,3 +28,32 @@ pub fn get_page_size() -> Result<usize, errno::Error> {
         ps => Ok(ps as usize),
     }
 }
+
+// The below fucntions will get merged in rust-vmm function once we will upstream it there
+fn xor_pseudo_rng_u8_bytes(rand_fn: &dyn Fn() -> u32) -> Vec<u8> {
+    let mut r = vec![];
+
+    for n in &rand_fn().to_ne_bytes() {
+        r.push(*n);
+    }
+    r
+}
+
+fn rand_bytes_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut done = 0;
+    loop {
+        for n in xor_pseudo_rng_u8_bytes(rand_fn) {
+            done += 1;
+            buf.push(n);
+            if done >= len {
+                return buf;
+            }
+        }
+    }
+}
+
+/// Get a pseudo random vector of length `len` with bytes.
+pub fn rand_bytes(len: usize) -> Vec<u8> {
+    rand_bytes_impl(&rand::xor_psuedo_rng_u32, len)
+}

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -526,6 +526,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 #[cfg(test)]
 mod tests {
     use devices::virtio::block::CacheType;
+    use utils::net::mac::MacAddr;
     use utils::tempfile::TempFile;
 
     use super::*;
@@ -695,7 +696,7 @@ mod tests {
             let network_interface = NetworkInterfaceConfig {
                 iface_id: String::from("netif"),
                 host_dev_name: String::from("hostname"),
-                guest_mac: None,
+                guest_mac: Some(MacAddr::parse_str("00:00:00:00:00:00").unwrap()),
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
             };

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -1076,11 +1076,13 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9"
+                            "host_dev_name": "hostname9",
+                            "guest_mac": "06:00:c0:00:32:de"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10"
+                            "host_dev_name": "hostname10",
+                            "guest_mac": "0a:00:20:00:a2:de"
                         }}
                     ],
                     "machine-config": {{
@@ -1151,11 +1153,13 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9"
+                            "host_dev_name": "hostname9",
+                            "guest_mac": "06:00:00:00:32:de"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10"
+                            "host_dev_name": "hostname10",
+                            "guest_mac": "06:00:00:00:a2:de"
                         }}
                     ],
                     "machine-config": {{
@@ -1210,11 +1214,13 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9"
+                            "host_dev_name": "hostname9",
+                            "guest_mac": "06:00:00:00:32:de"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10"
+                            "host_dev_name": "hostname10",
+                            "guest_mac": "06:00:00:00:a2:de"
                         }}
                     ],
                     "machine-config": {{

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -38,7 +38,7 @@ impl From<&Net> for NetworkInterfaceConfig {
         NetworkInterfaceConfig {
             iface_id: net.id().clone(),
             host_dev_name: net.iface_name(),
-            guest_mac: net.guest_mac().copied(),
+            guest_mac: Some(*net.guest_mac()),
             rx_rate_limiter: rx_rl.into_option(),
             tx_rate_limiter: tx_rl.into_option(),
         }
@@ -143,7 +143,7 @@ impl NetBuilder {
             let net = net.lock().expect("Poisoned lock");
             // Check if another net dev has same MAC.
             netif_config.guest_mac.is_some()
-                && netif_config.guest_mac.as_ref() == net.guest_mac()
+                && netif_config.guest_mac.as_ref().unwrap() == net.guest_mac()
                 && &netif_config.iface_id != net.id()
         };
         // Validate there is no Mac conflict.
@@ -407,6 +407,37 @@ mod tests {
                 .deref()
                 .id(),
             net_id
+        );
+    }
+
+    #[test]
+    fn test_mac_address_generation() {
+        let mut net_builder = NetBuilder::new();
+        let net_id = "test_id";
+        let host_dev_name = "dev";
+        let guest_mac = "00:00:00:00:00:00";
+
+        let net = Net::new_with_tap(
+            net_id.to_string(),
+            host_dev_name.to_string(),
+            None,
+            RateLimiter::default(),
+            RateLimiter::default(),
+        )
+        .unwrap();
+
+        net_builder.add_device(Arc::new(Mutex::new(net)));
+        assert_eq!(net_builder.net_devices.len(), 1);
+        assert_ne!(
+            net_builder
+                .net_devices
+                .pop()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .deref()
+                .guest_mac(),
+            MacAddr::parse_str(guest_mac).as_ref().unwrap()
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Vibha Acharya <vibharya@amazon.co.uk>

## Changes

Code to generate and assign a MAC address when it is not explicitly specified when a network interface is added.

## Reason

When MAC address is unspecified vm config reports it as null. Post restore it is reported as 00:00:00:00:00:00.
In reality the MAC address is assigned by the driver.

Related to: #2943 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
