### PR TITLE
arch/x86_64: save MSR_IA32_FEATURE_CONTROL

### DIFF
--- a/src/arch/src/x86_64/msr.rs
+++ b/src/arch/src/x86_64/msr.rs
@@ -247,8 +247,8 @@ static ALLOWED_MSR_RANGES: &[MsrRange] = &[
 ///
 /// * `index` - The index of the MSR that is checked whether it's needed for serialization.
 pub fn msr_should_serialize(index: u32) -> bool {
-    // Denied MSRs not exported by Linux: IA32_FEATURE_CONTROL and IA32_MCG_CTL
-    if index == MSR_IA32_FEATURE_CONTROL || index == MSR_IA32_MCG_CTL {
+    // Denied MSR not exported by Linux: IA32_MCG_CTL
+    if index == MSR_IA32_MCG_CTL {
         return false;
     };
     ALLOWED_MSR_RANGES.iter().any(|range| range.contains(index))
@@ -349,7 +349,7 @@ mod tests {
     fn test_msr_allowlist() {
         for range in ALLOWED_MSR_RANGES.iter() {
             for msr in range.base..(range.base + range.nmsrs) {
-                let should = !matches!(msr, MSR_IA32_FEATURE_CONTROL | MSR_IA32_MCG_CTL);
+                let should = !matches!(msr, MSR_IA32_MCG_CTL);
                 assert_eq!(msr_should_serialize(msr), should);
             }
         }


### PR DESCRIPTION
## Changes

This excludes MSR_IA32_FEATURE_CONTROL from the deny list while saving MSRs to snapshot.
The MSR was previously masked from saving, but this is no longer relevant.

## Reason

Testing showed that MSR_IA32_FEATURE_CONTROL did not preserve its value after being written to before taking snapshot and then restored. This is because it was in the deny list.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
