### PR TITLE
Fix gem dependencies in docker file

### DIFF
--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -75,7 +75,9 @@ RUN apt-get update \
         setuptools \
         wheel \
     && python3 -m pip install --upgrade pip \ 
-    && gem install chef-utils:16.6.14 mdl
+    && gem install \
+        chef-utils:16.6.14 \
+        mdl:0.11.0
 
 # Update Python to 3.10
 # This method isn't ideal, compiling from source can be dropped


### PR DESCRIPTION
## Changes

Specifies `mdl` version of `0.11.0` to resolve error with building `Dockerfile.x86_64`.

## Reason

When attempting to build the container with `devtool build_devctr` an error is produced like:
```
...
Setting up curl (7.58.0-2ubuntu3.20) ...
Setting up ruby2.5 (2.5.1-1ubuntu1.12) ...
Setting up ruby (1:2.5.1) ...
Setting up ruby-test-unit (3.2.5-1) ...
Setting up rake (12.3.1-1ubuntu0.1) ...
Setting up libruby2.5:amd64 (2.5.1-1ubuntu1.12) ...
Setting up ruby2.5-dev:amd64 (2.5.1-1ubuntu1.12) ...
Setting up ruby-dev:amd64 (1:2.5.1) ...
Processing triggers for libc-bin (2.27-3ubuntu1.6) ...
Processing triggers for ca-certificates (20211016~18.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Collecting setuptools
  Downloading https://files.pythonhosted.org/packages/b0/3a/88b210db68e56854d0bcf4b38e165e03be377e13907746f825790f3df5bf/setuptools-59.6.0-py3-none-any.whl (952kB)
Collecting wheel
  Downloading https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl
Installing collected packages: setuptools, wheel
Successfully installed setuptools-59.6.0 wheel-0.37.1
Collecting pip
  Downloading https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl (1.7MB)
Installing collected packages: pip
  Found existing installation: pip 9.0.1
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
Successfully installed pip-21.3.1
ERROR:  Error installing mdl:
        The last version of mdl (>= 0) to support your Ruby & RubyGems was 0.11.0. Try installing it with `gem install mdl -v 0.11.0`
        mdl requires Ruby version >= 2.7. The current ruby version is 2.5.0.
Successfully installed chef-utils-16.6.14
Parsing documentation for chef-utils-16.6.14
Installing ri documentation for chef-utils-16.6.14
Done installing documentation for chef-utils after 0 seconds
Successfully installed rexml-3.2.5
Successfully installed kramdown-2.4.0
Successfully installed kramdown-parser-gfm-1.1.0
Successfully installed mixlib-cli-2.1.8
Successfully installed tomlrb-2.0.3
Successfully installed mixlib-config-3.0.27
Successfully installed mixlib-shellout-3.2.7
1 gem installed
The command '/bin/sh -c apt-get update     && apt-get -y install --no-install-recommends         binutils-dev         clang         cmake         build-essential         zlib1g-dev         libncurses5-dev         libgdbm-dev          libnss3-dev         libreadline-dev         libffi-dev         libsqlite3-dev         wget         libbz2-dev         curl         file         g++         gcc         gcc-aarch64-linux-gnu         git         iperf3         iproute2         jq         libdw-dev         libiberty-dev         libssl-dev         libcurl4-openssl-dev         lsof         make         musl-tools         net-tools         openssh-client         pkgconf         python         python3         python3-dev         python3-pip         python3-venv         ruby-dev         zlib1g-dev         screen         tzdata         xz-utils         bc         flex         bison     && python3 -m pip install         setuptools         wheel     && python3 -m pip install --upgrade pip     && gem install chef-utils:16.6.14 mdl' returned a non-zero code: 1
631d071e-09e0-46f3-a9e9-10e2b327a85b
[ec2-user@ip-172-31-15-148 firecracker]$ 
```
By specifying an `mdl` version of `0.11.0` this resolves the error allowing the container to be built.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
