### PR TITLE
fix intermittent failure in serial_after_snapshot

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -939,7 +939,7 @@ class Microvm:
 class Serial:
     """Class for serial console communication with a Microvm."""
 
-    RX_TIMEOUT_S = 5
+    RX_TIMEOUT_S = 20
 
     def __init__(self, vm):
         """Initialize a new Serial object."""
@@ -988,6 +988,7 @@ class Serial:
             if rx_str.endswith(token):
                 break
             if (time.time() - start) >= self.RX_TIMEOUT_S:
+                self._vm.kill()
                 assert False
 
         return rx_str


### PR DESCRIPTION
The test started failling after latest AMI
update on 4.14. Seems that reading from the
screen log file the output of the microVM
became slower.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
