### PR TITLE
Ignore git-deleted files in pre-commit script

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -16,7 +16,7 @@ set -e
 # Audit code base
 cargo audit
 # For every staged file
-for i in $(git diff --name-only --cached); do
+for i in $(git diff --name-only --cached --diff-filter=d); do
     echo $i
     # Get the extension
     filename=$(basename -- "$i")


### PR DESCRIPTION
## Changes

Add an excludsionary [filter to the `git diff` command](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203) in the `pre-commit` script to filter out files deleted from code revision.

## Reason

Files that are attempted to be formatted (by rustfmt or black for example) when they no longer exist will cause the script to fail incorrectly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

