### PR TITLE
test/versioned_serialization: update vmm baselines

### DIFF
--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -23,11 +23,11 @@ BASELINES = {
     "Intel": {
         "serialize": {
             "no-crc": {"target": 0.150, "delta": 0.036},  # milliseconds  # milliseconds
-            "crc": {"target": 0.205, "delta": 0.04},  # milliseconds  # milliseconds
+            "crc": {"target": 0.244, "delta": 0.44},  # milliseconds  # milliseconds
         },
         "deserialize": {
-            "no-crc": {"target": 0.034, "delta": 0.02},  # milliseconds  # milliseconds
-            "crc": {"target": 0.042, "delta": 0.025},  # milliseconds  # milliseconds
+            "no-crc": {"target": 0.056, "delta": 0.02},  # milliseconds  # milliseconds
+            "crc": {"target": 0.046, "delta": 0.035},  # milliseconds  # milliseconds
         },
     },
     "AMD": {


### PR DESCRIPTION
## Changes

Increase baseline values in the VMM serialisation test.

## Reason

Serialisation takes longer due to addition of MTRR and MCE MSRs to the snapshot.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
