### PR TITLE
[Snapshot] Performance baselines for AMD 4.14

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -1063,350 +1063,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.628,
-                                                    "delta_percentage": 8
+                                                    "target": 7.179,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.046,
-                                                    "delta_percentage": 39
+                                                    "target": 7.681,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.724,
-                                                    "delta_percentage": 8
+                                                    "target": 7.277,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.968,
-                                                    "delta_percentage": 18
+                                                    "target": 7.835,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.878,
-                                                    "delta_percentage": 6
+                                                    "target": 7.385,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.053,
-                                                    "delta_percentage": 12
+                                                    "target": 7.881,
+                                                    "delta_percentage": 29
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.005,
-                                                    "delta_percentage": 7
+                                                    "target": 7.493,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.239,
-                                                    "delta_percentage": 20
+                                                    "target": 8.006,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.151,
-                                                    "delta_percentage": 8
+                                                    "target": 7.605,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.459,
-                                                    "delta_percentage": 24
+                                                    "target": 8.116,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.293,
-                                                    "delta_percentage": 7
+                                                    "target": 7.724,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.728,
-                                                    "delta_percentage": 20
+                                                    "target": 8.259,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.424,
-                                                    "delta_percentage": 9
+                                                    "target": 7.811,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.847,
-                                                    "delta_percentage": 18
+                                                    "target": 8.382,
+                                                    "delta_percentage": 33
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.594,
-                                                    "delta_percentage": 9
+                                                    "target": 7.986,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.017,
-                                                    "delta_percentage": 21
+                                                    "target": 8.644,
+                                                    "delta_percentage": 106
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.768,
-                                                    "delta_percentage": 11
+                                                    "target": 8.211,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.245,
-                                                    "delta_percentage": 18
+                                                    "target": 8.983,
+                                                    "delta_percentage": 94
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.836,
-                                                    "delta_percentage": 6
+                                                    "target": 8.388,
+                                                    "delta_percentage": 21
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.047,
-                                                    "delta_percentage": 14
+                                                    "target": 9.338,
+                                                    "delta_percentage": 131
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.841,
-                                                    "delta_percentage": 7
+                                                    "target": 7.136,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.016,
-                                                    "delta_percentage": 13
+                                                    "target": 7.642,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.326,
-                                                    "delta_percentage": 8
+                                                    "target": 7.174,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.586,
-                                                    "delta_percentage": 22
+                                                    "target": 7.677,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.289,
-                                                    "delta_percentage": 9
+                                                    "target": 7.294,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.695,
-                                                    "delta_percentage": 19
+                                                    "target": 7.873,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.139,
-                                                    "delta_percentage": 8
+                                                    "target": 7.469,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.602,
-                                                    "delta_percentage": 17
+                                                    "target": 8.064,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 11.393,
-                                                    "delta_percentage": 9
+                                                    "target": 8.246,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 12.981,
-                                                    "delta_percentage": 106
+                                                    "target": 8.999,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 19.163,
-                                                    "delta_percentage": 9
+                                                    "target": 8.504,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 20.203,
-                                                    "delta_percentage": 13
+                                                    "target": 9.444,
+                                                    "delta_percentage": 33
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 34.259,
-                                                    "delta_percentage": 9
+                                                    "target": 10.346,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 35.502,
-                                                    "delta_percentage": 12
+                                                    "target": 11.321,
+                                                    "delta_percentage": 27
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 65.014,
-                                                    "delta_percentage": 7
+                                                    "target": 13.732,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 67.837,
-                                                    "delta_percentage": 15
+                                                    "target": 14.627,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.351,
-                                                    "delta_percentage": 13
+                                                    "target": 7.821,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.07,
-                                                    "delta_percentage": 42
+                                                    "target": 8.617,
+                                                    "delta_percentage": 36
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.027,
-                                                    "delta_percentage": 14
+                                                    "target": 8.426,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.866,
-                                                    "delta_percentage": 27
+                                                    "target": 9.071,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.629,
-                                                    "delta_percentage": 9
+                                                    "target": 9.027,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.325,
-                                                    "delta_percentage": 24
+                                                    "target": 9.619,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.667,
-                                                    "delta_percentage": 9
+                                                    "target": 7.245,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.003,
-                                                    "delta_percentage": 29
+                                                    "target": 7.852,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.715,
-                                                    "delta_percentage": 8
+                                                    "target": 7.288,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.114,
-                                                    "delta_percentage": 34
+                                                    "target": 7.903,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.797,
-                                                    "delta_percentage": 19
+                                                    "target": 7.326,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.209,
-                                                    "delta_percentage": 37
+                                                    "target": 7.94,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.827,
-                                                    "delta_percentage": 8
+                                                    "target": 7.302,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.206,
-                                                    "delta_percentage": 31
+                                                    "target": 7.877,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         }
@@ -1417,167 +1417,167 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.623,
-                                                    "delta_percentage": 9
+                                                    "target": 7.158,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.04,
-                                                    "delta_percentage": 38
+                                                    "target": 7.718,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.732,
-                                                    "delta_percentage": 8
+                                                    "target": 7.278,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.128,
-                                                    "delta_percentage": 31
+                                                    "target": 7.831,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.876,
-                                                    "delta_percentage": 8
+                                                    "target": 7.392,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.205,
-                                                    "delta_percentage": 27
+                                                    "target": 7.958,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.01,
-                                                    "delta_percentage": 9
+                                                    "target": 7.513,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.428,
-                                                    "delta_percentage": 28
+                                                    "target": 8.091,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.165,
-                                                    "delta_percentage": 8
+                                                    "target": 7.611,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.648,
-                                                    "delta_percentage": 33
+                                                    "target": 8.225,
+                                                    "delta_percentage": 35
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.31,
-                                                    "delta_percentage": 8
+                                                    "target": 7.739,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.845,
-                                                    "delta_percentage": 29
+                                                    "target": 8.327,
+                                                    "delta_percentage": 44
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.438,
-                                                    "delta_percentage": 9
+                                                    "target": 7.87,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.976,
-                                                    "delta_percentage": 25
+                                                    "target": 8.465,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.61,
-                                                    "delta_percentage": 10
+                                                    "target": 8.019,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.163,
-                                                    "delta_percentage": 18
+                                                    "target": 8.703,
+                                                    "delta_percentage": 50
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.735,
-                                                    "delta_percentage": 9
+                                                    "target": 8.231,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.272,
-                                                    "delta_percentage": 32
+                                                    "target": 9.07,
+                                                    "delta_percentage": 138
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.818,
-                                                    "delta_percentage": 8
+                                                    "target": 8.401,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.196,
-                                                    "delta_percentage": 30
+                                                    "target": 9.15,
+                                                    "delta_percentage": 94
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.838,
-                                                    "delta_percentage": 7
+                                                    "target": 7.23,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.03,
-                                                    "delta_percentage": 14
+                                                    "target": 7.71,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.326,
-                                                    "delta_percentage": 7
+                                                    "target": 7.244,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.636,
+                                                    "target": 7.748,
                                                     "delta_percentage": 25
                                                 }
                                             }
@@ -1585,182 +1585,182 @@
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.256,
-                                                    "delta_percentage": 7
+                                                    "target": 7.324,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.617,
-                                                    "delta_percentage": 19
+                                                    "target": 7.807,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.153,
-                                                    "delta_percentage": 11
+                                                    "target": 7.482,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.67,
-                                                    "delta_percentage": 20
+                                                    "target": 8.138,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 11.385,
-                                                    "delta_percentage": 8
+                                                    "target": 8.258,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 12.168,
-                                                    "delta_percentage": 19
+                                                    "target": 9.018,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 19.075,
-                                                    "delta_percentage": 7
+                                                    "target": 8.434,
+                                                    "delta_percentage": 24
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 20.173,
-                                                    "delta_percentage": 15
+                                                    "target": 9.36,
+                                                    "delta_percentage": 40
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 34.023,
-                                                    "delta_percentage": 7
+                                                    "target": 10.223,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 35.506,
-                                                    "delta_percentage": 9
+                                                    "target": 11.032,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 64.664,
-                                                    "delta_percentage": 7
+                                                    "target": 13.561,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 66.687,
-                                                    "delta_percentage": 8
+                                                    "target": 14.275,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.312,
-                                                    "delta_percentage": 8
+                                                    "target": 7.746,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.629,
-                                                    "delta_percentage": 15
+                                                    "target": 8.271,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.981,
+                                                    "target": 8.398,
                                                     "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.502,
-                                                    "delta_percentage": 24
+                                                    "target": 8.908,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.702,
-                                                    "delta_percentage": 12
+                                                    "target": 9.024,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.491,
-                                                    "delta_percentage": 27
+                                                    "target": 9.516,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.665,
-                                                    "delta_percentage": 8
+                                                    "target": 7.214,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.882,
-                                                    "delta_percentage": 19
+                                                    "target": 7.737,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.728,
-                                                    "delta_percentage": 8
+                                                    "target": 7.256,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.994,
-                                                    "delta_percentage": 24
+                                                    "target": 7.79,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.761,
-                                                    "delta_percentage": 10
+                                                    "target": 7.316,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.979,
-                                                    "delta_percentage": 21
+                                                    "target": 7.841,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.822,
-                                                    "delta_percentage": 9
+                                                    "target": 7.289,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.064,
-                                                    "delta_percentage": 25
+                                                    "target": 7.773,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -1052,6 +1052,725 @@
                     }
                 ]
             },
+            "m6a.metal": {
+                "cpus": [
+                    {
+                        "model": "AMD EPYC 7R13 48-Core Processor",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.628,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.046,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.724,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.968,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.878,
+                                                    "delta_percentage": 6
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.053,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.005,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.239,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.151,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.459,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.293,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.728,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.424,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.847,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.594,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.017,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.768,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.245,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.836,
+                                                    "delta_percentage": 6
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.047,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.841,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.016,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.326,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.586,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.289,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.695,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.139,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.602,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 11.393,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 12.981,
+                                                    "delta_percentage": 106
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 19.163,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 20.203,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 34.259,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 35.502,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 65.014,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 67.837,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.351,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.07,
+                                                    "delta_percentage": 42
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.027,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.866,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.629,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.325,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.667,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.003,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.715,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.114,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.797,
+                                                    "delta_percentage": 19
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.209,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.827,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.206,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.623,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.04,
+                                                    "delta_percentage": 38
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.732,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.128,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.876,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.205,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.01,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.428,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.165,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.648,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.31,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.845,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.438,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.976,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.61,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.163,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.735,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.272,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.818,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.196,
+                                                    "delta_percentage": 30
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.838,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.03,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.326,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.636,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.256,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.617,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.153,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.67,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 11.385,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 12.168,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 19.075,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 20.173,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 34.023,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 35.506,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 64.664,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 66.687,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.312,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.629,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.981,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.502,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.702,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.491,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.665,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.882,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.728,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.994,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.761,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.979,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.822,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.064,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -123,7 +123,7 @@ def main():
         help="Instance type on which the baselines \
                             were obtained.",
         action="store",
-        choices=["m5d.metal", "m6g.metal"],
+        choices=["m5d.metal", "m6a.metal", "m6g.metal"],
         required=True,
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Changes

* support for parsing baselines on AMD
* gathered 4.14 baselines on AMD


## Reason

Snapshot GA

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
