### PR TITLE
v1.1: tests: backport changes to collect snapshot restore perf baselines 

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -29,350 +29,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.623,
-                                                    "delta_percentage": 18
+                                                    "target": 3.771,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.117,
-                                                    "delta_percentage": 45
+                                                    "target": 4.012,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.719,
-                                                    "delta_percentage": 14
+                                                    "target": 3.877,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.979,
-                                                    "delta_percentage": 25
+                                                    "target": 4.154,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.861,
-                                                    "delta_percentage": 10
+                                                    "target": 4.026,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.11,
-                                                    "delta_percentage": 25
+                                                    "target": 4.313,
+                                                    "delta_percentage": 29
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.992,
-                                                    "delta_percentage": 11
+                                                    "target": 4.163,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.309,
-                                                    "delta_percentage": 24
+                                                    "target": 4.485,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.134,
-                                                    "delta_percentage": 12
+                                                    "target": 4.312,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.43,
-                                                    "delta_percentage": 23
+                                                    "target": 4.598,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.28,
-                                                    "delta_percentage": 13
+                                                    "target": 4.46,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.676,
-                                                    "delta_percentage": 24
+                                                    "target": 4.799,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.414,
-                                                    "delta_percentage": 18
+                                                    "target": 4.584,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.796,
-                                                    "delta_percentage": 24
+                                                    "target": 5.017,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.569,
-                                                    "delta_percentage": 15
+                                                    "target": 4.736,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.977,
-                                                    "delta_percentage": 18
+                                                    "target": 5.178,
+                                                    "delta_percentage": 27
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.721,
-                                                    "delta_percentage": 14
+                                                    "target": 4.893,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.18,
-                                                    "delta_percentage": 71
+                                                    "target": 5.314,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.808,
-                                                    "delta_percentage": 14
+                                                    "target": 4.98,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.052,
-                                                    "delta_percentage": 24
+                                                    "target": 5.226,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.809,
-                                                    "delta_percentage": 10
+                                                    "target": 3.964,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.022,
-                                                    "delta_percentage": 26
+                                                    "target": 4.166,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.277,
-                                                    "delta_percentage": 11
+                                                    "target": 4.41,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.572,
-                                                    "delta_percentage": 25
+                                                    "target": 4.651,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.167,
-                                                    "delta_percentage": 13
+                                                    "target": 5.228,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.624,
-                                                    "delta_percentage": 24
+                                                    "target": 5.529,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 6.898,
-                                                    "delta_percentage": 14
+                                                    "target": 6.843,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.651,
-                                                    "delta_percentage": 221
+                                                    "target": 7.197,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.972,
-                                                    "delta_percentage": 13
+                                                    "target": 10.708,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 11.75,
-                                                    "delta_percentage": 23
+                                                    "target": 11.202,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 18.355,
-                                                    "delta_percentage": 14
+                                                    "target": 17.609,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 19.473,
-                                                    "delta_percentage": 18
+                                                    "target": 18.765,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 32.743,
-                                                    "delta_percentage": 15
+                                                    "target": 31.059,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 34.475,
-                                                    "delta_percentage": 25
+                                                    "target": 33.023,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 62.181,
-                                                    "delta_percentage": 14
+                                                    "target": 58.861,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 65.012,
-                                                    "delta_percentage": 31
+                                                    "target": 61.409,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.325,
-                                                    "delta_percentage": 23
+                                                    "target": 4.472,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.009,
-                                                    "delta_percentage": 55
+                                                    "target": 4.878,
+                                                    "delta_percentage": 33
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.957,
-                                                    "delta_percentage": 17
+                                                    "target": 5.17,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.733,
-                                                    "delta_percentage": 32
+                                                    "target": 5.739,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.614,
-                                                    "delta_percentage": 19
+                                                    "target": 5.887,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.443,
-                                                    "delta_percentage": 28
+                                                    "target": 6.874,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.652,
-                                                    "delta_percentage": 16
+                                                    "target": 3.846,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.006,
-                                                    "delta_percentage": 43
+                                                    "target": 4.094,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.705,
-                                                    "delta_percentage": 27
+                                                    "target": 3.881,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.172,
-                                                    "delta_percentage": 43
+                                                    "target": 4.065,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.745,
-                                                    "delta_percentage": 15
+                                                    "target": 3.932,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.188,
-                                                    "delta_percentage": 48
+                                                    "target": 4.138,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.807,
-                                                    "delta_percentage": 15
+                                                    "target": 3.985,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.151,
-                                                    "delta_percentage": 26
+                                                    "target": 4.21,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         }
@@ -383,350 +383,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.614,
-                                                    "delta_percentage": 10
+                                                    "target": 3.789,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.906,
-                                                    "delta_percentage": 57
+                                                    "target": 3.978,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.709,
-                                                    "delta_percentage": 15
+                                                    "target": 3.873,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.054,
-                                                    "delta_percentage": 43
+                                                    "target": 4.109,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.87,
-                                                    "delta_percentage": 10
+                                                    "target": 4.031,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.303,
-                                                    "delta_percentage": 41
+                                                    "target": 4.252,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.99,
-                                                    "delta_percentage": 12
+                                                    "target": 4.16,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.409,
-                                                    "delta_percentage": 34
+                                                    "target": 4.411,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.15,
-                                                    "delta_percentage": 20
+                                                    "target": 4.311,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.563,
-                                                    "delta_percentage": 38
+                                                    "target": 4.596,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.293,
-                                                    "delta_percentage": 12
+                                                    "target": 4.461,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.806,
-                                                    "delta_percentage": 38
+                                                    "target": 4.844,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.416,
-                                                    "delta_percentage": 12
+                                                    "target": 4.571,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.97,
-                                                    "delta_percentage": 32
+                                                    "target": 4.907,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.581,
-                                                    "delta_percentage": 16
+                                                    "target": 4.729,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.145,
-                                                    "delta_percentage": 34
+                                                    "target": 5.098,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.714,
-                                                    "delta_percentage": 14
+                                                    "target": 4.875,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.193,
-                                                    "delta_percentage": 31
+                                                    "target": 5.306,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.805,
-                                                    "delta_percentage": 15
+                                                    "target": 4.986,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.168,
-                                                    "delta_percentage": 35
+                                                    "target": 5.197,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.83,
-                                                    "delta_percentage": 10
+                                                    "target": 3.987,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.075,
-                                                    "delta_percentage": 38
+                                                    "target": 4.166,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.281,
-                                                    "delta_percentage": 11
+                                                    "target": 4.414,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.573,
-                                                    "delta_percentage": 29
+                                                    "target": 4.611,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.159,
-                                                    "delta_percentage": 13
+                                                    "target": 5.215,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.509,
-                                                    "delta_percentage": 25
+                                                    "target": 5.456,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 6.905,
-                                                    "delta_percentage": 20
+                                                    "target": 6.835,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.494,
-                                                    "delta_percentage": 31
+                                                    "target": 7.265,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.989,
-                                                    "delta_percentage": 17
+                                                    "target": 10.698,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 11.665,
-                                                    "delta_percentage": 23
+                                                    "target": 11.138,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 18.283,
-                                                    "delta_percentage": 14
+                                                    "target": 17.609,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 19.324,
-                                                    "delta_percentage": 23
+                                                    "target": 18.354,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 32.476,
-                                                    "delta_percentage": 13
+                                                    "target": 30.955,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 34.084,
-                                                    "delta_percentage": 24
+                                                    "target": 32.314,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 61.757,
-                                                    "delta_percentage": 14
+                                                    "target": 58.855,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 64.788,
-                                                    "delta_percentage": 30
+                                                    "target": 61.077,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.285,
+                                                    "target": 4.49,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.675,
-                                                    "delta_percentage": 35
+                                                    "target": 4.818,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.965,
-                                                    "delta_percentage": 25
+                                                    "target": 5.187,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.563,
-                                                    "delta_percentage": 24
+                                                    "target": 5.742,
+                                                    "delta_percentage": 27
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.643,
-                                                    "delta_percentage": 22
+                                                    "target": 5.88,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.396,
-                                                    "delta_percentage": 24
+                                                    "target": 6.721,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.65,
-                                                    "delta_percentage": 10
+                                                    "target": 3.842,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.855,
-                                                    "delta_percentage": 29
+                                                    "target": 4.076,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.7,
+                                                    "target": 3.887,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.941,
-                                                    "delta_percentage": 25
+                                                    "target": 4.122,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.733,
-                                                    "delta_percentage": 11
+                                                    "target": 3.92,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.006,
-                                                    "delta_percentage": 27
+                                                    "target": 4.141,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.815,
-                                                    "delta_percentage": 10
+                                                    "target": 3.998,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.065,
-                                                    "delta_percentage": 24
+                                                    "target": 4.193,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         }
@@ -744,350 +744,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.373,
-                                                    "delta_percentage": 18
+                                                    "target": 4.7,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.797,
-                                                    "delta_percentage": 41
+                                                    "target": 5.027,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.507,
-                                                    "delta_percentage": 18
+                                                    "target": 4.836,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.905,
-                                                    "delta_percentage": 23
+                                                    "target": 5.132,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.688,
-                                                    "delta_percentage": 18
+                                                    "target": 5.034,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.984,
-                                                    "delta_percentage": 20
+                                                    "target": 5.313,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.849,
-                                                    "delta_percentage": 18
+                                                    "target": 5.216,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.15,
-                                                    "delta_percentage": 25
+                                                    "target": 5.578,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.996,
-                                                    "delta_percentage": 18
+                                                    "target": 5.343,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.3,
-                                                    "delta_percentage": 21
+                                                    "target": 5.686,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.163,
-                                                    "delta_percentage": 18
+                                                    "target": 5.516,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.557,
-                                                    "delta_percentage": 25
+                                                    "target": 5.95,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.312,
-                                                    "delta_percentage": 17
+                                                    "target": 5.648,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.708,
-                                                    "delta_percentage": 21
+                                                    "target": 6.011,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.447,
-                                                    "delta_percentage": 17
+                                                    "target": 5.796,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.849,
-                                                    "delta_percentage": 19
+                                                    "target": 6.269,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.638,
-                                                    "delta_percentage": 16
+                                                    "target": 5.976,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.064,
-                                                    "delta_percentage": 20
+                                                    "target": 6.349,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.737,
-                                                    "delta_percentage": 17
+                                                    "target": 6.036,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.045,
-                                                    "delta_percentage": 22
+                                                    "target": 6.366,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.792,
-                                                    "delta_percentage": 21
+                                                    "target": 5.181,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.097,
-                                                    "delta_percentage": 23
+                                                    "target": 5.426,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.601,
-                                                    "delta_percentage": 25
+                                                    "target": 6.014,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.892,
-                                                    "delta_percentage": 27
+                                                    "target": 6.305,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.273,
-                                                    "delta_percentage": 30
+                                                    "target": 7.676,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.681,
-                                                    "delta_percentage": 32
+                                                    "target": 7.991,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.457,
-                                                    "delta_percentage": 36
+                                                    "target": 11.022,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 10.967,
-                                                    "delta_percentage": 38
+                                                    "target": 11.399,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 17.4,
-                                                    "delta_percentage": 40
+                                                    "target": 18.264,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 18.201,
-                                                    "delta_percentage": 39
+                                                    "target": 18.918,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 30.751,
-                                                    "delta_percentage": 42
+                                                    "target": 31.976,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 31.652,
-                                                    "delta_percentage": 43
+                                                    "target": 32.718,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 57.083,
-                                                    "delta_percentage": 45
+                                                    "target": 59.17,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 58.308,
-                                                    "delta_percentage": 46
+                                                    "target": 60.474,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 109.902,
-                                                    "delta_percentage": 47
+                                                    "target": 114.303,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 112.175,
-                                                    "delta_percentage": 47
+                                                    "target": 116.656,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.152,
-                                                    "delta_percentage": 23
+                                                    "target": 5.508,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.807,
-                                                    "delta_percentage": 32
+                                                    "target": 5.932,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.902,
-                                                    "delta_percentage": 21
+                                                    "target": 6.298,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.748,
-                                                    "delta_percentage": 42
+                                                    "target": 6.972,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 6.66,
-                                                    "delta_percentage": 25
+                                                    "target": 7.12,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.502,
-                                                    "delta_percentage": 27
+                                                    "target": 7.785,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.441,
-                                                    "delta_percentage": 18
+                                                    "target": 4.784,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.854,
-                                                    "delta_percentage": 21
+                                                    "target": 5.14,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.489,
-                                                    "delta_percentage": 19
+                                                    "target": 4.839,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.952,
-                                                    "delta_percentage": 30
+                                                    "target": 5.162,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.553,
-                                                    "delta_percentage": 18
+                                                    "target": 4.874,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.085,
-                                                    "delta_percentage": 34
+                                                    "target": 5.261,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.642,
-                                                    "delta_percentage": 18
+                                                    "target": 4.985,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.062,
-                                                    "delta_percentage": 24
+                                                    "target": 5.242,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         }
@@ -1098,293 +1098,1012 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.406,
-                                                    "delta_percentage": 18
+                                                    "target": 4.745,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.835,
-                                                    "delta_percentage": 57
+                                                    "target": 5.012,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.52,
-                                                    "delta_percentage": 19
+                                                    "target": 4.856,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.939,
-                                                    "delta_percentage": 38
+                                                    "target": 5.273,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.73,
-                                                    "delta_percentage": 19
+                                                    "target": 5.037,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.14,
-                                                    "delta_percentage": 30
+                                                    "target": 5.417,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.851,
-                                                    "delta_percentage": 19
+                                                    "target": 5.211,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.309,
-                                                    "delta_percentage": 30
+                                                    "target": 5.619,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.022,
-                                                    "delta_percentage": 18
+                                                    "target": 5.361,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.476,
-                                                    "delta_percentage": 34
+                                                    "target": 5.596,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.194,
-                                                    "delta_percentage": 18
+                                                    "target": 5.534,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.702,
-                                                    "delta_percentage": 23
+                                                    "target": 5.914,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.311,
-                                                    "delta_percentage": 18
+                                                    "target": 5.664,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.76,
-                                                    "delta_percentage": 22
+                                                    "target": 5.978,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.487,
-                                                    "delta_percentage": 21
+                                                    "target": 5.771,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.031,
-                                                    "delta_percentage": 30
+                                                    "target": 6.111,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.665,
-                                                    "delta_percentage": 18
+                                                    "target": 5.971,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.143,
-                                                    "delta_percentage": 37
+                                                    "target": 6.509,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.761,
-                                                    "delta_percentage": 17
+                                                    "target": 6.05,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.162,
-                                                    "delta_percentage": 27
+                                                    "target": 6.34,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.814,
-                                                    "delta_percentage": 22
+                                                    "target": 5.183,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.167,
-                                                    "delta_percentage": 25
+                                                    "target": 5.514,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.649,
-                                                    "delta_percentage": 26
+                                                    "target": 6.028,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.948,
-                                                    "delta_percentage": 29
+                                                    "target": 6.391,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.265,
-                                                    "delta_percentage": 31
+                                                    "target": 7.697,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.592,
-                                                    "delta_percentage": 31
+                                                    "target": 8.009,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.469,
-                                                    "delta_percentage": 36
+                                                    "target": 11.037,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 10.982,
-                                                    "delta_percentage": 31
+                                                    "target": 11.405,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 17.425,
-                                                    "delta_percentage": 40
+                                                    "target": 18.186,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 18.083,
-                                                    "delta_percentage": 37
+                                                    "target": 18.56,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 30.604,
-                                                    "delta_percentage": 43
+                                                    "target": 31.94,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 31.537,
-                                                    "delta_percentage": 44
+                                                    "target": 32.612,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 56.856,
-                                                    "delta_percentage": 47
+                                                    "target": 59.211,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 58.223,
-                                                    "delta_percentage": 46
+                                                    "target": 60.499,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 109.699,
-                                                    "delta_percentage": 48
+                                                    "target": 114.385,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 112.204,
-                                                    "delta_percentage": 47
+                                                    "target": 116.653,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.15,
-                                                    "delta_percentage": 21
+                                                    "target": 5.496,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.626,
-                                                    "delta_percentage": 23
+                                                    "target": 5.971,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.934,
-                                                    "delta_percentage": 28
+                                                    "target": 6.392,
+                                                    "delta_percentage": 22
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.476,
-                                                    "delta_percentage": 26
+                                                    "target": 6.936,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 6.641,
-                                                    "delta_percentage": 26
+                                                    "target": 7.233,
+                                                    "delta_percentage": 22
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.299,
+                                                    "target": 8.009,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.826,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.117,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.865,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.206,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.921,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.142,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.996,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.253,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.881,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.291,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.022,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.323,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.118,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.409,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.225,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.543,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.291,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.632,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.411,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.786,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.504,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.883,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.617,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.967,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.763,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.133,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.889,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.284,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.993,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.371,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.225,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.688,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.81,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.26,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.924,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.263,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.481,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.876,
+                                                    "delta_percentage": 43
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.452,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.432,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 21.766,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 24.272,
+                                                    "delta_percentage": 55
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 38.99,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 42.83,
+                                                    "delta_percentage": 73
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.396,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.801,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.972,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.38,
+                                                    "delta_percentage": 38
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.536,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.936,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.845,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.27,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.891,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.269,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.945,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.349,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.975,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.38,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.798,
+                                                    "delta_percentage": 21
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.248,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.874,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.314,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.014,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.412,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.148,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.54,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.272,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.65,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.395,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.778,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.492,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.876,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.632,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.018,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.771,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.208,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.871,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.343,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.944,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.352,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.186,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.658,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.77,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.216,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.855,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.242,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.48,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.986,
+                                                    "delta_percentage": 44
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.442,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.733,
+                                                    "delta_percentage": 42
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 21.795,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 23.503,
+                                                    "delta_percentage": 64
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 38.955,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 42.105,
+                                                    "delta_percentage": 77
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.362,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.768,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.962,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.359,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.531,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.914,
                                                     "delta_percentage": 23
                                                 }
                                             }
@@ -1392,56 +2111,56 @@
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.471,
-                                                    "delta_percentage": 19
+                                                    "target": 3.802,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.796,
-                                                    "delta_percentage": 22
+                                                    "target": 4.227,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.509,
-                                                    "delta_percentage": 19
+                                                    "target": 3.868,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.828,
-                                                    "delta_percentage": 26
+                                                    "target": 4.316,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.559,
-                                                    "delta_percentage": 20
+                                                    "target": 3.917,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.846,
-                                                    "delta_percentage": 22
+                                                    "target": 4.319,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.661,
-                                                    "delta_percentage": 20
+                                                    "target": 3.982,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.961,
-                                                    "delta_percentage": 23
+                                                    "target": 4.399,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -1,6 +1,6 @@
 {
     "measurements": {
-        "restore_latency": {
+        "latency": {
             "unit": "ms",
             "statistics": [
                 {
@@ -23,257 +23,357 @@
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
                         "baselines": {
-                            "restore_latency": {
+                            "latency": {
                                 "vmlinux-4.14.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 3.819,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.623,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.764,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 4.117,
+                                                    "delta_percentage": 45
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 3.884,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.719,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.024,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 3.979,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.031,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.861,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.323,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.11,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.066,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.992,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.262,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.309,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.209,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.134,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.253,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 4.43,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.333,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.28,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.544,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 4.676,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.508,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.414,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.619,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 4.796,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.642,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.569,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.82,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.977,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.86,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.721,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.26,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 5.18,
+                                                    "delta_percentage": 71
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.876,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.808,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.9,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 5.052,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 4.003,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.809,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.3,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 4.022,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 4.471,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.277,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.652,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 4.572,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 5.241,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 5.167,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.116,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 5.624,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 6.892,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 6.898,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 7.784,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 7.651,
+                                                    "delta_percentage": 221
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 10.694,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 10.972,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 11.991,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 11.75,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 17.443,
-                                                "delta_percentage": 18
+                                                "restore": {
+                                                    "target": 18.355,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 18.586,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 19.473,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 32.605,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 32.743,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.09,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 34.475,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 61.088,
-                                                "delta_percentage": 5
+                                                "restore": {
+                                                    "target": 62.181,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 64.086,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 65.012,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 4.441,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 4.325,
+                                                    "delta_percentage": 23
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.282,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 5.009,
+                                                    "delta_percentage": 55
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 5.115,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.957,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.653,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 5.733,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 5.784,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 5.614,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.578,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 6.443,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 3.813,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.652,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.715,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 4.006,
+                                                    "delta_percentage": 43
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 3.804,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.705,
+                                                    "delta_percentage": 27
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.669,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 4.172,
+                                                    "delta_percentage": 43
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 3.828,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.745,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.172,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.188,
+                                                    "delta_percentage": 48
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 3.947,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.807,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.324,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 4.151,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         }
                                     }
@@ -282,252 +382,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 3.74,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.614,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 3.871,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.906,
+                                                    "delta_percentage": 57
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 3.93,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.709,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 3.982,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 4.054,
+                                                    "delta_percentage": 43
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 3.955,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.87,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.198,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 4.303,
+                                                    "delta_percentage": 41
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.056,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.99,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.1,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 4.409,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.444,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 4.15,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.516,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 4.563,
+                                                    "delta_percentage": 38
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.356,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.293,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.161,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 4.806,
+                                                    "delta_percentage": 38
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.601,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.416,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.047,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.97,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.691,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 4.581,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.309,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 5.145,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.779,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.714,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.072,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 5.193,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.981,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.805,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.067,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 5.168,
+                                                    "delta_percentage": 35
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 4.019,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.83,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.868,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 4.075,
+                                                    "delta_percentage": 38
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 4.371,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.281,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.603,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 4.573,
+                                                    "delta_percentage": 29
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 5.193,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 5.159,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.482,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 5.509,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 7.024,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 6.905,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 8.801,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 7.494,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 10.583,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 10.989,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 11.803,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 11.665,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 17.709,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 18.283,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 18.118,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 19.324,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 32.144,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 32.476,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.276,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 34.084,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 59.455,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 61.757,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 61.421,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 64.788,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 4.476,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.285,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.681,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 4.675,
+                                                    "delta_percentage": 35
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 5.111,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.965,
+                                                    "delta_percentage": 25
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.485,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 5.563,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 5.663,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 5.643,
+                                                    "delta_percentage": 22
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.065,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 6.396,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 3.82,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.65,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.669,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 3.855,
+                                                    "delta_percentage": 29
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 3.731,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.7,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 3.887,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.941,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 3.87,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.733,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 3.96,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 4.006,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 3.938,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.815,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.146,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 4.065,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         }
                                     }
@@ -538,257 +738,357 @@
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
                         "baselines": {
-                            "restore_latency": {
+                            "latency": {
                                 "vmlinux-4.14.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.086,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.373,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.274,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 4.797,
+                                                    "delta_percentage": 41
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.243,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.507,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.419,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 4.905,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.417,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.688,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.579,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.984,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.451,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.849,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.661,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 5.15,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.582,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.996,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.733,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 5.3,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.811,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.163,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.956,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 5.557,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.957,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 5.312,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.064,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 5.708,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.069,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 5.447,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.67,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 5.849,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.243,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 5.638,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.476,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 6.064,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.326,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.737,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.571,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 6.045,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 4.371,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.792,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.456,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 5.097,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 4.799,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.601,
+                                                    "delta_percentage": 25
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.758,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 5.892,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 5.684,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 7.273,
+                                                    "delta_percentage": 30
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.623,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 7.681,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 7.228,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 10.457,
+                                                    "delta_percentage": 36
+                                                }
                                             },
                                             "P90": {
-                                                "target": 8.068,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 10.967,
+                                                    "delta_percentage": 38
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 10.985,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 17.4,
+                                                    "delta_percentage": 40
+                                                }
                                             },
                                             "P90": {
-                                                "target": 11.847,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 18.201,
+                                                    "delta_percentage": 39
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 18.14,
-                                                "delta_percentage": 18
+                                                "restore": {
+                                                    "target": 30.751,
+                                                    "delta_percentage": 42
+                                                }
                                             },
                                             "P90": {
-                                                "target": 19.63,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 31.652,
+                                                    "delta_percentage": 43
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 32.936,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 57.083,
+                                                    "delta_percentage": 45
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.018,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 58.308,
+                                                    "delta_percentage": 46
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 60.575,
-                                                "delta_percentage": 5
+                                                "restore": {
+                                                    "target": 109.902,
+                                                    "delta_percentage": 47
+                                                }
                                             },
                                             "P90": {
-                                                "target": 62.617,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 112.175,
+                                                    "delta_percentage": 47
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 5.684,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 5.152,
+                                                    "delta_percentage": 23
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.038,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 5.807,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 5.434,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.902,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.464,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 6.748,
+                                                    "delta_percentage": 42
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 6.248,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 6.66,
+                                                    "delta_percentage": 25
+                                                }
                                             },
                                             "P90": {
-                                                "target": 7.147,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 7.502,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 4.22,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.441,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.239,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 4.854,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 4.208,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 4.489,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.084,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 4.952,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 4.206,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 4.553,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.235,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 5.085,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 4.318,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 4.642,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.39,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 5.062,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         }
                                     }
@@ -797,252 +1097,1071 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.086,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.406,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.455,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 4.835,
+                                                    "delta_percentage": 57
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.328,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.52,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.115,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 4.939,
+                                                    "delta_percentage": 38
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.325,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.73,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.499,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 5.14,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.639,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.851,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.281,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 5.309,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.474,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 5.022,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.496,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 5.476,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.764,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 5.194,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.949,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 5.702,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 4.888,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 5.311,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.915,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 5.76,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.073,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 5.487,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.585,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 6.031,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.231,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 5.665,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.331,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 6.143,
+                                                    "delta_percentage": 37
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 5.36,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.761,
+                                                    "delta_percentage": 17
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.354,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 6.162,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 4.348,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.814,
+                                                    "delta_percentage": 22
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.504,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 5.167,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 4.757,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 5.649,
+                                                    "delta_percentage": 26
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.814,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 5.948,
+                                                    "delta_percentage": 29
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 5.555,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 7.265,
+                                                    "delta_percentage": 31
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.126,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 7.592,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 7.244,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 10.469,
+                                                    "delta_percentage": 36
+                                                }
                                             },
                                             "P90": {
-                                                "target": 8.26,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 10.982,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 10.905,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 17.425,
+                                                    "delta_percentage": 40
+                                                }
                                             },
                                             "P90": {
-                                                "target": 11.817,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 18.083,
+                                                    "delta_percentage": 37
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 17.976,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 30.604,
+                                                    "delta_percentage": 43
+                                                }
                                             },
                                             "P90": {
-                                                "target": 18.683,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 31.537,
+                                                    "delta_percentage": 44
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 32.604,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 56.856,
+                                                    "delta_percentage": 47
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.459,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 58.223,
+                                                    "delta_percentage": 46
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 61.04,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 109.699,
+                                                    "delta_percentage": 48
+                                                }
                                             },
                                             "P90": {
-                                                "target": 62.849,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 112.204,
+                                                    "delta_percentage": 47
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 4.896,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 5.15,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.377,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 5.626,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 5.489,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 5.934,
+                                                    "delta_percentage": 28
+                                                }
                                             },
                                             "P90": {
-                                                "target": 6.672,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 6.476,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 6.257,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 6.641,
+                                                    "delta_percentage": 26
+                                                }
                                             },
                                             "P90": {
-                                                "target": 7.717,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 7.299,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 4.189,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 4.471,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.452,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 4.796,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 4.165,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.509,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.485,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.828,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 4.262,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 4.559,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 4.332,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 4.846,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 4.382,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.661,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 5.028,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 4.961,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "m6a.metal": {
+                "cpus": [
+                    {
+                        "model": "AMD EPYC 7R13 48-Core Processor",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.179,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.681,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.277,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.835,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.385,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.881,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.493,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.006,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.605,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.116,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.724,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.259,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.811,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.382,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.986,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.644,
+                                                    "delta_percentage": 106
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.211,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.983,
+                                                    "delta_percentage": 94
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.388,
+                                                    "delta_percentage": 21
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.338,
+                                                    "delta_percentage": 131
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.136,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.642,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.174,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.677,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.294,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.873,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.469,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.064,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.246,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.999,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.504,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.444,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 10.346,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 11.321,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.732,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.627,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.821,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.617,
+                                                    "delta_percentage": 36
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.426,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.071,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 9.027,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.619,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.245,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.852,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.288,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.903,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.326,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.94,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.302,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.877,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.158,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.718,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.278,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.831,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.392,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.958,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.513,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.091,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.611,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.225,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.739,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.327,
+                                                    "delta_percentage": 44
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.87,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.465,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.019,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.703,
+                                                    "delta_percentage": 50
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.231,
+                                                    "delta_percentage": 19
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.07,
+                                                    "delta_percentage": 138
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.401,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.15,
+                                                    "delta_percentage": 94
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.23,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.71,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.244,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.748,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.324,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.807,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.482,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.138,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.258,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.018,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.434,
+                                                    "delta_percentage": 24
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.36,
+                                                    "delta_percentage": 40
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 10.223,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 11.032,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.561,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.275,
+                                                    "delta_percentage": 30
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.746,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.271,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.398,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.908,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 9.024,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.516,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.214,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.737,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.256,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.79,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.316,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.841,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.289,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.773,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         }
                                     }
@@ -1053,518 +2172,723 @@
                 ]
             },
             "m6g.metal": {
-                "baselines": {
-                    "restore_latency": {
-                        "vmlinux-4.14.bin": {
-                            "ubuntu-18.04.ext4": {
-                                "1vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.719,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 1.749,
-                                        "delta_percentage": 37
+                "cpus": [
+                    {
+                        "model": "ARM_NEOVERSE_N1",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.783,
+                                                    "delta_percentage": 31
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.825,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.92,
+                                                    "delta_percentage": 29
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.996,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.054,
+                                                    "delta_percentage": 26
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.107,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.178,
+                                                    "delta_percentage": 22
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.244,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.325,
+                                                    "delta_percentage": 21
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.398,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.467,
+                                                    "delta_percentage": 21
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.517,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.631,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.708,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.802,
+                                                    "delta_percentage": 19
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.884,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.991,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.052,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.184,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.282,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.09,
+                                                    "delta_percentage": 25
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.17,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.089,
+                                                    "delta_percentage": 25
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.166,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.075,
+                                                    "delta_percentage": 26
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.169,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.086,
+                                                    "delta_percentage": 31
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.161,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.107,
+                                                    "delta_percentage": 30
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.178,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.132,
+                                                    "delta_percentage": 33
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.202,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.155,
+                                                    "delta_percentage": 33
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.194,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.178,
+                                                    "delta_percentage": 34
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.259,
+                                                    "delta_percentage": 36
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.643,
+                                                    "delta_percentage": 27
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.729,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.245,
+                                                    "delta_percentage": 24
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.326,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.59,
+                                                    "delta_percentage": 25
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.711,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.843,
+                                                    "delta_percentage": 38
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.885,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.862,
+                                                    "delta_percentage": 37
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.965,
+                                                    "delta_percentage": 57
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.899,
+                                                    "delta_percentage": 38
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.96,
+                                                    "delta_percentage": 43
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.952,
+                                                    "delta_percentage": 36
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.012,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        }
                                     }
                                 },
-                                "2vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.849,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 1.866,
-                                        "delta_percentage": 68
-                                    }
-                                },
-                                "3vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.007,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.08,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "4vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.133,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.162,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "5vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.266,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.377,
-                                        "delta_percentage": 44
-                                    }
-                                },
-                                "6vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.422,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.448,
-                                        "delta_percentage": 89
-                                    }
-                                },
-                                "7vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.557,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.582,
-                                        "delta_percentage": 20
-                                    }
-                                },
-                                "8vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.75,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.846,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "9vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.929,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 2.993,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "10vcpu_128mb": {
-                                    "P50": {
-                                        "target": 3.15,
-                                        "delta_percentage": 17
-                                    },
-                                    "P90": {
-                                        "target": 3.216,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "1vcpu_256mb": {
-                                    "P50": {
-                                        "target": 2.106,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.168,
-                                        "delta_percentage": 7
-                                    }
-                                },
-                                "1vcpu_512mb": {
-                                    "P50": {
-                                        "target": 2.112,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.34,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "1vcpu_1024mb": {
-                                    "P50": {
-                                        "target": 2.173,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.316,
-                                        "delta_percentage": 16
-                                    }
-                                },
-                                "1vcpu_2048mb": {
-                                    "P50": {
-                                        "target": 2.248,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.47,
-                                        "delta_percentage": 25
-                                    }
-                                },
-                                "1vcpu_4096mb": {
-                                    "P50": {
-                                        "target": 2.191,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 2.349,
-                                        "delta_percentage": 16
-                                    }
-                                },
-                                "1vcpu_8192mb": {
-                                    "P50": {
-                                        "target": 2.307,
-                                        "delta_percentage": 18
-                                    },
-                                    "P90": {
-                                        "target": 2.369,
-                                        "delta_percentage": 14
-                                    }
-                                },
-                                "1vcpu_16384mb": {
-                                    "P50": {
-                                        "target": 2.261,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.412,
-                                        "delta_percentage": 10
-                                    }
-                                },
-                                "1vcpu_32768mb": {
-                                    "P50": {
-                                        "target": 2.392,
-                                        "delta_percentage": 5
-                                    },
-                                    "P90": {
-                                        "target": 2.442,
-                                        "delta_percentage": 8
-                                    }
-                                },
-                                "2net_dev": {
-                                    "P50": {
-                                        "target": 2.867,
-                                        "delta_percentage": 14
-                                    },
-                                    "P90": {
-                                        "target": 2.956,
-                                        "delta_percentage": 42
-                                    }
-                                },
-                                "3net_dev": {
-                                    "P50": {
-                                        "target": 3.469,
-                                        "delta_percentage": 14
-                                    },
-                                    "P90": {
-                                        "target": 3.568,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "4net_dev": {
-                                    "P50": {
-                                        "target": 3.455,
-                                        "delta_percentage": 14
-                                    },
-                                    "P90": {
-                                        "target": 3.512,
-                                        "delta_percentage": 21
-                                    }
-                                },
-                                "2block_dev": {
-                                    "P50": {
-                                        "target": 1.685,
-                                        "delta_percentage": 16
-                                    },
-                                    "P90": {
-                                        "target": 1.702,
-                                        "delta_percentage": 29
-                                    }
-                                },
-                                "3block_dev": {
-                                    "P50": {
-                                        "target": 1.721,
-                                        "delta_percentage": 16
-                                    },
-                                    "P90": {
-                                        "target": 1.748,
-                                        "delta_percentage": 27
-                                    }
-                                },
-                                "4block_dev": {
-                                    "P50": {
-                                        "target": 1.778,
-                                        "delta_percentage": 16
-                                    },
-                                    "P90": {
-                                        "target": 1.794,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "all_dev": {
-                                    "P50": {
-                                        "target": 1.801,
-                                        "delta_percentage": 16
-                                    },
-                                    "P90": {
-                                        "target": 1.824,
-                                        "delta_percentage": 39
-                                    }
-                                }
-                            }
-                        },
-                        "vmlinux-5.10.bin": {
-                            "ubuntu-18.04.ext4": {
-                                "1vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.648,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.675,
-                                        "delta_percentage": 39
-                                    }
-                                },
-                                "2vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.8,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.825,
-                                        "delta_percentage": 43
-                                    }
-                                },
-                                "3vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.939,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 1.976,
-                                        "delta_percentage": 41
-                                    }
-                                },
-                                "4vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.068,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 2.103,
-                                        "delta_percentage": 27
-                                    }
-                                },
-                                "5vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.214,
-                                        "delta_percentage": 6
-                                    },
-                                    "P90": {
-                                        "target": 2.258,
-                                        "delta_percentage": 43
-                                    }
-                                },
-                                "6vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.336,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 2.405,
-                                        "delta_percentage": 23
-                                    }
-                                },
-                                "7vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.507,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.532,
-                                        "delta_percentage": 7
-                                    }
-                                },
-                                "8vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.659,
-                                        "delta_percentage": 13
-                                    },
-                                    "P90": {
-                                        "target": 2.697,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "9vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.837,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.914,
-                                        "delta_percentage": 28
-                                    }
-                                },
-                                "10vcpu_128mb": {
-                                    "P50": {
-                                        "target": 3.051,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 3.15,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "1vcpu_256mb": {
-                                    "P50": {
-                                        "target": 1.971,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 2.081,
-                                        "delta_percentage": 35
-                                    }
-                                },
-                                "1vcpu_512mb": {
-                                    "P50": {
-                                        "target": 2.0,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.068,
-                                        "delta_percentage": 38
-                                    }
-                                },
-                                "1vcpu_1024mb": {
-                                    "P50": {
-                                        "target": 2.009,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 2.168,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "1vcpu_2048mb": {
-                                    "P50": {
-                                        "target": 2.037,
-                                        "delta_percentage": 6
-                                    },
-                                    "P90": {
-                                        "target": 2.184,
-                                        "delta_percentage": 22
-                                    }
-                                },
-                                "1vcpu_4096mb": {
-                                    "P50": {
-                                        "target": 2.032,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.205,
-                                        "delta_percentage": 17
-                                    }
-                                },
-                                "1vcpu_8192mb": {
-                                    "P50": {
-                                        "target": 2.182,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.21,
-                                        "delta_percentage": 14
-                                    }
-                                },
-                                "1vcpu_16384mb": {
-                                    "P50": {
-                                        "target": 2.188,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.251,
-                                        "delta_percentage": 15
-                                    }
-                                },
-                                "1vcpu_32768mb": {
-                                    "P50": {
-                                        "target": 2.201,
-                                        "delta_percentage": 12
-                                    },
-                                    "P90": {
-                                        "target": 2.277,
-                                        "delta_percentage": 29
-                                    }
-                                },
-                                "2net_dev": {
-                                    "P50": {
-                                        "target": 2.662,
-                                        "delta_percentage": 30
-                                    },
-                                    "P90": {
-                                        "target": 2.774,
-                                        "delta_percentage": 33
-                                    }
-                                },
-                                "3net_dev": {
-                                    "P50": {
-                                        "target": 3.348,
-                                        "delta_percentage": 26
-                                    },
-                                    "P90": {
-                                        "target": 3.403,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "4net_dev": {
-                                    "P50": {
-                                        "target": 3.946,
-                                        "delta_percentage": 18
-                                    },
-                                    "P90": {
-                                        "target": 3.996,
-                                        "delta_percentage": 36
-                                    }
-                                },
-                                "2block_dev": {
-                                    "P50": {
-                                        "target": 2.107,
-                                        "delta_percentage": 13
-                                    },
-                                    "P90": {
-                                        "target": 2.243,
-                                        "delta_percentage": 47
-                                    }
-                                },
-                                "3block_dev": {
-                                    "P50": {
-                                        "target": 2.138,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.302,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "4block_dev": {
-                                    "P50": {
-                                        "target": 2.183,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 2.322,
-                                        "delta_percentage": 42
-                                    }
-                                },
-                                "all_dev": {
-                                    "P50": {
-                                        "target": 2.231,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.365,
-                                        "delta_percentage": 50
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.843,
+                                                    "delta_percentage": 37
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.881,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.988,
+                                                    "delta_percentage": 35
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.049,
+                                                    "delta_percentage": 38
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.132,
+                                                    "delta_percentage": 33
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.177,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.276,
+                                                    "delta_percentage": 32
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.335,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.424,
+                                                    "delta_percentage": 30
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.473,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.569,
+                                                    "delta_percentage": 29
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.627,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.739,
+                                                    "delta_percentage": 28
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.797,
+                                                    "delta_percentage": 30
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.898,
+                                                    "delta_percentage": 28
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.969,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.978,
+                                                    "delta_percentage": 28
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.145,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.113,
+                                                    "delta_percentage": 26
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.178,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.97,
+                                                    "delta_percentage": 35
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.033,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.997,
+                                                    "delta_percentage": 34
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.064,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.996,
+                                                    "delta_percentage": 33
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.073,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.013,
+                                                    "delta_percentage": 33
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.077,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.057,
+                                                    "delta_percentage": 35
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.114,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.09,
+                                                    "delta_percentage": 34
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.178,
+                                                    "delta_percentage": 46
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.054,
+                                                    "delta_percentage": 40
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.127,
+                                                    "delta_percentage": 38
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.063,
+                                                    "delta_percentage": 43
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.205,
+                                                    "delta_percentage": 54
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.546,
+                                                    "delta_percentage": 32
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.659,
+                                                    "delta_percentage": 42
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.14,
+                                                    "delta_percentage": 29
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.226,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.757,
+                                                    "delta_percentage": 25
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.849,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.941,
+                                                    "delta_percentage": 38
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.999,
+                                                    "delta_percentage": 42
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.957,
+                                                    "delta_percentage": 37
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.005,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.001,
+                                                    "delta_percentage": 38
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.06,
+                                                    "delta_percentage": 40
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.085,
+                                                    "delta_percentage": 37
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.215,
+                                                    "delta_percentage": 56
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
+                ]
             }
         }
     }

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
@@ -1,6 +1,6 @@
 {
     "measurements": {
-        "restore_latency": {
+        "latency": {
             "unit": "ms",
             "statistics": [
                 {
@@ -23,257 +23,357 @@
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
                         "baselines": {
-                            "restore_latency": {
+                            "latency": {
                                 "vmlinux-4.14.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.55,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.921,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.597,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 3.171,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.591,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.039,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.999,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 3.274,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.732,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.145,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.697,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 3.426,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.875,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.264,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.642,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.602,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.751,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.379,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 52.09,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 3.715,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.143,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.503,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.452,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 3.818,
+                                                    "delta_percentage": 34
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.271,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.62,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.977,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 3.91,
+                                                    "delta_percentage": 31
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 44.772,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.725,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 60.873,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.064,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.868,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.86,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.351,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.197,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.854,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.972,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 61.115,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.247,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 36.22,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.915,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.167,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.145,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 32.4,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.061,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.225,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.294,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 32.759,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.343,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 63.718,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 3.609,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 29.254,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.942,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.389,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.172,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 26.282,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 5.439,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 30.884,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 5.748,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 33.514,
-                                                "delta_percentage": 18
+                                                "restore": {
+                                                    "target": 7.925,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.561,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.245,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 37.717,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 12.321,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.578,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 12.759,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 47.14,
-                                                "delta_percentage": 5
+                                                "restore": {
+                                                    "target": 21.536,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 59.323,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 22.013,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 33.228,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.535,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.441,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.747,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 29.508,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.229,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 53.623,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.494,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 38.268,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.917,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 50.611,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.231,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 27.82,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 2.851,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.269,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 3.075,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 27.8,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 2.852,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 32.118,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.036,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 31.649,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 2.85,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.291,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.029,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 27.764,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 2.969,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.808,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.182,
+                                                    "delta_percentage": 41
+                                                }
                                             }
                                         }
                                     }
@@ -282,252 +382,352 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.21,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.827,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 71.847,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.033,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.706,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 2.977,
+                                                    "delta_percentage": 21
+                                                }
                                             },
                                             "P90": {
-                                                "target": 47.744,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.175,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.779,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.106,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.062,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 3.37,
+                                                    "delta_percentage": 33
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.643,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.236,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.969,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.48,
+                                                    "delta_percentage": 30
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.485,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 3.373,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.924,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.581,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 47.504,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 3.497,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 72.148,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 3.726,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.038,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.607,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.851,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.811,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 35.154,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.714,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.362,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.931,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.39,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.841,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 83.423,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 4.028,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 39.954,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.959,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 50.982,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.183,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 39.097,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 2.87,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 51.546,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 3.061,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 31.628,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.021,
+                                                    "delta_percentage": 16
+                                                }
                                             },
                                             "P90": {
-                                                "target": 67.228,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 3.211,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 32.08,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.314,
+                                                    "delta_percentage": 20
+                                                }
                                             },
                                             "P90": {
-                                                "target": 56.08,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 3.547,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 29.606,
-                                                "delta_percentage": 6
+                                                "restore": {
+                                                    "target": 3.922,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.706,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 4.21,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 30.066,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 5.412,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.559,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 5.707,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 35.595,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 7.913,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.645,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.257,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 45.112,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 12.273,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 61.403,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 12.664,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 49.094,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 21.478,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 63.108,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 22.0,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 36.146,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.525,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.408,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.722,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 33.103,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.182,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 41.094,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 4.431,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 29.961,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.846,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.552,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 5.143,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 31.551,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 2.863,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 55.142,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 3.077,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 38.726,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.869,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 55.552,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.049,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 43.366,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 2.89,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 59.41,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.065,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 27.215,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 2.991,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.911,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 3.187,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         }
                                     }
@@ -538,257 +738,357 @@
                     {
                         "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
                         "baselines": {
-                            "restore_latency": {
+                            "latency": {
                                 "vmlinux-4.14.bin": {
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.451,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.37,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.852,
-                                                "delta_percentage": 37
+                                                "restore": {
+                                                    "target": 3.704,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 24.602,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.543,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.046,
-                                                "delta_percentage": 68
+                                                "restore": {
+                                                    "target": 3.884,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.054,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.701,
+                                                    "delta_percentage": 18
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.637,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.048,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.409,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.844,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.384,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.176,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.845,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.013,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.64,
-                                                "delta_percentage": 44
+                                                "restore": {
+                                                    "target": 4.311,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.937,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.146,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.576,
-                                                "delta_percentage": 89
+                                                "restore": {
+                                                    "target": 4.517,
+                                                    "delta_percentage": 24
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 36.341,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.26,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 44.04,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 4.56,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 24.908,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.378,
+                                                    "delta_percentage": 15
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.779,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 4.702,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 28.19,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 4.524,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.096,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 4.808,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 32.59,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.66,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.613,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.913,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 31.582,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.455,
+                                                    "delta_percentage": 19
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.06,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.776,
+                                                    "delta_percentage": 83
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 35.866,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 3.59,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.234,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 3.828,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 28.382,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.851,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.767,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 4.014,
+                                                    "delta_percentage": 27
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 25.107,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 4.456,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.934,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.64,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 26.241,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 5.952,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.544,
-                                                "delta_percentage": 16
+                                                "restore": {
+                                                    "target": 6.323,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 32.669,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 8.539,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 45.217,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.976,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 41.123,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 12.972,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.797,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 13.45,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 46.896,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 22.258,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 58.954,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 22.745,
+                                                    "delta_percentage": 9
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 31.828,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 4.08,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.256,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 4.242,
+                                                    "delta_percentage": 14
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 28.855,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.799,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.005,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 5.039,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 30.343,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 5.537,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.467,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.891,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 27.093,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.332,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.298,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 3.562,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 27.379,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 3.342,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 31.364,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.511,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 31.529,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.387,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.571,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.539,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 26.479,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 3.506,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.266,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.762,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         }
                                     }
@@ -797,252 +1097,1071 @@
                                     "ubuntu-18.04.ext4": {
                                         "1vcpu_128mb": {
                                             "P50": {
-                                                "target": 26.604,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 3.328,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.539,
-                                                "delta_percentage": 39
+                                                "restore": {
+                                                    "target": 3.539,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.316,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 3.49,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.395,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 3.735,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
-                                                "target": 34.796,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.651,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.099,
-                                                "delta_percentage": 41
+                                                "restore": {
+                                                    "target": 3.883,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.109,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.778,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.525,
-                                                "delta_percentage": 27
+                                                "restore": {
+                                                    "target": 3.95,
+                                                    "delta_percentage": 28
+                                                }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.266,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 3.946,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.126,
-                                                "delta_percentage": 43
+                                                "restore": {
+                                                    "target": 4.122,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.216,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 4.059,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.795,
-                                                "delta_percentage": 23
+                                                "restore": {
+                                                    "target": 4.244,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.857,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 4.187,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.746,
-                                                "delta_percentage": 25
+                                                "restore": {
+                                                    "target": 4.45,
+                                                    "delta_percentage": 20
+                                                }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.466,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 4.315,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.158,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 4.625,
+                                                    "delta_percentage": 32
+                                                }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
-                                                "target": 31.473,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.456,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.435,
-                                                "delta_percentage": 28
+                                                "restore": {
+                                                    "target": 4.598,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
-                                                "target": 27.569,
-                                                "delta_percentage": 9
+                                                "restore": {
+                                                    "target": 4.599,
+                                                    "delta_percentage": 14
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.654,
-                                                "delta_percentage": 32
+                                                "restore": {
+                                                    "target": 4.757,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
-                                                "target": 30.815,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 3.367,
+                                                    "delta_percentage": 13
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.683,
-                                                "delta_percentage": 35
+                                                "restore": {
+                                                    "target": 3.56,
+                                                    "delta_percentage": 25
+                                                }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
-                                                "target": 27.148,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 3.542,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 42.55,
-                                                "delta_percentage": 38
+                                                "restore": {
+                                                    "target": 3.695,
+                                                    "delta_percentage": 18
+                                                }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
-                                                "target": 27.907,
-                                                "delta_percentage": 7
+                                                "restore": {
+                                                    "target": 3.799,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.234,
-                                                "delta_percentage": 30
+                                                "restore": {
+                                                    "target": 3.943,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
-                                                "target": 30.826,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 4.485,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.115,
-                                                "delta_percentage": 22
+                                                "restore": {
+                                                    "target": 4.683,
+                                                    "delta_percentage": 14
+                                                }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
-                                                "target": 29.149,
-                                                "delta_percentage": 20
+                                                "restore": {
+                                                    "target": 5.932,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.659,
-                                                "delta_percentage": 17
+                                                "restore": {
+                                                    "target": 6.305,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
-                                                "target": 31.864,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 8.51,
+                                                    "delta_percentage": 9
+                                                }
                                             },
                                             "P90": {
-                                                "target": 39.736,
-                                                "delta_percentage": 14
+                                                "restore": {
+                                                    "target": 8.854,
+                                                    "delta_percentage": 10
+                                                }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
-                                                "target": 36.649,
-                                                "delta_percentage": 10
+                                                "restore": {
+                                                    "target": 12.956,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 48.614,
-                                                "delta_percentage": 15
+                                                "restore": {
+                                                    "target": 13.508,
+                                                    "delta_percentage": 26
+                                                }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
-                                                "target": 46.127,
-                                                "delta_percentage": 12
+                                                "restore": {
+                                                    "target": 22.23,
+                                                    "delta_percentage": 8
+                                                }
                                             },
                                             "P90": {
-                                                "target": 49.913,
-                                                "delta_percentage": 29
+                                                "restore": {
+                                                    "target": 22.695,
+                                                    "delta_percentage": 12
+                                                }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
-                                                "target": 30.035,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 4.062,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 43.493,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 4.228,
+                                                    "delta_percentage": 16
+                                                }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
-                                                "target": 28.425,
-                                                "delta_percentage": 24
+                                                "restore": {
+                                                    "target": 4.804,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 36.304,
-                                                "delta_percentage": 31
+                                                "restore": {
+                                                    "target": 5.053,
+                                                    "delta_percentage": 15
+                                                }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
-                                                "target": 29.074,
-                                                "delta_percentage": 21
+                                                "restore": {
+                                                    "target": 5.557,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 40.734,
-                                                "delta_percentage": 36
+                                                "restore": {
+                                                    "target": 5.86,
+                                                    "delta_percentage": 22
+                                                }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
-                                                "target": 31.115,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.348,
+                                                    "delta_percentage": 12
+                                                }
                                             },
                                             "P90": {
-                                                "target": 34.543,
-                                                "delta_percentage": 47
+                                                "restore": {
+                                                    "target": 3.502,
+                                                    "delta_percentage": 19
+                                                }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
-                                                "target": 31.065,
-                                                "delta_percentage": 8
+                                                "restore": {
+                                                    "target": 3.372,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 35.003,
-                                                "delta_percentage": 34
+                                                "restore": {
+                                                    "target": 3.538,
+                                                    "delta_percentage": 23
+                                                }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
-                                                "target": 30.368,
-                                                "delta_percentage": 11
+                                                "restore": {
+                                                    "target": 3.398,
+                                                    "delta_percentage": 10
+                                                }
                                             },
                                             "P90": {
-                                                "target": 38.063,
-                                                "delta_percentage": 42
+                                                "restore": {
+                                                    "target": 3.554,
+                                                    "delta_percentage": 21
+                                                }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
-                                                "target": 34.139,
-                                                "delta_percentage": 13
+                                                "restore": {
+                                                    "target": 3.512,
+                                                    "delta_percentage": 11
+                                                }
                                             },
                                             "P90": {
-                                                "target": 37.06,
-                                                "delta_percentage": 50
+                                                "restore": {
+                                                    "target": 3.634,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "m6a.metal": {
+                "cpus": [
+                    {
+                        "model": "AMD EPYC 7R13 48-Core Processor",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.885,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.355,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.957,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.439,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.084,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.588,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.144,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.648,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.257,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.807,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.427,
+                                                    "delta_percentage": 19
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.996,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.546,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.185,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.834,
+                                                    "delta_percentage": 19
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.492,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.028,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.7,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.267,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.936,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.654,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.081,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.74,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.189,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.888,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.331,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.078,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.499,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.893,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.46,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.075,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.584,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 9.504,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 10.07,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 12.763,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 13.437,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.712,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.223,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.466,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.869,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.994,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.386,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.667,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.103,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.716,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.184,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.737,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.203,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.847,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.316,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.623,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.054,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.752,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.296,
+                                                    "delta_percentage": 68
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.9,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.397,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.026,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.553,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.146,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.678,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.294,
+                                                    "delta_percentage": 18
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.89,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.445,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.026,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.728,
+                                                    "delta_percentage": 20
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.391,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.922,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.624,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.171,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.86,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.643,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.053,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.702,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.156,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.862,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.342,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.022,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.463,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.817,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.331,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.003,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.505,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 9.439,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 10.038,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 12.526,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 13.161,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 6.695,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.159,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.423,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.805,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.904,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.377,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.657,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.098,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.685,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.131,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.729,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.187,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.807,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.306,
+                                                    "delta_percentage": 17
+                                                }
                                             }
                                         }
                                     }
@@ -1053,518 +2172,723 @@
                 ]
             },
             "m6g.metal": {
-                "baselines": {
-                    "restore_latency": {
-                        "vmlinux-4.14.bin": {
-                            "ubuntu-18.04.ext4": {
-                                "1vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.819,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.838,
-                                        "delta_percentage": 37
+                "cpus": [
+                    {
+                        "model": "ARM_NEOVERSE_N1",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.808,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.836,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.923,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.946,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.064,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.097,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.195,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.219,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.325,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.36,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.456,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.486,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.608,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.651,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.747,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.791,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.902,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.937,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.038,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.095,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.838,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.859,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.844,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.875,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.848,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.883,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.85,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.878,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.85,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.877,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.855,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.88,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.855,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.883,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.862,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.89,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.42,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.453,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.029,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.066,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.628,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.667,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.83,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.856,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.853,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.883,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.878,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.909,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.965,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.992,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        }
                                     }
                                 },
-                                "2vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.905,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.953,
-                                        "delta_percentage": 68
-                                    }
-                                },
-                                "3vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.056,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.097,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "4vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.177,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.206,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "5vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.27,
-                                        "delta_percentage": 14
-                                    },
-                                    "P90": {
-                                        "target": 2.312,
-                                        "delta_percentage": 44
-                                    }
-                                },
-                                "6vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.389,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.422,
-                                        "delta_percentage": 89
-                                    }
-                                },
-                                "7vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.533,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.565,
-                                        "delta_percentage": 20
-                                    }
-                                },
-                                "8vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.65,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.679,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "9vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.777,
-                                        "delta_percentage": 14
-                                    },
-                                    "P90": {
-                                        "target": 2.798,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "10vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.922,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.957,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "1vcpu_256mb": {
-                                    "P50": {
-                                        "target": 1.838,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.873,
-                                        "delta_percentage": 7
-                                    }
-                                },
-                                "1vcpu_512mb": {
-                                    "P50": {
-                                        "target": 1.836,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.879,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "1vcpu_1024mb": {
-                                    "P50": {
-                                        "target": 1.843,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.867,
-                                        "delta_percentage": 16
-                                    }
-                                },
-                                "1vcpu_2048mb": {
-                                    "P50": {
-                                        "target": 1.841,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.883,
-                                        "delta_percentage": 25
-                                    }
-                                },
-                                "1vcpu_4096mb": {
-                                    "P50": {
-                                        "target": 1.827,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 1.881,
-                                        "delta_percentage": 16
-                                    }
-                                },
-                                "1vcpu_8192mb": {
-                                    "P50": {
-                                        "target": 1.839,
-                                        "delta_percentage": 18
-                                    },
-                                    "P90": {
-                                        "target": 1.874,
-                                        "delta_percentage": 14
-                                    }
-                                },
-                                "1vcpu_16384mb": {
-                                    "P50": {
-                                        "target": 1.845,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.887,
-                                        "delta_percentage": 10
-                                    }
-                                },
-                                "1vcpu_32768mb": {
-                                    "P50": {
-                                        "target": 1.858,
-                                        "delta_percentage": 5
-                                    },
-                                    "P90": {
-                                        "target": 1.899,
-                                        "delta_percentage": 8
-                                    }
-                                },
-                                "2net_dev": {
-                                    "P50": {
-                                        "target": 2.455,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 2.528,
-                                        "delta_percentage": 42
-                                    }
-                                },
-                                "3net_dev": {
-                                    "P50": {
-                                        "target": 3.102,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 3.108,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "4net_dev": {
-                                    "P50": {
-                                        "target": 3.722,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 3.734,
-                                        "delta_percentage": 21
-                                    }
-                                },
-                                "2block_dev": {
-                                    "P50": {
-                                        "target": 1.864,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 1.878,
-                                        "delta_percentage": 29
-                                    }
-                                },
-                                "3block_dev": {
-                                    "P50": {
-                                        "target": 1.869,
-                                        "delta_percentage": 13
-                                    },
-                                    "P90": {
-                                        "target": 1.907,
-                                        "delta_percentage": 27
-                                    }
-                                },
-                                "4block_dev": {
-                                    "P50": {
-                                        "target": 1.901,
-                                        "delta_percentage": 12
-                                    },
-                                    "P90": {
-                                        "target": 1.941,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "all_dev": {
-                                    "P50": {
-                                        "target": 1.989,
-                                        "delta_percentage": 12
-                                    },
-                                    "P90": {
-                                        "target": 1.994,
-                                        "delta_percentage": 39
-                                    }
-                                }
-                            }
-                        },
-                        "vmlinux-5.10.bin": {
-                            "ubuntu-18.04.ext4": {
-                                "1vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.806,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.838,
-                                        "delta_percentage": 39
-                                    }
-                                },
-                                "2vcpu_128mb": {
-                                    "P50": {
-                                        "target": 1.914,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.927,
-                                        "delta_percentage": 43
-                                    }
-                                },
-                                "3vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.04,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.072,
-                                        "delta_percentage": 41
-                                    }
-                                },
-                                "4vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.149,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 2.246,
-                                        "delta_percentage": 27
-                                    }
-                                },
-                                "5vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.277,
-                                        "delta_percentage": 6
-                                    },
-                                    "P90": {
-                                        "target": 2.304,
-                                        "delta_percentage": 43
-                                    }
-                                },
-                                "6vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.398,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 2.418,
-                                        "delta_percentage": 23
-                                    }
-                                },
-                                "7vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.525,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.556,
-                                        "delta_percentage": 7
-                                    }
-                                },
-                                "8vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.662,
-                                        "delta_percentage": 13
-                                    },
-                                    "P90": {
-                                        "target": 2.695,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "9vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.812,
-                                        "delta_percentage": 11
-                                    },
-                                    "P90": {
-                                        "target": 2.827,
-                                        "delta_percentage": 28
-                                    }
-                                },
-                                "10vcpu_128mb": {
-                                    "P50": {
-                                        "target": 2.929,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 2.965,
-                                        "delta_percentage": 32
-                                    }
-                                },
-                                "1vcpu_256mb": {
-                                    "P50": {
-                                        "target": 1.826,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 1.856,
-                                        "delta_percentage": 35
-                                    }
-                                },
-                                "1vcpu_512mb": {
-                                    "P50": {
-                                        "target": 1.827,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.857,
-                                        "delta_percentage": 38
-                                    }
-                                },
-                                "1vcpu_1024mb": {
-                                    "P50": {
-                                        "target": 1.829,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 1.854,
-                                        "delta_percentage": 30
-                                    }
-                                },
-                                "1vcpu_2048mb": {
-                                    "P50": {
-                                        "target": 1.847,
-                                        "delta_percentage": 6
-                                    },
-                                    "P90": {
-                                        "target": 1.895,
-                                        "delta_percentage": 22
-                                    }
-                                },
-                                "1vcpu_4096mb": {
-                                    "P50": {
-                                        "target": 1.847,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 1.89,
-                                        "delta_percentage": 17
-                                    }
-                                },
-                                "1vcpu_8192mb": {
-                                    "P50": {
-                                        "target": 1.854,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.873,
-                                        "delta_percentage": 14
-                                    }
-                                },
-                                "1vcpu_16384mb": {
-                                    "P50": {
-                                        "target": 1.853,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.87,
-                                        "delta_percentage": 15
-                                    }
-                                },
-                                "1vcpu_32768mb": {
-                                    "P50": {
-                                        "target": 1.867,
-                                        "delta_percentage": 12
-                                    },
-                                    "P90": {
-                                        "target": 1.894,
-                                        "delta_percentage": 29
-                                    }
-                                },
-                                "2net_dev": {
-                                    "P50": {
-                                        "target": 2.441,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 2.458,
-                                        "delta_percentage": 11
-                                    }
-                                },
-                                "3net_dev": {
-                                    "P50": {
-                                        "target": 3.056,
-                                        "delta_percentage": 10
-                                    },
-                                    "P90": {
-                                        "target": 3.088,
-                                        "delta_percentage": 31
-                                    }
-                                },
-                                "4net_dev": {
-                                    "P50": {
-                                        "target": 3.682,
-                                        "delta_percentage": 9
-                                    },
-                                    "P90": {
-                                        "target": 3.731,
-                                        "delta_percentage": 36
-                                    }
-                                },
-                                "2block_dev": {
-                                    "P50": {
-                                        "target": 1.816,
-                                        "delta_percentage": 13
-                                    },
-                                    "P90": {
-                                        "target": 1.847,
-                                        "delta_percentage": 47
-                                    }
-                                },
-                                "3block_dev": {
-                                    "P50": {
-                                        "target": 1.856,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.87,
-                                        "delta_percentage": 34
-                                    }
-                                },
-                                "4block_dev": {
-                                    "P50": {
-                                        "target": 1.878,
-                                        "delta_percentage": 7
-                                    },
-                                    "P90": {
-                                        "target": 1.894,
-                                        "delta_percentage": 42
-                                    }
-                                },
-                                "all_dev": {
-                                    "P50": {
-                                        "target": 1.932,
-                                        "delta_percentage": 8
-                                    },
-                                    "P90": {
-                                        "target": 1.963,
-                                        "delta_percentage": 50
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.82,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.845,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.937,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.968,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.077,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.108,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.211,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.237,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.342,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.367,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.466,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.493,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.612,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.641,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.74,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.776,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.887,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.919,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.031,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.087,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.845,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.874,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.848,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.877,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.859,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.887,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.862,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.889,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.866,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.896,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.88,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.947,
+                                                    "delta_percentage": 44
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.881,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.92,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.883,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.913,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.43,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.461,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.032,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.067,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.632,
+                                                    "delta_percentage": 7
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.673,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.843,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.869,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.861,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.882,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.886,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.912,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 1.96,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 1.984,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
+                ]
             }
         }
     }

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
@@ -29,335 +29,335 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.921,
-                                                    "delta_percentage": 12
+                                                    "target": 3.057,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.171,
-                                                    "delta_percentage": 26
+                                                    "target": 3.319,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.039,
-                                                    "delta_percentage": 14
+                                                    "target": 3.178,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.274,
-                                                    "delta_percentage": 20
+                                                    "target": 3.458,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.145,
-                                                    "delta_percentage": 12
+                                                    "target": 3.274,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.426,
-                                                    "delta_percentage": 26
+                                                    "target": 3.548,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.264,
-                                                    "delta_percentage": 19
+                                                    "target": 3.395,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.602,
-                                                    "delta_percentage": 27
+                                                    "target": 3.701,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.379,
-                                                    "delta_percentage": 14
+                                                    "target": 3.521,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.715,
-                                                    "delta_percentage": 28
+                                                    "target": 3.823,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.503,
-                                                    "delta_percentage": 13
+                                                    "target": 3.629,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.818,
-                                                    "delta_percentage": 34
+                                                    "target": 3.884,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.62,
-                                                    "delta_percentage": 15
+                                                    "target": 3.751,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.91,
-                                                    "delta_percentage": 31
+                                                    "target": 4.083,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.725,
-                                                    "delta_percentage": 13
+                                                    "target": 3.879,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.064,
-                                                    "delta_percentage": 21
+                                                    "target": 4.206,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.86,
-                                                    "delta_percentage": 16
+                                                    "target": 4.021,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.197,
-                                                    "delta_percentage": 20
+                                                    "target": 4.292,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.972,
-                                                    "delta_percentage": 12
+                                                    "target": 4.129,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.247,
-                                                    "delta_percentage": 22
+                                                    "target": 4.394,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.915,
-                                                    "delta_percentage": 15
+                                                    "target": 3.064,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.145,
-                                                    "delta_percentage": 24
+                                                    "target": 3.291,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.061,
-                                                    "delta_percentage": 21
+                                                    "target": 3.183,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.294,
-                                                    "delta_percentage": 22
+                                                    "target": 3.376,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.343,
-                                                    "delta_percentage": 19
+                                                    "target": 3.468,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.609,
-                                                    "delta_percentage": 27
+                                                    "target": 3.775,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.942,
-                                                    "delta_percentage": 11
+                                                    "target": 4.064,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.172,
-                                                    "delta_percentage": 19
+                                                    "target": 4.302,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.439,
-                                                    "delta_percentage": 11
+                                                    "target": 5.534,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.748,
-                                                    "delta_percentage": 17
+                                                    "target": 5.886,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.925,
-                                                    "delta_percentage": 12
+                                                    "target": 8.037,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.245,
-                                                    "delta_percentage": 15
+                                                    "target": 8.367,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 12.321,
+                                                    "target": 12.414,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 12.759,
-                                                    "delta_percentage": 26
+                                                    "target": 12.831,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 21.536,
+                                                    "target": 21.599,
                                                     "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 22.013,
-                                                    "delta_percentage": 12
+                                                    "target": 22.08,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.535,
-                                                    "delta_percentage": 13
+                                                    "target": 3.727,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.747,
-                                                    "delta_percentage": 21
+                                                    "target": 4.004,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.229,
+                                                    "target": 4.428,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.494,
-                                                    "delta_percentage": 17
+                                                    "target": 4.71,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.917,
-                                                    "delta_percentage": 12
+                                                    "target": 5.151,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.231,
-                                                    "delta_percentage": 20
+                                                    "target": 5.415,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.851,
-                                                    "delta_percentage": 15
+                                                    "target": 3.009,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.075,
-                                                    "delta_percentage": 22
+                                                    "target": 3.209,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.852,
-                                                    "delta_percentage": 12
+                                                    "target": 3.011,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.036,
-                                                    "delta_percentage": 24
+                                                    "target": 3.204,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.85,
-                                                    "delta_percentage": 14
+                                                    "target": 3.005,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.029,
+                                                    "target": 3.186,
                                                     "delta_percentage": 19
                                                 }
                                             }
@@ -365,14 +365,14 @@
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.969,
-                                                    "delta_percentage": 12
+                                                    "target": 3.134,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.182,
-                                                    "delta_percentage": 41
+                                                    "target": 3.324,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         }
@@ -383,350 +383,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.827,
-                                                    "delta_percentage": 12
+                                                    "target": 2.997,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.033,
-                                                    "delta_percentage": 21
+                                                    "target": 3.254,
+                                                    "delta_percentage": 32
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.977,
-                                                    "delta_percentage": 21
+                                                    "target": 3.144,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.175,
-                                                    "delta_percentage": 30
+                                                    "target": 3.348,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.106,
-                                                    "delta_percentage": 19
+                                                    "target": 3.267,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.37,
-                                                    "delta_percentage": 33
+                                                    "target": 3.429,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.236,
-                                                    "delta_percentage": 11
+                                                    "target": 3.383,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.48,
-                                                    "delta_percentage": 30
+                                                    "target": 3.575,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.373,
-                                                    "delta_percentage": 12
+                                                    "target": 3.522,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.581,
-                                                    "delta_percentage": 21
+                                                    "target": 3.71,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.497,
-                                                    "delta_percentage": 12
+                                                    "target": 3.634,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.726,
-                                                    "delta_percentage": 22
+                                                    "target": 3.895,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.607,
-                                                    "delta_percentage": 13
+                                                    "target": 3.752,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.811,
-                                                    "delta_percentage": 24
+                                                    "target": 3.994,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.714,
-                                                    "delta_percentage": 13
+                                                    "target": 3.865,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.931,
-                                                    "delta_percentage": 22
+                                                    "target": 4.034,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.841,
-                                                    "delta_percentage": 11
+                                                    "target": 3.986,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.028,
-                                                    "delta_percentage": 23
+                                                    "target": 4.203,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.959,
-                                                    "delta_percentage": 11
+                                                    "target": 4.086,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.183,
-                                                    "delta_percentage": 23
+                                                    "target": 4.286,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.87,
-                                                    "delta_percentage": 18
+                                                    "target": 3.019,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.061,
-                                                    "delta_percentage": 22
+                                                    "target": 3.213,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.021,
-                                                    "delta_percentage": 16
+                                                    "target": 3.146,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.211,
-                                                    "delta_percentage": 23
+                                                    "target": 3.351,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.314,
-                                                    "delta_percentage": 20
+                                                    "target": 3.432,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.547,
-                                                    "delta_percentage": 23
+                                                    "target": 3.661,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.922,
-                                                    "delta_percentage": 15
+                                                    "target": 4.019,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.21,
-                                                    "delta_percentage": 20
+                                                    "target": 4.264,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.412,
-                                                    "delta_percentage": 12
+                                                    "target": 5.529,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.707,
-                                                    "delta_percentage": 16
+                                                    "target": 5.811,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.913,
-                                                    "delta_percentage": 10
+                                                    "target": 8.023,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.257,
-                                                    "delta_percentage": 19
+                                                    "target": 8.37,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 12.273,
+                                                    "target": 12.392,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 12.664,
-                                                    "delta_percentage": 28
+                                                    "target": 12.747,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 21.478,
+                                                    "target": 21.599,
                                                     "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 22.0,
-                                                    "delta_percentage": 24
+                                                    "target": 22.04,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.525,
-                                                    "delta_percentage": 13
+                                                    "target": 3.688,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.722,
-                                                    "delta_percentage": 18
+                                                    "target": 3.907,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.182,
-                                                    "delta_percentage": 10
+                                                    "target": 4.372,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.431,
-                                                    "delta_percentage": 18
+                                                    "target": 4.684,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.846,
-                                                    "delta_percentage": 11
+                                                    "target": 5.068,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.143,
-                                                    "delta_percentage": 19
+                                                    "target": 5.341,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.863,
-                                                    "delta_percentage": 14
+                                                    "target": 3.016,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.077,
-                                                    "delta_percentage": 23
+                                                    "target": 3.169,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.869,
-                                                    "delta_percentage": 14
+                                                    "target": 3.023,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.049,
-                                                    "delta_percentage": 22
+                                                    "target": 3.17,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.89,
-                                                    "delta_percentage": 11
+                                                    "target": 3.048,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.065,
-                                                    "delta_percentage": 22
+                                                    "target": 3.196,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.991,
-                                                    "delta_percentage": 10
+                                                    "target": 3.126,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.187,
-                                                    "delta_percentage": 21
+                                                    "target": 3.276,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         }
@@ -744,139 +744,139 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.37,
-                                                    "delta_percentage": 12
+                                                    "target": 3.597,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.704,
-                                                    "delta_percentage": 24
+                                                    "target": 3.871,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.543,
-                                                    "delta_percentage": 15
+                                                    "target": 3.767,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.884,
-                                                    "delta_percentage": 25
+                                                    "target": 4.058,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.701,
-                                                    "delta_percentage": 18
+                                                    "target": 3.921,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.048,
-                                                    "delta_percentage": 17
+                                                    "target": 4.248,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.844,
+                                                    "target": 4.036,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.176,
-                                                    "delta_percentage": 22
+                                                    "target": 4.32,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.013,
-                                                    "delta_percentage": 14
+                                                    "target": 4.201,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.311,
-                                                    "delta_percentage": 21
+                                                    "target": 4.451,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.146,
-                                                    "delta_percentage": 10
+                                                    "target": 4.34,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.517,
-                                                    "delta_percentage": 24
+                                                    "target": 4.674,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.26,
+                                                    "target": 4.459,
                                                     "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.56,
-                                                    "delta_percentage": 23
+                                                    "target": 4.783,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.378,
-                                                    "delta_percentage": 15
+                                                    "target": 4.603,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.702,
-                                                    "delta_percentage": 19
+                                                    "target": 4.857,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.524,
-                                                    "delta_percentage": 10
+                                                    "target": 4.751,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.808,
-                                                    "delta_percentage": 22
+                                                    "target": 5.01,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.66,
-                                                    "delta_percentage": 11
+                                                    "target": 4.878,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.913,
+                                                    "target": 5.131,
                                                     "delta_percentage": 17
                                                 }
                                             }
@@ -884,55 +884,55 @@
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.455,
-                                                    "delta_percentage": 19
+                                                    "target": 3.628,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.776,
-                                                    "delta_percentage": 83
+                                                    "target": 3.849,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.59,
-                                                    "delta_percentage": 11
+                                                    "target": 3.784,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.828,
-                                                    "delta_percentage": 17
+                                                    "target": 3.959,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.851,
-                                                    "delta_percentage": 10
+                                                    "target": 4.048,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.014,
-                                                    "delta_percentage": 27
+                                                    "target": 4.247,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.456,
+                                                    "target": 4.673,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.64,
+                                                    "target": 4.828,
                                                     "delta_percentage": 16
                                                 }
                                             }
@@ -940,69 +940,69 @@
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.952,
-                                                    "delta_percentage": 13
+                                                    "target": 6.173,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.323,
-                                                    "delta_percentage": 17
+                                                    "target": 6.536,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.539,
+                                                    "target": 8.781,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.976,
-                                                    "delta_percentage": 12
+                                                    "target": 9.25,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 12.972,
-                                                    "delta_percentage": 8
+                                                    "target": 13.231,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 13.45,
-                                                    "delta_percentage": 21
+                                                    "target": 13.587,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 22.258,
-                                                    "delta_percentage": 8
+                                                    "target": 22.622,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 22.745,
-                                                    "delta_percentage": 9
+                                                    "target": 23.102,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.08,
-                                                    "delta_percentage": 9
+                                                    "target": 4.344,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.242,
+                                                    "target": 4.565,
                                                     "delta_percentage": 14
                                                 }
                                             }
@@ -1010,13 +1010,13 @@
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.799,
-                                                    "delta_percentage": 10
+                                                    "target": 5.102,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.039,
+                                                    "target": 5.378,
                                                     "delta_percentage": 22
                                                 }
                                             }
@@ -1024,69 +1024,69 @@
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.537,
+                                                    "target": 5.881,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.891,
-                                                    "delta_percentage": 16
+                                                    "target": 6.145,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.332,
+                                                    "target": 3.579,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.562,
-                                                    "delta_percentage": 19
+                                                    "target": 3.781,
+                                                    "delta_percentage": 22
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.342,
-                                                    "delta_percentage": 9
+                                                    "target": 3.6,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.511,
-                                                    "delta_percentage": 18
+                                                    "target": 3.764,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.387,
-                                                    "delta_percentage": 10
+                                                    "target": 3.641,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.539,
-                                                    "delta_percentage": 19
+                                                    "target": 3.757,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.506,
-                                                    "delta_percentage": 11
+                                                    "target": 3.749,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.762,
+                                                    "target": 3.937,
                                                     "delta_percentage": 19
                                                 }
                                             }
@@ -1098,209 +1098,928 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.328,
-                                                    "delta_percentage": 12
+                                                    "target": 3.565,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.539,
-                                                    "delta_percentage": 23
+                                                    "target": 3.746,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.49,
-                                                    "delta_percentage": 10
+                                                    "target": 3.725,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.735,
-                                                    "delta_percentage": 20
+                                                    "target": 3.885,
+                                                    "delta_percentage": 27
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.651,
+                                                    "target": 3.871,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.883,
-                                                    "delta_percentage": 18
+                                                    "target": 4.087,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.778,
-                                                    "delta_percentage": 10
+                                                    "target": 3.994,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.95,
-                                                    "delta_percentage": 28
+                                                    "target": 4.186,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.946,
-                                                    "delta_percentage": 14
+                                                    "target": 4.158,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.122,
-                                                    "delta_percentage": 22
+                                                    "target": 4.327,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.059,
+                                                    "target": 4.297,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.244,
-                                                    "delta_percentage": 19
+                                                    "target": 4.503,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.187,
-                                                    "delta_percentage": 10
+                                                    "target": 4.418,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.45,
-                                                    "delta_percentage": 20
+                                                    "target": 4.589,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.315,
-                                                    "delta_percentage": 10
+                                                    "target": 4.547,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.625,
-                                                    "delta_percentage": 32
+                                                    "target": 4.693,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.456,
-                                                    "delta_percentage": 10
+                                                    "target": 4.692,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.598,
-                                                    "delta_percentage": 15
+                                                    "target": 4.862,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.599,
-                                                    "delta_percentage": 14
+                                                    "target": 4.819,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.757,
-                                                    "delta_percentage": 23
+                                                    "target": 5.009,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.367,
-                                                    "delta_percentage": 13
+                                                    "target": 3.59,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.56,
-                                                    "delta_percentage": 25
+                                                    "target": 3.727,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.542,
+                                                    "target": 3.763,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.695,
-                                                    "delta_percentage": 18
+                                                    "target": 3.899,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.799,
-                                                    "delta_percentage": 9
+                                                    "target": 4.03,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.943,
-                                                    "delta_percentage": 17
+                                                    "target": 4.176,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.485,
-                                                    "delta_percentage": 10
+                                                    "target": 4.711,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.683,
-                                                    "delta_percentage": 14
+                                                    "target": 4.967,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.932,
+                                                    "target": 6.16,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.525,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.749,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.14,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.209,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.305,
+                                                    "target": 13.703,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 22.495,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 22.945,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.342,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.483,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.074,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.336,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.889,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.169,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.566,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.7,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.607,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.74,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.623,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.77,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.733,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.885,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.424,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.612,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.529,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.717,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.628,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.814,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.692,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.872,
+                                                    "delta_percentage": 46
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.779,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.955,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.857,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.06,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.949,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.194,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.043,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.342,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.146,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.447,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.234,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.529,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.414,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.613,
+                                                    "delta_percentage": 38
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.524,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.793,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.671,
+                                                    "delta_percentage": 15
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.868,
+                                                    "delta_percentage": 30
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.968,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.189,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.857,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.101,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.292,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.484,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.816,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.041,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.807,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.18,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.932,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.108,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.491,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.693,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.013,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.184,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.389,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.635,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.41,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.644,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.443,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.664,
+                                                    "delta_percentage": 45
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.511,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.75,
+                                                    "delta_percentage": 36
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.387,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.612,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.499,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.719,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.599,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.861,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.691,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.945,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.794,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.066,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.883,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.153,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.96,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.196,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.037,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.352,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.14,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.43,
+                                                    "delta_percentage": 40
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.215,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.479,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.422,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.683,
+                                                    "delta_percentage": 46
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.531,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.773,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.685,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.892,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.989,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.191,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.861,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.087,
                                                     "delta_percentage": 19
                                                 }
                                             }
@@ -1308,130 +2027,60 @@
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.51,
-                                                    "delta_percentage": 9
+                                                    "target": 5.303,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.854,
-                                                    "delta_percentage": 10
+                                                    "target": 5.545,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 12.956,
-                                                    "delta_percentage": 11
+                                                    "target": 7.807,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 13.508,
-                                                    "delta_percentage": 26
+                                                    "target": 8.075,
+                                                    "delta_percentage": 34
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 22.23,
-                                                    "delta_percentage": 8
+                                                    "target": 13.733,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 22.695,
-                                                    "delta_percentage": 12
+                                                    "target": 14.098,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.062,
-                                                    "delta_percentage": 10
+                                                    "target": 2.966,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.228,
-                                                    "delta_percentage": 16
+                                                    "target": 3.214,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "3net_dev": {
-                                            "P50": {
-                                                "restore": {
-                                                    "target": 4.804,
-                                                    "delta_percentage": 10
-                                                }
-                                            },
-                                            "P90": {
-                                                "restore": {
-                                                    "target": 5.053,
-                                                    "delta_percentage": 15
-                                                }
-                                            }
-                                        },
-                                        "4net_dev": {
-                                            "P50": {
-                                                "restore": {
-                                                    "target": 5.557,
-                                                    "delta_percentage": 12
-                                                }
-                                            },
-                                            "P90": {
-                                                "restore": {
-                                                    "target": 5.86,
-                                                    "delta_percentage": 22
-                                                }
-                                            }
-                                        },
-                                        "2block_dev": {
-                                            "P50": {
-                                                "restore": {
-                                                    "target": 3.348,
-                                                    "delta_percentage": 12
-                                                }
-                                            },
-                                            "P90": {
-                                                "restore": {
-                                                    "target": 3.502,
-                                                    "delta_percentage": 19
-                                                }
-                                            }
-                                        },
-                                        "3block_dev": {
-                                            "P50": {
-                                                "restore": {
-                                                    "target": 3.372,
-                                                    "delta_percentage": 11
-                                                }
-                                            },
-                                            "P90": {
-                                                "restore": {
-                                                    "target": 3.538,
-                                                    "delta_percentage": 23
-                                                }
-                                            }
-                                        },
-                                        "4block_dev": {
-                                            "P50": {
-                                                "restore": {
-                                                    "target": 3.398,
-                                                    "delta_percentage": 10
-                                                }
-                                            },
-                                            "P90": {
-                                                "restore": {
-                                                    "target": 3.554,
-                                                    "delta_percentage": 21
-                                                }
-                                            }
-                                        },
-                                        "all_dev": {
                                             "P50": {
                                                 "restore": {
                                                     "target": 3.512,
@@ -1440,8 +2089,78 @@
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.634,
-                                                    "delta_percentage": 16
+                                                    "target": 3.724,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.05,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.269,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.408,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.636,
+                                                    "delta_percentage": 45
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.415,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.588,
+                                                    "delta_percentage": 32
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.448,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.627,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.503,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.699,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -9,8 +9,11 @@ import tempfile
 
 import pytest
 from conftest import _test_images_s3_bucket
-from framework.artifacts import ArtifactCollection, ArtifactSet, \
-    create_net_devices_configuration
+from framework.artifacts import (
+    ArtifactCollection,
+    ArtifactSet,
+    create_net_devices_configuration,
+)
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.matrix import TestContext, TestMatrix
 from framework.stats import core
@@ -25,10 +28,10 @@ from integration_tests.performance.configs import defs
 from integration_tests.performance.utils import handle_failure
 
 TEST_ID = "snap_restore_performance"
-CONFIG_NAME_REL = "test_{}_config_{}.json".format(
-    TEST_ID, get_kernel_version(level=1))
+CONFIG_NAME_REL = "test_{}_config_{}.json"\
+    .format(TEST_ID, get_kernel_version(level=1))
 CONFIG_NAME_ABS = os.path.join(defs.CFG_LOCATION, CONFIG_NAME_REL)
-CONFIG_DICT = json.load(open(CONFIG_NAME_ABS, encoding='utf-8'))
+CONFIG_DICT = json.load(open(CONFIG_NAME_ABS, encoding="utf-8"))
 
 DEBUG = False
 BASE_VCPU_COUNT = 1
@@ -38,7 +41,7 @@ BASE_BLOCK_COUNT = 1
 USEC_IN_MSEC = 1000
 
 # Measurements tags.
-RESTORE_LATENCY = "restore_latency"
+RESTORE_LATENCY = "latency"
 
 # Define 4 net device configurations.
 net_ifaces = create_net_devices_configuration(4)
@@ -53,18 +56,21 @@ scratch_drives = []
 class SnapRestoreBaselinesProvider(BaselineProvider):
     """Baselines provider for snapshot restore latency."""
 
-    def __init__(self, env_id):
+    def __init__(self, env_id, workload):
         """Snapshot baseline provider initialization."""
         cpu_model_name = get_cpu_model_name()
-        baselines = list(filter(
-            lambda cpu_baseline: cpu_baseline["model"] == cpu_model_name,
-            CONFIG_DICT["hosts"]["instances"][get_instance_type()]["cpus"]))
+        baselines = list(
+            filter(
+                lambda cpu_baseline: cpu_baseline["model"] == cpu_model_name,
+                CONFIG_DICT["hosts"]["instances"][get_instance_type()]["cpus"],
+            )
+        )
 
         super().__init__(DictQuery({}))
         if len(baselines) > 0:
             super().__init__(DictQuery(baselines[0]))
 
-        self._tag = "baselines/{}/" + env_id + "/{}"
+        self._tag = "baselines/{}/" + env_id + "/{}/" + workload
 
     def get(self, ms_name: str, st_name: str) -> dict:
         """Return the baseline value corresponding to the key."""
@@ -84,33 +90,35 @@ def construct_scratch_drives():
     """Create an array of scratch disks."""
     scratchdisks = ["vdb", "vdc", "vdd", "vde"]
     disk_files = [
-        drive_tools.FilesystemFile(tempfile.mktemp(), size=64)
-        for _ in scratchdisks
+        drive_tools.FilesystemFile(
+            tempfile.mktemp(), size=64
+        ) for _ in scratchdisks
     ]
     return list(zip(scratchdisks, disk_files))
 
 
-def default_lambda_consumer(env_id):
+def default_lambda_consumer(env_id, workload):
     """Create a default lambda consumer for the snapshot restore test."""
     return st.consumer.LambdaConsumer(
         metadata_provider=DictMetadataProvider(
             CONFIG_DICT["measurements"],
-            SnapRestoreBaselinesProvider(env_id)
+            SnapRestoreBaselinesProvider(env_id, workload)
         ),
         func=consume_output,
-        func_kwargs={})
+        func_kwargs={},
+    )
 
 
 def get_snap_restore_latency(
-        context,
-        vcpus,
-        mem_size,
-        nets=1,
-        blocks=1,
-        all_devices=False,
-        iterations=10):
+    context, vcpus, mem_size, nets=1, blocks=1, all_devices=False,
+    iterations=10
+):
     """Restore snapshots with various configs to measure latency."""
-    vm_builder = context.custom['builder']
+    vm_builder = context.custom["builder"]
+    logger = context.custom["logger"]
+    balloon = vsock = 1 if all_devices else 0
+    microvm_spec = f"{vcpus}vcpu_{mem_size}mb_{nets}net_{blocks}\
+        block_{vsock}vsock_{balloon}balloon"
 
     # Create a rw copy artifact.
     rw_disk = context.disk.copy()
@@ -128,7 +136,9 @@ def get_snap_restore_latency(
         ssh_key=ssh_key,
         config=context.microvm,
         net_ifaces=ifaces,
-        use_ramdisk=True)
+        use_ramdisk=True,
+        io_engine="Sync",
+    )
     basevm = vm_instance.vm
     response = basevm.machine_cfg.put(
         vcpu_count=vcpus,
@@ -138,28 +148,31 @@ def get_snap_restore_latency(
 
     extra_disk_paths = []
     if blocks > 1:
-        for (name, diskfile) in scratch_drives[:(blocks - 1)]:
-            basevm.add_drive(name, diskfile.path, use_ramdisk=True)
+        for (name, diskfile) in scratch_drives[: (blocks - 1)]:
+            basevm.add_drive(
+                name, diskfile.path, use_ramdisk=True, io_engine="Sync"
+            )
             extra_disk_paths.append(diskfile.path)
         assert len(extra_disk_paths) > 0
 
     if all_devices:
         response = basevm.balloon.put(
-            amount_mib=0,
-            deflate_on_oom=True,
-            stats_polling_interval_s=1
+            amount_mib=0, deflate_on_oom=True, stats_polling_interval_s=1
         )
         assert basevm.api_session.is_status_no_content(response.status_code)
 
         response = basevm.vsock.put(
-            vsock_id="vsock0",
-            guest_cid=3,
-            uds_path="/v.sock"
+            vsock_id="vsock0", guest_cid=3, uds_path="/v.sock"
         )
         assert basevm.api_session.is_status_no_content(response.status_code)
 
     basevm.start()
 
+    logger.info(
+        'Testing with microvm: "{}", kernel {}, disk {}'.format(
+            microvm_spec, context.kernel.name(), context.disk.name()
+        )
+    )
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(basevm)
     full_snapshot = snapshot_builder.create(
@@ -167,15 +180,13 @@ def get_snap_restore_latency(
         ssh_key,
         SnapshotType.FULL,
         net_ifaces=ifaces,
-        use_ramdisk=True
+        use_ramdisk=True,
     )
     basevm.kill()
     values = []
     for _ in range(iterations):
         microvm, metrics_fifo = vm_builder.build_from_snapshot(
-            full_snapshot,
-            resume=True,
-            use_ramdisk=True
+            full_snapshot, resume=True, use_ramdisk=True
         )
         # Attempt to connect to resumed microvm.
         ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
@@ -188,7 +199,7 @@ def get_snap_restore_latency(
         metrics = microvm.get_all_metrics(metrics_fifo)
         for data_point in metrics:
             metrics = json.loads(data_point)
-            cur_value = metrics['latencies_us']['load_snapshot']
+            cur_value = metrics["latencies_us"]["load_snapshot"]
             if cur_value > 0:
                 value = cur_value / USEC_IN_MSEC
                 break
@@ -215,9 +226,7 @@ def consume_output(cons, result):
 @pytest.mark.nonci
 @pytest.mark.timeout(300 * 1000)  # 1.40 hours
 @pytest.mark.parametrize(
-    'results_file_dumper',
-    [CONFIG_NAME_ABS],
-    indirect=True
+    "results_file_dumper", [CONFIG_NAME_ABS], indirect=True
 )
 def test_snap_restore_performance(bin_cloner_path, results_file_dumper):
     """
@@ -236,62 +245,70 @@ def test_snap_restore_performance(bin_cloner_path, results_file_dumper):
     # Create a test context and add builder, logger, network.
     test_context = TestContext()
     test_context.custom = {
-        'builder': MicrovmBuilder(bin_cloner_path),
-        'logger': logger,
-        'name': TEST_ID,
-        'results_file_dumper': results_file_dumper
+        "builder": MicrovmBuilder(bin_cloner_path),
+        "logger": logger,
+        "name": TEST_ID,
+        "results_file_dumper": results_file_dumper,
+        "workload": "restore",
     }
 
-    test_matrix = TestMatrix(context=test_context,
-                             artifact_sets=[
-                                 microvm_artifacts,
-                                 kernel_artifacts,
-                                 disk_artifacts
-                             ])
+    test_matrix = TestMatrix(
+        context=test_context,
+        artifact_sets=[microvm_artifacts, kernel_artifacts, disk_artifacts],
+    )
     test_matrix.run_test(snapshot_workload)
 
 
 def snapshot_scaling_vcpus(context, st_core, vcpu_count=10):
     """Restore snapshots with variable vcpu count."""
+    workload = context.custom["workload"]
     for i in range(vcpu_count):
-        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+        env_id = (
+            f"{context.kernel.name()}/{context.disk.name()}/"
             f"{BASE_VCPU_COUNT + i}vcpu_{BASE_MEM_SIZE_MIB}mb"
+        )
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
             func_kwargs={
                 "context": context,
                 "vcpus": BASE_VCPU_COUNT + i,
-                "mem_size": BASE_MEM_SIZE_MIB
-            }
+                "mem_size": BASE_MEM_SIZE_MIB,
+            },
         )
-        st_cons = default_lambda_consumer(env_id)
-        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+        st_cons = default_lambda_consumer(env_id, workload)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/{workload}")
 
 
 def snapshot_scaling_mem(context, st_core, mem_exponent=9):
     """Restore snapshots with variable memory size."""
+    workload = context.custom["workload"]
     for i in range(1, mem_exponent):
-        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+        env_id = (
+            f"{context.kernel.name()}/{context.disk.name()}/"
             f"{BASE_VCPU_COUNT}vcpu_{BASE_MEM_SIZE_MIB * (2 ** i)}mb"
+        )
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
             func_kwargs={
                 "context": context,
                 "vcpus": BASE_VCPU_COUNT,
-                "mem_size": BASE_MEM_SIZE_MIB * (2 ** i)
-            }
+                "mem_size": BASE_MEM_SIZE_MIB * (2**i),
+            },
         )
-        st_cons = default_lambda_consumer(env_id)
-        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+        st_cons = default_lambda_consumer(env_id, workload)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/{workload}")
 
 
 def snapshot_scaling_net(context, st_core, net_count=4):
     """Restore snapshots with variable net device count."""
+    workload = context.custom["workload"]
     for i in range(1, net_count):
-        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+        env_id = (
+            f"{context.kernel.name()}/{context.disk.name()}/"
             f"{BASE_NET_COUNT + i}net_dev"
+        )
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
@@ -299,22 +316,25 @@ def snapshot_scaling_net(context, st_core, net_count=4):
                 "context": context,
                 "vcpus": BASE_VCPU_COUNT,
                 "mem_size": BASE_MEM_SIZE_MIB,
-                "nets": BASE_NET_COUNT + i
-            }
+                "nets": BASE_NET_COUNT + i,
+            },
         )
-        st_cons = default_lambda_consumer(env_id)
-        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+        st_cons = default_lambda_consumer(env_id, workload)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/{workload}")
 
 
 def snapshot_scaling_block(context, st_core, block_count=4):
     """Restore snapshots with variable block device count."""
     # pylint: disable=W0603
+    workload = context.custom["workload"]
     global scratch_drives
     scratch_drives = construct_scratch_drives()
 
     for i in range(1, block_count):
-        env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
+        env_id = (
+            f"{context.kernel.name()}/{context.disk.name()}/"
             f"{BASE_BLOCK_COUNT + i}block_dev"
+        )
 
         st_prod = st.producer.LambdaProducer(
             func=get_snap_restore_latency,
@@ -322,29 +342,28 @@ def snapshot_scaling_block(context, st_core, block_count=4):
                 "context": context,
                 "vcpus": BASE_VCPU_COUNT,
                 "mem_size": BASE_MEM_SIZE_MIB,
-                "blocks": BASE_BLOCK_COUNT + i
-            }
+                "blocks": BASE_BLOCK_COUNT + i,
+            },
         )
-        st_cons = default_lambda_consumer(env_id)
-        st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+        st_cons = default_lambda_consumer(env_id, workload)
+        st_core.add_pipe(st_prod, st_cons, f"{env_id}/{workload}")
 
 
 def snapshot_all_devices(context, st_core):
     """Restore snapshots with one of each devices."""
-    env_id = f"{context.kernel.name()}/{context.disk.name()}/" \
-        f"all_dev"
-
+    workload = context.custom["workload"]
+    env_id = f"{context.kernel.name()}/{context.disk.name()}/" f"all_dev"
     st_prod = st.producer.LambdaProducer(
         func=get_snap_restore_latency,
         func_kwargs={
             "context": context,
             "vcpus": BASE_VCPU_COUNT,
             "mem_size": BASE_MEM_SIZE_MIB,
-            "all_devices": True
-        }
+            "all_devices": True,
+        },
     )
-    st_cons = default_lambda_consumer(env_id)
-    st_core.add_pipe(st_prod, st_cons, f"{env_id}/restore_latency")
+    st_cons = default_lambda_consumer(env_id, workload)
+    st_core.add_pipe(st_prod, st_cons, f"{env_id}/{workload}")
 
 
 def snapshot_workload(context):
@@ -352,8 +371,7 @@ def snapshot_workload(context):
     file_dumper = context.custom["results_file_dumper"]
 
     st_core = core.Core(
-        name=TEST_ID,
-        iterations=1,
+        name=TEST_ID, iterations=1,
         custom={"cpu_model_name": get_cpu_model_name()}
     )
 

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -17,26 +17,29 @@ from providers.types import FileDataProvider
 from providers.iperf3 import Iperf3DataParser
 from providers.block import BlockDataParser
 from providers.snapshot_restore import SnapshotRestoreDataParser
+from providers.latency import LatencyDataParser
 
-sys.path.append(os.path.join(os.getcwd(), 'tests'))
+sys.path.append(os.path.join(os.getcwd(), "tests"))
 
 from framework.defs import SUPPORTED_KERNELS  # noqa: E402
 
 OUTPUT_FILENAMES = {
-    'vsock_throughput': ['test_vsock_throughput'],
-    'network_tcp_throughput': ['test_network_tcp_throughput'],
-    'block_performance': [
-        'test_block_performance_sync',
-        'test_block_performance_async'
+    "vsock_throughput": ["test_vsock_throughput"],
+    "network_tcp_throughput": ["test_network_tcp_throughput"],
+    "block_performance": [
+        "test_block_performance_sync",
+        "test_block_performance_async",
     ],
-    'snapshot_restore_performance': ['test_snap_restore_performance']
+    "snap_restore_performance": ["test_snap_restore_performance"],
+    "network_latency": ["test_network_latency"],
 }
 
 DATA_PARSERS = {
-    'vsock_throughput': Iperf3DataParser,
-    'network_tcp_throughput': Iperf3DataParser,
-    'block_performance': BlockDataParser,
-    'snapshot_restore_performance': SnapshotRestoreDataParser,
+    "vsock_throughput": Iperf3DataParser,
+    "network_tcp_throughput": Iperf3DataParser,
+    "block_performance": BlockDataParser,
+    "snap_restore_performance": SnapshotRestoreDataParser,
+    "network_latency": LatencyDataParser,
 }
 
 
@@ -45,8 +48,10 @@ def get_data_files(args) -> List[str]:
     assert os.path.isdir(args.data_folder)
 
     file_list = []
-    res_files = [f"{filename}_results_{args.kernel}.json"
-                 for filename in OUTPUT_FILENAMES[args.test]]
+    res_files = [
+        f"{filename}_results_{args.kernel}.json"
+        for filename in OUTPUT_FILENAMES[args.test]
+    ]
     # Get all files in the dir tree that have the right name.
     for root, _, files in os.walk(args.data_folder):
         for file in files:
@@ -64,9 +69,10 @@ def concatenate_data_files(data_files: List[str]):
     outfile = tempfile.NamedTemporaryFile()
 
     for filename in data_files:
-        with open(filename, encoding='utf-8') as infile:
-            outfile.write(str.encode(infile.read()))
-
+        with open(filename, encoding="utf-8") as infile:
+            contents = str.encode(infile.read())
+            outfile.write(contents)
+    outfile.flush()
     return outfile
 
 
@@ -80,32 +86,46 @@ def main():
      (e.q test_results/buildX/test_vsock_throughput_results_5.10.json).
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--data-folder",
-                        help="Path to folder containing raw test data.",
-                        action="store",
-                        required=True)
-    parser.add_argument("-t", "--test",
-                        help="Performance test for which baselines \
+    parser.add_argument(
+        "-d",
+        "--data-folder",
+        help="Path to folder containing raw test data.",
+        action="store",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        help="Performance test for which baselines \
                             are calculated.",
-                        action="store",
-                        choices=['vsock_throughput',
-                                 'network_tcp_throughput',
-                                 'block_performance',
-                                 'snapshot_restore_performance'],
-                        required=True)
-    parser.add_argument("-k", "--kernel",
-                        help="Host kernel version on which baselines \
+        action="store",
+        choices=[
+            "block_performance",
+            "network_latency",
+            "network_tcp_throughput",
+            "snap_restore_performance",
+            "vsock_throughput",
+        ],
+        required=True,
+    )
+    parser.add_argument(
+        "-k",
+        "--kernel",
+        help="Host kernel version on which baselines \
                             are obtained.",
-                        action="store",
-                        choices=SUPPORTED_KERNELS,
-                        required=True)
-    parser.add_argument("-i", "--instance",
-                        help="Instance type on which the baselines \
+        action="store",
+        choices=SUPPORTED_KERNELS,
+        required=True,
+    )
+    parser.add_argument(
+        "-i",
+        "--instance",
+        help="Instance type on which the baselines \
                             were obtained.",
-                        action="store",
-                        choices=['m5d.metal',
-                                 'm6gd.metal'],
-                        required=True)
+        action="store",
+        choices=["m5d.metal", "m6i.metal", "m6a.metal", "m6g.metal"],
+        required=True,
+    )
     args = parser.parse_args()
 
     # Create the concatenated data file.
@@ -118,16 +138,32 @@ def main():
     parser = DATA_PARSERS[args.test](data_provider)
 
     # Finally, parse and update the baselines.
-    with open(f"./tests/integration_tests/performance/configs/"
-              f"test_{args.test}_config_{args.kernel}.json",
-              'r+', encoding="utf8") as baselines_file:
+    with open(
+        f"./tests/integration_tests/performance/configs/"
+        f"test_{args.test}_config_{args.kernel}.json",
+        "r+",
+        encoding="utf8",
+    ) as baselines_file:
         json_baselines = json.load(baselines_file)
+        current_cpus = \
+            json_baselines["hosts"]["instances"][args.instance]["cpus"]
         cpus = parser.parse()
-        json_baselines["hosts"]["instances"][args.instance] = {"cpus": cpus}
 
+        for cpu in cpus:
+            model = cpu["model"]
+            for old_cpu in current_cpus:
+                if old_cpu["model"] == model:
+                    old_cpu["baselines"] = cpu["baselines"]
         baselines_file.truncate(0)
         baselines_file.seek(0, 0)
         json.dump(json_baselines, baselines_file, indent=4)
+
+        # Warn against the fact that not all CPUs pertaining to
+        # some arch were updated.
+        assert len(cpus) == len(current_cpus), (
+            "It may be that only a subset of CPU types were updated! "
+            "Need to run again! Nevertheless we updated the baselines..."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

This brings changes in test framework and baseline collection script from main in order to be able to collect performance baselines for snapshot restore.
The change includes update in the baseline config schema and baseline config files themselves.

## Reason

It was impossible to collect snapshot restore performance baselines for v1.1 in order to compare them with the main within the same environment (e.g., same testing instances). 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
