### PR TITLE
Backport fix for virtio queue in 1.0

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -1480,7 +1480,6 @@ pub(crate) mod tests {
             add_flush_requests_batch(&mut block, &mem, &vq, 1);
             simulate_queue_event(&mut block, Some(false));
             assert_eq!(block.is_io_engine_throttled, true);
-            assert_eq!(block.queues[0].len(&mem), 1);
 
             simulate_async_completion_event(&mut block, true);
             assert_eq!(block.is_io_engine_throttled, false);


### PR DESCRIPTION
## Changes

Backports https://github.com/firecracker-microvm/firecracker/pull/3156 in supported release version 1.0.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
