### PR TITLE
rename error on block device update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 test_results/*
 *.core
 *.profraw
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,6 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 name = "api_server"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "libc",
  "logger",
  "micro_http",
@@ -285,7 +284,6 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "arch_gen",
- "derive_more",
  "kvm-bindings",
  "kvm-ioctls",
  "thiserror",
@@ -1090,7 +1088,6 @@ name = "seccompiler"
 version = "1.2.0"
 dependencies = [
  "bincode",
- "derive_more",
  "libc",
  "serde",
  "serde_json",

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -10,7 +10,6 @@ libc = "0.2.117"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.78"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"
 
 logger = { path = "../logger" }

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -255,7 +255,7 @@ pub(crate) fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
     }
 }
 
-#[derive(Debug, derive_more::From, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     // The resource ID is empty.
     #[error("The ID cannot be empty.")]
@@ -271,7 +271,7 @@ pub(crate) enum Error {
     InvalidPathMethod(String, Method),
     // An error occurred when deserializing the json body of a request.
     #[error("An error occurred when deserializing the json body of a request: {0}.")]
-    SerdeJson(serde_json::Error),
+    SerdeJson(#[from] serde_json::Error),
 }
 
 // It's convenient to turn errors into HTTP responses directly.

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+bitflags = "1.3.2"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 libc = "0.2.117"
@@ -13,9 +15,7 @@ linux-loader = "0.8.1"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-fdt = "0.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"
-bitflags = "1.3.2"
 
 arch_gen = { path = "../arch_gen" }
 logger = { path = "../logger" }

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -8,9 +8,8 @@ license = "Apache-2.0"
 [dependencies]
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"
 
-utils = { path = "../utils"}
 arch = { path = "../arch" }
 arch_gen = { path = "../arch_gen" }
+utils = { path = "../utils"}

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 event-manager = "0.3.0"
 libc = "0.2.117"
 thiserror = "1.0.32"
@@ -13,7 +14,6 @@ timerfd = "1.2.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-superio = "0.7.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -34,7 +34,7 @@ pub enum Error {
     /// Error while creating ifreq structure
     #[error(
         "Error while creating ifreq structure: {0}. Invalid TUN/TAP Backend provided by {1}. \
-         Check our documentation on setting up the network devices"
+         Check our documentation on setting up the network devices."
     )]
     IfreqExecuteError(IoError, String),
     /// Error while setting the offload flags

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 use std::cmp::min;
-use std::fmt;
 use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
 
@@ -26,26 +25,14 @@ pub(super) const VIRTQ_DESC_F_WRITE: u16 = 0x2;
 // The Virtio Spec 1.0 defines the alignment of VirtIO descriptor is 16 bytes,
 // which fulfills the explicit constraint of GuestMemoryMmap::read_obj_from_addr().
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum QueueError {
     /// Descriptor index out of bounds.
+    #[error("Descriptor index out of bounds: {0}.")]
     DescIndexOutOfBounds(u16),
     /// Attempted an invalid write into the used ring.
-    UsedRing(GuestMemoryError),
-}
-
-impl fmt::Display for QueueError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::QueueError::*;
-
-        match self {
-            DescIndexOutOfBounds(val) => write!(f, "Descriptor index out of bounds: {val}"),
-            UsedRing(err) => write!(
-                f,
-                "Failed to write value into the virtio queue used ring: {err}"
-            ),
-        }
-    }
+    #[error("Failed to write value into the virtio queue used ring: {0}")]
+    UsedRing(#[from] GuestMemoryError),
 }
 
 /// A virtio descriptor constraints with C representative.

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -39,11 +39,10 @@ impl fmt::Display for QueueError {
         use self::QueueError::*;
 
         match self {
-            DescIndexOutOfBounds(val) => write!(f, "Descriptor index out of bounds: {}", val),
+            DescIndexOutOfBounds(val) => write!(f, "Descriptor index out of bounds: {val}"),
             UsedRing(err) => write!(
                 f,
-                "Failed to write value into the virtio queue used ring: {}",
-                err
+                "Failed to write value into the virtio queue used ring: {err}"
             ),
         }
     }

--- a/src/io_uring/Cargo.toml
+++ b/src/io_uring/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 libc = "0.2.117"
+
 utils = { path = "../utils" }
 vm-memory = { path="../vm-memory" }
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 [dev-dependencies]
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 aes-gcm = "0.10.1"
 base64 = "0.13.0"
 bincode = "1.2.1"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 thiserror = "1.0.32"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -46,7 +46,7 @@ pub enum OutputFormat {
     Imds,
 }
 
-#[derive(Debug, derive_more::From, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("The MMDS patch request doesn't fit.")]
     DataStoreLimitExceeded,
@@ -55,7 +55,7 @@ pub enum Error {
     #[error("The MMDS data store is not initialized.")]
     NotInitialized,
     #[error("Token Authority error: {0}")]
-    TokenAuthority(TokenError),
+    TokenAuthority(#[from] TokenError),
     #[error("Cannot retrieve value. The value has an unsupported type.")]
     UnsupportedValueType,
 }

--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -45,11 +45,11 @@ const TOKEN_LENGTH_LIMIT: usize = 70;
 /// too much memory when deserializing tokens.
 const DESERIALIZATION_BYTES_LIMIT: usize = std::mem::size_of::<Token>();
 
-#[derive(Debug, derive_more::From, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to extract entropy from /dev/urandom entropy pool: {0}.")]
     /// Failed to extract entropy from pool.
-    EntropyPool(io::Error),
+    EntropyPool(#[from] io::Error),
     /// Failed to extract expiry from token sequence.
     #[error("Failed to extract expiry value from token.")]
     ExpiryExtraction,
@@ -66,7 +66,7 @@ pub enum Error {
     InvalidTtlValue(u32),
     /// Token serialization failed.
     #[error("Bincode serialization failed: {0}.")]
-    Serialization(BincodeError),
+    Serialization(#[from] BincodeError),
     /// Failed to encrypt token.
     #[error("Failed to encrypt token.")]
     TokenEncryption,

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/seccompiler_bin.rs"
 
 [dependencies]
 bincode = "1.2.1"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 libc = "0.2.117"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -4,10 +4,8 @@
 //! This module defines the data structures used for the intermmediate representation (IR),
 //! as well as the logic for compiling the filter into BPF code, the final form of the filter.
 
-use core::fmt::Formatter;
 use std::collections::BTreeMap;
 use std::convert::{Into, TryFrom, TryInto};
-use std::fmt::Display;
 
 use serde::{Deserialize, Deserializer};
 
@@ -129,20 +127,11 @@ pub(crate) enum TargetArch {
 }
 
 /// Errors related to target arch.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub(crate) enum TargetArchError {
     /// Invalid string.
+    #[error("Invalid target arch string: {0}")]
     InvalidString(String),
-}
-
-impl Display for TargetArchError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::TargetArchError::*;
-
-        match *self {
-            InvalidString(ref arch) => write!(f, "Invalid target arch string: {}", arch),
-        }
-    }
 }
 
 impl TargetArch {

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -34,14 +34,14 @@ use crate::syscall_table::SyscallTable;
 type Result<T> = result::Result<T, Error>;
 
 /// Errors compiling Filters into BPF.
-#[derive(Debug, PartialEq, derive_more::From, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub(crate) enum Error {
     /// Filter and default actions are equal.
     #[error("`filter_action` and `default_action` are equal.")]
     IdenticalActions,
     /// Error from the SeccompFilter.
     #[error("{0}")]
-    SeccompFilter(SeccompFilterError),
+    SeccompFilter(#[from] SeccompFilterError),
     /// Invalid syscall name for the given arch.
     #[error("Invalid syscall name: {0} for given arch: {1:?}.")]
     SyscallName(String, TargetArch),

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -13,8 +13,8 @@ mod common;
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::Arc;
-use bincode::{DefaultOptions, Error as BincodeError, Options};
 
+use bincode::{DefaultOptions, Error as BincodeError, Options};
 use common::BPF_MAX_LEN;
 // Re-export the data types needed for calling the helper functions.
 pub use common::{sock_filter, BpfProgram};

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
-linux-loader = "0.8.1"
-vm-superio = "0.7.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"
+linux-loader = "0.8.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
+thiserror = "1.0.32"
 userfaultfd = "0.5.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = "0.1.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
-thiserror = "1.0.32"
+vm-superio = "0.7.0"
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[cfg(target_arch = "aarch64")]
@@ -33,44 +32,35 @@ use vm_allocator::{AddressAllocator, AllocPolicy, IdAllocator};
 use vm_memory::GuestAddress;
 
 /// Errors for MMIO device manager.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Allocation logic error.
+    #[error("Failed to allocate requested resource: {0}")]
     Allocator(vm_allocator::Error),
     /// Failed to insert device on the bus.
+    #[error("Failed to insert device on the bus: {0}")]
     BusInsert(devices::BusError),
     /// Appending to kernel command line failed.
+    #[error("Failed to allocate requested resourc: {0}")]
     Cmdline(linux_loader::cmdline::Error),
     /// The device couldn't be found on the bus.
+    #[error("Failed to find the device on the bus.")]
     DeviceNotFound,
     /// Incorrect device type.
+    #[error("Invalid device type found on the MMIO bus.")]
     InvalidDeviceType,
     /// Internal device error.
+    #[error("{0}")]
     InternalDeviceError(String),
     /// Invalid configuration attempted.
+    #[error("Invalid MMIO IRQ configuration.")]
     InvalidIrqConfig,
     /// Registering an IO Event failed.
+    #[error("Failed to register IO event: {0}")]
     RegisterIoEvent(kvm_ioctls::Error),
     /// Registering an IRQ FD failed.
+    #[error("Failed to register irqfd: {0}")]
     RegisterIrqFd(kvm_ioctls::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Allocator(err) => write!(f, "Failed to allocate requested resource: {err}"),
-            Error::BusInsert(err) => write!(f, "Failed to insert device on the bus: {err}",),
-            Error::Cmdline(err) => {
-                write!(f, "Failed to add device to the kernel command line: {err}")
-            }
-            Error::DeviceNotFound => write!(f, "Failed to find the device on the bus"),
-            Error::InvalidDeviceType => write!(f, "Invalid device type found on the MMIO bus"),
-            Error::InternalDeviceError(err) => write!(f, "{err}"),
-            Error::InvalidIrqConfig => write!(f, "Invalid MMIO IRQ configuration"),
-            Error::RegisterIoEvent(err) => write!(f, "Failed to register IO event: {err}"),
-            Error::RegisterIrqFd(err) => write!(f, "Failed to register irqfd: {err}"),
-        }
-    }
 }
 
 type Result<T> = ::std::result::Result<T, Error>;

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Error {
             }
             Error::EventFd(err) => write!(f, "failed to create or clone event descriptor: {}", err),
             Error::IncorrectDeviceType => write!(f, "incorrect device type"),
-            Error::InternalDeviceError(err) => write!(f, "device error: {}", err),
+            Error::InternalDeviceError(err) => write!(f, "{err}"),
             Error::InvalidInput => write!(f, "invalid configuration"),
             Error::RegisterIoEvent(e) => write!(f, "failed to register IO event: {}", e),
             Error::RegisterIrqFd(e) => write!(f, "failed to register irqfd: {}", e),

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -351,7 +351,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                             MMIO_LEN,
                             AllocPolicy::ExactMatch(state.device_info.addr),
                         )
-                        .map_err(|e| Error::DeviceManager(super::mmio::Error::AllocatorError(e)))?;
+                        .map_err(|e| Error::DeviceManager(super::mmio::Error::Allocator(e)))?;
 
                     dev_manager.register_mmio_serial(
                         vm,
@@ -368,7 +368,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                             MMIO_LEN,
                             AllocPolicy::ExactMatch(state.device_info.addr),
                         )
-                        .map_err(|e| Error::DeviceManager(super::mmio::Error::AllocatorError(e)))?;
+                        .map_err(|e| Error::DeviceManager(super::mmio::Error::Allocator(e)))?;
                     dev_manager.register_mmio_rtc(rtc, Some(state.device_info.clone()))?;
                 }
             }
@@ -405,7 +405,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
                     MMIO_LEN,
                     AllocPolicy::ExactMatch(device_info.addr),
                 )
-                .map_err(|e| Error::DeviceManager(super::mmio::Error::AllocatorError(e)))?;
+                .map_err(|e| Error::DeviceManager(super::mmio::Error::Allocator(e)))?;
 
             dev_manager.register_mmio_virtio(vm, id.clone(), mmio_transport, device_info)?;
 

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -793,7 +793,7 @@ impl RuntimeApiController {
         if let Some(new_path) = new_cfg.path_on_host {
             vmm.update_block_device_path(&new_cfg.drive_id, new_path)
                 .map(|()| VmmData::Empty)
-                .map_err(DriveError::DeviceUpdate)?;
+                .map_err(DriveError::BlockDeviceUpdate)?;
         }
         if new_cfg.rate_limiter.is_some() {
             vmm.update_block_rate_limiter(
@@ -802,7 +802,7 @@ impl RuntimeApiController {
                 RateLimiterUpdate::from(new_cfg.rate_limiter).ops,
             )
             .map(|()| VmmData::Empty)
-            .map_err(DriveError::DeviceUpdate)?;
+            .map_err(DriveError::BlockDeviceUpdate)?;
         }
         Ok(VmmData::Empty)
     }
@@ -1963,7 +1963,7 @@ mod tests {
         });
         check_runtime_request_err(
             req,
-            VmmActionError::DriveConfig(DriveError::DeviceUpdate(VmmError::DeviceManager(
+            VmmActionError::DriveConfig(DriveError::BlockDeviceUpdate(VmmError::DeviceManager(
                 crate::device_manager::mmio::Error::IncorrectDeviceType,
             ))),
         );

--- a/src/vmm/src/rpc_interface.rs
+++ b/src/vmm/src/rpc_interface.rs
@@ -793,7 +793,7 @@ impl RuntimeApiController {
         if let Some(new_path) = new_cfg.path_on_host {
             vmm.update_block_device_path(&new_cfg.drive_id, new_path)
                 .map(|()| VmmData::Empty)
-                .map_err(DriveError::BlockDeviceUpdate)?;
+                .map_err(DriveError::DeviceUpdate)?;
         }
         if new_cfg.rate_limiter.is_some() {
             vmm.update_block_rate_limiter(
@@ -802,7 +802,7 @@ impl RuntimeApiController {
                 RateLimiterUpdate::from(new_cfg.rate_limiter).ops,
             )
             .map(|()| VmmData::Empty)
-            .map_err(DriveError::BlockDeviceUpdate)?;
+            .map_err(DriveError::DeviceUpdate)?;
         }
         Ok(VmmData::Empty)
     }
@@ -1101,7 +1101,7 @@ mod tests {
         pub fn update_block_device_path(&mut self, _: &str, _: String) -> Result<(), VmmError> {
             if self.force_errors {
                 return Err(VmmError::DeviceManager(
-                    crate::device_manager::mmio::Error::IncorrectDeviceType,
+                    crate::device_manager::mmio::Error::InvalidDeviceType,
                 ));
             }
             self.update_block_device_path_called = true;
@@ -1127,7 +1127,7 @@ mod tests {
         ) -> Result<(), VmmError> {
             if self.force_errors {
                 return Err(VmmError::DeviceManager(
-                    crate::device_manager::mmio::Error::IncorrectDeviceType,
+                    crate::device_manager::mmio::Error::InvalidDeviceType,
                 ));
             }
             self.update_net_rate_limiters_called = true;
@@ -1963,8 +1963,8 @@ mod tests {
         });
         check_runtime_request_err(
             req,
-            VmmActionError::DriveConfig(DriveError::BlockDeviceUpdate(VmmError::DeviceManager(
-                crate::device_manager::mmio::Error::IncorrectDeviceType,
+            VmmActionError::DriveConfig(DriveError::DeviceUpdate(VmmError::DeviceManager(
+                crate::device_manager::mmio::Error::InvalidDeviceType,
             ))),
         );
     }
@@ -1989,7 +1989,7 @@ mod tests {
         check_runtime_request_err(
             req,
             VmmActionError::NetworkConfig(NetworkInterfaceError::DeviceUpdate(
-                VmmError::DeviceManager(crate::device_manager::mmio::Error::IncorrectDeviceType),
+                VmmError::DeviceManager(crate::device_manager::mmio::Error::InvalidDeviceType),
             )),
         );
     }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -23,17 +23,14 @@ type Result<T> = result::Result<T, DriveError>;
 /// Errors associated with the operations allowed on a drive.
 #[derive(Debug)]
 pub enum DriveError {
-    /// Error during block device update (patch).
-    BlockDeviceUpdate(VmmError),
-    /// Unable to seek the block device backing file due to invalid permissions or
-    /// the file was corrupted.
+    /// Could not create a Block Device.
     CreateBlockDevice(BlockError),
     /// Failed to create a `RateLimiter` object.
     CreateRateLimiter(io::Error),
+    /// Error during block device update (patch).
+    DeviceUpdate(VmmError),
     /// The block device path is invalid.
     InvalidBlockDevicePath(String),
-    /// Cannot open block device due to invalid permissions or path.
-    OpenBlockDevice(io::Error),
     /// A root block device was already added.
     RootBlockDeviceAlreadyAdded,
 }
@@ -42,17 +39,12 @@ impl Display for DriveError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::DriveError::*;
         match self {
-            BlockDeviceUpdate(err) => {
+            DeviceUpdate(err) => {
                 write!(f, "Unable to patch the block device: {err}")
             }
             CreateBlockDevice(err) => write!(f, "Unable to create the block device: {err:?}"),
-            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {}", err),
-            InvalidBlockDevicePath(path) => write!(f, "Invalid block device path: {}", path),
-            OpenBlockDevice(err) => write!(
-                f,
-                "Cannot open block device. Invalid permission/path: {}",
-                err
-            ),
+            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {err}"),
+            InvalidBlockDevicePath(path) => write!(f, "Invalid block device path: {path}"),
             RootBlockDeviceAlreadyAdded => write!(f, "A root block device already exists!"),
         }
     }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -39,11 +39,9 @@ impl Display for DriveError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use self::DriveError::*;
         match self {
-            DeviceUpdate(err) => {
-                write!(f, "Unable to patch the block device: {err}")
-            }
             CreateBlockDevice(err) => write!(f, "Unable to create the block device: {err:?}"),
             CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {err}"),
+            DeviceUpdate(err) => write!(f, "Unable to patch the block device: {err}"),
             InvalidBlockDevicePath(path) => write!(f, "Invalid block device path: {path}"),
             RootBlockDeviceAlreadyAdded => write!(f, "A root block device already exists!"),
         }

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -3,7 +3,6 @@
 
 use std::collections::VecDeque;
 use std::convert::TryInto;
-use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -18,35 +17,27 @@ use serde::{Deserialize, Serialize};
 use super::RateLimiterConfig;
 use crate::Error as VmmError;
 
-type Result<T> = result::Result<T, DriveError>;
-
 /// Errors associated with the operations allowed on a drive.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DriveError {
     /// Could not create a Block Device.
+    #[error("Unable to create the block device: {0:?}")]
     CreateBlockDevice(BlockError),
     /// Failed to create a `RateLimiter` object.
+    #[error("Cannot create RateLimiter: {0}")]
     CreateRateLimiter(io::Error),
     /// Error during block device update (patch).
+    #[error("Unable to patch the block device: {0}")]
     DeviceUpdate(VmmError),
     /// The block device path is invalid.
+    #[error("Invalid block device path: {0}")]
     InvalidBlockDevicePath(String),
     /// A root block device was already added.
+    #[error("A root block device already exists!")]
     RootBlockDeviceAlreadyAdded,
 }
 
-impl Display for DriveError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::DriveError::*;
-        match self {
-            CreateBlockDevice(err) => write!(f, "Unable to create the block device: {err:?}"),
-            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {err}"),
-            DeviceUpdate(err) => write!(f, "Unable to patch the block device: {err}"),
-            InvalidBlockDevicePath(path) => write!(f, "Invalid block device path: {path}"),
-            RootBlockDeviceAlreadyAdded => write!(f, "A root block device already exists!"),
-        }
-    }
-}
+type Result<T> = result::Result<T, DriveError>;
 
 /// Use this structure to set up the Block Device before booting the kernel.
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -60,23 +60,23 @@ pub struct NetworkInterfaceUpdateConfig {
     pub tx_rate_limiter: Option<RateLimiterConfig>,
 }
 
-/// Errors associated with `NetworkInterfaceConfig`.
+/// Errors associated with the operations allowed on a net device.
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkInterfaceError {
-    /// Could not create Network Device
-    #[error("Could not create Network Device: {0}")]
+    /// Could not create the network device.
+    #[error("Could not create the network device: {0}")]
     CreateNetworkDevice(#[from] devices::virtio::net::Error),
     /// Failed to create a `RateLimiter` object
-    #[error("Failed to create a `RateLimiter` object: {0}")]
+    #[error("Cannot create the rate limiter: {0}")]
     CreateRateLimiter(#[from] std::io::Error),
-    /// The MAC address is already in use
+    /// Error during interface update (patch).
+    #[error("Unable to update the net device: {0}")]
+    DeviceUpdate(#[from] VmmError),
+    /// The MAC address is already in use.
     #[error("The MAC address is already in use: {0}")]
     GuestMacAddressInUse(String),
-    /// Error during interface update (patch)
-    #[error("Error during interface update (patch): {0}")]
-    DeviceUpdate(#[from] VmmError),
-    /// Cannot open/create tap device
-    #[error("Cannot open/create tap device: {0}")]
+    /// Cannot open/create the tap device.
+    #[error("Cannot open/create the tap device: {0}")]
     OpenTap(#[from] TapError),
 }
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.88, "AMD": 81.86, "ARM": 82.36}
+    COVERAGE_DICT = {"Intel": 82.98, "AMD": 81.92, "ARM": 82.43}
 else:
-    COVERAGE_DICT = {"Intel": 80.02, "AMD": 78.99, "ARM": 79.27}
+    COVERAGE_DICT = {"Intel": 80.11, "AMD": 79.05, "ARM": 79.34}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -263,7 +263,7 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
         iface_id="1", host_dev_name=second_if_name, guest_mac="06:00:00:00:00:01"
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert "Could not create Network Device" in response.text
+    assert "Could not create the network device" in response.text
 
     # Updates to a network interface with an available name are allowed.
     iface_id = "1"

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -74,10 +74,9 @@ def test_drive_io_engine(test_microvm_with_api, network_config):
     if not supports_io_uring:
         # The Async engine is not supported for older kernels.
         assert test_microvm.api_session.is_status_bad_request(response.status_code)
-
         test_microvm.check_log_message(
             "Received Error. Status code: 400 Bad Request. Message: Unable"
-            " to create the block device FileEngine(UnsupportedEngine(Async))"
+            " to create the block device: FileEngine(UnsupportedEngine(Async))"
         )
 
         # Now configure the default engine type and check that it works.
@@ -906,7 +905,7 @@ def _drive_patch(test_microvm):
     response = test_microvm.drive.patch(drive_id="scratch", path_on_host="foo.bar")
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert (
-        "drive update (patch): device error: BackingFile(Os { code: 2, "
+        "Unable to patch the block device: BackingFile(Os { code: 2, "
         'kind: NotFound, message: \\"No such file or directory\\" })' in response.text
     )
 

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -75,7 +75,7 @@ def test_attach_too_many_devices(test_microvm_with_api, network_config):
     response = test_microvm.actions.put(action_type="InstanceStart")
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     error_str = (
-        "failed to allocate requested resource: The requested resource"
+        "Failed to allocate requested resource: The requested resource"
         " is not available."
     )
     assert error_str in response.text

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -75,8 +75,8 @@ def test_multi_queue_unsupported(test_microvm_with_api):
     )
 
     assert response.json()["fault_message"] == (
-        "Could not create Network Device: Open tap device failed:"
+        "Could not create the network device: Open tap device failed:"
         " Error while creating ifreq structure: Invalid argument (os error 22)."
         " Invalid TUN/TAP Backend provided by {}. Check our documentation on setting"
-        " up the network devices"
+        " up the network devices."
     ).format(tapname)


### PR DESCRIPTION
Signed-off-by: Diana Popa <dpopa@amazon.com>

## Changes

* be consistent when referring to the block device (sometimes it would be block device, sometimes drive)
* remove unused error entry

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
