### PR TITLE
Revert default behavior of cargo build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [build]
 target-dir = "build/cargo_target"
+target = "x86_64-unknown-linux-musl"
 
 [net]
 git-fetch-with-cli = true

--- a/src/vmm/build.rs
+++ b/src/vmm/build.rs
@@ -51,6 +51,11 @@ fn main() {
 
 // Run seccompiler with the given arguments.
 fn run_seccompiler_bin(json_path: &str, out_path: &str) {
+    // We have a global `target` directive in our .cargo/config file specifying x86_64 architecture.
+    // However, seccompiler-bin has to be compiled for the host architecture. Without this, cargo
+    // would produce a x86_64 binary on aarch64 host, causing this compilation step to fail as such
+    // a binary would not be executable.
+    let host_arch = env::var("HOST").expect("Could not determine compilation host");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Missing target arch.");
 
     // Command for running seccompiler-bin
@@ -60,6 +65,8 @@ fn run_seccompiler_bin(json_path: &str, out_path: &str) {
         "-p",
         "seccompiler",
         "--verbose",
+        "--target",
+        &host_arch,
         // We need to specify a separate build directory for seccompiler-bin. Otherwise, cargo will
         // deadlock waiting to acquire a lock on the build folder that the parent cargo process is
         // holding.


### PR DESCRIPTION
 Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

This commit restored the old behavior while still fixing cross-compilation. For this, instead of relying on the default target matching the compilation host, we instead explicitly read the host target from the HOST variable that cargo sets for build scripts.

## Reason

My PR #3213 carelessly changed the default behavior of cargo build.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
