### PR TITLE
[CI][perf] update vsock baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -521,68 +521,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6793,
-                                                    "delta_percentage": 7
+                                                    "target": 6780,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6872,
-                                                    "delta_percentage": 6
+                                                    "target": 6883,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2289,
-                                                    "delta_percentage": 10
+                                                    "target": 2271,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4631,
-                                                    "delta_percentage": 7
+                                                    "target": 4616,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4555,
-                                                    "delta_percentage": 7
+                                                    "target": 4507,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1755,
-                                                    "delta_percentage": 9
+                                                    "target": 1753,
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 7507,
-                                                    "delta_percentage": 5
+                                                    "target": 7440,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 7524,
+                                                    "target": 7386,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2911,
-                                                    "delta_percentage": 5
+                                                    "target": 2860,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5541,
+                                                    "target": 5543,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5460,
+                                                    "target": 5459,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2229,
-                                                    "delta_percentage": 11
+                                                    "target": 2271,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 5260,
-                                                    "delta_percentage": 6
+                                                    "target": 5243,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 5231,
-                                                    "delta_percentage": 5
+                                                    "target": 5192,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 1924,
-                                                    "delta_percentage": 14
+                                                    "target": 1950,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         }
@@ -593,68 +593,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 12079,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 12238,
+                                                    "target": 12119,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 12271,
+                                                    "delta_percentage": 5
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2450,
-                                                    "delta_percentage": 8
+                                                    "target": 2440,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4737,
-                                                    "delta_percentage": 8
+                                                    "target": 4707,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4604,
-                                                    "delta_percentage": 7
+                                                    "target": 4569,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2135,
-                                                    "delta_percentage": 7
+                                                    "target": 2128,
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 16391,
+                                                    "target": 16409,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 16607,
+                                                    "target": 16679,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2926,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 5643,
+                                                    "target": 2902,
                                                     "delta_percentage": 6
                                                 },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 5425,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 2965,
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 5639,
                                                     "delta_percentage": 5
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5456,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2948,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 5508,
+                                                    "target": 5492,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 5468,
-                                                    "delta_percentage": 7
+                                                    "target": 5459,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2357,
-                                                    "delta_percentage": 7
+                                                    "target": 2369,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -671,24 +671,24 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 98,
+                                                    "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 98,
-                                                    "delta_percentage": 5
+                                                    "target": 99,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
@@ -696,19 +696,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 198,
-                                                    "delta_percentage": 4
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 197,
-                                                    "delta_percentage": 6
+                                                    "target": 198,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 6
+                                                    "target": 84,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 129,
-                                                    "delta_percentage": 5
+                                                    "target": 128,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 129,
@@ -720,7 +720,7 @@
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 118,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 119,
@@ -728,7 +728,7 @@
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 198,
-                                                    "delta_percentage": 4
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -740,19 +740,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
@@ -760,14 +760,14 @@
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 4
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -775,32 +775,32 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 78,
-                                                    "delta_percentage": 12
+                                                    "target": 79,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 118,
-                                                    "delta_percentage": 7
+                                                    "target": 117,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 118,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 151,
-                                                    "delta_percentage": 5
+                                                    "target": 152,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 105,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 106,
-                                                    "delta_percentage": 7
+                                                    "target": 105,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 119,
-                                                    "delta_percentage": 25
+                                                    "target": 123,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         }
@@ -813,27 +813,27 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 51,
-                                                    "delta_percentage": 11
+                                                    "target": 52,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 52,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 50,
-                                                    "delta_percentage": 7
+                                                    "target": 51,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 61,
-                                                    "delta_percentage": 6
+                                                    "target": 62,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 61,
-                                                    "delta_percentage": 7
+                                                    "target": 62,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 46,
+                                                    "target": 45,
                                                     "delta_percentage": 9
                                                 }
                                             }
@@ -841,7 +841,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 64,
+                                                    "target": 65,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -854,27 +854,27 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 77,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 77,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 65,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 64,
+                                                    "target": 65,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 64,
-                                                    "delta_percentage": 6
+                                                    "target": 65,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 68,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 }
                                             }
                                         }
@@ -885,28 +885,28 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 40,
+                                                    "target": 39,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 40,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 52,
-                                                    "delta_percentage": 7
+                                                    "target": 53,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 64,
-                                                    "delta_percentage": 6
+                                                    "target": 63,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 63,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 47,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
@@ -914,39 +914,39 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 46,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 46,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 69,
-                                                    "delta_percentage": 9
+                                                    "target": 70,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 69,
-                                                    "delta_percentage": 7
+                                                    "target": 70,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 70,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 61,
+                                                    "target": 62,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 63,
-                                                    "delta_percentage": 9
+                                                    "target": 62,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 61,
+                                                    "target": 62,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 52,
-                                                    "delta_percentage": 16
+                                                    "target": 54,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         }
@@ -968,27 +968,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6751,
+                                                    "target": 6739,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6756,
+                                                    "target": 6748,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2062,
-                                                    "delta_percentage": 9
+                                                    "target": 2064,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5278,
+                                                    "target": 5392,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5165,
-                                                    "delta_percentage": 6
+                                                    "target": 5267,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1680,
+                                                    "target": 1672,
                                                     "delta_percentage": 6
                                                 }
                                             }
@@ -996,40 +996,40 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6533,
+                                                    "target": 6517,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6543,
+                                                    "target": 6526,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2537,
-                                                    "delta_percentage": 12
+                                                    "target": 2558,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 7216,
-                                                    "delta_percentage": 6
+                                                    "target": 7079,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 7132,
-                                                    "delta_percentage": 5
+                                                    "target": 7114,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 3178,
+                                                    "target": 3167,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6087,
-                                                    "delta_percentage": 6
+                                                    "target": 6052,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6312,
-                                                    "delta_percentage": 5
+                                                    "target": 6293,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3385,
-                                                    "delta_percentage": 5
+                                                    "target": 3410,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -1040,67 +1040,67 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 14630,
+                                                    "target": 14636,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 14646,
+                                                    "target": 14624,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 1798,
-                                                    "delta_percentage": 18
+                                                    "target": 1866,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5269,
-                                                    "delta_percentage": 5
+                                                    "target": 5353,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5193,
-                                                    "delta_percentage": 5
+                                                    "target": 5276,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2534,
-                                                    "delta_percentage": 6
+                                                    "target": 2543,
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 18595,
-                                                    "delta_percentage": 5
+                                                    "target": 18777,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 18651,
+                                                    "target": 18658,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2837,
-                                                    "delta_percentage": 6
+                                                    "target": 2862,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 7663,
+                                                    "target": 7747,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 7515,
+                                                    "target": 7611,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 4254,
+                                                    "target": 4268,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 8061,
-                                                    "delta_percentage": 10
+                                                    "target": 8028,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 8281,
-                                                    "delta_percentage": 10
+                                                    "target": 8249,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3790,
+                                                    "target": 3836,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -1162,8 +1162,8 @@
                                                     "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 192,
-                                                    "delta_percentage": 8
+                                                    "target": 190,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 200,
@@ -1195,7 +1195,7 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 100,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 100,
@@ -1227,7 +1227,7 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 200,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 200,
@@ -1265,11 +1265,11 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 58,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 62,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 79,
@@ -1277,10 +1277,10 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 79,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 58,
+                                                    "target": 57,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -1289,39 +1289,39 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 71,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 70,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 75,
-                                                    "delta_percentage": 8
+                                                    "target": 74,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 84,
-                                                    "delta_percentage": 6
+                                                    "target": 85,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 85,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 83,
+                                                    "target": 82,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 81,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 82,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 91,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -1332,12 +1332,12 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 54,
-                                                    "delta_percentage": 9
+                                                    "target": 55,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 55,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 60,
@@ -1345,15 +1345,15 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 77,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 77,
+                                                    "target": 78,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 59,
-                                                    "delta_percentage": 7
+                                                    "target": 60,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
@@ -1361,7 +1361,7 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 59,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 59,
@@ -1373,18 +1373,18 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 84,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 84,
+                                                    "target": 85,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 87,
+                                                    "target": 88,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 78,
+                                                    "target": 77,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1392,7 +1392,7 @@
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 88,
+                                                    "target": 89,
                                                     "delta_percentage": 7
                                                 }
                                             }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -78,68 +78,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6763,
-                                                    "delta_percentage": 5
+                                                    "target": 6749,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6777,
+                                                    "target": 6801,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2157,
-                                                    "delta_percentage": 6
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 5167,
+                                                    "target": 2143,
                                                     "delta_percentage": 7
                                                 },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 5228,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5036,
+                                                    "target": 5101,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 1791,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 7174,
-                                                    "delta_percentage": 8
+                                                    "target": 7171,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 7195,
-                                                    "delta_percentage": 8
+                                                    "target": 7187,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2771,
-                                                    "delta_percentage": 8
+                                                    "target": 2801,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5851,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 5788,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 2539,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-p1024K-bd": {
-                                                    "target": 5779,
+                                                    "target": 5858,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5798,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2565,
+                                                    "delta_percentage": 4
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 5789,
+                                                    "delta_percentage": 5
+                                                },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 5718,
+                                                    "target": 5738,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2534,
-                                                    "delta_percentage": 10
+                                                    "target": 2605,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -150,27 +150,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 12255,
+                                                    "target": 12281,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 12380,
+                                                    "target": 12381,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2324,
-                                                    "delta_percentage": 5
+                                                    "target": 2317,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5301,
-                                                    "delta_percentage": 5
+                                                    "target": 5321,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5125,
+                                                    "target": 5163,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2185,
+                                                    "target": 2194,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -178,40 +178,40 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 16338,
-                                                    "delta_percentage": 4
+                                                    "target": 16467,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 16511,
-                                                    "delta_percentage": 5
+                                                    "target": 16736,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 2762,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 6076,
-                                                    "delta_percentage": 6
+                                                    "target": 6110,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5876,
-                                                    "delta_percentage": 6
+                                                    "target": 5902,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2674,
-                                                    "delta_percentage": 6
+                                                    "target": 2665,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6070,
-                                                    "delta_percentage": 7
+                                                    "target": 6110,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6027,
-                                                    "delta_percentage": 7
+                                                    "target": 6057,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2759,
-                                                    "delta_percentage": 6
+                                                    "target": 2797,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -225,11 +225,11 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
@@ -256,36 +256,36 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 89,
+                                                    "target": 91,
                                                     "delta_percentage": 13
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 131,
-                                                    "delta_percentage": 8
+                                                    "target": 133,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 133,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 178,
-                                                    "delta_percentage": 7
+                                                    "target": 177,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 121,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 122,
-                                                    "delta_percentage": 6
+                                                    "target": 121,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 196,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -329,18 +329,18 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 198,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 81,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 120,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 83,
+                                                    "delta_percentage": 13
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 119,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 120,
+                                                    "target": 119,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -352,11 +352,11 @@
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 106,
-                                                    "delta_percentage": 5
+                                                    "target": 105,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 140,
+                                                    "target": 141,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -370,20 +370,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 53,
-                                                    "delta_percentage": 8
+                                                    "target": 54,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 54,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 54,
-                                                    "delta_percentage": 8
+                                                    "target": 55,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 7
+                                                    "target": 61,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 60,
@@ -391,7 +391,7 @@
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 48,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
@@ -402,35 +402,35 @@
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 66,
-                                                    "delta_percentage": 10
+                                                    "target": 67,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 75,
-                                                    "delta_percentage": 7
+                                                    "target": 76,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 78,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 77,
-                                                    "delta_percentage": 10
+                                                    "target": 78,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 68,
-                                                    "delta_percentage": 6
+                                                    "target": 69,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 63,
+                                                    "target": 64,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 64,
-                                                    "delta_percentage": 6
+                                                    "target": 65,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 74,
+                                                    "target": 75,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -446,20 +446,20 @@
                                                     "delta_percentage": 10
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 41,
-                                                    "delta_percentage": 11
+                                                    "target": 42,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 56,
-                                                    "delta_percentage": 8
+                                                    "target": 57,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 61,
+                                                    "target": 62,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 62,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 50,
@@ -471,39 +471,39 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 49,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 49,
-                                                    "delta_percentage": 12
+                                                    "target": 50,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 75,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 68,
+                                                    "target": 76,
                                                     "delta_percentage": 8
                                                 },
-                                                "vsock-pDEFAULT-h2g": {
+                                                "vsock-p1024K-h2g": {
                                                     "target": 69,
                                                     "delta_percentage": 7
                                                 },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 60,
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 69,
                                                     "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 61,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 60,
-                                                    "delta_percentage": 6
+                                                    "target": 61,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 67,
-                                                    "delta_percentage": 8
+                                                    "target": 69,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         }
@@ -521,68 +521,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 5710,
+                                                    "target": 5403,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 5716,
+                                                    "target": 5459,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 1105,
-                                                    "delta_percentage": 29
+                                                    "target": 1380,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 3983,
+                                                    "target": 3450,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 3888,
+                                                    "target": 3375,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 303,
-                                                    "delta_percentage": 13
+                                                    "target": 799,
+                                                    "delta_percentage": 32
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6429,
-                                                    "delta_percentage": 6
+                                                    "target": 6179,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6425,
-                                                    "delta_percentage": 6
+                                                    "target": 6208,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2340,
-                                                    "delta_percentage": 8
+                                                    "target": 2138,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4678,
-                                                    "delta_percentage": 6
+                                                    "target": 4262,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4618,
+                                                    "target": 4177,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1659,
-                                                    "delta_percentage": 10
+                                                    "target": 1616,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 4434,
-                                                    "delta_percentage": 6
+                                                    "target": 3885,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 4414,
-                                                    "delta_percentage": 6
+                                                    "target": 3863,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 1351,
-                                                    "delta_percentage": 9
+                                                    "target": 1413,
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -593,68 +593,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 10707,
-                                                    "delta_percentage": 6
+                                                    "target": 10422,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 11093,
+                                                    "target": 10744,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 1631,
-                                                    "delta_percentage": 6
+                                                    "target": 1544,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4077,
+                                                    "target": 3519,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 3933,
-                                                    "delta_percentage": 6
+                                                    "target": 3409,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1394,
-                                                    "delta_percentage": 5
+                                                    "target": 1335,
+                                                    "delta_percentage": 4
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 15917,
+                                                    "target": 15511,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 15886,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 2395,
+                                                    "target": 15605,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2350,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4785,
+                                                    "target": 4209,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4631,
-                                                    "delta_percentage": 6
+                                                    "target": 4066,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2158,
-                                                    "delta_percentage": 5
+                                                    "target": 1950,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 4722,
-                                                    "delta_percentage": 5
+                                                    "target": 4116,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 4667,
+                                                    "target": 4090,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 1597,
-                                                    "delta_percentage": 5
+                                                    "target": 1576,
+                                                    "delta_percentage": 7
                                                 }
                                             }
                                         }
@@ -672,7 +672,7 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
@@ -684,7 +684,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
@@ -695,40 +695,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 197,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 117,
-                                                    "delta_percentage": 14
+                                                    "target": 97,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 126,
+                                                    "target": 123,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 126,
-                                                    "delta_percentage": 7
+                                                    "target": 123,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 182,
+                                                    "target": 180,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 116,
-                                                    "delta_percentage": 7
+                                                    "target": 115,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 118,
-                                                    "delta_percentage": 6
+                                                    "target": 115,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 198,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -740,7 +740,7 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
@@ -748,15 +748,15 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 99,
-                                                    "delta_percentage": 6
+                                                    "target": 100,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
@@ -767,40 +767,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 198,
-                                                    "delta_percentage": 6
+                                                    "target": 197,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 106,
-                                                    "delta_percentage": 10
+                                                    "target": 107,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 116,
-                                                    "delta_percentage": 6
+                                                    "target": 113,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 116,
+                                                    "target": 114,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 162,
-                                                    "delta_percentage": 7
+                                                    "target": 163,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 105,
-                                                    "delta_percentage": 6
+                                                    "target": 104,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 105,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 136,
-                                                    "delta_percentage": 7
+                                                    "target": 135,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -813,67 +813,67 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 54,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 54,
+                                                    "target": 56,
                                                     "delta_percentage": 10
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 57,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 48,
-                                                    "delta_percentage": 9
+                                                    "target": 52,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 66,
-                                                    "delta_percentage": 8
+                                                    "target": 69,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 65,
+                                                    "target": 68,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 33,
-                                                    "delta_percentage": 13
+                                                    "target": 38,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 65,
-                                                    "delta_percentage": 9
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 65,
+                                                    "target": 66,
                                                     "delta_percentage": 7
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 66,
+                                                    "delta_percentage": 8
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 73,
-                                                    "delta_percentage": 10
+                                                    "target": 72,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 80,
-                                                    "delta_percentage": 8
+                                                    "target": 79,
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 80,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 8
+                                                    "target": 62,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 69,
-                                                    "delta_percentage": 8
+                                                    "target": 71,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 69,
-                                                    "delta_percentage": 8
+                                                    "target": 72,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 67,
+                                                    "target": 72,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -885,68 +885,68 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 39,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 42,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 51,
-                                                    "delta_percentage": 9
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 68,
+                                                    "target": 41,
                                                     "delta_percentage": 8
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 43,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 54,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 70,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 67,
-                                                    "delta_percentage": 10
+                                                    "target": 69,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 39,
-                                                    "delta_percentage": 12
+                                                    "target": 42,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 53,
-                                                    "delta_percentage": 11
+                                                    "target": 55,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 53,
-                                                    "delta_percentage": 9
+                                                    "target": 56,
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 74,
-                                                    "delta_percentage": 8
+                                                    "target": 77,
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 74,
-                                                    "delta_percentage": 8
+                                                    "target": 76,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 74,
-                                                    "delta_percentage": 7
+                                                    "target": 75,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 59,
-                                                    "delta_percentage": 10
+                                                    "target": 60,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 67,
+                                                    "target": 70,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 66,
+                                                    "target": 68,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 56,
-                                                    "delta_percentage": 11
+                                                    "target": 59,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -968,27 +968,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6309,
+                                                    "target": 6300,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6317,
+                                                    "target": 6321,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2132,
+                                                    "target": 2136,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5841,
-                                                    "delta_percentage": 5
+                                                    "target": 5814,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5648,
-                                                    "delta_percentage": 5
+                                                    "target": 5615,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1569,
+                                                    "target": 1558,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -996,39 +996,39 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
+                                                    "target": 6424,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
                                                     "target": 6433,
                                                     "delta_percentage": 7
                                                 },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 6452,
-                                                    "delta_percentage": 6
-                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2463,
-                                                    "delta_percentage": 10
+                                                    "target": 2485,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5485,
+                                                    "target": 5400,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5541,
-                                                    "delta_percentage": 9
+                                                    "target": 5474,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2891,
+                                                    "target": 2881,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6028,
+                                                    "target": 5974,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6066,
+                                                    "target": 6011,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3174,
+                                                    "target": 3168,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -1040,27 +1040,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 13558,
-                                                    "delta_percentage": 6
+                                                    "target": 13652,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 13595,
-                                                    "delta_percentage": 8
+                                                    "target": 13600,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2055,
+                                                    "target": 2077,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5820,
+                                                    "target": 5811,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5570,
+                                                    "target": 5556,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2314,
+                                                    "target": 2318,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -1068,39 +1068,39 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 17340,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 17334,
+                                                    "target": 17240,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 17363,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2749,
-                                                    "delta_percentage": 8
+                                                    "target": 2803,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 6064,
-                                                    "delta_percentage": 5
+                                                    "target": 6027,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 6001,
+                                                    "target": 5967,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 3731,
-                                                    "delta_percentage": 6
+                                                    "target": 3736,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6740,
+                                                    "target": 6708,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6721,
-                                                    "delta_percentage": 5
+                                                    "target": 6707,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3526,
+                                                    "target": 3537,
                                                     "delta_percentage": 6
                                                 }
                                             }
@@ -1114,7 +1114,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 100,
+                                                    "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1150,7 +1150,7 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -1158,7 +1158,7 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -1166,7 +1166,7 @@
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1175,7 +1175,7 @@
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 198,
-                                                    "delta_percentage": 4
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -1187,7 +1187,7 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
@@ -1214,20 +1214,20 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 197,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
-                                                "vsock-p1024-g2h": {
+                                                "vsock-pDEFAULT-g2h": {
                                                     "target": 197,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 197,
-                                                    "delta_percentage": 4
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 197,
@@ -1247,7 +1247,7 @@
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 197,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         }
@@ -1268,20 +1268,20 @@
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 64,
-                                                    "delta_percentage": 8
+                                                    "target": 63,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 79,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 79,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 64,
-                                                    "delta_percentage": 10
+                                                    "target": 63,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
@@ -1289,27 +1289,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 71,
-                                                    "delta_percentage": 11
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 71,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 77,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 99,
+                                                    "target": 98,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 91,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 87,
@@ -1321,7 +1321,7 @@
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -1333,19 +1333,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 56,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 56,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 63,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 79,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 79,
@@ -1361,19 +1361,19 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 60,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 60,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 83,
-                                                    "delta_percentage": 6
+                                                    "target": 82,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 86,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 87,
@@ -1381,14 +1381,14 @@
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 79,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 79,
+                                                    "target": 80,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {


### PR DESCRIPTION
## Changes

Updating performance baselines for vsock

## Reason

Multiple failures in vsock performance tests with varying performance

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
