### PR TITLE
test: reduce snapshot size in test

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -309,9 +309,9 @@ def test_5_inc_snapshots(
     # Testing matrix:
     # - Guest kernel: All supported ones
     # - Rootfs: Ubuntu 18.04
-    # - Microvm: 2vCPU with 4096 MB RAM
+    # - Microvm: 2vCPU with 512MB RAM
     # TODO: Multiple microvm sizes must be tested in the async pipeline.
-    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_4096mb"))
+    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_512mb"))
     kernel_artifacts = ArtifactSet(artifacts.kernels())
     disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
 


### PR DESCRIPTION
## Changes

Reduce the uVM memory in `test_5_inc_snapshots` test from 4GB to 512MB.

## Reason

The memory size of the VM was causing the test to take a long time to complete and some times it would hit the CI timeout, causing intermittent failures. Moreover, the size of the memory does not add any value to the test itself.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
