### PR TITLE
doc: fix typo in AMD kernel version: 4.15 -> 4.14

### DIFF
--- a/docs/kernel-policy.md
+++ b/docs/kernel-policy.md
@@ -127,11 +127,11 @@ registers incompatibility.
 <table>
   <tr>
     <th></th>
-    <th>Snapshot taken on host 4.15</th>
+    <th>Snapshot taken on host 4.14</th>
     <th>Snapshot taken on host 5.10</th>
   </tr>
   <tr>
-    <th>Load snapshot on host 4.15</th>
+    <th>Load snapshot on host 4.14</th>
     <td style="background-color:mediumseagreen">successful</td>
     <td style="background-color:mediumseagreen">unsuccessful due to mismatch in MSRs</td>
   </tr>


### PR DESCRIPTION
## Changes

Replace AMD kernel version 4.14 with 4.15 in the snapshot compatibility matrix.

## Reason

Snapshot compatibility matrix gives wrong impression about supported kernel versions on AMD.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
