### PR TITLE
Revert "make tests fail when criteria not found"

### DIFF
--- a/tests/framework/stats/consumer.py
+++ b/tests/framework/stats/consumer.py
@@ -7,8 +7,7 @@ from abc import ABC, abstractmethod
 from numbers import Number
 from typing import Any, Callable
 from collections import defaultdict
-from framework.utils import ExceptionAggregator, get_kernel_version
-from framework.utils_cpuid import get_cpu_model_name, get_instance_type
+from framework.utils import ExceptionAggregator
 
 from .criteria import CriteriaException
 from .metadata import Provider as MetadataProvider
@@ -142,16 +141,6 @@ class Consumer(ABC):
                         self._failure_aggregator.add_row(fail_msg)
                         if fail_fast:
                             raise self._failure_aggregator
-                else:
-                    self._statistics[ms_name][st_def.name]["outcome"] = "FAILED"
-                    fail_msg = (
-                        f"'{ms_name}/{st_def.name}': Criteria not found for "
-                        f"{get_instance_type()} / {get_cpu_model_name()} / "
-                        f"kernel {get_kernel_version(1)}."
-                    )
-                    self._failure_aggregator.add_row(fail_msg)
-                    if fail_fast:
-                        raise self._failure_aggregator
 
         self._reset()
 


### PR DESCRIPTION
## Changes

This reverts commit 082e58fbd931040a777da06f963eab71b6e8b8ff ([PR/3245](https://github.com/firecracker-microvm/firecracker/pull/3245)).

## Description

A change was introduced in [PR/3245](https://github.com/firecracker-microvm/firecracker/pull/3245) to force performance tests to fail if a given baseline configuration was missing for a given CPU. While this seems to have had the desired affect, the commit did not include baseline configurations for actual missing configurations:

* Intel m6i (4.14) - Vsock Throughput
* Intel m6i (5.10) - Vsock Throughput
* Intel m6i (4.14) - Network TCP Throughput
* Intel m6i (5.10) - Network TCP Throughput
* Arm (4.14) - Vsock Throughput

While the change is good and should be introduced, results in failures of performance pipelines for missing performance baseline configuration. This makes it harder to tell if other regressions are introduced as the performance pipelines are consistently in alarm. This change needs to be re-introduced with the missing baselines before merging into firecracker:main.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
