### PR TITLE
MMDS: Make header parsing case-insensitive (cherry picked)

### DIFF
--- a/src/mmds/src/token_headers.rs
+++ b/src/mmds/src/token_headers.rs
@@ -39,12 +39,19 @@ impl TokenHeaders {
     /// Return `TokenHeaders` from headers map.
     pub fn try_from(map: &HashMap<String, String>) -> Result<TokenHeaders, RequestError> {
         let mut headers = Self::default();
+        let lowercased_headers: HashMap<String, String> = map
+            .iter()
+            .map(|(k, v)| (k.to_lowercase(), v.clone()))
+            .collect();
 
-        if let Some(token) = map.get(TokenHeaders::X_METADATA_TOKEN) {
+        if let Some(token) = lowercased_headers.get(&TokenHeaders::X_METADATA_TOKEN.to_lowercase())
+        {
             headers.x_metadata_token = Some(token.to_string());
         }
 
-        if let Some(value) = map.get(TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS) {
+        if let Some(value) =
+            lowercased_headers.get(&TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS.to_lowercase())
+        {
             match value.parse::<u32>() {
                 Ok(seconds) => {
                     headers.x_metadata_token_ttl_seconds = Some(seconds);
@@ -126,6 +133,17 @@ mod tests {
         map.insert(TokenHeaders::X_METADATA_TOKEN.to_string(), "".to_string());
         let headers = TokenHeaders::try_from(&map).unwrap();
         assert_eq!(*headers.x_metadata_token().unwrap(), "".to_string());
+
+        // Lowercased headers
+        let mut map: HashMap<String, String> = HashMap::default();
+        map.insert(
+            TokenHeaders::X_METADATA_TOKEN_TTL_SECONDS
+                .to_string()
+                .to_lowercase(),
+            "60".to_string(),
+        );
+        let headers = TokenHeaders::try_from(&map).unwrap();
+        assert_eq!(headers.x_metadata_token_ttl_seconds().unwrap(), 60);
 
         // Invalid value.
         let mut map: HashMap<String, String> = HashMap::default();


### PR DESCRIPTION
This PR is cherry picked from https://github.com/firecracker-microvm/firecracker/pull/3006

# Reason for This PR
The MMDS API requires the `X` to be uppercased in header names (e.g. `X-metadata-token`). According to the HTTP1 spec, headers should be ignorant of capitalisation, and because of this libraries like `hyper` automatically lowercase all header names. Because of this, some HTTP clients cannot send requests to the MMDS API.

## Description of Changes
Make the header parsing for MMDS ignorant to casing.

## License Acceptance
By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist
`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x]  All commits in this PR are signed (git commit -s).
- [ ]  The issue which led to this PR has a clear conclusion.
- [ ]  This PR follows the solution outlined in the related issue.
- [x]  The description of changes is clear and encompassing.
- [x]  Any required documentation changes (code and docs) are included in this PR.
- [x]  Any newly added unsafe code is properly documented.
- [x]  Any API changes follow the [Runbook for Firecracker API changes](https://github.com/firecracker-microvm/firecracker/docs/api-change-runbook.md).
- [ ]  Any user-facing changes are mentioned in CHANGELOG.md.
- [x]  All added/changed functionality is tested.