### PR TITLE
Support DIRECT_IO in virtio device

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -9,6 +9,7 @@ use std::convert::From;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -76,6 +77,7 @@ impl FileEngineType {
 /// Helper object for setting up all `Block` fields derived from its backing file.
 pub(crate) struct DiskProperties {
     cache_type: CacheType,
+    is_disk_direct_io: bool,
     file_path: String,
     file_engine: FileEngine<PendingRequest>,
     nsectors: u64,
@@ -86,12 +88,15 @@ impl DiskProperties {
     pub fn new(
         disk_image_path: String,
         is_disk_read_only: bool,
+        is_disk_direct_io: bool,
         cache_type: CacheType,
         file_engine_type: FileEngineType,
     ) -> result::Result<Self, Error> {
+        let custom_flags = if is_disk_direct_io { libc::O_DIRECT } else { 0 };
         let mut disk_image = OpenOptions::new()
             .read(true)
             .write(!is_disk_read_only)
+            .custom_flags(custom_flags)
             .open(PathBuf::from(&disk_image_path))
             .map_err(Error::BackingFile)?;
         let disk_size = disk_image
@@ -110,6 +115,7 @@ impl DiskProperties {
 
         Ok(Self {
             cache_type,
+            is_disk_direct_io,
             nsectors: disk_size >> SECTOR_SHIFT,
             image_id: Self::build_disk_image_id(&disk_image),
             file_path: disk_image_path,
@@ -239,12 +245,14 @@ impl Block {
         disk_image_path: String,
         is_disk_read_only: bool,
         is_disk_root: bool,
+        is_disk_direct_io: bool,
         rate_limiter: RateLimiter,
         file_engine_type: FileEngineType,
     ) -> result::Result<Block, Error> {
         let disk_properties = DiskProperties::new(
             disk_image_path,
             is_disk_read_only,
+            is_disk_direct_io,
             cache_type,
             file_engine_type,
         )?;
@@ -449,6 +457,7 @@ impl Block {
         let disk_properties = DiskProperties::new(
             disk_image_path,
             self.is_read_only(),
+            self.is_direct_io(),
             self.cache_type(),
             self.file_engine_type(),
         )?;
@@ -485,6 +494,11 @@ impl Block {
     /// Specifies if this block device is read only.
     pub fn is_read_only(&self) -> bool {
         self.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0
+    }
+
+    /// Specifies if his block device uses DIRECT_IO.
+    pub fn is_direct_io(&self) -> bool {
+        self.disk.is_disk_direct_io
     }
 
     /// Specifies if this block device is read only.
@@ -661,6 +675,7 @@ pub(crate) mod tests {
         let disk_properties = DiskProperties::new(
             String::from(f.as_path().to_str().unwrap()),
             true,
+            false,
             CacheType::Unsafe,
             default_engine_type_for_kv(),
         )
@@ -679,6 +694,7 @@ pub(crate) mod tests {
         assert!(DiskProperties::new(
             "invalid-disk-path".to_string(),
             true,
+            false,
             CacheType::Unsafe,
             default_engine_type_for_kv(),
         )

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -99,6 +99,8 @@ pub struct BlockState {
     // v1.0 are incompatible with older FC versions (due to incompatible notification suppression
     // feature).
     file_engine_type: FileEngineTypeState,
+    #[version(start = 4, default_fn = "default_is_direct_io")]
+    is_direct_io: bool,
 }
 
 impl BlockState {
@@ -115,6 +117,10 @@ impl BlockState {
 
     fn default_cache_type_flush(_source_version: u16) -> CacheTypeState {
         CacheTypeState::Unsafe
+    }
+
+    fn default_is_direct_io(_source_version: u16) -> bool {
+        false
     }
 }
 
@@ -134,6 +140,7 @@ impl Persist<'_> for Block {
             partuuid: self.partuuid.clone(),
             cache_type: CacheTypeState::from(self.cache_type()),
             root_device: self.root_device,
+            is_direct_io: self.is_direct_io(),
             disk_path: self.disk.file_path().clone(),
             virtio_state: VirtioDeviceState::from_device(self),
             rate_limiter_state: self.rate_limiter.save(),
@@ -156,6 +163,7 @@ impl Persist<'_> for Block {
             state.disk_path.clone(),
             is_disk_read_only,
             state.root_device,
+            state.is_direct_io,
             rate_limiter,
             state.file_engine_type.into(),
         )
@@ -177,6 +185,7 @@ impl Persist<'_> for Block {
                     state.disk_path.clone(),
                     is_disk_read_only,
                     state.root_device,
+                    state.is_direct_io,
                     rate_limiter,
                     FileEngineType::Sync,
                 )
@@ -255,6 +264,7 @@ mod tests {
             f.as_path().to_str().unwrap().to_string(),
             false,
             false,
+            false,
             RateLimiter::default(),
             FileEngineType::default(),
         )
@@ -307,6 +317,7 @@ mod tests {
                 f.as_path().to_str().unwrap().to_string(),
                 false,
                 false,
+                false,
                 RateLimiter::default(),
                 // Need to use Sync because it will otherwise return an error.
                 // We'll overwrite the state instead.
@@ -350,6 +361,7 @@ mod tests {
             None,
             CacheType::Unsafe,
             f.as_path().to_str().unwrap().to_string(),
+            false,
             false,
             false,
             RateLimiter::default(),

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -51,6 +51,7 @@ pub fn default_block_with_path(path: String, file_engine_type: FileEngineType) -
         path,
         false,
         false,
+        false,
         rate_limiter,
         file_engine_type,
     )

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -696,6 +696,7 @@ mod tests {
                 true,
                 None,
                 true,
+                false,
                 CacheType::Unsafe,
             )];
             _block_files =
@@ -798,7 +799,8 @@ mod tests {
       "is_read_only": true,
       "cache_type": "Unsafe",
       "rate_limiter": null,
-      "io_engine": "Sync"
+      "io_engine": "Sync",
+      "is_direct_io": false
     }}
   ],
   "boot-source": {{

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -788,6 +788,7 @@ mod tests {
             true,
             None,
             true,
+            false,
             CacheType::Unsafe,
         )];
         insert_block_devices(&mut vmm, &mut cmdline, &mut event_manager, block_configs);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -550,6 +550,7 @@ mod tests {
                 partuuid: Some("0eaa91a0-01".to_string()),
                 cache_type: CacheType::Unsafe,
                 is_read_only: false,
+                is_direct_io: false,
                 rate_limiter: Some(RateLimiterConfig::default()),
                 file_engine_type: FileEngineType::default(),
             },

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -1316,6 +1316,7 @@ mod tests {
             drive_id: String::new(),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         });
         check_preboot_request(req, |result, vm_res| {
             assert_eq!(result, Ok(VmmData::Empty));
@@ -1331,6 +1332,7 @@ mod tests {
             drive_id: String::new(),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         });
         check_preboot_request_err(
             req,
@@ -2025,6 +2027,7 @@ mod tests {
                 drive_id: String::new(),
                 rate_limiter: None,
                 file_engine_type: FileEngineType::default(),
+                is_direct_io: false,
             }),
             VmmActionError::OperationNotSupportedPostBoot,
         );
@@ -2128,6 +2131,7 @@ mod tests {
             drive_id: String::new(),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         });
         verify_load_snap_disallowed_after_boot_resources(req, "InsertBlockDevice");
 

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -28,6 +28,8 @@ pub const FC_V1_0_SNAP_VERSION: u16 = 4;
 pub const FC_V1_1_SNAP_VERSION: u16 = 5;
 /// Snap version for Firecracker v1.2
 pub const FC_V1_2_SNAP_VERSION: u16 = 6;
+/// Snap version for Firecracker v1.3
+pub const FC_V1_3_SNAP_VERSION: u16 = 7;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -56,6 +58,9 @@ lazy_static! {
         #[cfg(target_arch = "x86_64")]
         version_map.set_type_version(VcpuState::type_id(), 3);
 
+        // v1.3 state change mappings.
+        version_map.new_version().set_type_version(BlockState::type_id(), 4);
+
         version_map
     };
 
@@ -71,6 +76,7 @@ lazy_static! {
         mapping.insert(String::from("1.0.0"), FC_V1_0_SNAP_VERSION);
         mapping.insert(String::from("1.1.0"), FC_V1_1_SNAP_VERSION);
         mapping.insert(String::from("1.2.0"), FC_V1_2_SNAP_VERSION);
+        mapping.insert(String::from("1.3.0"), FC_V1_3_SNAP_VERSION);
 
         mapping
     };

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -87,6 +87,9 @@ pub struct BlockDeviceConfig {
     #[serde(default)]
     #[serde(rename = "io_engine")]
     pub file_engine_type: FileEngineType,
+    /// If set to true, the disk is opened using DIRECT_IO.
+    #[serde(default)]
+    pub is_direct_io: bool,
 }
 
 impl From<&Block> for BlockDeviceConfig {
@@ -98,6 +101,7 @@ impl From<&Block> for BlockDeviceConfig {
             is_root_device: block.is_root_device(),
             partuuid: block.partuuid().cloned(),
             is_read_only: block.is_read_only(),
+            is_direct_io: block.is_direct_io(),
             cache_type: block.cache_type(),
             rate_limiter: rl.into_option(),
             file_engine_type: block.file_engine_type(),
@@ -227,6 +231,7 @@ impl BlockBuilder {
             block_device_config.path_on_host,
             block_device_config.is_read_only,
             block_device_config.is_root_device,
+            block_device_config.is_direct_io,
             rate_limiter.unwrap_or_default(),
             block_device_config.file_engine_type,
         )
@@ -266,6 +271,7 @@ mod tests {
                 partuuid: self.partuuid.clone(),
                 cache_type: self.cache_type,
                 is_read_only: self.is_read_only,
+                is_direct_io: self.is_direct_io,
                 drive_id: self.drive_id.clone(),
                 rate_limiter: None,
                 file_engine_type: FileEngineType::default(),
@@ -290,6 +296,7 @@ mod tests {
             partuuid: None,
             cache_type: CacheType::Writeback,
             is_read_only: false,
+            is_direct_io: false,
             drive_id: dummy_id.clone(),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
@@ -321,6 +328,7 @@ mod tests {
             partuuid: None,
             cache_type: CacheType::Unsafe,
             is_read_only: true,
+            is_direct_io: false,
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
@@ -352,6 +360,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_2 = TempFile::new().unwrap();
@@ -365,6 +374,7 @@ mod tests {
             drive_id: String::from("2"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let mut block_devs = BlockBuilder::new();
@@ -389,6 +399,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_2 = TempFile::new().unwrap();
@@ -402,6 +413,7 @@ mod tests {
             drive_id: String::from("2"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_3 = TempFile::new().unwrap();
@@ -415,6 +427,7 @@ mod tests {
             drive_id: String::from("3"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let mut block_devs = BlockBuilder::new();
@@ -453,6 +466,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_2 = TempFile::new().unwrap();
@@ -466,6 +480,7 @@ mod tests {
             drive_id: String::from("2"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_3 = TempFile::new().unwrap();
@@ -479,6 +494,7 @@ mod tests {
             drive_id: String::from("3"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let mut block_devs = BlockBuilder::new();
@@ -518,6 +534,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let dummy_file_2 = TempFile::new().unwrap();
@@ -531,6 +548,7 @@ mod tests {
             drive_id: String::from("2"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let mut block_devs = BlockBuilder::new();
@@ -590,6 +608,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
         // Switch roots and add a PARTUUID for the new one.
         let mut root_block_device_old = root_block_device;
@@ -603,6 +622,7 @@ mod tests {
             drive_id: String::from("2"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
         assert!(block_devs.insert(root_block_device_old).is_ok());
         let root_block_id = root_block_device_new.drive_id.clone();
@@ -625,6 +645,7 @@ mod tests {
             drive_id: String::from("1"),
             rate_limiter: None,
             file_engine_type: FileEngineType::default(),
+            is_direct_io: false,
         };
 
         let mut block_devs = BlockBuilder::new();
@@ -647,6 +668,7 @@ mod tests {
             backing_file.as_path().to_str().unwrap().to_string(),
             true,
             true,
+            false,
             RateLimiter::default(),
             FileEngineType::default(),
         )

--- a/tests/framework/vm_config.json
+++ b/tests/framework/vm_config.json
@@ -13,7 +13,8 @@
       "is_read_only": false,
       "cache_type": "Unsafe",
       "io_engine": "Sync",
-      "rate_limiter": null
+      "rate_limiter": null,
+      "is_direct_io":false
     }
   ],
   "machine-config": {

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -964,6 +964,7 @@ def _drive_patch(test_microvm):
             "is_root_device": True,
             "partuuid": None,
             "is_read_only": False,
+            "is_direct_io": False,
             "cache_type": "Unsafe",
             "io_engine": "Sync",
             "rate_limiter": None,
@@ -974,6 +975,7 @@ def _drive_patch(test_microvm):
             "is_root_device": False,
             "partuuid": None,
             "is_read_only": False,
+            "is_direct_io": False,
             "cache_type": "Unsafe",
             "io_engine": "Async" if is_io_uring_supported() else "Sync",
             "rate_limiter": {
@@ -1217,6 +1219,7 @@ def test_get_full_config_after_restoring_snapshot(bin_cloner_path):
             "cache_type": "Unsafe",
             "rate_limiter": None,
             "io_engine": "Sync",
+            "is_direct_io": False,
         }
     ]
 
@@ -1334,6 +1337,7 @@ def test_get_full_config(test_microvm_with_api):
             "cache_type": "Unsafe",
             "rate_limiter": None,
             "io_engine": "Sync",
+            "is_direct_io": False,
         }
     ]
 


### PR DESCRIPTION
This changes allows using DIRECT_IO for reading and writing from files backing virtio device. This improves read and write throughput and latency when working set of the backing file is larger than available host memory.

Performance result of random read/write when DIRECT_IO was not enabled.
```
read: IOPS=105k, BW=409MiB/s (429MB/s)(1439GiB/3600001msec)
lat percentiles (usec):
     |  50th=[  363],  60th=[  404],  70th=[  445],  80th=[  494],
     |  90th=[  578],  95th=[  676],  99th=[  914]

write: IOPS=105k, BW=409MiB/s (429MB/s)(1439GiB/3600001msec)
lat percentiles (usec):
     |  50th=[  182],  60th=[  194],  70th=[  210],  80th=[  233],
     |  90th=[  277],  95th=[  297],  99th=[  322]
```

Performance result of random read/write when DIRECT_IO was enabled.
```
read: IOPS=134k, BW=523MiB/s (548MB/s)(1839GiB/3600001msec)
lat percentiles (usec):
     |  50th=[  241],  60th=[  258],  70th=[  277],  80th=[  314],
     |  90th=[  400],  95th=[  498],  99th=[  717]

write: IOPS=134k, BW=523MiB/s (548MB/s)(1839GiB/3600001msec)
lat percentiles (usec):
     |  50th=[  163],  60th=[  172],  70th=[  182],  80th=[  196],
     |  90th=[  227],  95th=[  258],  99th=[  322]
```

The above performance test was performed on R6GD.METAL instance using Fio. The following Fio job configuration was used for the test.
```
size=100G
ioengine=libaio
direct=1
rw=randrw
iodepth=4
bs=4K
numjobs=15
offset_increment=100G
percentile_list=50:60:70:80:90:95:99
filename=/dev/vdb
overwrite=1
group_reporting
time_based
runtime=3600
```

Signed-off-by: Gourav Roy <gouravr@amazon.com>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
