### PR TITLE
[perf] baselines update for net latency Intel 5.10

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -89,8 +89,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.249,
-                                                    "delta_percentage": 2.1
+                                                    "target": 0.255,
+                                                    "delta_percentage": 4.1
                                                 }
                                             }
                                         }
@@ -101,7 +101,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "target": 0.262,
+                                                    "target": 0.267,
                                                     "delta_percentage": 4.1
                                                 }
                                             }


### PR DESCRIPTION
Signed-off-by: Diana Popa <dpopa@amazon.com>

## Changes

* updated net latency on Intel 5.10

## Reason

* baselines on 8175M processor (Skylake) have suffered some changes most probably after the RetBleed update

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
