### PR TITLE
[devtool] change the default size of rootfs

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -2116,12 +2116,12 @@ cmd_build_kernel() {
     say "Kernel binary placed in: $kernel_dir_host/linux-$KERNEL_VERSION/$KERNEL_BINARY_NAME"
 }
 
-# `./devtool build_rootfs -s 500MB`
+# `./devtool build_rootfs -s 500M`
 # Build a rootfs of custom size.
 #
 cmd_build_rootfs() {
-    # Default size for the resulting rootfs image is 300MB.
-    SIZE="300MB"
+    # Default size for the resulting rootfs image is 300M.
+    SIZE="300M"
     FROM_CTR=ubuntu:18.04
     flavour="bionic"
     ROOTFS_DIR=/firecracker/build/rootfs


### PR DESCRIPTION
Signed-off-by: Takahiro Itazuri <itazur@amazon.com>

## Changes

- Changes the default size of rootfs used in `tools/devtool build_rootfs`

## Reason

Closes #3147

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
