### PR TITLE
[perf] new baselines for block on 4.14 ARM

### DIFF
--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -1061,39 +1061,39 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 87066,
+                                                    "target": 87094,
                                                     "delta_percentage": 7
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 180900,
-                                                    "delta_percentage": 7
+                                                    "target": 180141,
+                                                    "delta_percentage": 8
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 184847,
-                                                    "delta_percentage": 7
+                                                    "target": 183796,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 89263,
-                                                    "delta_percentage": 7
+                                                    "target": 89049,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 152170,
-                                                    "delta_percentage": 9
+                                                    "target": 152018,
+                                                    "delta_percentage": 8
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 313370,
+                                                    "target": 313200,
                                                     "delta_percentage": 8
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 323835,
-                                                    "delta_percentage": 10
+                                                    "target": 322555,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 156124,
+                                                    "target": 156603,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -1105,40 +1105,40 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 68422,
-                                                    "delta_percentage": 7
+                                                    "target": 72060,
+                                                    "delta_percentage": 11
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 140436,
-                                                    "delta_percentage": 8
+                                                    "target": 154839,
+                                                    "delta_percentage": 14
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 166154,
-                                                    "delta_percentage": 13
+                                                    "target": 174797,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 78361,
-                                                    "delta_percentage": 13
+                                                    "target": 82701,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 151429,
-                                                    "delta_percentage": 7
+                                                    "target": 153409,
+                                                    "delta_percentage": 14
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 296909,
-                                                    "delta_percentage": 20
+                                                    "target": 297954,
+                                                    "delta_percentage": 26
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 347983,
-                                                    "delta_percentage": 17
+                                                    "target": 361602,
+                                                    "delta_percentage": 7
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 167420,
-                                                    "delta_percentage": 11
+                                                    "target": 172523,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1151,23 +1151,23 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 87061,
+                                                    "target": 87097,
                                                     "delta_percentage": 7
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 89260,
-                                                    "delta_percentage": 7
+                                                    "target": 89051,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 152166,
-                                                    "delta_percentage": 9
+                                                    "target": 152021,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 156120,
+                                                    "target": 156596,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -1179,24 +1179,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 68424,
-                                                    "delta_percentage": 7
+                                                    "target": 72065,
+                                                    "delta_percentage": 11
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 78363,
-                                                    "delta_percentage": 13
+                                                    "target": 82696,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 151451,
-                                                    "delta_percentage": 7
+                                                    "target": 153407,
+                                                    "delta_percentage": 14
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 167405,
-                                                    "delta_percentage": 11
+                                                    "target": 172514,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1209,39 +1209,39 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 348262,
+                                                    "target": 348376,
                                                     "delta_percentage": 7
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 723600,
-                                                    "delta_percentage": 7
+                                                    "target": 720562,
+                                                    "delta_percentage": 8
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 739385,
-                                                    "delta_percentage": 7
+                                                    "target": 735183,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 357049,
-                                                    "delta_percentage": 7
+                                                    "target": 356193,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 608680,
-                                                    "delta_percentage": 9
+                                                    "target": 608073,
+                                                    "delta_percentage": 8
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 1253480,
+                                                    "target": 1252800,
                                                     "delta_percentage": 8
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 1295339,
-                                                    "delta_percentage": 10
+                                                    "target": 1290221,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 624496,
+                                                    "target": 626412,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -1253,40 +1253,40 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 273685,
-                                                    "delta_percentage": 7
+                                                    "target": 288238,
+                                                    "delta_percentage": 11
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 561744,
-                                                    "delta_percentage": 8
+                                                    "target": 619355,
+                                                    "delta_percentage": 14
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 664614,
-                                                    "delta_percentage": 13
+                                                    "target": 699185,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 313444,
-                                                    "delta_percentage": 13
+                                                    "target": 330802,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 605715,
-                                                    "delta_percentage": 7
+                                                    "target": 613636,
+                                                    "delta_percentage": 14
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 1187633,
-                                                    "delta_percentage": 20
+                                                    "target": 1191813,
+                                                    "delta_percentage": 26
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 1391929,
-                                                    "delta_percentage": 17
+                                                    "target": 1446408,
+                                                    "delta_percentage": 7
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 669679,
-                                                    "delta_percentage": 11
+                                                    "target": 690093,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1299,23 +1299,23 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 348244,
+                                                    "target": 348388,
                                                     "delta_percentage": 7
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 357037,
-                                                    "delta_percentage": 7
+                                                    "target": 356202,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 608663,
-                                                    "delta_percentage": 9
+                                                    "target": 608084,
+                                                    "delta_percentage": 8
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 624481,
+                                                    "target": 626382,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -1327,24 +1327,24 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 273693,
-                                                    "delta_percentage": 7
+                                                    "target": 288260,
+                                                    "delta_percentage": 11
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 313452,
-                                                    "delta_percentage": 13
+                                                    "target": 330784,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 605804,
-                                                    "delta_percentage": 7
+                                                    "target": 613626,
+                                                    "delta_percentage": 14
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 669618,
-                                                    "delta_percentage": 11
+                                                    "target": 690055,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1447,20 +1447,20 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 59,
-                                                    "delta_percentage": 8
+                                                    "target": 58,
+                                                    "delta_percentage": 9
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 60,
+                                                    "target": 59,
                                                     "delta_percentage": 9
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 58,
-                                                    "delta_percentage": 8
+                                                    "target": 57,
+                                                    "delta_percentage": 9
                                                 },
                                                 "readwrite-bs4096": {
                                                     "target": 57,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
@@ -1491,39 +1491,39 @@
                                         "sync_1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 50,
-                                                    "delta_percentage": 6
+                                                    "target": 51,
+                                                    "delta_percentage": 9
                                                 },
                                                 "randread-bs4096": {
-                                                    "target": 51,
-                                                    "delta_percentage": 7
+                                                    "target": 52,
+                                                    "delta_percentage": 10
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 54,
-                                                    "delta_percentage": 9
+                                                    "target": 55,
+                                                    "delta_percentage": 7
                                                 },
                                                 "readwrite-bs4096": {
                                                     "target": 53,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "sync_2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "randrw-bs4096": {
-                                                    "target": 72,
-                                                    "delta_percentage": 7
+                                                    "target": 71,
+                                                    "delta_percentage": 10
                                                 },
                                                 "randread-bs4096": {
                                                     "target": 70,
-                                                    "delta_percentage": 13
+                                                    "delta_percentage": 14
                                                 },
                                                 "read-bs4096": {
-                                                    "target": 73,
-                                                    "delta_percentage": 9
+                                                    "target": 74,
+                                                    "delta_percentage": 5
                                                 },
                                                 "readwrite-bs4096": {
-                                                    "target": 72,
+                                                    "target": 73,
                                                     "delta_percentage": 6
                                                 }
                                             }


### PR DESCRIPTION
## Changes

* update block perf baselines for ARM

## Reason

* failures in nightly long run

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
