### PR TITLE
x86_64: save extra msrs (mtrr and mce)

### DIFF
--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -61,6 +61,8 @@ pub mod leaf_0x1 {
     }
 
     pub mod edx {
+        pub const MCE_BITINDEX: u32 = 7; // Memory Check Exception
+        pub const MTRR_BITINDEX: u32 = 12; // Memory Type Range Registers
         pub const PSN_BITINDEX: u32 = 18; // Processor Serial Number
         pub const SSE42_BITINDEX: u32 = 20; // SSE 4.2
         pub const DS_BITINDEX: u32 = 21; // Debug Store.

--- a/src/cpuid/src/template/intel/c3.rs
+++ b/src/cpuid/src/template/intel/c3.rs
@@ -26,7 +26,7 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
         // Stepping = 4
         .write_bits_in_range(&eax::STEPPING_BITRANGE, 4);
 
-    // Disable Features
+    // Enable/disable Features
     entry
         .ecx
         .write_bit(ecx::DTES64_BITINDEX, false)
@@ -44,6 +44,8 @@ fn update_feature_info_entry(entry: &mut kvm_cpuid_entry2, _vm_spec: &VmSpec) ->
 
     entry
         .edx
+        .write_bit(edx::MCE_BITINDEX, true)
+        .write_bit(edx::MTRR_BITINDEX, true)
         .write_bit(edx::PSN_BITINDEX, false)
         .write_bit(edx::DS_BITINDEX, false)
         .write_bit(edx::ACPI_BITINDEX, false)

--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -35,9 +35,9 @@ pub(crate) fn msrs_to_save_by_cpuid(cpuid: &CpuId) -> HashSet<u32> {
 
     // Macro used for easy definition of CPUID-MSR dependencies.
     macro_rules! cpuid_msr_dep {
-        ($leaf:expr, $index:expr, $reg:tt, $feature_bit:expr, [$($msr:expr),+]) => {
+        ($leaf:expr, $index:expr, $reg:tt, $feature_bit:expr, $msr:expr) => {
             if cpuid_is_feature_set!(cpuid, $leaf, $index, $reg, $feature_bit) {
-                msrs.extend(&[$($msr),*]);
+                msrs.extend($msr)
             }
         };
     }

--- a/src/cpuid/src/template/intel/mod.rs
+++ b/src/cpuid/src/template/intel/mod.rs
@@ -50,6 +50,40 @@ pub(crate) fn msrs_to_save_by_cpuid(cpuid: &CpuId) -> HashSet<u32> {
         leaf_0x7::index0::ebx::MPX_BITINDEX,
         [MSR_IA32_BNDCFGS]
     );
+
+    // IA32_MTRR_PHYSBASEn, IA32_MTRR_PHYSMASKn
+    cpuid_msr_dep!(0x1, 0, edx, leaf_0x1::edx::MTRR_BITINDEX, 0x200..0x210);
+
+    // Other MTRR MSRs
+    cpuid_msr_dep!(
+        0x1,
+        0,
+        edx,
+        leaf_0x1::edx::MTRR_BITINDEX,
+        [
+            0x250, // IA32_MTRR_FIX64K_00000
+            0x258, // IA32_MTRR_FIX16K_80000
+            0x259, // IA32_MTRR_FIX16K_A0000
+            0x268, // IA32_MTRR_FIX4K_C0000
+            0x269, // IA32_MTRR_FIX4K_C8000
+            0x26a, // IA32_MTRR_FIX4K_D0000
+            0x26b, // IA32_MTRR_FIX4K_D8000
+            0x26c, // IA32_MTRR_FIX4K_E0000
+            0x26d, // IA32_MTRR_FIX4K_E8000
+            0x26e, // IA32_MTRR_FIX4K_F0000
+            0x26f, // IA32_MTRR_FIX4K_F8000
+            0x277, // IA32_PAT
+            0x2ff  // IA32_MTRR_DEF_TYPE
+        ]
+    );
+
+    // MCE MSRs
+    // We are saving 32 MCE banks here as this is the maximum number supported by KVM
+    // and configured by default.
+    // The physical number of the MCE banks depends on the CPU.
+    // The number of emulated MCE banks can be configured via KVM_X86_SETUP_MCE.
+    cpuid_msr_dep!(0x1, 0, edx, leaf_0x1::edx::MCE_BITINDEX, 0x400..0x480);
+
     msrs
 }
 

--- a/src/cpuid/src/template/intel/t2.rs
+++ b/src/cpuid/src/template/intel/t2.rs
@@ -29,7 +29,7 @@ pub(crate) fn update_feature_info_entry(
         // Stepping = 2
         .write_bits_in_range(&eax::STEPPING_BITRANGE, 2);
 
-    // Disable Features
+    // Enable/disable Features
     entry
         .ecx
         .write_bit(ecx::DTES64_BITINDEX, false)
@@ -48,6 +48,8 @@ pub(crate) fn update_feature_info_entry(
 
     entry
         .edx
+        .write_bit(edx::MCE_BITINDEX, true)
+        .write_bit(edx::MTRR_BITINDEX, true)
         .write_bit(edx::PSN_BITINDEX, false)
         .write_bit(edx::SSE42_BITINDEX, false)
         .write_bit(edx::DS_BITINDEX, false)


### PR DESCRIPTION
## Changes

This adds a new set of MSRs to be saved in x86_64: MTRR and MCE.

## Reason

Both MTRR and MCE MSRs are not advertised by KVM via KVM_GET_MSR_INDEX_LIST, however are emulated by it. This means that they have to be saved/restored when taking a snapshot.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
