### PR TITLE
add performance baseline for m6i.metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - A MAC address is generated if one is not explicitly specified while adding
   network interfaces. This address can be obtained as part of the GET
   `/vm/config`.
+- Added baselines for m6i.metal for all long running performance tests.
 
 ### Changed
 

--- a/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_4.14.json
@@ -1050,6 +1050,491 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "iops_read": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 107486,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 221155,
+                                                    "delta_percentage": 6
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 224415,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 109176,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 231707,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 481350,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 494876,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 238695,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 107618,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 221437,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 225681,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 109347,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 220573,
+                                                    "delta_percentage": 9
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 473231,
+                                                    "delta_percentage": 10
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 495515,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 231340,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "iops_write": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 107485,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 109178,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 231711,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 238700,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 107617,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 109349,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 220577,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 231335,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "bw_read": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 429942,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 884618,
+                                                    "delta_percentage": 6
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 897660,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 436702,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 926828,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 1925400,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 1979503,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 954778,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 430472,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 885750,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 902725,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 437389,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 882291,
+                                                    "delta_percentage": 9
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 1892925,
+                                                    "delta_percentage": 10
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 1982062,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 925359,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "bw_write": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 429939,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 436713,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 926844,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 954800,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 430469,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 437397,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 882310,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 925341,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 52,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 51,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 51,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 50,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 74,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 73,
+                                                    "delta_percentage": 6
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 72,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 72,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 51,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 51,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 50,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 50,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 70,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 70,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_block_performance_config_5.10.json
@@ -985,6 +985,907 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "iops_read": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 75261,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 178239,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 180748,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 76805,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 209284,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 526859,
+                                                    "delta_percentage": 13
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 525047,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 213753,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 103699,
+                                                    "delta_percentage": 11
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 224204,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 227852,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 106238,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 232213,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 485586,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 496960,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 239545,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 75703,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 179196,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 181838,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 76452,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 212193,
+                                                    "delta_percentage": 21
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 590724,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 606503,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 216728,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 103602,
+                                                    "delta_percentage": 11
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 223488,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 227658,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 106932,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 228738,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 465055,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 482268,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 230167,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "iops_write": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 75263,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 76811,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 209288,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 213744,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 103695,
+                                                    "delta_percentage": 11
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 106235,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 232206,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 239541,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 75701,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 76452,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 212194,
+                                                    "delta_percentage": 21
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 216722,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 103596,
+                                                    "delta_percentage": 11
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 106931,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 228735,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 230167,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "bw_read": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 301045,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 712957,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 722992,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 307219,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 837135,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 2107438,
+                                                    "delta_percentage": 13
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 2100188,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 855014,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 414795,
+                                                    "delta_percentage": 11
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 896816,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 911409,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 424953,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 928853,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 1942343,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 1987840,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 958179,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 302811,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 716785,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 727353,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 305808,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 848775,
+                                                    "delta_percentage": 21
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 2362896,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 2426011,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 866913,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 414407,
+                                                    "delta_percentage": 11
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 893950,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 910631,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 427729,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 914953,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 1860219,
+                                                    "delta_percentage": 8
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 1929071,
+                                                    "delta_percentage": 9
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 920669,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "bw_write": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 301050,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 307242,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 837152,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 854977,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 414780,
+                                                    "delta_percentage": 11
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 424938,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 928826,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 958165,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 302802,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 305806,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 848779,
+                                                    "delta_percentage": 21
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 866890,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 414385,
+                                                    "delta_percentage": 11
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 427724,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 914939,
+                                                    "delta_percentage": 8
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 920668,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 171,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 86,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 172,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 57,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 54,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 53,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 57,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 78,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 81,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 79,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 78,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 50,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 50,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 49,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 48,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 74,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 73,
+                                                    "delta_percentage": 6
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 72,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 73,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "async_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 57,
+                                                    "delta_percentage": 6
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 54,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 53,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 56,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "async_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 77,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 83,
+                                                    "delta_percentage": 6
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 82,
+                                                    "delta_percentage": 6
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 77,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "sync_1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 49,
+                                                    "delta_percentage": 8
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 49,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 49,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 48,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        },
+                                        "sync_2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "randrw-bs4096": {
+                                                    "target": 71,
+                                                    "delta_percentage": 7
+                                                },
+                                                "randread-bs4096": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                },
+                                                "read-bs4096": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                },
+                                                "readwrite-bs4096": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -139,6 +139,67 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.245,
+                                                    "delta_percentage": 8.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.261,
+                                                    "delta_percentage": 6.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "pkt_loss": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_5.10.json
@@ -139,6 +139,67 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.255,
+                                                    "delta_percentage": 6.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.268,
+                                                    "delta_percentage": 5.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "pkt_loss": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "ping": {
+                                                    "target": 0.0,
+                                                    "delta_percentage": 0.1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -1689,6 +1689,813 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "throughput": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 3541,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 27456,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 36110,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 3530,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 27002,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 35103,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 3401,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 20941,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 49307,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3406,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 22587,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 47349,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 6473,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 31606,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 35792,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 6435,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 31260,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 33577,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 5391,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 35357,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 47512,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 5404,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 37445,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 45448,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 5799,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 33934,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 41349,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 5808,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 32276,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 38828,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 3263,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 24342,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 36292,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 3207,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 24067,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 35402,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 3061,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 20219,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 48448,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3062,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 22203,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 45651,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 5225,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 30267,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 36393,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 5197,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 29878,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 33958,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 4821,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 26748,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 48621,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 4813,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 30132,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 48828,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 4655,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 38313,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 44174,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 4648,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 34553,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 42967,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 54,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 117,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 13
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 187,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 193,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 169,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 162,
+                                                    "delta_percentage": 9
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 112,
+                                                    "delta_percentage": 12
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 98,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 191,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 196,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 126,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 121,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 58,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 86,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 92,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 58,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 85,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 92,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 39,
+                                                    "delta_percentage": 12
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 48,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 86,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 39,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 71,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 89,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 71,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 88,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 47,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 81,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 86,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 47,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 91,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 59,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 86,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 59,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 86,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 76,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 92,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 76,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 37,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 48,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 86,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 38,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 90,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 58,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 86,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 92,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 58,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 85,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 44,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 44,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 78,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 94,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 96,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 94,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 91,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 96,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
@@ -1689,6 +1689,813 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "throughput": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 3737,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 28887,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 39800,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 3731,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 28227,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 38276,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 3528,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 20589,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 49899,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3524,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 22168,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 47730,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 6689,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 33460,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 38851,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 6661,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 32959,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 35671,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 5523,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 35527,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 48111,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 5515,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 37036,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 46657,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 5844,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 34764,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 42902,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 5850,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 32965,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 39970,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 3469,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 25526,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 42545,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 3321,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 25342,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 39083,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 3187,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 20115,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 48326,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3184,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 22177,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 47703,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 5261,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 32216,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 39712,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 5240,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 31501,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 36279,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 4903,
+                                                    "delta_percentage": 4
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 26534,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 50682,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 4906,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 30562,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 50376,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 4596,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 36586,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 46153,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 4570,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 35636,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 44133,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 59,
+                                                    "delta_percentage": 12
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 119,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 102,
+                                                    "delta_percentage": 14
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 193,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 195,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 178,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 172,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 115,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 104,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 192,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 197,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 128,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 121,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 87,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 57,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 85,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 39,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 49,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 88,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 40,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 92,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 72,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 72,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 48,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 84,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 89,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 48,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 91,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 93,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 60,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 87,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 60,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 86,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 50,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 77,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 52,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 76,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 38,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 49,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 88,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 38,
+                                                    "delta_percentage": 12
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 62,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 93,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "tcp-p1024K-ws16K-g2h": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 85,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 59,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 85,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 91,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 45,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 60,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 93,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 45,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 80,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 97,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 92,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 94,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 92,
+                                                    "delta_percentage": 6
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 96,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -1452,6 +1452,725 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.657,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.149,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.779,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.083,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.859,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.153,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.968,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.276,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.104,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.464,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.164,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.515,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.301,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.717,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.454,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.86,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.57,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.937,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.696,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.18,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.711,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.11,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.957,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.408,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.523,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.955,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.68,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.069,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.204,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 8.646,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.005,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 14.216,
+                                                    "delta_percentage": 56
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 21.707,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 23.296,
+                                                    "delta_percentage": 57
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 38.884,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 39.98,
+                                                    "delta_percentage": 12
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.109,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.609,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.62,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.09,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.2,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.638,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.584,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.025,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.589,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.011,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.703,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.238,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.714,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.135,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.554,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.982,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.627,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.053,
+                                                    "delta_percentage": 18
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.794,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.197,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.931,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.451,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.079,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.48,
+                                                    "delta_percentage": 29
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.231,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.641,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.322,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.793,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.435,
+                                                    "delta_percentage": 16
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.902,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.569,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.985,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.691,
+                                                    "delta_percentage": 17
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.116,
+                                                    "delta_percentage": 20
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.694,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.047,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.936,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.32,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.486,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.902,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.703,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 6.417,
+                                                    "delta_percentage": 40
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 8.241,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 9.048,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.1,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 13.818,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 21.647,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 23.511,
+                                                    "delta_percentage": 57
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 38.559,
+                                                    "delta_percentage": 8
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 40.368,
+                                                    "delta_percentage": 51
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.035,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.433,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 4.574,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.019,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.134,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.57,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.529,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.949,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.583,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.965,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.63,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.028,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.653,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 4.088,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6a.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
@@ -1452,6 +1452,725 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "latency": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.183,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.401,
+                                                    "delta_percentage": 43
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.295,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.515,
+                                                    "delta_percentage": 36
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.41,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.584,
+                                                    "delta_percentage": 43
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.503,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.729,
+                                                    "delta_percentage": 44
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.604,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.851,
+                                                    "delta_percentage": 44
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.696,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.969,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.802,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.142,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.888,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.152,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.016,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.326,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.117,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.402,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.176,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.334,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.292,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.553,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.434,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.654,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.743,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.984,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.625,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.897,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.051,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.303,
+                                                    "delta_percentage": 17
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.56,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.805,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.527,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 13.881,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.666,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.878,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.167,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.389,
+                                                    "delta_percentage": 30
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.669,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.934,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.183,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.442,
+                                                    "delta_percentage": 35
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.192,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.407,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.214,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.43,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.268,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.554,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.157,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.386,
+                                                    "delta_percentage": 39
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.28,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.555,
+                                                    "delta_percentage": 34
+                                                }
+                                            }
+                                        },
+                                        "3vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.375,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.634,
+                                                    "delta_percentage": 37
+                                                }
+                                            }
+                                        },
+                                        "4vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.483,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.759,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "5vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.592,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.901,
+                                                    "delta_percentage": 23
+                                                }
+                                            }
+                                        },
+                                        "6vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.696,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.93,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        },
+                                        "7vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.788,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.087,
+                                                    "delta_percentage": 33
+                                                }
+                                            }
+                                        },
+                                        "8vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.885,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.103,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "9vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.994,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.188,
+                                                    "delta_percentage": 15
+                                                }
+                                            }
+                                        },
+                                        "10vcpu_128mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.084,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.27,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_256mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.176,
+                                                    "delta_percentage": 14
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.432,
+                                                    "delta_percentage": 31
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_512mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.284,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.532,
+                                                    "delta_percentage": 25
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_1024mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.441,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.677,
+                                                    "delta_percentage": 24
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_2048mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.756,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.981,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_4096mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.606,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.816,
+                                                    "delta_percentage": 19
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_8192mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 5.057,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 5.281,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_16384mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 7.536,
+                                                    "delta_percentage": 9
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 7.754,
+                                                    "delta_percentage": 13
+                                                }
+                                            }
+                                        },
+                                        "1vcpu_32768mb": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 13.403,
+                                                    "delta_percentage": 10
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 13.756,
+                                                    "delta_percentage": 16
+                                                }
+                                            }
+                                        },
+                                        "2net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.658,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.89,
+                                                    "delta_percentage": 26
+                                                }
+                                            }
+                                        },
+                                        "3net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.166,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.418,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "4net_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 3.679,
+                                                    "delta_percentage": 11
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 3.947,
+                                                    "delta_percentage": 27
+                                                }
+                                            }
+                                        },
+                                        "2block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.16,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.387,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "3block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.184,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.377,
+                                                    "delta_percentage": 28
+                                                }
+                                            }
+                                        },
+                                        "4block_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.203,
+                                                    "delta_percentage": 13
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.411,
+                                                    "delta_percentage": 41
+                                                }
+                                            }
+                                        },
+                                        "all_dev": {
+                                            "P50": {
+                                                "restore": {
+                                                    "target": 2.261,
+                                                    "delta_percentage": 12
+                                                }
+                                            },
+                                            "P90": {
+                                                "restore": {
+                                                    "target": 2.525,
+                                                    "delta_percentage": 43
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6a.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -957,6 +957,453 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "throughput": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 8215,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 8307,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2907,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 5389,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5264,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2180,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 9871,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 9804,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 3686,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 6651,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 6534,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2897,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 6250,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 6171,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 2881,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 13983,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 14198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 3102,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 5536,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5387,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2677,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 20324,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 20708,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 3778,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 6866,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 6583,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 3727,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 6470,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 6442,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 2895,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 141,
+                                                    "delta_percentage": 19
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 126,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 127,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 166,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 118,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 120,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 191,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 140,
+                                                    "delta_percentage": 32
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 119,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 118,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 152,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 105,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 105,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 108,
+                                                    "delta_percentage": 6
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 52,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 53,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 60,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 44,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 61,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 61,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 65,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 73,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 73,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 63,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 63,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 63,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 68,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 39,
+                                                    "delta_percentage": 11
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 40,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 53,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 61,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 47,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 47,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 47,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 67,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 68,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 68,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 62,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 60,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 48,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -957,6 +957,453 @@
                     }
                 ]
             },
+            "m6i.metal": {
+                "cpus": [
+                    {
+                        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                        "baselines": {
+                            "throughput": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 8198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 8293,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2686,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 5956,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5800,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2148,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 9658,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 9584,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 3483,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 7095,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 6976,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2997,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 6852,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 6776,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 2924,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 14148,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 14342,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2880,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 6121,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 5958,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 2629,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "total": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 19888,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 20231,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 3547,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 7425,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 7119,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 3215,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 7157,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 7097,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 2840,
+                                                    "delta_percentage": 14
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vcpus_total": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 140,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 130,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 131,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 172,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 120,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 121,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 190,
+                                                    "delta_percentage": 7
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 99,
+                                                    "delta_percentage": 5
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 130,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 122,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 121,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 163,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 105,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 105,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 114,
+                                                    "delta_percentage": 21
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "cpu_utilization_vmm": {
+                                "vmlinux-4.14.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 54,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 54,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 53,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 58,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 58,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 49,
+                                                    "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 63,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 63,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 70,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 74,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 74,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 68,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 61,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 62,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 72,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 40,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 41,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 58,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 60,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 52,
+                                                    "delta_percentage": 10
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 70,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 68,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 67,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 62,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 59,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 58,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 54,
+                                                    "delta_percentage": 22
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
             "m6g.metal": {
                 "cpus": [
                     {

--- a/tools/parse_baselines/main.py
+++ b/tools/parse_baselines/main.py
@@ -123,7 +123,7 @@ def main():
         help="Instance type on which the baselines \
                             were obtained.",
         action="store",
-        choices=["m5d.metal", "m6a.metal", "m6g.metal"],
+        choices=["m5d.metal", "m6i.metal", "m6a.metal", "m6g.metal"],
         required=True,
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Changes

Add performance baseline for m6i.metal.

## Reason

Currently, performance baseline on m6i.metal (newer Intel instance type) are not included.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
