### PR TITLE
[RFC] Add clippy::cast_precision_loss warning

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.
 //! It is constructed on top of an HTTP Server that uses Unix Domain Sockets and `EPOLL` to

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.
 use std::{fmt, result};

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 #![cfg(target_arch = "x86_64")]

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Emulates virtual and hardware devices.
 use std::io;
 

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
 pub mod pdu;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 mod api_server_adapter;
 mod metrics;

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! High-level interface over Linux io_uring.
 //!
 //! Aims to provide an easy-to-use interface, while making some Firecracker-specific simplifying

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 mod cgroup;
 mod chroot;

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 //! Crate that implements Firecracker specific functionality as far as logging and metrics
 //! collecting.
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 pub mod data_store;
 pub mod ns;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_precision_loss)]
 //! # Rate Limiter
 //!
 //! Provides a rate limiter written in Rust useful for IO operations that need to

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 //! The library crate that defines common helper functions that are generally used in
 //! conjunction with seccompiler-bin.

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 //! Provides version tolerant serialization and deserialization facilities and
 //! implements a persistent storage format for Firecracker state snapshots.

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::ptr_as_ptr)]
+#![warn(clippy::cast_precision_loss)]
 
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).

--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -31,7 +31,8 @@ function fc-bindgen {
     non_upper_case_globals,
     dead_code,
     non_snake_case,
-    clippy::ptr_as_ptr
+    clippy::ptr_as_ptr,
+    clippy::cast_precision_loss
 )]
 
 EOF


### PR DESCRIPTION
## Changes
Adds clippy::cast_precision_loss warning.

## Reason
Closes #3199

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
