### PR TITLE
Deny undocumented unsafe blocks using clippy

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.
 //! It is constructed on top of an HTTP Server that uses Unix Domain Sockets and `EPOLL` to

--- a/src/arch/src/aarch64/gic/gicv2/regs/dist_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv2/regs/dist_regs.rs
@@ -126,6 +126,8 @@ pub(crate) fn set_dist_regs(fd: &DeviceFd, state: &[GicRegState<u32>]) -> Result
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+
     use std::os::unix::io::AsRawFd;
 
     use kvm_ioctls::Kvm;

--- a/src/arch/src/aarch64/gic/gicv2/regs/icc_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv2/regs/icc_regs.rs
@@ -77,6 +77,7 @@ pub(crate) fn set_icc_regs(fd: &DeviceFd, mpidr: u64, state: &VgicSysRegsState) 
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
     use kvm_ioctls::Kvm;

--- a/src/arch/src/aarch64/gic/gicv3/mod.rs
+++ b/src/arch/src/aarch64/gic/gicv3/mod.rs
@@ -142,6 +142,7 @@ fn save_pending_tables(fd: &DeviceFd) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use kvm_ioctls::Kvm;
 
     use super::*;

--- a/src/arch/src/aarch64/gic/gicv3/regs/dist_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/dist_regs.rs
@@ -129,6 +129,7 @@ pub(crate) fn set_dist_regs(fd: &DeviceFd, state: &[GicRegState<u32>]) -> Result
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
     use kvm_ioctls::Kvm;

--- a/src/arch/src/aarch64/gic/gicv3/regs/icc_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/icc_regs.rs
@@ -165,6 +165,7 @@ pub(crate) fn set_icc_regs(fd: &DeviceFd, mpidr: u64, state: &VgicSysRegsState) 
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
     use kvm_ioctls::Kvm;

--- a/src/arch/src/aarch64/gic/gicv3/regs/redist_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/redist_regs.rs
@@ -79,6 +79,7 @@ pub(crate) fn set_redist_regs(fd: &DeviceFd, mpidr: u64, data: &[GicRegState<u32
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
     use kvm_ioctls::Kvm;

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -84,6 +84,8 @@ const NR_FP_VREGS: usize = 32;
 // Same as bindgen offset tests.
 macro_rules! offset__of {
     ($container:ty, $field:ident) => {
+        // SAFETY: The implementation closely matches that of the memoffset crate,
+        // which have been under extensive review.
         unsafe {
             let uninit = std::mem::MaybeUninit::<$container>::uninit();
             let ptr = uninit.as_ptr();
@@ -451,6 +453,7 @@ pub fn set_mpstate(vcpu: &VcpuFd, state: kvm_mp_state) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use kvm_ioctls::Kvm;
 
     use super::*;

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.
 use std::{fmt, result};

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -35,12 +35,19 @@ struct MpcLintsrcWrapper(mpspec::mpc_lintsrc);
 struct MpfIntelWrapper(mpspec::mpf_intel);
 
 // These `mpspec` wrapper types are only data, reading them from data is a safe initialization.
+// SAFETY: POD
 unsafe impl ByteValued for MpcBusWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpcCpuWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpcIntsrcWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpcIoapicWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpcTableWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpcLintsrcWrapper {}
+// SAFETY: POD
 unsafe impl ByteValued for MpfIntelWrapper {}
 
 // MPTABLE, describing VCPUS.
@@ -101,9 +108,11 @@ const CPU_FEATURE_APIC: u32 = 0x200;
 const CPU_FEATURE_FPU: u32 = 0x001;
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
-    // Safe because we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice =
-        unsafe { slice::from_raw_parts((v as *const T).cast::<u8>(), mem::size_of::<T>()) };
+    // SAFETY: Safe because we are only reading the bytes within the size of the `T` reference `v`.
+    let v_slice = unsafe {
+        let ptr = (v as *const T).cast::<u8>();
+        slice::from_raw_parts(ptr, mem::size_of::<T>())
+    };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);

--- a/src/arch_gen/src/lib.rs
+++ b/src/arch_gen/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(clippy::all)]
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod x86;

--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -104,6 +104,13 @@ impl BrandString {
     /// of the host CPU.
     pub fn from_host_cpuid() -> Result<Self, Error> {
         let mut this = Self::new();
+        // This operation is safe as long as the processor implements this
+        // funcion of CPUID.
+        // 0x8000_0000 is the defined code getting the highest extended function
+        // implemented by the processor.
+        // It is hinted by the [spec](https://doc.rust-lang.org/beta/core/arch/x86_64/fn.__cpuid_count.html)
+        // that this is always available, but this is unclear.
+        #[allow(clippy::undocumented_unsafe_blocks)]
         let mut cpuid_regs = unsafe { host_cpuid(0x8000_0000) };
 
         if cpuid_regs.eax < 0x8000_0004 {
@@ -112,6 +119,8 @@ impl BrandString {
         }
 
         for leaf in 0x8000_0002..=0x8000_0004 {
+            // SAFETY: This is safe because we checked that the highest
+            // extended function includes the processor brand string.
             cpuid_regs = unsafe { host_cpuid(leaf) };
             this.set_reg_for_leaf(leaf, Reg::Eax, cpuid_regs.eax);
             this.set_reg_for_leaf(leaf, Reg::Ebx, cpuid_regs.ebx);
@@ -161,7 +170,7 @@ impl BrandString {
     /// Gets an immutable `u8` slice view into the brand string buffer.
     #[inline]
     fn as_bytes(&self) -> &[u8] {
-        // This is actually safe, because self.reg_buf has a fixed, known size,
+        // SAFETY: This is actually safe, because self.reg_buf has a fixed, known size,
         // and also there's no risk of misalignment, since we're downgrading
         // alignment constraints from dword to byte.
         unsafe { slice::from_raw_parts(self.reg_buf.as_ptr().cast::<u8>(), Self::REG_BUF_SIZE * 4) }
@@ -170,6 +179,10 @@ impl BrandString {
     /// Gets a mutable `u8` slice view into the brand string buffer.
     #[inline]
     fn as_bytes_mut(&mut self) -> &mut [u8] {
+        // SAFETY: This is actually safe, because self.reg_buf has a fixed, known size,
+        // and also there's no risk of misalignment, since we're downgrading
+        // alignment constraints from dword to byte.
+        // Returned mut reference is exclusive because the mut self reference is also exclusive.
         unsafe {
             slice::from_raw_parts_mut(
                 self.reg_buf.as_mut_ptr().cast::<u8>(),
@@ -309,6 +322,7 @@ fn null_terminator_index(slice: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::iter::repeat;
 
     use super::*;

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 #![cfg(target_arch = "x86_64")]

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -6,6 +6,8 @@
 // found in the THIRD-PARTY file.
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Emulates virtual and hardware devices.
 use std::io;
 

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -48,7 +48,7 @@ pub(crate) struct ConfigSpace {
     pub actual_pages: u32,
 }
 
-// Safe because ConfigSpace only contains plain data.
+// SAFETY: Safe because ConfigSpace only contains plain data.
 unsafe impl ByteValued for ConfigSpace {}
 
 // This structure needs the `packed` attribute, otherwise Rust will assume
@@ -60,7 +60,7 @@ struct BalloonStat {
     pub val: u64,
 }
 
-// Safe because BalloonStat only contains plain data.
+// SAFETY: Safe because BalloonStat only contains plain data.
 unsafe impl ByteValued for BalloonStat {}
 
 // BalloonStats holds statistics returned from the stats_queue.

--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -118,8 +118,8 @@ impl<T> AsyncFileEngine<T> {
 
         let wrapped_user_data = WrappedUserData::new_with_dirty_tracking(addr, user_data);
 
-        // Safe because we trust that the host kernel will pass us back a completed entry with this
-        // same `user_data`, so that the value will not be leaked.
+        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
+        // with this same `user_data`, so that the value will not be leaked.
         unsafe {
             self.ring.push(Operation::read(
                 0,
@@ -155,8 +155,8 @@ impl<T> AsyncFileEngine<T> {
 
         let wrapped_user_data = WrappedUserData::new(user_data);
 
-        // Safe because we trust that the host kernel will pass us back a completed entry with this
-        // same `user_data`, so that the value will not be leaked.
+        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
+        // with this same `user_data`, so that the value will not be leaked.
         unsafe {
             self.ring.push(Operation::write(
                 0,
@@ -175,8 +175,8 @@ impl<T> AsyncFileEngine<T> {
     pub fn push_flush(&mut self, user_data: T) -> Result<(), UserDataError<T, Error>> {
         let wrapped_user_data = WrappedUserData::new(user_data);
 
-        // Safe because we trust that the host kernel will pass us back a completed entry with this
-        // same `user_data`, so that the value will not be leaked.
+        // SAFETY: Safe because we trust that the host kernel will pass us back a completed entry
+        // with this same `user_data`, so that the value will not be leaked.
         unsafe { self.ring.push(Operation::fsync(0, wrapped_user_data)) }.map_err(|err_tuple| {
             UserDataError {
                 user_data: err_tuple.1.user_data,
@@ -215,7 +215,7 @@ impl<T> AsyncFileEngine<T> {
     }
 
     fn do_pop(&mut self) -> Result<Option<Cqe<WrappedUserData<T>>>, Error> {
-        // We trust that the host kernel did not touch the operation's `user_data` field.
+        // SAFETY: We trust that the host kernel did not touch the operation's `user_data` field.
         // The `T` type is the same one used for `push`ing and since the kernel made this entry
         // available in the completion queue, we now have full ownership of it.
 

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -173,6 +173,7 @@ impl<T> FileEngine<T> {
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::FromRawFd;
 

--- a/src/devices/src/virtio/block/io/sync_io.rs
+++ b/src/devices/src/virtio/block/io/sync_io.rs
@@ -19,6 +19,7 @@ pub struct SyncFileEngine {
     file: File,
 }
 
+// SAFETY: `File` is send and ultimately a POD.
 unsafe impl Send for SyncFileEngine {}
 
 impl SyncFileEngine {

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -188,7 +188,7 @@ pub struct RequestHeader {
     sector: u64,
 }
 
-// Safe because RequestHeader only contains plain data.
+// SAFETY: Safe because RequestHeader only contains plain data.
 unsafe impl ByteValued for RequestHeader {}
 
 impl RequestHeader {
@@ -400,6 +400,8 @@ impl Request {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+
     use vm_memory::test_utils::create_anon_guest_memory;
     use vm_memory::{Address, GuestAddress, GuestMemory};
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -102,6 +102,7 @@ impl Default for ConfigSpace {
     }
 }
 
+// SAFETY: `ConfigSpace` contains only PODs.
 unsafe impl ByteValued for ConfigSpace {}
 
 pub struct Net {

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -59,6 +59,7 @@ struct Descriptor {
     next: u16,
 }
 
+// SAFETY: `Descriptor` is a POD and contains no padding.
 unsafe impl ByteValued for Descriptor {}
 
 /// A virtio descriptor chain.

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -240,6 +240,7 @@ pub struct VirtqUsedElem {
     pub len: u32,
 }
 
+// SAFETY: `VirtqUsedElem` is a POD and contains no padding.
 unsafe impl vm_memory::ByteValued for VirtqUsedElem {}
 
 pub type VirtqAvail<'a> = VirtqRing<'a, u16>;

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -79,6 +79,7 @@ pub struct VsockPacketHeader {
 /// The vsock packet header struct size (the struct is packed).
 pub const VSOCK_PKT_HDR_SIZE: usize = 44;
 
+// SAFETY: `VsockPacketHeader` is a POD and contains no padding.
 unsafe impl ByteValued for VsockPacketHeader {}
 
 /// The vsock packet, implemented as a wrapper over a virtq descriptor chain:

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
 pub mod pdu;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 mod api_server_adapter;
 mod metrics;
@@ -45,6 +46,10 @@ pub fn enable_ssbd_mitigation() {
     const PR_SPEC_STORE_BYPASS: u64 = 0;
     const PR_SPEC_FORCE_DISABLE: u64 = 1u64 << 3;
 
+    // SAFETY: Parameters are valid since they are copied verbatim
+    // from the kernel's UAPI.
+    // PR_SET_SPECULATION_CTRL only uses those 2 parameters, so it's ok
+    // to leave the latter 2 as zero.
     let ret = unsafe {
         libc::prctl(
             PR_SET_SPECULATION_CTRL,

--- a/src/io_uring/src/bindings.rs
+++ b/src/io_uring/src/bindings.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 #[repr(C)]

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! High-level interface over Linux io_uring.
 //!
 //! Aims to provide an easy-to-use interface, while making some Firecracker-specific simplifying
@@ -13,6 +15,7 @@
 //! For more information on io_uring, refer to the man pages.
 //! [This pdf](https://kernel.dk/io_uring.pdf) is also very useful, though outdated at times.
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 mod bindings;
 pub mod operation;
 mod probe;
@@ -125,7 +128,7 @@ impl IoUring {
             ..Default::default()
         };
 
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         let fd = SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_setup,
@@ -136,7 +139,7 @@ impl IoUring {
         .into_result()
         .map_err(Error::Setup)? as i32;
 
-        // Safe because the fd is valid and because this struct owns the fd.
+        // SAFETY: Safe because the fd is valid and because this struct owns the fd.
         let file = unsafe { File::from_raw_fd(fd) };
 
         Self::check_features(params)?;
@@ -245,7 +248,7 @@ impl IoUring {
     }
 
     fn enable(&mut self) -> Result<()> {
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_register,
@@ -270,7 +273,7 @@ impl IoUring {
             return Err(Error::RegisterFileLimitExceeded);
         }
 
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_register,
@@ -294,7 +297,7 @@ impl IoUring {
     }
 
     fn register_eventfd(&self, fd: RawFd) -> Result<()> {
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_register,
@@ -313,7 +316,7 @@ impl IoUring {
             // No-op.
             return Ok(());
         }
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_register,
@@ -349,7 +352,7 @@ impl IoUring {
     fn check_operations(&self) -> Result<()> {
         let mut probes = ProbeWrapper::new(PROBE_LEN).map_err(Error::Fam)?;
 
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_register,
@@ -381,6 +384,7 @@ impl IoUring {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::fs::FileExt;
 
     use proptest::prelude::*;

--- a/src/io_uring/src/operation/cqe.rs
+++ b/src/io_uring/src/operation/cqe.rs
@@ -7,6 +7,7 @@ use vm_memory::ByteValued;
 
 use crate::bindings::io_uring_cqe;
 
+// SAFETY: Struct is POD and contains no references or niches.
 unsafe impl ByteValued for io_uring_cqe {}
 
 /// Wrapper over a completed operation.
@@ -61,6 +62,7 @@ impl<T> Cqe<T> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use super::*;
     #[test]
     fn test_result() {

--- a/src/io_uring/src/operation/sqe.rs
+++ b/src/io_uring/src/operation/sqe.rs
@@ -5,6 +5,7 @@ use vm_memory::ByteValued;
 
 use crate::bindings::io_uring_sqe;
 
+// SAFETY: Struct is POD and contains no references or niches.
 unsafe impl ByteValued for io_uring_sqe {}
 
 /// Newtype wrapper over a raw sqe.
@@ -28,6 +29,7 @@ impl Sqe {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use super::*;
     #[test]
     fn test_user_data() {

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -100,7 +100,7 @@ impl CompletionQueue {
 
 impl Drop for CompletionQueue {
     fn drop(&mut self) {
-        // Safe because parameters are valid.
+        // SAFETY: Safe because parameters are valid.
         unsafe { libc::munmap(self.cqes.as_ptr().cast::<libc::c_void>(), self.cqes.size()) };
     }
 }

--- a/src/io_uring/src/queue/mmap.rs
+++ b/src/io_uring/src/queue/mmap.rs
@@ -17,13 +17,13 @@ pub(crate) fn mmap(size: usize, fd: RawFd, offset: i64) -> Result<MmapRegion, Er
     let prot = libc::PROT_READ | libc::PROT_WRITE;
     let flags = libc::MAP_SHARED | libc::MAP_POPULATE;
 
-    // Safe because values are valid and we check the return value.
+    // SAFETY: Safe because values are valid and we check the return value.
     let ptr = unsafe { libc::mmap(std::ptr::null_mut(), size, prot, flags, fd, offset) };
     if (ptr as isize) < 0 {
         return Err(Error::Os(IOError::last_os_error()));
     }
 
-    // Safe because the mmap did not return error.
+    // SAFETY: Safe because the mmap did not return error.
     unsafe {
         MmapRegion::build_raw(ptr.cast::<u8>(), size, prot, flags).map_err(Error::BuildMmapRegion)
     }

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -131,7 +131,7 @@ impl SubmissionQueue {
         if min_complete > 0 {
             flags |= bindings::IORING_ENTER_GETEVENTS;
         }
-        // Safe because values are valid and we check the return value.
+        // SAFETY: Safe because values are valid and we check the return value.
         let submitted = SyscallReturnCode(unsafe {
             libc::syscall(
                 libc::SYS_io_uring_enter,
@@ -192,8 +192,9 @@ impl SubmissionQueue {
 
 impl Drop for SubmissionQueue {
     fn drop(&mut self) {
-        // Safe because parameters are valid.
+        // SAFETY: Safe because parameters are valid.
         unsafe { libc::munmap(self.ring.as_ptr().cast::<libc::c_void>(), self.ring.size()) };
+        // SAFETY: Safe because parameters are valid.
         unsafe { libc::munmap(self.sqes.as_ptr().cast::<libc::c_void>(), self.sqes.size()) };
     }
 }

--- a/src/io_uring/src/restriction.rs
+++ b/src/io_uring/src/restriction.rs
@@ -27,7 +27,7 @@ impl From<&Restriction> for bindings::io_uring_restriction {
     fn from(restriction: &Restriction) -> Self {
         use Restriction::*;
 
-        // Safe because it only contains integer values.
+        // SAFETY: Safe because it only contains integer values.
         let mut instance: Self = unsafe { std::mem::zeroed() };
 
         match restriction {

--- a/src/jailer/src/chroot.rs
+++ b/src/jailer/src/chroot.rs
@@ -17,7 +17,8 @@ const CURRENT_DIR_NUL_TERMINATED: &[u8] = b".\0";
 // This uses switching to a new mount namespace + pivot_root(), together with the regular chroot,
 // to provide a hardened jail (at least compared to only relying on chroot).
 pub fn chroot(path: &Path) -> Result<()> {
-    // We unshare into a new mount namespace. The call is safe because we're invoking a C library
+    // We unshare into a new mount namespace.
+    // SAFETY: The call is safe because we're invoking a C library
     // function with valid parameters.
     SyscallReturnCode(unsafe { libc::unshare(libc::CLONE_NEWNS) })
         .into_empty_result()
@@ -27,7 +28,8 @@ pub fn chroot(path: &Path) -> Result<()> {
         CStr::from_bytes_with_nul(ROOT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
 
     // Recursively change the propagation type of all the mounts in this namespace to SLAVE, so
-    // we can call pivot_root. Safe because we provide valid parameters.
+    // we can call pivot_root.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe {
         libc::mount(
             null(),
@@ -45,7 +47,8 @@ pub fn chroot(path: &Path) -> Result<()> {
 
     // Bind mount the jail root directory over itself, so we can go around a restriction
     // imposed by pivot_root, which states that the new root and the old root should not
-    // be on the same filesystem. Safe because we provide valid parameters.
+    // be on the same filesystem.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe {
         libc::mount(
             chroot_dir.as_ptr(),
@@ -66,8 +69,8 @@ pub fn chroot(path: &Path) -> Result<()> {
     let old_root_dir = CStr::from_bytes_with_nul(OLD_ROOT_DIR_NAME_NUL_TERMINATED)
         .map_err(Error::FromBytesWithNul)?;
 
-    // Create the old_root folder we're going to use for pivot_root, using a relative path. The call
-    // is safe because we provide valid arguments.
+    // Create the old_root folder we're going to use for pivot_root, using a relative path.
+    // SAFETY: The call is safe because we provide valid arguments.
     SyscallReturnCode(unsafe { libc::mkdir(old_root_dir.as_ptr(), libc::S_IRUSR | libc::S_IWUSR) })
         .into_empty_result()
         .map_err(Error::MkdirOldRoot)?;
@@ -76,7 +79,8 @@ pub fn chroot(path: &Path) -> Result<()> {
         CStr::from_bytes_with_nul(CURRENT_DIR_NUL_TERMINATED).map_err(Error::FromBytesWithNul)?;
 
     // We are now ready to call pivot_root. We have to use sys_call because there is no libc
-    // wrapper for pivot_root. Safe because we provide valid parameters.
+    // wrapper for pivot_root.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe {
         libc::syscall(libc::SYS_pivot_root, cwd.as_ptr(), old_root_dir.as_ptr())
     } as libc::c_int)
@@ -84,18 +88,20 @@ pub fn chroot(path: &Path) -> Result<()> {
     .map_err(Error::PivotRoot)?;
 
     // pivot_root doesn't guarantee that we will be in "/" at this point, so switch to "/"
-    // explicitly. Safe because we provide valid parameters.
+    // explicitly.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::chdir(root_dir.as_ptr()) })
         .into_empty_result()
         .map_err(Error::ChdirNewRoot)?;
 
     // Umount the old_root, thus isolating the process from everything outside the jail root folder.
-    // Safe because we provide valid parameters.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::umount2(old_root_dir.as_ptr(), libc::MNT_DETACH) })
         .into_empty_result()
         .map_err(Error::UmountOldRoot)?;
 
     // Remove the no longer necessary old_root directory.
+    // SAFETY: Safe because we provide valid parameters.
     SyscallReturnCode(unsafe { libc::rmdir(old_root_dir.as_ptr()) })
         .into_empty_result()
         .map_err(Error::RmOldRootDir)

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 mod cgroup;
 mod chroot;
@@ -359,7 +360,7 @@ fn sanitize_process() {
             let fd = fd_str.parse::<i32>().unwrap_or(0);
 
             if fd > 2 {
-                // Safe because close() cannot fail when passed a valid parameter.
+                // SAFETY: Safe because close() cannot fail when passed a valid parameter.
                 unsafe { libc::close(fd) };
             }
         }
@@ -436,6 +437,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::env;
     use std::fs::File;
     use std::os::unix::io::IntoRawFd;

--- a/src/jailer/src/resource_limits.rs
+++ b/src/jailer/src/resource_limits.rs
@@ -74,6 +74,8 @@ impl ResourceLimits {
             rlim_max: target,
         };
 
+        // SAFETY: Safe because `resource` is a known-valid constant, and `&rlim`
+        // is non-dangling.
         SyscallReturnCode(unsafe { libc::setrlimit(u32::from(resource) as _, &rlim) })
             .into_empty_result()
             .map_err(|_| Error::Setrlimit(resource.to_string()))
@@ -90,6 +92,7 @@ impl ResourceLimits {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use super::*;
 
     #[test]

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! Crate that implements Firecracker specific functionality as far as logging and metrics
 //! collecting.
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 pub mod data_store;
 pub mod ns;

--- a/src/net_gen/src/if_tun.rs
+++ b/src/net_gen/src/if_tun.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const ETH_ALEN: u32 = 6;

--- a/src/net_gen/src/iff.rs
+++ b/src/net_gen/src/iff.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const IFNAMSIZ: u32 = 16;

--- a/src/net_gen/src/inn.rs
+++ b/src/net_gen/src/inn.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const IP_TOS: u32 = 1;

--- a/src/net_gen/src/sockios.rs
+++ b/src/net_gen/src/sockios.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const FIOSETOWN: u32 = 35073;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 //! # Rate Limiter
 //!
 //! Provides a rate limiter written in Rust useful for IO operations that need to

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -876,6 +876,7 @@ fn EXAMINE_SYSCALL() -> Vec<sock_filter> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::env::consts::ARCH;
     use std::thread;
 

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! The library crate that defines common helper functions that are generally used in
 //! conjunction with seccompiler-bin.
@@ -115,6 +116,7 @@ pub fn apply_filter(bpf_filter: BpfProgramRef) -> std::result::Result<(), Instal
         return Err(InstallationError::FilterTooLarge);
     }
 
+    // SAFETY: Safe because the parameters are valid.
     unsafe {
         {
             let rc = libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
@@ -145,6 +147,8 @@ pub fn apply_filter(bpf_filter: BpfProgramRef) -> std::result::Result<(), Instal
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::thread;

--- a/src/seccompiler/src/seccompiler_bin.rs
+++ b/src/seccompiler/src/seccompiler_bin.rs
@@ -213,6 +213,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::collections::HashMap;
     use std::io;
     use std::io::Write;

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Provides version tolerant serialization and deserialization facilities and
 //! implements a persistent storage format for Firecracker state snapshots.

--- a/src/utils/src/kernel_version.rs
+++ b/src/utils/src/kernel_version.rs
@@ -40,6 +40,7 @@ impl KernelVersion {
             machine: [0; 65],
             domainname: [0; 65],
         };
+        // SAFETY: Safe because the parameters are valid.
         let res = unsafe { uname((&mut name) as *mut utsname) };
 
         if res < 0 {

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).
@@ -25,6 +26,7 @@ use std::result::Result;
 
 /// Return the default page size of the platform, in bytes.
 pub fn get_page_size() -> Result<usize, errno::Error> {
+    // SAFETY: Safe because the parameters are valid.
     match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
         -1 => Err(errno::Error::last()),
         ps => Ok(ps as usize),

--- a/src/utils/src/signal.rs
+++ b/src/utils/src/signal.rs
@@ -10,9 +10,11 @@ extern "C" {
 }
 
 pub fn sigrtmin() -> c_int {
+    // SAFETY: Function has no invariants that can be broken.
     unsafe { __libc_current_sigrtmin() }
 }
 
 pub fn sigrtmax() -> c_int {
+    // SAFETY: Function has no invariants that can be broken.
     unsafe { __libc_current_sigrtmax() }
 }

--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -70,7 +70,7 @@ impl LocalTime {
             tm_zone: std::ptr::null(),
         };
 
-        // Safe because the parameters are valid.
+        // SAFETY: Safe because the parameters are valid.
         unsafe {
             libc::clock_gettime(libc::CLOCK_REALTIME, &mut timespec);
             libc::localtime_r(&timespec.tv_sec, &mut tm);
@@ -127,7 +127,7 @@ impl Default for TimestampUs {
 /// Uses `_rdstc` on `x86_64` and [`get_time`](fn.get_time.html) on other architectures.
 pub fn timestamp_cycles() -> u64 {
     #[cfg(target_arch = "x86_64")]
-    // Safe because there's nothing that can go wrong with this call.
+    // SAFETY: Safe because there's nothing that can go wrong with this call.
     unsafe {
         std::arch::x86_64::_rdtsc() as u64
     }
@@ -147,7 +147,7 @@ pub fn get_time_ns(clock_type: ClockType) -> u64 {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    // Safe because the parameters are valid.
+    // SAFETY: Safe because the parameters are valid.
     unsafe { libc::clock_gettime(clock_type.into(), &mut time_struct) };
     seconds_to_nanoseconds(time_struct.tv_sec).expect("Time conversion overflow") as u64
         + (time_struct.tv_nsec as u64)

--- a/src/virtio_gen/src/virtio_blk.rs
+++ b/src/virtio_gen/src/virtio_blk.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: u32 = 24;

--- a/src/virtio_gen/src/virtio_net.rs
+++ b/src/virtio_gen/src/virtio_net.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: u32 = 24;

--- a/src/virtio_gen/src/virtio_ring.rs
+++ b/src/virtio_gen/src/virtio_ring.rs
@@ -8,7 +8,8 @@
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 pub const VIRTIO_RING_F_EVENT_IDX: u32 = 29;

--- a/src/vm-memory/src/lib.rs
+++ b/src/vm-memory/src/lib.rs
@@ -4,6 +4,7 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 use std::io::Error as IoError;
 use std::os::unix::io::AsRawFd;
@@ -50,6 +51,7 @@ fn build_guarded_region(
     let guarded_size = size + GUARD_PAGE_COUNT * 2 * page_size;
 
     // Map the guarded range to PROT_NONE
+    // SAFETY: Safe because the parameters are valid.
     let guard_addr = unsafe {
         libc::mmap(
             std::ptr::null_mut(),
@@ -77,6 +79,7 @@ fn build_guarded_region(
 
     // Inside the protected range, starting with guard_addr + PAGE_SIZE,
     // map the requested range with received protection and flags
+    // SAFETY: Safe because the parameters are valid.
     let region_addr = unsafe {
         libc::mmap(
             region_start_addr as *mut libc::c_void,
@@ -97,6 +100,7 @@ fn build_guarded_region(
         false => None,
     };
 
+    // SAFETY: Safe because the parameters are valid.
     unsafe {
         MmapRegionBuilder::new_with_bitmap(size, bitmap)
             .with_raw_mmap_pointer(region_addr as *mut u8)
@@ -189,6 +193,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use utils::get_page_size;
     use utils::tempfile::TempFile;
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1001,10 +1001,12 @@ fn attach_balloon_device(
 
 // Adds `O_NONBLOCK` to the stdout flags.
 pub(crate) fn set_stdout_nonblocking() {
+    // SAFETY: Call is safe since parameters are valid.
     let flags = unsafe { libc::fcntl(libc::STDOUT_FILENO, libc::F_GETFL, 0) };
     if flags < 0 {
         error!("Could not get Firecracker stdout flags.");
     }
+    // SAFETY: Call is safe since parameters are valid.
     let rc = unsafe { libc::fcntl(libc::STDOUT_FILENO, libc::F_SETFL, flags | libc::O_NONBLOCK) };
     if rc < 0 {
         error!("Could not set Firecracker stdout to non-blocking.");

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -9,6 +9,7 @@
 //! and other virtualization features to run a single lightweight micro-virtual
 //! machine (microVM).
 #![deny(missing_docs)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -24,7 +24,7 @@ fn exit_with_code(exit_code: FcExitCode) {
     if let Err(err) = METRICS.write() {
         error!("Failed to write metrics while stopping: {}", err);
     }
-    // Safe because we're terminating the process anyway.
+    // SAFETY: Safe because we're terminating the process anyway.
     unsafe { libc::_exit(exit_code as i32) };
 }
 
@@ -32,8 +32,9 @@ macro_rules! generate_handler {
     ($fn_name:ident ,$signal_name:ident, $exit_code:ident, $signal_metric:expr, $body:ident) => {
         #[inline(always)]
         extern "C" fn $fn_name(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) {
-            // Safe because we're just reading some fields from a supposedly valid argument.
+            // SAFETY: Safe because we're just reading some fields from a supposedly valid argument.
             let si_signo = unsafe { (*info).si_signo };
+            // SAFETY: Safe because we're just reading some fields from a supposedly valid argument.
             let si_code = unsafe { (*info).si_code };
 
             if num != si_signo || num != $signal_name {
@@ -63,7 +64,7 @@ fn log_sigsys_err(si_code: c_int, info: *mut siginfo_t) {
         exit_with_code(FcExitCode::UnexpectedError);
     }
 
-    // Other signals which might do async unsafe things incompatible with the rest of this
+    // SAFETY: Other signals which might do async unsafe things incompatible with the rest of this
     // function are blocked due to the sa_mask used when registering the signal handler.
     let syscall = unsafe { *(info as *const i32).offset(SI_OFF_SYSCALL) as usize };
     error!(
@@ -134,8 +135,9 @@ extern "C" fn sigpipe_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_
     // Just record the metric and allow the process to continue, the EPIPE error needs
     // to be handled at caller level.
 
-    // Safe because we're just reading some fields from a supposedly valid argument.
+    // SAFETY: Safe because we're just reading some fields from a supposedly valid argument.
     let si_signo = unsafe { (*info).si_signo };
+    // SAFETY: Safe because we're just reading some fields from a supposedly valid argument.
     let si_code = unsafe { (*info).si_code };
 
     if num != si_signo || num != SIGPIPE {
@@ -170,6 +172,7 @@ pub fn register_signal_handlers() -> utils::errno::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::{env, process, thread};
 
     use libc::syscall;

--- a/src/vmm/src/vstate/system.rs
+++ b/src/vmm/src/vstate/system.rs
@@ -119,6 +119,7 @@ impl KvmContext {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::fs::File;
 
     use super::*;

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -188,6 +188,7 @@ pub struct VcpuState {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
     use kvm_bindings::kvm_one_reg;

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -182,7 +182,7 @@ impl Vcpu {
     /// kick the vcpu running on the current thread, if there is one.
     pub fn register_kick_signal_handler() {
         extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {
-            // This is safe because it's temporarily aliasing the `Vcpu` object, but we are
+            // SAFETY: This is safe because it's temporarily aliasing the `Vcpu` object, but we are
             // only reading `vcpu.fd` which does not change for the lifetime of the `Vcpu`.
             unsafe {
                 let _ = Vcpu::run_on_thread_local(|vcpu| {
@@ -656,6 +656,7 @@ pub enum VcpuEmulation {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::fmt;
     use std::sync::{Arc, Barrier, Mutex};
 

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -614,6 +614,7 @@ impl VcpuState {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     extern crate cpuid;
 
     use std::os::unix::io::AsRawFd;

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -365,7 +365,7 @@ impl Vm {
                     flags,
                 };
 
-                // Safe because the fd is a valid KVM file descriptor.
+                // SAFETY: Safe because the fd is a valid KVM file descriptor.
                 unsafe { self.fd.set_user_memory_region(memory_region) }
             })
             .map_err(Error::SetUserMemoryRegion)?;
@@ -396,6 +396,7 @@ pub struct VmState {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::FromRawFd;
 
     use vm_memory::GuestAddress;

--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -31,7 +31,8 @@ function fc-bindgen {
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::undocumented_unsafe_blocks
 )]
 
 EOF


### PR DESCRIPTION
## Changes
Test that all unsafe blocks must be documented; resulting in a test failure otherwise.
PR template is also modified to drop this bullet-point.

It looks like the pre-commit hook's `black` invocation changed `test_clippy.py` a tad bit; is that acceptable?

I've added some missing comments to satisfy clippy and modified existing comments to conform to clippy's formatting.
Test modules that used unsafe are excluded from the lint, as well as auto-generated bindgen code.

## Reason

Closes #3177

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~API changes follow the [Runbook for Firecracker API changes][2].~ (No API was changed)
- [x] ~User-facing changes are mentioned in `CHANGELOG.md`.~ (There are no user-facing changes)
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
