### PR TITLE
Log kernel version and CPU in tests

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -1250,6 +1250,7 @@ cmd_test() {
 
     # If we got to here, we've got all we need to continue.
     say "$(date -u +'%F %H:%M:%S %Z')"
+    say "Kernel version: $(uname -r)"
     say "Starting test run ..."
 
     if [[ $ramdisk = true ]]; then
@@ -1285,6 +1286,9 @@ cmd_test() {
     # Running as root would have created some root-owned files under the build
     # dir. Let's fix that.
     cmd_fix_perms
+
+    # Log CPU information
+    say "$(lscpu)"
 
     return $ret
 }


### PR DESCRIPTION
## Changes

* Added kernel version log line in devtool
* Add CPU information with `lscpu`

### `aarch64`

```
[Firecracker devtool] 2022-10-12 16:38:51 UTC
[Firecracker devtool] Kernel version: 4.14.291-218.527.amzn2.aarch64
[Firecracker devtool] Starting test run ...
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
...
======================== 7 passed in 496.44s (0:08:16) =========================
[Firecracker devtool] Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              64
On-line CPU(s) list: 0-63
Thread(s) per core:  1
Core(s) per socket:  64
Socket(s):           1
NUMA node(s):        1
Model:               1
BogoMIPS:            243.75
L1d cache:           64K
L1i cache:           64K
L2 cache:            1024K
L3 cache:            32768K
NUMA node0 CPU(s):   0-63
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
```

### `x86-64`

```
[Firecracker devtool] 2022-10-12 16:39:04 UTC
[Firecracker devtool] Kernel version: 4.14.291-218.527.amzn2.x86_64
[Firecracker devtool] Starting test run ...
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
...
======================== 9 passed in 385.89s (0:06:25) =========================
[Firecracker devtool] Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              96
On-line CPU(s) list: 0-95
Thread(s) per core:  2
Core(s) per socket:  24
Socket(s):           2
NUMA node(s):        2
Vendor ID:           GenuineIntel
CPU family:          6
Model:               85
Model name:          Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Stepping:            7
CPU MHz:             2870.728
CPU max MHz:         3500.0000
CPU min MHz:         1200.0000
BogoMIPS:            5000.00
Virtualization:      VT-x
L1d cache:           32K
L1i cache:           32K
L2 cache:            1024K
L3 cache:            36608K
NUMA node0 CPU(s):   0-23,48-71
NUMA node1 CPU(s):   24-47,72-95
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req pku ospke avx512_vnni md_clear flush_l1d arch_capabilities
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
