### PR TITLE
[jailer] add check of --exec-file parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
   network interfaces. This address can be obtained as part of the GET
   `/vm/config`.
 
+### Changed
+
+- Changed the jailer option `--exec-file` to fail if the filename does not
+  contain the string `firecracker` to prevent from running non-firecracker
+  binaries.
+
 ### Fixed
 
 - Make the `T2` template more robust by explicitly disabling additional

--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -32,8 +32,8 @@ jailer --id <id> \
 - `id` is the unique VM identification string, which may contain alphanumeric
   characters and hyphens. The maximum `id` length is currently 64 characters.
 - `exec_file` is the path to the Firecracker binary that will be exec-ed by the
-  jailer. The user can provide a path to any binary, but the interaction with
-  the jailer is mostly Firecracker specific.
+  jailer. The filename must include the string `firecracker`. This is enforced
+  because the interaction with the jailer is Firecracker specific.
 - `uid` and `gid` are the uid and gid the jailer switches to as it execs the
   target binary.
 - `parent-cgroup` is used to allow the placement of microvm cgroups in custom

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -38,7 +38,8 @@ pub enum Error {
     CStringParsing(NulError),
     Dup2(io::Error),
     Exec(io::Error),
-    FileName(PathBuf),
+    ExecFileName(String),
+    ExtractFileName(PathBuf),
     FileOpen(PathBuf, io::Error),
     FromBytesWithNul(std::ffi::FromBytesWithNulError),
     GetOldFdFlags(io::Error),
@@ -140,7 +141,13 @@ impl fmt::Display for Error {
             CStringParsing(_) => write!(f, "Encountered interior \\0 while parsing a string"),
             Dup2(ref err) => write!(f, "Failed to duplicate fd: {}", err),
             Exec(ref err) => write!(f, "Failed to exec into Firecracker: {}", err),
-            FileName(ref path) => write!(
+            ExecFileName(ref filename) => write!(
+                f,
+                "Invalid filename. The filename of `--exec-file` option must contain \
+                 \"firecracker\": {}",
+                filename
+            ),
+            ExtractFileName(ref path) => write!(
                 f,
                 "{}",
                 format!("Failed to extract filename from path {:?}", path).replace("\"", "")
@@ -609,7 +616,12 @@ mod tests {
             format!("Failed to exec into Firecracker: {}", err2_str)
         );
         assert_eq!(
-            format!("{}", Error::FileName(file_path.clone())),
+            format!("{}", Error::ExecFileName("foobarbaz".to_string())),
+            "Invalid filename. The filename of `--exec-file` option must contain \"firecracker\": \
+             foobarbaz",
+        );
+        assert_eq!(
+            format!("{}", Error::ExtractFileName(file_path.clone())),
             "Failed to extract filename from path /foo/bar",
         );
         assert_eq!(


### PR DESCRIPTION
## Changes

- check that the given `--exec-file` parameter contains `firecracker`.
- create `/tmp/pseudo_firecracker_exec_file` before tests with arguments.

## Reason

Issue: #1082
As the doc states, the `--exec-file` parameter is intended to be specified a firecracker binary. 
> `exec_file` is the path to the Firecracker binary that will be exec-ed by the jailer. The user can provide a path to any binary, but the interaction with the jailer is mostly Firecracker specific.

But jailer didn't check if the given executable file as `--exec-file` is firecracker.
If jailer run it without this check, it might output nothing or uninterpretable messages.
This situation made it difficult for users to identify the root cause.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
