### PR TITLE
doc: add MSR_IA32_TSX_CTRL snapshot limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ plans, check out our [kernel support policy](docs/kernel-policy.md).
 - The [SendCtrlAltDel](docs/api_requests/actions.md#sendctrlaltdel) API request
   is not supported for aarch64 enabled microVMs.
 - Configuring CPU templates is only supported for Intel enabled microVMs.
+- If a CPU template is not used on x86_64, overwrites of `MSR_IA32_TSX_CTRL` MSR
+  value will not be preserved after restoring from a snapshot.
 - The `pl031` RTC device on aarch64 does not support interrupts, so guest
   programs which use an RTC alarm (e.g. `hwclock`) will not work.
 


### PR DESCRIPTION
## Changes

Document MSR_IA32_TSX_CTRL limitation when taking snapshot.

## Reason

Inform users of a known limitation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
