### PR TITLE
Clarify documentation on building Firecracker without devtool

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -314,6 +314,17 @@ arguments is available via:
 tools/devtool --help
 ```
 
+### Alternative: Building Firecracker without devtool
+
+It is possible to build Firecracker without invoking `devtool` by instead
+running `cargo build`. However, binaries generated like this should not
+be used in production and are considered experimental.
+
+Note that the default target for Firecracker is `x86_64-unknown-linux-musl`
+(set in `.cargo/config`). If you want to build an ARM binary, you need to
+pass `--target aarch64-unknown-linux-musl` to `cargo build`, even if
+compiling on an ARM machine. Otherwise it will try to build an `x86_64` binary.
+
 ### Alternative: Building Firecracker using glibc
 
 The toolchain that Firecracker is tested against and that is recommended for
@@ -331,9 +342,8 @@ arch=`uname -m`
 cargo build --target ${arch}-unknown-linux-gnu
 ```
 
-That being said, Firecracker binaries linked with glibc or built without
-`devtool` are always considered experimental and should not be used in
-production.
+That being said, Firecracker binaries linked with glibc are always considered
+experimental and should not be used in production.
 
 ## Running the Integration Test Suite
 


### PR DESCRIPTION
Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Updates the documentation to include information about us setting a default target in .cargo/config which is incompatible with ARM, which causes issues if trying to build Firecracker on ARM without devtool.

## Reason

The behavior here is unintuitive and has already tripped up multiple team members trying to build firecracker outside of docker on ARM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
