### PR TITLE
Warn on `clippy::ptr_as_ptr`

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.
 //! It is constructed on top of an HTTP Server that uses Unix Domain Sockets and `EPOLL` to

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.
 use std::{fmt, result};

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -102,7 +102,8 @@ const CPU_FEATURE_FPU: u32 = 0x001;
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
     // Safe because we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v as *const T as *const u8, mem::size_of::<T>()) };
+    let v_slice =
+        unsafe { slice::from_raw_parts((v as *const T).cast::<u8>(), mem::size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);

--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -164,14 +164,17 @@ impl BrandString {
         // This is actually safe, because self.reg_buf has a fixed, known size,
         // and also there's no risk of misalignment, since we're downgrading
         // alignment constraints from dword to byte.
-        unsafe { slice::from_raw_parts(self.reg_buf.as_ptr() as *const u8, Self::REG_BUF_SIZE * 4) }
+        unsafe { slice::from_raw_parts(self.reg_buf.as_ptr().cast::<u8>(), Self::REG_BUF_SIZE * 4) }
     }
 
     /// Gets a mutable `u8` slice view into the brand string buffer.
     #[inline]
     fn as_bytes_mut(&mut self) -> &mut [u8] {
         unsafe {
-            slice::from_raw_parts_mut(self.reg_buf.as_mut_ptr() as *mut u8, Self::REG_BUF_SIZE * 4)
+            slice::from_raw_parts_mut(
+                self.reg_buf.as_mut_ptr().cast::<u8>(),
+                Self::REG_BUF_SIZE * 4,
+            )
         }
     }
 

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 #![cfg(target_arch = "x86_64")]

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#![warn(clippy::ptr_as_ptr)]
 //! Emulates virtual and hardware devices.
 use std::io;
 

--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -86,7 +86,7 @@ pub(crate) fn remove_range(
         if restored {
             let ret = unsafe {
                 libc::mmap(
-                    phys_address as *mut _,
+                    phys_address.cast(),
                     range_len as usize,
                     libc::PROT_READ | libc::PROT_WRITE,
                     libc::MAP_FIXED | libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
@@ -100,13 +100,8 @@ pub(crate) fn remove_range(
         };
 
         // Madvise the region in order to mark it as not used.
-        let ret = unsafe {
-            libc::madvise(
-                phys_address as *mut _,
-                range_len as usize,
-                libc::MADV_DONTNEED,
-            )
-        };
+        let ret =
+            unsafe { libc::madvise(phys_address.cast(), range_len as usize, libc::MADV_DONTNEED) };
         if ret < 0 {
             return Err(RemoveRegionError::MadviseFail(io::Error::last_os_error()));
         }

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -493,7 +493,8 @@ mod tests {
             let host_addr = self
                 .mem
                 .get_host_address(GuestAddress(self.mut_hdr_desc().addr.get()))
-                .unwrap() as *mut _;
+                .unwrap()
+                .cast();
             unsafe { &mut *host_addr }
         }
 

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -109,7 +109,7 @@ impl Tap {
             // Open calls are safe because we give a constant null-terminated
             // string and verify the result.
             libc::open(
-                b"/dev/net/tun\0".as_ptr() as *const c_char,
+                b"/dev/net/tun\0".as_ptr().cast::<c_char>(),
                 libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
             )
         };

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -142,7 +142,7 @@ impl TapTrafficSimulator {
         let ret = unsafe {
             libc::bind(
                 socket.as_raw_fd(),
-                send_addr_ptr as *const _,
+                send_addr_ptr.cast(),
                 mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
             )
         };
@@ -158,7 +158,7 @@ impl TapTrafficSimulator {
 
         Self {
             socket,
-            send_addr: unsafe { *(send_addr_ptr as *const _) },
+            send_addr: unsafe { *(send_addr_ptr.cast()) },
         }
     }
 
@@ -166,10 +166,10 @@ impl TapTrafficSimulator {
         let res = unsafe {
             libc::sendto(
                 self.socket.as_raw_fd(),
-                buf.as_ptr() as *const _,
+                buf.as_ptr().cast(),
                 buf.len(),
                 0,
-                (&self.send_addr as *const libc::sockaddr_ll) as *const _,
+                (&self.send_addr as *const libc::sockaddr_ll).cast(),
                 mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
             )
         };
@@ -185,7 +185,7 @@ impl TapTrafficSimulator {
                 buf.as_ptr() as *mut _,
                 buf.len(),
                 0,
-                (&mut mem::zeroed() as *mut libc::sockaddr_storage) as *mut _,
+                (&mut mem::zeroed() as *mut libc::sockaddr_storage).cast(),
                 &mut (mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t),
             )
         };

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
 pub mod pdu;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -1,5 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#![warn(clippy::ptr_as_ptr)]
+
 mod api_server_adapter;
 mod metrics;
 

--- a/src/io_uring/src/bindings.rs
+++ b/src/io_uring/src/bindings.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 #[repr(C)]

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -101,6 +101,6 @@ impl CompletionQueue {
 impl Drop for CompletionQueue {
     fn drop(&mut self) {
         // Safe because parameters are valid.
-        unsafe { libc::munmap(self.cqes.as_ptr() as *mut libc::c_void, self.cqes.size()) };
+        unsafe { libc::munmap(self.cqes.as_ptr().cast::<libc::c_void>(), self.cqes.size()) };
     }
 }

--- a/src/io_uring/src/queue/mmap.rs
+++ b/src/io_uring/src/queue/mmap.rs
@@ -25,6 +25,6 @@ pub(crate) fn mmap(size: usize, fd: RawFd, offset: i64) -> Result<MmapRegion, Er
 
     // Safe because the mmap did not return error.
     unsafe {
-        MmapRegion::build_raw(ptr as *mut u8, size, prot, flags).map_err(Error::BuildMmapRegion)
+        MmapRegion::build_raw(ptr.cast::<u8>(), size, prot, flags).map_err(Error::BuildMmapRegion)
     }
 }

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -139,7 +139,7 @@ impl SubmissionQueue {
                 self.to_submit,
                 min_complete,
                 flags,
-                std::ptr::null() as *const libc::sigset_t,
+                std::ptr::null::<libc::sigset_t>(),
             )
         } as libc::c_int)
         .into_result()?
@@ -193,7 +193,7 @@ impl SubmissionQueue {
 impl Drop for SubmissionQueue {
     fn drop(&mut self) {
         // Safe because parameters are valid.
-        unsafe { libc::munmap(self.ring.as_ptr() as *mut libc::c_void, self.ring.size()) };
-        unsafe { libc::munmap(self.sqes.as_ptr() as *mut libc::c_void, self.sqes.size()) };
+        unsafe { libc::munmap(self.ring.as_ptr().cast::<libc::c_void>(), self.ring.size()) };
+        unsafe { libc::munmap(self.sqes.as_ptr().cast::<libc::c_void>(), self.sqes.size()) };
     }
 }

--- a/src/jailer/src/env.rs
+++ b/src/jailer/src/env.rs
@@ -365,7 +365,7 @@ impl Env {
             .map_err(|err| Error::Chmod(path_buf.clone(), err))?;
 
         #[cfg(target_arch = "x86_64")]
-        let folder_bytes_ptr = folder.as_ptr() as *const i8;
+        let folder_bytes_ptr = folder.as_ptr().cast::<i8>();
         #[cfg(target_arch = "aarch64")]
         let folder_bytes_ptr = folder.as_ptr();
         SyscallReturnCode(unsafe { libc::chown(folder_bytes_ptr, self.uid(), self.gid()) })
@@ -548,7 +548,7 @@ impl Env {
             Some(
                 SyscallReturnCode(unsafe {
                     libc::open(
-                        DEV_NULL_WITH_NUL.as_ptr() as *const libc::c_char,
+                        DEV_NULL_WITH_NUL.as_ptr().cast::<libc::c_char>(),
                         libc::O_RDWR,
                     )
                 })

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -1,5 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#![warn(clippy::ptr_as_ptr)]
+
 mod cgroup;
 mod chroot;
 mod env;

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! Crate that implements Firecracker specific functionality as far as logging and metrics
 //! collecting.
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(clippy::ptr_as_ptr)]
+
 pub mod data_store;
 pub mod ns;
 pub mod persist;

--- a/src/net_gen/src/if_tun.rs
+++ b/src/net_gen/src/if_tun.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const ETH_ALEN: u32 = 6;

--- a/src/net_gen/src/iff.rs
+++ b/src/net_gen/src/iff.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const IFNAMSIZ: u32 = 16;

--- a/src/net_gen/src/inn.rs
+++ b/src/net_gen/src/inn.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const IP_TOS: u32 = 1;

--- a/src/net_gen/src/sockios.rs
+++ b/src/net_gen/src/sockios.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const FIOSETOWN: u32 = 35073;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 //! # Rate Limiter
 //!
 //! Provides a rate limiter written in Rust useful for IO operations that need to

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(clippy::ptr_as_ptr)]
+
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;
@@ -103,7 +105,7 @@ fn rebase(base_file: &mut File, diff_file: &mut File) -> Result<(), Error> {
                 libc::sendfile64(
                     base_file.as_raw_fd(),
                     diff_file.as_raw_fd(),
-                    &mut cursor as *mut u64 as *mut i64,
+                    (&mut cursor as *mut u64).cast::<i64>(),
                     block_end.saturating_sub(cursor) as usize,
                 )
             };

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 
 //! The library crate that defines common helper functions that are generally used in
 //! conjunction with seccompiler-bin.

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
+#![warn(clippy::ptr_as_ptr)]
 
 //! Provides version tolerant serialization and deserialization facilities and
 //! implements a persistent storage format for Firecracker state snapshots.

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![warn(clippy::ptr_as_ptr)]
+
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).
 // More specifically, we are re-exporting modules from `vmm_sys_util` as part

--- a/src/virtio_gen/src/virtio_blk.rs
+++ b/src/virtio_gen/src/virtio_blk.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: u32 = 24;

--- a/src/virtio_gen/src/virtio_net.rs
+++ b/src/virtio_gen/src/virtio_net.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: u32 = 24;

--- a/src/virtio_gen/src/virtio_ring.rs
+++ b/src/virtio_gen/src/virtio_ring.rs
@@ -7,7 +7,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 pub const VIRTIO_RING_F_EVENT_IDX: u32 = 29;

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -29,9 +29,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.41}
+    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.47}
 else:
-    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.59}
+    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.68}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -30,7 +30,8 @@ function fc-bindgen {
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    non_snake_case
+    non_snake_case,
+    clippy::ptr_as_ptr
 )]
 
 EOF


### PR DESCRIPTION
## Changes

Sets clippy to warn on the lint `clippy::ptr_as_ptr`.

## Reason

Closes #3203

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
