### PR TITLE
[Snapshot] Performance baselines on 5.10 on AL2

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
@@ -28,252 +28,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.55,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.921,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.597,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 3.171,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.591,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.039,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.999,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 3.274,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.732,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.145,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.697,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 3.426,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.875,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.264,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.642,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.602,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.751,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.379,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 52.09,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 3.715,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.143,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.503,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.452,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 3.818,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.271,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.62,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.977,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 3.91,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 44.772,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.725,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 60.873,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.064,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.868,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.86,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.351,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.197,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.854,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.972,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 61.115,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.247,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 36.22,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.915,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.167,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.145,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 32.4,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.061,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.225,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.294,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 32.759,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.343,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 63.718,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 3.609,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 29.254,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.942,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.389,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.172,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 26.282,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 5.439,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 30.884,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 5.748,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 33.514,
-                                                "delta_percentage": 18
+                                                "restore": {
+                                                    "target": 7.925,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.561,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.245,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 37.717,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 12.321,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.578,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 12.759,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 47.14,
-                                                "delta_percentage": 5
+                                                "restore": {
+                                                    "target": 21.536,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 59.323,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 22.013,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 33.228,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.535,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.441,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.747,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 29.508,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.229,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 53.623,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.494,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 38.268,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.917,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 50.611,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.231,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 27.82,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 2.851,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.269,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 3.075,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 27.8,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 2.852,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 32.118,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.036,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 31.649,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 2.85,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.291,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.029,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 27.764,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 2.969,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.808,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.182,
+                                                    "delta_percentage": 41
+                                                }
                                             }
                                         }
                                     }
@@ -282,252 +382,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.21,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.827,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 71.847,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.033,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.706,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.977,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 47.744,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.175,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.779,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.106,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.062,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 3.37,
+                                                    "delta_percentage": 33
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.643,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.236,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.969,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.48,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.485,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 3.373,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.924,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.581,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 47.504,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.497,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 72.148,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 3.726,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.038,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.607,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.851,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.811,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.154,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.714,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.362,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.931,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.39,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.841,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 83.423,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 4.028,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.954,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.959,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 50.982,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.183,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 39.097,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 2.87,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.546,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 3.061,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 31.628,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.021,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 67.228,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 3.211,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 32.08,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.314,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.08,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 3.547,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 29.606,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 3.922,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.706,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 4.21,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 30.066,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.412,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.559,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 5.707,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 35.595,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 7.913,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.645,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.257,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 45.112,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 12.273,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 61.403,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 12.664,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 49.094,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 21.478,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 63.108,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 22.0,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 36.146,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.525,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.408,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.722,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 33.103,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.182,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 41.094,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 4.431,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 29.961,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.846,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.552,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 5.143,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 31.551,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 2.863,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 55.142,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 3.077,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 38.726,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.869,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 55.552,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.049,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 43.366,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 2.89,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 59.41,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.065,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 27.215,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.991,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.911,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 3.187,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         }
                                     }
@@ -543,252 +743,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.451,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.37,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.852,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 3.704,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 24.602,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.543,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.046,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 3.884,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.054,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.701,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.637,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.048,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.409,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.844,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.384,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.176,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.845,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.013,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.64,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 4.311,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.937,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.146,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.576,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 4.517,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.341,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.26,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.04,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 4.56,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 24.908,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.378,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.779,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.702,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.19,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.524,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.096,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.808,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.59,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.66,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.613,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.913,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 31.582,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.455,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.06,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.776,
+                                                    "delta_percentage": 83
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 35.866,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.59,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.234,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.828,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 28.382,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.851,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.767,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 4.014,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 25.107,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 4.456,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.934,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.64,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 26.241,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 5.952,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.544,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 6.323,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 32.669,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 8.539,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.217,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.976,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 41.123,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 12.972,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.797,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 13.45,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 46.896,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 22.258,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 58.954,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 22.745,
+                                                    "delta_percentage": 9
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 31.828,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.08,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.256,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 4.242,
+                                                    "delta_percentage": 14
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 28.855,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.799,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.005,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 5.039,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 30.343,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 5.537,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.467,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.891,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 27.093,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.332,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.298,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 3.562,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 27.379,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 3.342,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 31.364,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.511,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 31.529,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.387,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.571,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.539,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 26.479,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.506,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.266,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.762,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         }
                                     }
@@ -797,252 +1097,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 26.604,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 3.328,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.539,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.539,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.316,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 3.49,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.395,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.735,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 34.796,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.651,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.099,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 3.883,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.109,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.778,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.525,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.95,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.266,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.946,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.126,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 4.122,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.216,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 4.059,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.795,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 4.244,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.857,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 4.187,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.746,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.45,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.466,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 4.315,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.158,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 4.625,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.473,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.456,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.435,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 4.598,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.569,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.599,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.654,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.757,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 30.815,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.367,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.683,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 3.56,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 27.148,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 3.542,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 42.55,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 3.695,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 27.907,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.799,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.234,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 3.943,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 30.826,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 4.485,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.115,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 4.683,
+                                                    "delta_percentage": 14
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 29.149,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 5.932,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.659,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 6.305,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 31.864,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 8.51,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.736,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.854,
+                                                    "delta_percentage": 10
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 36.649,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 12.956,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.614,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 13.508,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 46.127,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 22.23,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.913,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 22.695,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 30.035,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.062,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.493,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.228,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 28.425,
-                                                "delta_percentage": 24
+                                                "restore": {
+                                                    "target": 4.804,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.304,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 5.053,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 29.074,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.557,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.734,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 5.86,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 31.115,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.348,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.543,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 3.502,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 31.065,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.372,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.003,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.538,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 30.368,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.398,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.063,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.554,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 34.139,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.512,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.06,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 3.634,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         }
                                     }

--- a/tools/parse_baselines/providers/snapshot_restore.py
+++ b/tools/parse_baselines/providers/snapshot_restore.py
@@ -12,7 +12,7 @@ from providers.types import DataParser
 # that were not caught while gathering baselines. This provides
 # slightly better reliability, while not affecting regression
 # detection.
-DELTA_EXTRA_MARGIN = 4
+DELTA_EXTRA_MARGIN = 6
 
 
 # pylint: disable=R0903
@@ -33,8 +33,14 @@ class SnapshotRestoreDataParser(DataParser):
     def calculate_baseline(self, data: List[float]) -> dict:
         """Return the target and delta values, given a list of data points."""
         avg = statistics.mean(data)
-        stddev = statistics.stdev(data)
+        min_ = min(data)
+        max_ = max(data)
+
+        min_delta = 100 * abs(avg - min_) / avg
+        max_delta = 100 * abs(avg - max_) / avg
+        delta = max(max_delta, min_delta)
+
         return {
             "target": round(avg, 3),
-            "delta_percentage": math.ceil(3 * stddev / avg * 100) + DELTA_EXTRA_MARGIN,
+            "delta_percentage": math.ceil(delta) + DELTA_EXTRA_MARGIN,
         }


### PR DESCRIPTION
## Changes

* changed the way we compute baselines for snap resume latency
* gathered 5.10 baselines on cgroup v2 AL2 5.10

## Reason

Make snapshot GA.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
