### PR TITLE
rust: update to edition2021

### DIFF
--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "api_server"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arch"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arch_gen"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cpuid"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -2,7 +2,7 @@
 name = "devices"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dumbo"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "firecracker"
 version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 build = "../../build.rs"
 description = "Firecracker enables you to deploy workloads in lightweight virtual machines, called microVMs, which provide enhanced security and workload isolation over traditional VMs, while enabling the speed and resource efficiency of containers."
 homepage = "https://firecracker-microvm.github.io/"

--- a/src/io_uring/Cargo.toml
+++ b/src/io_uring/Cargo.toml
@@ -2,7 +2,7 @@
 name = "io_uring"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jailer"
 version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 build = "../../build.rs"
 description = "Process for starting Firecracker in production scenarios; applies a cgroup/namespace isolation barrier and then drops privileges."
 homepage = "https://firecracker-microvm.github.io/"

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "logger"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmds"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/net_gen/Cargo.toml
+++ b/src/net_gen/Cargo.toml
@@ -2,5 +2,5 @@
 name = "net_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"

--- a/src/rate_limiter/Cargo.toml
+++ b/src/rate_limiter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rate_limiter"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/rebase-snap/Cargo.toml
+++ b/src/rebase-snap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rebase-snap"
 version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 build = "../../build.rs"
 license = "Apache-2.0"
 

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "seccompiler"
 version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 build = "../../build.rs"
 description = "Program that compiles multi-threaded seccomp-bpf filters expressed as JSON into raw BPF programs, serializing them and outputting them to a file."
 homepage = "https://firecracker-microvm.github.io/"

--- a/src/snapshot/Cargo.toml
+++ b/src/snapshot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "snapshot"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 autobenches = false
 license = "Apache-2.0"
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "utils"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/virtio_gen/Cargo.toml
+++ b/src/virtio_gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "virtio_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/vm-memory/Cargo.toml
+++ b/src/vm-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-memory"
 version = "0.3.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vmm"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.47}
+    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.39}
 else:
-    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.68}
+    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.60}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Update rust edition to 2021

## Reason

Since we updated to cargo 1.64.0 we don't need to require edition 2018 any more

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
