### PR TITLE
doc: Tweak markdown formatting

### DIFF
--- a/docs/jailer.md
+++ b/docs/jailer.md
@@ -52,7 +52,7 @@ jailer --id <id> \
   Supported options are "1" for cgroup-v1 and "2" for cgroup-v2.
 - `cgroup` cgroups can be passed to the jailer to let it set the values
   when the microVM process is spawned. The `--cgroup` argument must follow this format:
-  `<cgroup_file>=<value>` (e.g cpuset.cpus=0). This argument can be used multiple
+  `<cgroup_file>=<value>` (e.g `cpuset.cpus=0`). This argument can be used multiple
   times to set multiple cgroups. This is useful to avoid providing privileged permissions
   to another process for setting the cgroups before or after the jailer is executed.
   The `--cgroup` flag can help as well to set Firecracker process cgroups


### PR DESCRIPTION
## Changes

Tweak markdown formatting by adding ` around code.

## Reason

Tweak markdown formatting by adding ` around code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
