### PR TITLE
CI: generate PR pipeline dynamically

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite pipelines dynamically"""
+
+import json
+
+INSTANCES = [
+    "m5d.metal",
+    "m6i.metal",
+    "m6a.metal",
+    "m6gd.metal",
+]
+
+KERNELS = ["4.14", "5.10"]
+
+
+def group(group_name, command, agent_tags=None, priority=0, timeout=30):
+    """
+    Generate a group step with specified parameters, for each instance+kernel
+    combination
+
+    https://buildkite.com/docs/pipelines/group-step
+    """
+    if agent_tags is None:
+        agent_tags = []
+    # Use the 1st character of the group name (should be an emoji)
+    label1 = group_name[0]
+    steps = []
+    for instance in INSTANCES:
+        for kv in KERNELS:
+            agents = [
+                f"type={instance}",
+                f"kv={kv}",
+            ]
+            agents.extend(agent_tags)
+            step = {
+                "command": command,
+                "label": f"{label1} {instance} kv={kv}",
+                "priority": priority,
+                "timeout": timeout,
+                "agents": agents,
+            }
+            steps.append(step)
+
+    return {"group": group_name, "steps": steps}
+
+
+step_block_unless_maintainer = {
+    "block": "Waiting for approval to run",
+    "if": '(build.creator.teams includes "prod-compute-capsule") == false',
+}
+
+step_style = {
+    "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
+    "label": "🪶 Style",
+    # no agent tags, it doesn't matter where this runs
+}
+
+build_grp = group(
+    "📦 Build",
+    "./tools/devtool -y test -- ../tests/integration_tests/build/",
+    priority=1,
+)
+
+functional_1_grp = group(
+    "⚙ Functional [a-n]",
+    "./tools/devtool -y test -- `cd tests; ls integration_tests/functional/test_[a-n]*.py`",
+    priority=1,
+)
+
+functional_2_grp = group(
+    "⚙ Functional [o-z]",
+    "./tools/devtool -y test -- `cd tests; ls integration_tests/functional/test_[o-z]*.py`",
+    priority=1,
+)
+
+security_grp = group(
+    "🔒 Security",
+    "./tools/devtool -y test -- ../tests/integration_tests/security/",
+    priority=1,
+)
+
+performance_grp = group(
+    "⏱ Performance",
+    "./tools/devtool -y test -- ../tests/integration_tests/performance/",
+    priority=1,
+    agent_tags=["ag=1"],
+)
+
+pipeline = {
+    "agents": {"queue": "default"},
+    "steps": [
+        step_block_unless_maintainer,
+        step_style,
+        build_grp,
+        functional_1_grp,
+        functional_2_grp,
+        security_grp,
+        performance_grp,
+    ],
+}
+
+print(json.dumps(pipeline, indent=4, sort_keys=True, ensure_ascii=False))

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -50,13 +50,13 @@ def _validate_license(filename):
     Python and Rust files should have the licenses on the first 2 lines
     Shell files license is located on lines 3-4 to account for shebang
     """
-    with open(filename, "r+", encoding="utf-8") as file:
-        if filename.endswith(".sh"):
-            # Move iterator to third line without reading file into memory
-            file.readline()
-            file.readline()
-        # The copyright message is always on the first line.
-        copyright_info = file.readline()
+    with open(filename, "r", encoding="utf-8") as file:
+        # Find the copyright line
+        while True:
+            line = file.readline()
+            if line.startswith(("// Copyright", "# Copyright")):
+                copyright_info = line
+                break
 
         has_amazon_copyright = _has_amazon_copyright(
             copyright_info
@@ -104,8 +104,8 @@ def test_for_valid_licenses():
     error_msg = []
     for file in all_files:
         if _validate_license(file) is False:
-            error_msg.append("{}".format(str(file)))
-    assert not error_msg, "Files {} have invalid licenses".format((error_msg))
+            error_msg.append(file)
+    assert not error_msg, f"Files {error_msg} have invalid licenses"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

- Made a script that can generate the build script we run for every PR
- Made the license check a bit more robust by finding the copyright line instead of expecting it to be at an exact location.

## Reason

We have more control to decide what steps run and on what agents. Also there is less clicking when trying to find a failed job. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- [X] If a specific issue led to this PR, this PR closes the issue.
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- [X] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
