### PR TITLE
Rename seccompiler_bin

### DIFF
--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -20,7 +20,7 @@ Firecracker uses JSON files for expressing the filter rules and relies on the
 ## Default filters (recommended)
 
 At build time, the default target-specific JSON file is compiled into the
-serialized binary file, using seccompiler-bin, and gets embedded in the
+serialized binary file, using seccompiler, and gets embedded in the
 Firecracker binary.
 
 This process is performed automatically, when building the executable.
@@ -51,7 +51,7 @@ with fully customisable alternatives, leveraging the same JSON/seccompiler
 tooling, at startup time.
 
 Via Firecracker's optional `--seccomp-filter` parameter, one can supply
-the path to a custom filter file compiled with seccompiler-bin.
+the path to a custom filter file compiled with seccompiler.
 
 Potential use cases:
 

--- a/docs/seccompiler.md
+++ b/docs/seccompiler.md
@@ -2,28 +2,28 @@
 
 ## Overview
 
-Seccompiler-bin is a tool that compiles seccomp filters expressed as JSON files
+Seccompiler is a tool that compiles seccomp filters expressed as JSON files
 into serialized, binary BPF code that is directly consumed by Firecracker,
 at build or launch time.
 
-Seccompiler-bin uses a custom [JSON file structure](#json-file-format),
+Seccompiler uses a custom [JSON file structure](#json-file-format),
 detailed further below, that the filters must adhere to.
 
-Besides the seccompiler-bin executable, seccompiler also exports a library
+Besides the seccompiler executable, seccompiler also exports a library
 interface, with helper functions for deserializing and installing the binary
 filters.
 
 ## Usage
 
-### Seccompiler-bin
+### Seccompiler
 
-To view the seccompiler-bin command line arguments, pass the `--help` parameter
+To view the seccompiler command line arguments, pass the `--help` parameter
 to the executable.
 
 Example usage:
 
 ```bash
-./seccompiler-bin
+./seccompiler
     --target-arch "x86_64"  # The CPU arch where the BPF program will run.
                             # Supported architectures: x86_64, aarch64.
     --input-file "x86_64_musl.json" # File path of the JSON input.
@@ -45,12 +45,12 @@ workspace. The code is located at `firecracker/src/seccompiler/src`.
 
 ## Supported platforms
 
-Seccompiler-bin is supported on the
+Seccompiler is supported on the
 [same platforms as Firecracker](../README.md#supported-platforms).
 
 ## Release policy
 
-Seccompiler-bin follows Firecracker's [release policy](RELEASE_POLICY.md) and
+Seccompiler follows Firecracker's [release policy](RELEASE_POLICY.md) and
 version (it's released at the same time, with the same version number and
 adheres to the same support window).
 
@@ -133,7 +133,7 @@ In order to allow a syscall with multiple alternatives for the same parameters,
 you can write multiple syscall rule objects at the filter-level, each with its
 own rules.
 
-Note that, when passing the deprecated `--basic` flag to seccompiler-bin, all
+Note that, when passing the deprecated `--basic` flag to seccompiler, all
 `args` fields of the `SeccompRule`s are ignored.
 
 A **condition object** is made up of the following mandatory properties:

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -8,10 +8,6 @@ description = "Program that compiles multi-threaded seccomp-bpf filters expresse
 homepage = "https://firecracker-microvm.github.io/"
 license = "Apache-2.0"
 
-[[bin]]
-name = "seccompiler-bin"
-path = "src/seccompiler_bin.rs"
-
 [dependencies]
 bincode = "1.2.1"
 libc = ">=0.2.39"

--- a/src/seccompiler/src/common.rs
+++ b/src/seccompiler/src/common.rs
@@ -1,8 +1,8 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Module that defines common data structures used by both the library crate
-//! and seccompiler-bin.
+//! Module that defines common data structures used by both the seccompiler
+//! library and executable.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module defining the logic for compiling the deserialized filter objects into the IR.
-//! Used by seccompiler-bin.
+//! Used by seccompiler.
 //!
 //! Via the `Compiler::compile_blob()` method, it also drives the entire JSON -> BLOB
 //! transformation process.

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(clippy::ptr_as_ptr)]
 
 //! The library crate that defines common helper functions that are generally used in
-//! conjunction with seccompiler-bin.
+//! conjunction with seccompiler.
 
 mod common;
 

--- a/src/seccompiler/src/main.rs
+++ b/src/seccompiler/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! seccompiler-bin is a program that compiles multi-threaded seccomp-bpf filters expressed as JSON
+//! seccompiler is a program that compiles multi-threaded seccomp-bpf filters expressed as JSON
 //! into raw BPF programs, serializing them and outputting them to a file.
 //!
 //! Used in conjunction with the provided library crate, one can deserialize the binary filters
@@ -189,12 +189,12 @@ fn main() {
     }
 
     if arg_parser.arguments().flag_present("help") {
-        println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
+        println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
         println!("{}", arg_parser.formatted_help());
         return;
     }
     if arg_parser.arguments().flag_present("version") {
-        println!("Seccompiler-bin v{}\n", SECCOMPILER_VERSION);
+        println!("Seccompiler v{}\n", SECCOMPILER_VERSION);
         return;
     }
 
@@ -403,7 +403,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler-bin",
+                    "seccompiler",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -429,7 +429,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler-bin",
+                    "seccompiler",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -458,7 +458,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler-bin"]
+                vec!["seccompiler"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -470,7 +470,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler-bin", "--input-file", "foo.txt"]
+                vec!["seccompiler", "--input-file", "foo.txt"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -482,7 +482,7 @@ mod tests {
         let arguments = &mut arg_parser.arguments().clone();
         assert!(arguments
             .parse(
-                vec!["seccompiler-bin", "--target-arch", "x86_64"]
+                vec!["seccompiler", "--target-arch", "x86_64"]
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
@@ -495,7 +495,7 @@ mod tests {
         arguments
             .parse(
                 vec![
-                    "seccompiler-bin",
+                    "seccompiler",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",
@@ -516,7 +516,7 @@ mod tests {
         assert!(arguments
             .parse(
                 vec![
-                    "seccompiler-bin",
+                    "seccompiler",
                     "--input-file",
                     "foo.txt",
                     "--target-arch",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,7 +317,7 @@ def bin_seccomp_paths(test_fc_session_root_path):
 
     They currently consist of:
 
-    * a jailer that receives filter generated using seccompiler-bin;
+    * a jailer that receives filter generated using seccompiler;
     * a jailed binary that follows the seccomp rules;
     * a jailed binary that breaks the seccomp rules.
     """

--- a/tests/host_tools/cargo_build.py
+++ b/tests/host_tools/cargo_build.py
@@ -92,7 +92,7 @@ def get_rustflags():
 
 def run_seccompiler_bin(bpf_path, json_path=defs.SECCOMP_JSON_DIR, basic=False):
     """
-    Run seccompiler-bin.
+    Run seccompiler.
 
     :param bpf_path: path to the output file
     :param json_path: optional path to json file

--- a/tests/integration_tests/security/test_seccomp.py
+++ b/tests/integration_tests/security/test_seccomp.py
@@ -114,7 +114,7 @@ def test_seccomp_ls(bin_seccomp_paths):
         _get_basic_syscall_list()
     )
 
-    # Run seccompiler-bin.
+    # Run seccompiler.
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer.
@@ -131,7 +131,7 @@ def test_seccomp_ls(bin_seccomp_paths):
 
 def test_advanced_seccomp(bin_seccomp_paths):
     """
-    Test seccompiler-bin with `demo_jailer`.
+    Test seccompiler with `demo_jailer`.
 
     Test that the demo jailer (with advanced seccomp) allows the harmless demo
     binary, denies the malicious demo binary and that an empty allowlist
@@ -182,7 +182,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
         _get_basic_syscall_list()
     )
 
-    # Run seccompiler-bin.
+    # Run seccompiler.
     bpf_path = _run_seccompiler_bin(json_filter)
 
     # Run the mini jailer for harmless binary.
@@ -203,7 +203,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
 
     os.unlink(bpf_path)
 
-    # Run seccompiler-bin with `--basic` flag.
+    # Run seccompiler with `--basic` flag.
     bpf_path = _run_seccompiler_bin(json_filter, basic=True)
 
     # Run the mini jailer for malicious binary.
@@ -227,7 +227,7 @@ def test_advanced_seccomp(bin_seccomp_paths):
         }
     }"""
 
-    # Run seccompiler-bin.
+    # Run seccompiler.
     bpf_path = _run_seccompiler_bin(json_filter)
 
     outcome = utils.run_cmd(
@@ -275,7 +275,7 @@ def test_default_seccomp_level(test_microvm_with_api):
 
 def test_seccomp_rust_panic(bin_seccomp_paths):
     """
-    Test seccompiler-bin with `demo_panic`.
+    Test seccompiler with `demo_panic`.
 
     Test that the Firecracker filters allow a Rust panic to run its
     course without triggering a seccomp violation.

--- a/tools/devtool
+++ b/tools/devtool
@@ -250,7 +250,7 @@ build_jailer_bin_path() {
 build_seccomp_bin_path() {
     target="$1"
     profile="$2"
-    echo "$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin"
+    echo "$CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler"
 }
 
 build_rebase_snap_bin_path() {
@@ -798,13 +798,13 @@ cmd_build() {
     # We don't need any special privileges for the build phase, so we run the
     # container as the current user/group.
 
-    # Build seccompiler-bin.
+    # Build seccompiler.
     run_devctr \
         --user "$(id -u):$(id -g)" \
         --workdir "$CTR_FC_ROOT_DIR" \
         ${extra_args} \
         -- \
-        cargo build -p seccompiler --bin seccompiler-bin \
+        cargo build -p seccompiler --bin seccompiler \
             --target-dir "$CTR_CARGO_SECCOMPILER_TARGET_DIR" \
             "${cargo_args[@]}"
     ret=$?
@@ -860,7 +860,7 @@ cmd_build() {
         # messages.
         say "Build successful."
         say "Firecracker and Jailer binaries placed under $cargo_bin_dir"
-        say "Seccompiler-bin binary placed under $seccompiler_bin_dir"
+        say "Seccompiler binary placed under $seccompiler_bin_dir"
         say "Rebase_snap binary placed under $rebase_snap_bin_dir"
     }
 
@@ -928,14 +928,14 @@ cmd_strip() {
       strip $strip_flags\
         "$CTR_CARGO_TARGET_DIR/$target/$profile/firecracker" \
         "$CTR_CARGO_TARGET_DIR/$target/$profile/jailer" \
-        "$CTR_CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler-bin" \
+        "$CTR_CARGO_SECCOMPILER_TARGET_DIR/$target/$profile/seccompiler" \
         "$CTR_CARGO_REBASE_SNAP_TARGET_DIR/$target/$profile/rebase-snap"
     ret=$?
 
     [ $ret -eq 0 ] && {
         say "Stripping was successful."
         say "Stripped Firecracker and Jailer binaries placed under $CARGO_TARGET_DIR/$target/$profile."
-        say "Stripped seccompiler-bin binary placed under $CARGO_SECCOMPILER_TARGET_DIR/$target/$profile."
+        say "Stripped seccompiler binary placed under $CARGO_SECCOMPILER_TARGET_DIR/$target/$profile."
         say "Stripped rebase-snap binary placed under $CARGO_REBASE_SNAP_TARGET_DIR/$target/$profile."
     }
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -115,13 +115,13 @@ fi
 # to make sure that `firecracker --version` reports the latest changes.
 touch build.rs
 
-ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap)
+ARTIFACTS=(firecracker jailer seccompiler rebase-snap)
 
 if [ "$LIBC" == "gnu" ]; then
     # Don't build jailer. See commit 3bf285c8f
     echo "Not building jailer because glibc selected instead of musl"
     CARGO_OPTS+=" --exclude jailer"
-    ARTIFACTS=(firecracker seccompiler-bin rebase-snap)
+    ARTIFACTS=(firecracker seccompiler rebase-snap)
 fi
 
 say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

## Changes

Uses `main.rs` for the seccompiler binary instead of `seccompiler_bin.rs` and specifying it in `Cargo.toml`.

## Reason

This approach is, simpler, the default, and a commonly used pattern.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
