### PR TITLE
Fix cargo kcov crashing/generating incorrect reports for proc-macros

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -81,6 +81,14 @@ def test_coverage(test_fc_session_root_path, test_session_tmp_path):
     exclude_region = "'mod tests {'"
     target = "{}-unknown-linux-musl".format(platform.machine())
 
+    # Temporarily modify PATH so that "rustc" resolved to our wrapper script
+    # This is required as cargo kcov parses cargo's verbose output, and looking for lines starting
+    # with "Running `rustc":
+    # https://github.com/kennytm/cargo-kcov/blob/master/src/target_finder.rs#L44
+    # However, if we use the RUSTC_WRAPPER environment variable to make cargo run out script, the
+    # output will contain the lines "Running /firecracker/tests/rustc", and thus cargo kcov will
+    # fail to resolve the paths of the binaries compiled.
+    os.environ["PATH"] = "/firecracker/tests" + os.pathsep + os.environ["PATH"]
     cmd = (
         'CARGO_WRAPPER="kcov" RUSTFLAGS="{}" CARGO_TARGET_DIR={} '
         "cargo kcov --all "

--- a/tests/rustc
+++ b/tests/rustc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# We have to fully qualify the path to rustc here, as we modified $PATH in a way that this script is founds before
+# the actual rust executable.
+# Then we invoke normal rustc, but force the 'link-dead-code' codegen option. This option is required for gathering
+# coverage reports on proc-macros during cross-compilation, as the 'RUSTFLAGS' environment variable is ignored by cargo
+# for build-scripts, plugins and proc-macros in this case.
+# See also https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+/usr/local/rust/bin/rustc $@ -Clink-dead-code


### PR DESCRIPTION
Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Introduces a hack that forces every invocation of `rustc` from within the `tests/test_coverage.py` integration test to include the `-Clink-dead-code` option, which is required for gathering meaningful coverage reports

## Reason

When cross-compiling, `cargo` does not pass the value of the `RUSTFLAGS` environment variable to `rustc` invocations for build scripts, proc-macros and plugins: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags. The second case here is a problem, as we will (most likely) start introducing procedural macros into our workspace via upcoming PRs. On these PRs, the CI has been either crashing (due to a [bug](https://github.com/rust-lang/rust/issues/103481) in rustc relating to incorrect debug information being generated for proc-macro crates compiled without `-Clink-dead-code` option), or generating incorrect coverage reports (since due to the way proc-macro crates are built, uncovered code gets eliminated during linking, meaning it will not show up as "uncovered" in the resulting report (this is kcov specific behavior)). 

## Alternatives considered

1. We can work around cargo's handling of the `--target` flag in relation to `RUSTFLAGS` by passing the `--target` option via `RUSTFLAGS`. This generally works, but causes problems in `seccompiler-bin` 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
