### PR TITLE
[snapshot-ga] Additional info added to snap state.

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -51,7 +51,7 @@ use crate::vmm_config::machine_config::{VmConfigError, VmUpdateConfig};
 use crate::vstate::system::KvmContext;
 use crate::vstate::vcpu::{Vcpu, VcpuConfig};
 use crate::vstate::vm::Vm;
-use crate::{device_manager, mem_size_mib, Error, EventManager, Vmm, VmmEventsObserver};
+use crate::{device_manager, Error, EventManager, Vmm, VmmEventsObserver};
 
 /// Errors associated with starting the instance.
 #[derive(Debug)]
@@ -565,11 +565,14 @@ pub fn build_microvm_from_snapshot(
 
     vm_resources.update_vm_config(&VmUpdateConfig {
         vcpu_count: Some(vcpu_count),
-        mem_size_mib: Some(mem_size_mib(&guest_memory) as usize),
-        smt: Some(false),
-        cpu_template: None,
+        mem_size_mib: Some(microvm_state.vm_info.mem_size_mib as usize),
+        smt: Some(microvm_state.vm_info.smt),
+        cpu_template: Some(microvm_state.vm_info.cpu_template),
         track_dirty_pages: Some(track_dirty_pages),
     })?;
+
+    // Restore the boot source config paths.
+    vm_resources.set_boot_source_config(microvm_state.vm_info.boot_source);
 
     // Restore devices states.
     let mmio_ctor_args = MMIODevManagerConstructorArgs {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -461,7 +461,10 @@ impl Vmm {
     }
 
     /// Saves the state of a paused Microvm.
-    pub fn save_state(&mut self) -> std::result::Result<MicrovmState, MicrovmStateError> {
+    pub fn save_state(
+        &mut self,
+        vm_info: &VmInfo,
+    ) -> std::result::Result<MicrovmState, MicrovmStateError> {
         use self::MicrovmStateError::SaveVmState;
         let vcpu_states = self.save_vcpu_states()?;
         let vm_state = {
@@ -478,11 +481,10 @@ impl Vmm {
         };
         let device_states = self.mmio_device_manager.save();
 
-        let mem_size_mib = mem_size_mib(self.guest_memory());
         let memory_state = self.guest_memory().describe();
 
         Ok(MicrovmState {
-            vm_info: VmInfo { mem_size_mib },
+            vm_info: vm_info.clone(),
             memory_state,
             vm_state,
             vcpu_states,

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 use versionize::{VersionMap, Versionize};
 
 use crate::device_manager::persist::DeviceStates;
+use crate::persist::VmInfo;
 #[cfg(target_arch = "x86_64")]
 use crate::vstate::vcpu::VcpuState;
 
@@ -25,6 +26,8 @@ pub const FC_V0_25_SNAP_VERSION: u16 = 3;
 pub const FC_V1_0_SNAP_VERSION: u16 = 4;
 /// Snap version for Firecracker v1.1
 pub const FC_V1_1_SNAP_VERSION: u16 = 5;
+/// Snap version for Firecracker v1.2
+pub const FC_V1_2_SNAP_VERSION: u16 = 6;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -48,6 +51,9 @@ lazy_static! {
         // v1.1 state change mappings.
         version_map.new_version().set_type_version(DeviceStates::type_id(), 3);
 
+        // v1.2 state change mappings.
+        version_map.new_version().set_type_version(VmInfo::type_id(), 2);
+
         version_map
     };
 
@@ -62,6 +68,7 @@ lazy_static! {
         mapping.insert(String::from("0.25.0"), FC_V0_25_SNAP_VERSION);
         mapping.insert(String::from("1.0.0"), FC_V1_0_SNAP_VERSION);
         mapping.insert(String::from("1.1.0"), FC_V1_1_SNAP_VERSION);
+        mapping.insert(String::from("1.2.0"), FC_V1_2_SNAP_VERSION);
 
         mapping
     };

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -6,6 +6,8 @@ use std::fs::File;
 use std::io;
 
 use serde::{Deserialize, Serialize};
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
 
 /// Default guest kernel command line:
 /// - `reboot=k` shut down the guest on reboot, instead of well... rebooting;
@@ -22,7 +24,7 @@ pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules 825
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, Versionize)]
 #[serde(deny_unknown_fields)]
 pub struct BootSourceConfig {
     /// Path of the kernel image.

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -1,9 +1,10 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 use std::fmt;
 
 use serde::{de, Deserialize, Serialize};
+use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
+use versionize_derive::Versionize;
 
 /// The default memory size of the VM, in MiB.
 pub const DEFAULT_MEM_SIZE_MIB: usize = 128;
@@ -237,7 +238,7 @@ where
 
 /// Template types available for configuring the CPU features that map
 /// to EC2 instances.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, Versionize)]
 pub enum CpuFeaturesTemplate {
     /// C3 Template.
     C3,

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1199,6 +1199,9 @@ def test_get_full_config_after_restoring_snapshot(bin_cloner_path):
         "track_dirty_pages": False,
     }
 
+    if cpu_vendor == utils.CpuVendor.ARM:
+        setup_cfg["machine-config"]["smt"] = False
+
     if cpu_vendor == utils.CpuVendor.INTEL:
         setup_cfg["machine-config"]["cpu_template"] = "C3"
 
@@ -1277,14 +1280,12 @@ def test_get_full_config_after_restoring_snapshot(bin_cloner_path):
 
     expected_cfg = setup_cfg.copy()
 
-    # We expect boot-source, machine-config.smt, and
-    # machine-config.cpu_template to all be empty/default after restoring
-    # from a snapshot.
-    expected_cfg["boot-source"] = {"kernel_image_path": "", "initrd_path": None}
-    expected_cfg["machine-config"]["smt"] = False
-
-    if cpu_vendor == utils.CpuVendor.INTEL:
-        expected_cfg["machine-config"].pop("cpu_template")
+    # We expect boot-source to be set with the following values
+    expected_cfg["boot-source"] = {
+        "kernel_image_path": test_microvm.get_jailed_resource(test_microvm.kernel_file),
+        "initrd_path": None,
+        "boot_args": "console=ttyS0 reboot=k panic=1",
+    }
 
     # no ipv4 specified during PUT /mmds/config so we expect the default
     expected_cfg["mmds-config"] = {


### PR DESCRIPTION
## Changes

Added `boot_source`, `smt`, `cpu_template` information to the snap state file in order to maintain consistency post restore.

## Reason

This information was not being persisted into the snapshot and was missing from the VM config result as well.

Related to: #2943 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
