### PR TITLE
Wrong Cmdline max size constant value

### DIFF
--- a/src/arch/src/x86_64/layout.rs
+++ b/src/arch/src/x86_64/layout.rs
@@ -12,8 +12,8 @@ pub const BOOT_STACK_POINTER: u64 = 0x8ff0;
 
 /// Kernel command line start address.
 pub const CMDLINE_START: u64 = 0x20000;
-/// Kernel command line start address maximum size.
-pub const CMDLINE_MAX_SIZE: usize = 0x10000;
+/// Kernel command line maximum size.
+pub const CMDLINE_MAX_SIZE: usize = 2048;
 
 /// Start of the high memory.
 pub const HIMEM_START: u64 = 0x0010_0000; // 1 MB.


### PR DESCRIPTION
# Reason for This PR

According to the [spec](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html),
the kernel command line should have a maximum size of COMMAND_LINE_SIZE bytes, where
COMMAND_LINE_SIZE is defined as a constant in Linux kernel. For x86, this constant has a value of 2048
according to the [kernel's source](https://elixir.bootlin.com/linux/v5.10.139/source/arch/x86/include/asm/setup.h#L7).

This PR is intended to correct the value of the constant that has a similar meaning on Firecracker side.

## Description of Changes

Correcting the value of the CMDLINE_MAX_SIZE const. Updating the comment of the const.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The issue which led to this PR has a clear conclusion.
- [ ] This PR follows the solution outlined in the related issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes follow the [Runbook for Firecracker API changes][2].
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
