### PR TITLE
CI: fix 5_inc_snapshots intermittent failure

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -18,10 +18,13 @@ from framework.artifacts import (
 from framework.builder import MicrovmBuilder
 from framework.defs import FC_WORKSPACE_DIR, DEFAULT_TEST_SESSION_ROOT_PATH
 from framework.utils_vsock import check_vsock_device
-from framework.utils import generate_mmds_session_token, generate_mmds_get_request
+from framework.utils import (
+    generate_mmds_session_token,
+    generate_mmds_get_request,
+    guest_run_fio_iteration,
+)
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from integration_tests.functional.test_mmds import _populate_data_store
-from integration_tests.functional.test_snapshot_basic import _guest_run_fio_iteration
 from integration_tests.functional.test_balloon import (
     get_stable_rss_mem_by_pid,
     make_guest_dirty_memory,
@@ -184,6 +187,8 @@ def test_snap_restore_from_artifacts(
         )
 
         # Run fio on the guest.
-        _guest_run_fio_iteration(ssh_connection, 0)
+        # TODO: check the result of FIO or use fsck to check that the root device is
+        # not corrupted. No obvious errors will be returned here.
+        guest_run_fio_iteration(ssh_connection, 0)
 
         vm.kill()


### PR DESCRIPTION
## Changes


## Reason

We have stumbled upon an OOM scenario in one of our integration tests (5_inc and 5_full snapshots) due to the fact that we spawn FIO in the guest in every create/resume snapshot sequence. Doing it upon each invocation of snap/resume might possibly lead to multiple FIO instances on the guest (the FIO processes from the previous guest might get snapshotted). This can result in an OOM and thus lead to an intermittent failure in the CI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
