### PR TITLE
Increase serialize(no-crc) target benchmark

### DIFF
--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -22,12 +22,12 @@ NSEC_IN_MSEC = 1000000
 BASELINES = {
     "Intel": {
         "serialize": {
-            "no-crc": {"target": 0.215, "delta": 0.020},  # milliseconds  # milliseconds
+            "no-crc": {"target": 0.205, "delta": 0.050},  # milliseconds  # milliseconds
             "crc": {"target": 0.244, "delta": 0.44},  # milliseconds  # milliseconds
         },
         "deserialize": {
             "no-crc": {"target": 0.056, "delta": 0.02},  # milliseconds  # milliseconds
-            "crc": {"target": 0.046, "delta": 0.035},  # milliseconds  # milliseconds
+            "crc": {"target": 0.075, "delta": 0.030},  # milliseconds  # milliseconds
         },
     },
     "AMD": {

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -22,7 +22,7 @@ NSEC_IN_MSEC = 1000000
 BASELINES = {
     "Intel": {
         "serialize": {
-            "no-crc": {"target": 0.150, "delta": 0.036},  # milliseconds  # milliseconds
+            "no-crc": {"target": 0.215, "delta": 0.020},  # milliseconds  # milliseconds
             "crc": {"target": 0.244, "delta": 0.44},  # milliseconds  # milliseconds
         },
         "deserialize": {


### PR DESCRIPTION
## Changes

Increase the Intel benchmark target in `test_versioned_serialization_benchmark.py` to unblock development.

## Reason

Following changes to the Linux Kernel to handle
RETBLEED mitigations Skylake CPUs perform signicantly worse.

This affects the Firecracker baseline for all Intel testing. Until Firecracker's CI and performance pipelines can move off of Skylake, we will need drop our baseline to prevent unrelated disruptions to our pipeline.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
