### PR TITLE
Update rust-vmm/vmm-sys-util to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
 dependencies = [
  "bitflags",
  "libc",

--- a/src/arch/src/x86_64/interrupts.rs
+++ b/src/arch/src/x86_64/interrupts.rs
@@ -9,7 +9,7 @@ use kvm_bindings::kvm_lapic_state;
 use kvm_ioctls::VcpuFd;
 use utils::byte_order;
 /// Errors thrown while configuring the LAPIC.
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
     /// Failure in getting the LAPIC configuration.
     #[error("Failure in getting the LAPIC configuration: {0}")]
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_apic_delivery_mode() {
-        let mut v: Vec<u32> = (0..20).map(|_| utils::rand::xor_psuedo_rng_u32()).collect();
+        let mut v: Vec<u32> = (0..20).map(|_| utils::rand::xor_pseudo_rng_u32()).collect();
 
         v.iter_mut()
             .for_each(|x| *x = set_apic_delivery_mode(*x, 2));

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -19,7 +19,7 @@ const PDPTE_START: u64 = 0xa000;
 const PDE_START: u64 = 0xb000;
 
 /// Errors thrown while setting up x86_64 registers.
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
     /// Failed to get SREGs for this CPU.
     #[error("Failed to get SREGs for this CPU: {0}")]
@@ -52,7 +52,7 @@ pub enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 /// Error type for [`setup_fpu`].
-#[derive(Debug, derive_more::From, PartialEq)]
+#[derive(Debug, derive_more::From, PartialEq, Eq)]
 pub struct SetupFpuError(utils::errno::Error);
 impl std::error::Error for SetupFpuError {}
 impl fmt::Display for SetupFpuError {
@@ -81,7 +81,7 @@ pub fn setup_fpu(vcpu: &VcpuFd) -> std::result::Result<(), SetupFpuError> {
 }
 
 /// Error type of [`setup_regs`].
-#[derive(Debug, derive_more::From, PartialEq)]
+#[derive(Debug, derive_more::From, PartialEq, Eq)]
 pub struct SetupRegistersError(utils::errno::Error);
 impl std::error::Error for SetupRegistersError {}
 impl fmt::Display for SetupRegistersError {
@@ -120,7 +120,7 @@ pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64) -> std::result::Result<(), SetupR
 }
 
 /// Error type for [`setup_sregs`].
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SetupSpecialRegistersError {
     /// Failed to get special registers
     #[error("Failed to get special registers: {0}")]

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -437,7 +437,7 @@ pub mod test {
                 addr += len as u64;
                 // Add small random gaps between descriptor addresses in order to make sure we
                 // don't blindly read contiguous memory.
-                addr += utils::rand::xor_psuedo_rng_u32() as u64 % 10;
+                addr += utils::rand::xor_pseudo_rng_u32() as u64 % 10;
             }
 
             // Mark the chain as available.

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -9,7 +9,7 @@
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize, Wrapping};
 
 use bitflags::bitflags;
-use utils::rand::xor_psuedo_rng_u32;
+use utils::rand::xor_pseudo_rng_u32;
 
 use crate::pdu::bytes::NetworkBytes;
 use crate::pdu::tcp::{Error as TcpSegmentError, Flags as TcpFlags, TcpSegment};
@@ -240,7 +240,7 @@ impl Connection {
         let ack_to_send = Wrapping(segment.sequence_number()) + Wrapping(1);
 
         // Let's pick the initial sequence number.
-        let isn = Wrapping(xor_psuedo_rng_u32());
+        let isn = Wrapping(xor_pseudo_rng_u32());
         let first_not_sent = isn + Wrapping(1);
         let remote_rwnd_edge = first_not_sent + Wrapping(u32::from(segment.window_size()));
 

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -60,5 +60,5 @@ fn rand_bytes_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> Vec<u8> {
 
 /// Get a pseudo random vector of length `len` with bytes.
 pub fn rand_bytes(len: usize) -> Vec<u8> {
-    rand_bytes_impl(&rand::xor_psuedo_rng_u32, len)
+    rand_bytes_impl(&rand::xor_pseudo_rng_u32, len)
 }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -166,7 +166,7 @@ impl Display for Error {
 type Result<T> = result::Result<T, Error>;
 
 /// Error type for [`KvmVcpu::get_tsc_khz`] and [`KvmVcpu::is_tsc_scaling_required`].
-#[derive(Debug, derive_more::From, PartialEq)]
+#[derive(Debug, derive_more::From, PartialEq, Eq)]
 pub struct GetTscError(utils::errno::Error);
 impl fmt::Display for GetTscError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -175,7 +175,7 @@ impl fmt::Display for GetTscError {
 }
 impl std::error::Error for GetTscError {}
 /// Error type for [`KvmVcpu::set_tsc_khz`].
-#[derive(Debug, derive_more::From, PartialEq)]
+#[derive(Debug, derive_more::From, PartialEq, Eq)]
 pub struct SetTscError(kvm_ioctls::Error);
 impl fmt::Display for SetTscError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -67,7 +67,7 @@ pub enum Error {
 
 /// Error type for [`Vm::restore_state`]
 #[cfg(target_arch = "x86_64")]
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum RestoreStateError {
     #[error("{0}")]
     SetPit2(kvm_ioctls::Error),

--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
 dependencies = [
  "bitflags",
  "libc",

--- a/tests/integration_tests/security/demo_seccomp/Cargo.lock
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
 dependencies = [
  "bitflags",
  "libc",


### PR DESCRIPTION
See https://github.com/firecracker-microvm/firecracker/pull/3249 and https://github.com/firecracker-microvm/firecracker/pull/3248.

rust-vmm/event-manager still uses comparision requirements, so we have to play catch up with any new rust-vmm version for now

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
