### PR TITLE
PR template: change relative link to absolute link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,4 @@ the terms of the Apache 2.0 license.
 - [ ] This functionality can be added in [`rust-vmm`][1].
 
 [1]: https://github.com/rust-vmm
-[2]: ../docs/api-change-runbook.md
+[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md


### PR DESCRIPTION
## Changes

Changes the link of "Runbook for Firecracker API changes" from relative link to absolute link.

## Reason

Fixes #2782 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: ../docs/api-change-runbook.md
