### PR TITLE
Issue 361 bindgen 2

### DIFF
--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -82,15 +82,16 @@ const NR_FP_VREGS: usize = 32;
 
 // This macro gets the offset of a structure (i.e `str`) member (i.e `field`) without having
 // an instance of that structure.
-// It uses a null pointer to retrieve the offset to the field.
-// Inspired by C solution: `#define offsetof(str, f) ((size_t)(&((str *)0)->f))`.
-// Doing `offset__of!(user_pt_regs, pstate)` in our rust code will trigger the following:
-// unsafe { &(*(0 as *const user_pt_regs)).pstate as *const _ as usize }
-// The dereference expression produces an lvalue, but that lvalue is not actually read from,
-// we're just doing pointer math on it, so in theory, it should be safe.
+// It relies on `std::mem::MaybeUninit` to get an uninitialized instance of the struct `str`
+// and uses `std::ptr::addr_of` macro to get a raw pointer to `field` without dereferencing
+// `str`. Having those too we can take their diff to find the offset of `field` in `str`.
 macro_rules! offset__of {
     ($str:ty, $field:ident) => {
-        unsafe { &(*(std::ptr::null::<$str>())).$field as *const _ as usize }
+        unsafe {
+            let uninit = std::mem::MaybeUninit::<$str>::uninit();
+            let ptr = uninit.as_ptr();
+            std::ptr::addr_of!((*ptr).$field) as usize - ptr as usize
+        }
     };
 }
 

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.52.1"
+ARG RUST_TOOLCHAIN="1.64.0"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG TMP_POETRY_DIR

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 # The Rust toolchain layer will get updated most frequently, but we could keep the system
 # dependencies layer intact for much longer.
 
-ARG RUST_TOOLCHAIN="1.52.1"
+ARG RUST_TOOLCHAIN="1.64.0"
 ARG TINI_VERSION_TAG="v0.18.0"
 ARG TMP_BUILD_DIR=/tmp/build
 ARG TMP_POETRY_DIR

--- a/tools/devtool
+++ b/tools/devtool
@@ -354,17 +354,16 @@ cmd_fix_perms() {
 # Builds the development container from its Dockerfile.
 #
 cmd_build_devctr() {
-    arch=$(uname -m)
-    docker_file_name="Dockerfile.$arch"
+    local ARCH="x86_64"
     build_args="--build-arg TMP_POETRY_DIR=$CTR_POETRY_TMP_DIR"
 
     while [ $# -gt 0 ]; do
         case "$1" in
             "-h"|"--help")      { cmd_help; exit 1; } ;;
             "-n"|"--no-python-package-upgrade")
-                shift
                 build_args="$build_args --build-arg POETRY_LOCK_PATH=tools/devctr/poetry.lock"
                 ;;
+	    "-a"|"--arch")      { ARCH="$2"; shift; } ;;
             "--")               { shift; break;     } ;;
             *)
                 die "Unknown argument: $1. Please use --help for help."
@@ -373,7 +372,19 @@ cmd_build_devctr() {
         shift
     done
 
-    docker build -t "$DEVCTR_IMAGE_NO_TAG" -f "$FC_DEVCTR_DIR/$docker_file_name" $build_args .
+    if [[ $ARCH == "x86_64" ]]; then
+	docker_file_name="Dockerfile.x86_64"
+	build_target="linux/amd64"
+	say "Building container image for x86_64"
+    elif [[ $ARCH == "aarch64" ]] || [[ $ARCH == "arm64" ]]; then
+	docker_file_name="Dockerfile.aarch64"
+	build_target="linux/arm64"
+	say "Building container image for aarch64"
+    else
+        die "Unknown architecture '$ARCH'"
+    fi
+
+    docker build --platform $build_target -t "$DEVCTR_IMAGE_NO_TAG" -f "$FC_DEVCTR_DIR/$docker_file_name" $build_args .
 
     # Copy back the lockfile, since a new dependency or version would have
     # updated it.
@@ -686,6 +697,9 @@ cmd_help() {
     echo "    build_devctr [--no-python-package-upgrade]"
     echo "        Builds the development container from its Dockerfile."
     echo "        -n, --no-python-package-upgrade  Do not update python packages."
+    echo "        -a, --arch <arch>"
+    echo "          Define architecture to build the container for."
+    echo "          Supported options: x86_64, aarch64 and arm64. (Default: x86_64)"
     echo ""
     echo "    build_kernel -c|--config [-n|--nproc]"
     echo "        Builds a kernel image custom-tailored for our CI."

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,8 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v43"
+# TODO: add a proper tag once we are ready
+DEVCTR_IMAGE_TAG="rust_update"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Several fixes/additions:

* Fix issue with unsafe block in `src/arch/src/aarch64/regs.rs` triggered with 1.64.0 toolchain
* Amend `devtool build_devctr` command to allow building the Docker images for both x86 and ARM regardless of the hosts architecture, using `--platform` flag of `docker build` command.
* Change `devtool` to use newly created docker images with rust 1.64.0 for building the project

I created new docker images with 1.64.0 toolchain which I uploaded as tagging them as `rust_update_$(arch)`

## Reason

Start building the project using latest stable toolchain.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
