### PR TITLE
gitlint: Fix Co-authored-by handling

### DIFF
--- a/tests/framework/gitlint_rules.py
+++ b/tests/framework/gitlint_rules.py
@@ -137,7 +137,7 @@ class EndsSigned(CommitRule):
 
         # Checks lines following co-author are only additional co-authors.
         for i, line in message_iter:
-            if not line.startswith(co_auth):
+            if not line.startswith(co_auth) and line.strip():
                 return rtn(
                     f"Non '{co_auth}' string found after 1st '{co_auth}'",
                     i,


### PR DESCRIPTION
## Changes

Prior to this commit, Firecracker's gitlint rules failed any commit message which had any line after the last Co-authored-by tag, including a blank line.  This commit ignores blank lines in this case.

## Reason

Gitlint test was failing on #3155 without any good reason.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- [N/A] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [N/A] Any required documentation changes (code and docs) are included in this PR.
- [N/A] New `unsafe` code is documented.
- [N/A] API changes follow the [Runbook for Firecracker API changes][2].
- [N/A] User-facing changes are mentioned in `CHANGELOG.md`.
- [N/A] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
