### PR TITLE
separate boot source config from the associated runtime details

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -78,7 +78,7 @@ pub enum StartMicrovmError {
     KernelLoader(linux_loader::loader::Error),
     /// Cannot load command line string.
     LoadCommandline(linux_loader::loader::Error),
-    /// Cannot start the VM because the kernel was not configured.
+    /// Cannot start the VM because the kernel builder was not configured.
     MissingKernelConfig,
     /// Cannot start the VM because the size of the guest memory  was not specified.
     MissingMemSizeConfig,
@@ -326,7 +326,9 @@ pub fn build_microvm_for_boot(
     // Timestamp for measuring microVM boot duration.
     let request_ts = TimestampUs::default();
 
-    let boot_config = vm_resources.boot_source().ok_or(MissingKernelConfig)?;
+    let boot_config = vm_resources
+        .boot_source_builder()
+        .ok_or(MissingKernelConfig)?;
 
     let track_dirty_pages = vm_resources.track_dirty_pages();
     let guest_memory =

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -925,7 +925,7 @@ mod tests {
             Ok(())
         }
 
-        pub fn set_boot_source(
+        pub fn build_boot_source(
             &mut self,
             _: BootSourceConfig,
         ) -> Result<(), BootSourceConfigError> {

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -483,7 +483,7 @@ impl<'a> PrebootApiController<'a> {
     fn set_boot_source(&mut self, cfg: BootSourceConfig) -> ActionResult {
         self.boot_path = true;
         self.vm_resources
-            .set_boot_source(cfg)
+            .build_boot_source(cfg)
             .map(|()| VmmData::Empty)
             .map_err(VmmActionError::BootSource)
     }

--- a/src/vmm/src/utilities/mock_resources/mod.rs
+++ b/src/vmm/src/utilities/mock_resources/mod.rs
@@ -73,7 +73,7 @@ impl MockVmResources {
     }
 
     pub fn with_boot_source(mut self, boot_source_cfg: BootSourceConfig) -> Self {
-        self.0.set_boot_source(boot_source_cfg).unwrap();
+        self.0.build_boot_source(boot_source_cfg).unwrap();
         self
     }
 

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -130,12 +130,8 @@ pub(crate) mod tests {
             kernel_image_path: kernel_path,
         };
 
-        let boot_cfg = BootConfig::new(boot_src_cfg.clone()).unwrap();
+        let boot_cfg = BootConfig::new(&boot_src_cfg).unwrap();
         assert!(boot_cfg.initrd_file.is_none());
         assert_eq!(boot_cfg.cmdline.as_str(), DEFAULT_KERNEL_CMDLINE);
-        assert_eq!(boot_cfg.description, boot_src_cfg);
-
-        let generated_cfg = BootSourceConfig::from(&boot_cfg);
-        assert_eq!(generated_cfg, boot_src_cfg);
     }
 }


### PR DESCRIPTION
## Changes

Separate boot source configuration from boot source builder in vmm resources.


## Reason

Depending on whether or not we are dealing with a resumed microVM or freshly booted up microVM, the vmm resources will contain a BootConfig (i.e a BootSourceConfig which has gone through the cmdline validation process and also opening of the kernel image) or not.

We want to decouple the BootSourceConfig (the description of the BootSource details like path to the kernel image) from the BootConfig which holds the fd to the kernel etc.

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
