### PR TITLE
tests: make tests fail when baseline not found

### DIFF
--- a/tests/framework/stats/criteria.py
+++ b/tests/framework/stats/criteria.py
@@ -54,6 +54,9 @@ class ComparisonCriteria(ABC):
     @property
     def target(self):
         """Return criteria target."""
+        if self._baseline is None:
+            raise CriteriaException("Baseline data not defined.")
+
         target = self._baseline.get("target")
         if target is None:
             raise CriteriaException("Baseline target not defined.")
@@ -122,6 +125,9 @@ class EqualWith(ComparisonCriteria):
     @property
     def delta(self):
         """Return the `delta` field of the baseline."""
+        if self._baseline is None:
+            raise CriteriaException("Baseline data not defined.")
+
         delta = self._baseline.get("delta")
         if delta is None:
             raise CriteriaException("Baseline delta not defined.")


### PR DESCRIPTION
## Reason

When baseline is not available, performance tests pass without any errors.
By making tests fail in such situations, we can be aware of missing performance baselines.

## Changes

Raise exception when baseline is not available.

## Context

A commit which has the same purpose was merged in PR #3245 .
But since it lead many false alarms, it was reverted in PR #3253 .
Before submitting this PR, I confirmed that it doesn't generate those false alarms and make tests fail correctly when baseline is not available.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
