### PR TITLE
Consuming linux-loader v0.7.0 for bugfix of the Cmdline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Fixed a self-DoS scenario in the virtio-queue code by reporting and
   terminating execution when the number of available descriptors reported
   by the driver is higher than the queue size.
+- Fixed the bad handling of kernel cmdline parameters when init arguments
+  where provided in the `boot_args` field of the JSON body of the
+  PUT `/boot-source` request.
 
 ## [1.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,11 +607,11 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
+checksum = "f8242360c7d79a7713a28043c994b815e9820b0e97e44b228ec9bd913c16bdfe"
 dependencies = [
- "vm-memory 0.8.0",
+ "vm-memory 0.9.0",
 ]
 
 [[package]]
@@ -1244,14 +1244,14 @@ version = "0.3.0"
 dependencies = [
  "libc",
  "utils",
- "vm-memory 0.8.0",
+ "vm-memory 0.9.0",
 ]
 
 [[package]]
 name = "vm-memory"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
+checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
 dependencies = [
  "libc",
  "winapi",

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::fmt::Debug;
 use std::result;
 
@@ -66,7 +67,7 @@ type Result<T> = result::Result<T, Error>;
 pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     vcpu_mpidr: Vec<u64>,
-    cmdline: &str,
+    cmdline: CString,
     device_info: &HashMap<(DeviceType, String), T, S>,
     gic_device: &dyn GICDevice,
     initrd: &Option<InitrdConfig>,
@@ -230,11 +231,16 @@ fn create_memory_node(fdt: &mut FdtWriter, guest_mem: &GuestMemoryMmap) -> Resul
 
 fn create_chosen_node(
     fdt: &mut FdtWriter,
-    cmdline: &str,
+    cmdline: CString,
     initrd: &Option<InitrdConfig>,
 ) -> Result<()> {
     let chosen = fdt.begin_node("chosen")?;
-    fdt.property_string("bootargs", cmdline)?;
+    // Workaround to be able to reuse an existing property_*() method; in property_string() method,
+    // the cmdline is reconverted to a CString to be written in memory as a null terminated string.
+    let cmdline_string = cmdline
+        .into_string()
+        .map_err(|_| vm_fdt::Error::InvalidString)?;
+    fdt.property_string("bootargs", cmdline_string.as_str())?;
 
     if let Some(initrd_config) = initrd {
         fdt.property_u64(
@@ -415,6 +421,8 @@ fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildH
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
+
     use kvm_ioctls::Kvm;
 
     use super::*;
@@ -481,7 +489,7 @@ mod tests {
         assert!(create_fdt(
             &mem,
             vec![0],
-            "console=tty0",
+            CString::new("console=tty0").unwrap(),
             &dev_info,
             gic.as_ref(),
             &None,
@@ -507,7 +515,7 @@ mod tests {
         let current_dtb_bytes = create_fdt(
             &mem,
             vec![0],
-            "console=tty0",
+            CString::new("console=tty0").unwrap(),
             &HashMap::<(DeviceType, std::string::String), MMIODeviceInfo>::new(),
             gic.as_ref(),
             &None,
@@ -570,7 +578,7 @@ mod tests {
         let current_dtb_bytes = create_fdt(
             &mem,
             vec![0],
-            "console=tty0",
+            CString::new("console=tty0").unwrap(),
             &HashMap::<(DeviceType, std::string::String), MMIODeviceInfo>::new(),
             gic.as_ref(),
             &Some(initrd),

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -12,6 +12,7 @@ pub mod regs;
 
 use std::cmp::min;
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::fmt::Debug;
 
 use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
@@ -54,7 +55,7 @@ pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
 /// * `initrd` - Information about an optional initrd.
 pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug, S: std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
-    cmdline_cstring: &str,
+    cmdline_cstring: CString,
     vcpu_mpidr: Vec<u64>,
     device_info: &HashMap<(DeviceType, String), T, S>,
     gic_device: &dyn GICDevice,

--- a/src/vm-memory/Cargo.toml
+++ b/src/vm-memory/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 libc = ">=0.2.80"
-vm-memory-upstream = { package = "vm-memory",  version = ">=0.7.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory-upstream = { package = "vm-memory",  version = ">=0.9.0", features = ["backend-mmap", "backend-bitmap"] }
 
 utils = { path = "../utils" }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -594,7 +594,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
         #[cfg(target_arch = "x86_64")]
         assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
@@ -623,7 +623,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         #[cfg(target_arch = "x86_64")]
         assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
         #[cfg(target_arch = "aarch64")]
@@ -722,7 +722,7 @@ mod tests {
             (arch::IRQ_BASE, arch::IRQ_MAX),
         )
         .unwrap();
-        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096).unwrap();
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
 
         let type_id = dummy.lock().unwrap().device_type();

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -118,6 +118,10 @@ pub const HTTP_MAX_PAYLOAD_SIZE: usize = 51200;
 /// have permissions to open the KVM fd).
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[cfg(target_arch = "aarch64")]
+    #[error("Invalid cmdline")]
+    /// Invalid command line error.
+    Cmdline,
     /// Legacy devices work with Event file descriptors and the creation can fail because
     /// of resource exhaustion.
     #[cfg(target_arch = "x86_64")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -565,8 +565,8 @@ mod tests {
     }
 
     fn default_boot_cfg() -> BootSource {
-        let mut kernel_cmdline = linux_loader::cmdline::Cmdline::new(4096);
-        kernel_cmdline.insert_str(DEFAULT_KERNEL_CMDLINE).unwrap();
+        let kernel_cmdline =
+            linux_loader::cmdline::Cmdline::try_from(DEFAULT_KERNEL_CMDLINE, 4096).unwrap();
         let tmp_file = TempFile::new().unwrap();
         BootSource {
             config: BootSourceConfig::default(),
@@ -594,7 +594,7 @@ mod tests {
 
     impl PartialEq for BootConfig {
         fn eq(&self, other: &Self) -> bool {
-            self.cmdline.as_str().eq(other.cmdline.as_str())
+            self.cmdline.eq(&other.cmdline)
                 && self.kernel_file.metadata().unwrap().st_ino()
                     == other.kernel_file.metadata().unwrap().st_ino()
                 && self
@@ -1397,7 +1397,14 @@ mod tests {
         let boot_builder = vm_resources.boot_source_builder().unwrap();
         let tmp_ino = tmp_file.as_file().metadata().unwrap().st_ino();
 
-        assert_ne!(boot_builder.cmdline.as_str(), cmdline);
+        assert_ne!(
+            boot_builder
+                .cmdline
+                .as_cstring()
+                .unwrap()
+                .as_bytes_with_nul(),
+            [cmdline.as_bytes(), &[b'\0']].concat()
+        );
         assert_ne!(
             boot_builder.kernel_file.metadata().unwrap().st_ino(),
             tmp_ino
@@ -1415,7 +1422,14 @@ mod tests {
 
         vm_resources.build_boot_source(expected_boot_cfg).unwrap();
         let boot_source_builder = vm_resources.boot_source_builder().unwrap();
-        assert_eq!(boot_source_builder.cmdline.as_str(), cmdline);
+        assert_eq!(
+            boot_source_builder
+                .cmdline
+                .as_cstring()
+                .unwrap()
+                .as_bytes_with_nul(),
+            [cmdline.as_bytes(), &[b'\0']].concat()
+        );
         assert_eq!(
             boot_source_builder.kernel_file.metadata().unwrap().st_ino(),
             tmp_ino

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -98,13 +98,12 @@ impl BootConfig {
             Some(path) => Some(File::open(path).map_err(InvalidInitrdPath)?),
             None => None,
         };
-        let mut cmdline = linux_loader::cmdline::Cmdline::new(arch::CMDLINE_MAX_SIZE);
-        let boot_args = match cfg.boot_args.as_ref() {
+
+        let cmdline_str = match cfg.boot_args.as_ref() {
             None => DEFAULT_KERNEL_CMDLINE,
             Some(str) => str.as_str(),
         };
-        cmdline
-            .insert_str(boot_args)
+        let cmdline = linux_loader::cmdline::Cmdline::try_from(cmdline_str, arch::CMDLINE_MAX_SIZE)
             .map_err(|err| InvalidKernelCommandLine(err.to_string()))?;
 
         Ok(BootConfig {
@@ -134,6 +133,9 @@ pub(crate) mod tests {
 
         let boot_cfg = BootConfig::new(&boot_src_cfg).unwrap();
         assert!(boot_cfg.initrd_file.is_none());
-        assert_eq!(boot_cfg.cmdline.as_str(), DEFAULT_KERNEL_CMDLINE);
+        assert_eq!(
+            boot_cfg.cmdline.as_cstring().unwrap().as_bytes_with_nul(),
+            [DEFAULT_KERNEL_CMDLINE.as_bytes(), &[b'\0']].concat()
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Traistaru Andrei Cristian <atc@amazon.com>

## Changes

This PR contains code changes done for the integration of the new Cmdline parser implemented
in rust-vmm/linux-loader v0.7.0. The new version of the Cmdline struct allows better kernel
parameters handling (supporting both boot args and init args), catching some corner cases that
we currently do not handle properly. 

## Reason

The PR should fix [this bug](https://github.com/firecracker-microvm/firecracker/issues/3023).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
