### PR TITLE
Fixes to allow using ramdisk to run tests

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -1251,7 +1251,7 @@ cmd_test() {
 
     if [[ $ramdisk = true ]]; then
         mount_ramdisk ${ramdisk_size}
-        ramdisk_args="--volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
+        ramdisk_args="--env TMPDIR=${DEFAULT_TEST_SESSION_ROOT_PATH}/tmp --volume ${DEFAULT_RAMDISK_PATH}:${DEFAULT_TEST_SESSION_ROOT_PATH}"
     fi
 
     # Testing (running Firecracker via the jailer) needs root access,

--- a/tools/devtool
+++ b/tools/devtool
@@ -1186,14 +1186,17 @@ get_swagger_version() {
 }
 
 mount_ramdisk() {
-    say "Using ramdisk ..."
     local ramdisk_size="$1"
     umount_ramdisk
+    DEFAULT_RAMDISK_PATH=$(sudo mktemp -d /mnt/devtool-ramdisk.XXXXXX)
+    ok_or_die "Could not create ramdisk directory"
     sudo mkdir -p ${DEFAULT_RAMDISK_PATH} && \
     sudo mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
     ok_or_die "Failed to mount ramdisk to ${DEFAULT_RAMDISK_PATH}. Check the permission."
     sudo mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
     sudo mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
+
+    say "Using ramdisk: ${DEFAULT_RAMDISK_PATH}"
 }
 
 umount_ramdisk() {

--- a/tools/devtool
+++ b/tools/devtool
@@ -1189,11 +1189,11 @@ mount_ramdisk() {
     say "Using ramdisk ..."
     local ramdisk_size="$1"
     umount_ramdisk
-    mkdir -p ${DEFAULT_RAMDISK_PATH} && \
-    mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
+    sudo mkdir -p ${DEFAULT_RAMDISK_PATH} && \
+    sudo mount -t tmpfs -o size=${ramdisk_size} tmpfs ${DEFAULT_RAMDISK_PATH}
     ok_or_die "Failed to mount ramdisk to ${DEFAULT_RAMDISK_PATH}. Check the permission."
-    mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
-    mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
+    sudo mkdir -p ${DEFAULT_RAMDISK_PATH}/srv
+    sudo mkdir -p  ${DEFAULT_RAMDISK_PATH}/tmp
 }
 
 umount_ramdisk() {
@@ -1206,8 +1206,8 @@ umount_ramdisk() {
     if [ ! -w "${DEFAULT_RAMDISK_PATH}" ]; then
         die "Failed to unmount ${DEFAULT_RAMDISK_PATH}. Check the permission."
     fi
-    umount ${DEFAULT_RAMDISK_PATH} &>/dev/null
-    rmdir ${DEFAULT_RAMDISK_PATH} &>/dev/null
+    sudo umount ${DEFAULT_RAMDISK_PATH} &>/dev/null
+    sudo rmdir ${DEFAULT_RAMDISK_PATH} &>/dev/null
 }
 
 # `$0 test` - run integration tests


### PR DESCRIPTION
## Changes

This PR makes a few fixes to make it easier to use `devtool` with a ramdisk in order to run integration tests:

1. It prefixes with `sudo` commands used in `devtool` to create the ramdisk. Until now we need to run `devtool` with sudo which messes up with the build directory of the repo (makes it root-owned).
2. It makes TMPDIR point to the ramdisk
3. It uses `mktemp` for the directory of the ramdisk to avoid collisions when more than one test campaigns are running

## Reason

Make it easier to run tests using a ramdisk. This can be potentially faster and also reduce interference (for example disk I/O) when running multiple tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
