### PR TITLE
Fix release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,3 +21,4 @@ Jonathan Woollett-Light <jcawl@amazon.co.uk> <jonthanwoollettlight@gmail.com>
 karthik nedunchezhiyan <karthik.n@zohocorp.com>
 Babis Chalios <bchalios@amazon.es> <babis.chalios@gmail.com>
 Pablo Barbáchano <pablob@amazon.com>
+Nikita Kalyazin <kalyazin@amazon.co.uk> <kalyazin@amazon.com>

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -70,16 +70,24 @@ done
 # `Cargo.lock`.
 say "Updating lockfile..."
 cargo check
+CHANGED=(Cargo.lock)
+
+cd tests/integration_tests/security/demo_seccomp
+cargo check
+cd -
+CHANGED+=(tests/integration_tests/security/demo_seccomp/Cargo.lock)
 
 # Update credits.
 say "Updating credits..."
 $FC_TOOLS_DIR/update-credits.sh
+CHANGED+=(CREDITS.md)
 
 # Update changelog.
 say "Updating changelog..."
 sed -i "s/\[Unreleased\]/\[$version\]/g" "$FC_ROOT_DIR/CHANGELOG.md"
+CHANGED+=(CHANGELOG.md)
 
-git add "${files_to_change[@]}" Cargo.lock CREDITS.md CHANGELOG.md
+git add "${files_to_change[@]}" "${CHANGED[@]}"
 git commit -s -m "Releasing v$version"
 
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -27,7 +27,7 @@ function check_swagger_artifact {
     swagger_path=$1
     version=$2
     swagger_ver=$(get_swagger_version "$swagger_path")
-    if [[ $version =~ v$swagger_ver.* ]]; then
+    if [[ ! $version =~ v$swagger_ver.* ]]; then
         die "Artifact $swagger_path's version: $swagger_ver does not match release version $version."
     fi
 }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -98,6 +98,12 @@ PROFILE_DIR=$(get-profile-dir "$PROFILE")
 CARGO_TARGET=$ARCH-unknown-linux-$LIBC
 CARGO_TARGET_DIR=build/cargo_target/$CARGO_TARGET/$PROFILE_DIR
 
+if [[ $VERSION =~ "-dirty$" ]]; then
+    say_warn "Building dirty version.. dirty because:"
+    git status -s --untracked-files=no
+    git diff
+fi
+
 CARGO_REGISTRY_DIR="build/cargo_registry"
 CARGO_GIT_REGISTRY_DIR="build/cargo_git_registry"
 for dir in "$CARGO_REGISTRY_DIR" "$CARGO_GIT_REGISTRY_DIR"; do


### PR DESCRIPTION
## Changes

- Fix a version bump we didn't do before.
- During release, print some more info in case of a dirty version.
- Fix one entry in `CREDITS.md`.
- Fix a bug when comparing the swagger version to the release version.

## Reason

To make releases work for all supported branches.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
