### PR TITLE
CI: enforce clippy rules in clippy command

### DIFF
--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -6,8 +6,6 @@
 // found in the THIRD-PARTY file.
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -5,9 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 //! Emulates virtual and hardware devices.
 use std::io;
 

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -1,9 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 mod api_server_adapter;
 mod metrics;
 

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! High-level interface over Linux io_uring.
 //!

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -1,9 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 mod cgroup;
 mod chroot;
 mod env;

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Crate that implements Firecracker specific functionality as far as logging and metrics
 //! collecting.

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 pub mod data_store;
 pub mod ns;
 pub mod persist;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! # Rate Limiter
 //!

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -1,9 +1,6 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -1,8 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! The library crate that defines common helper functions that are generally used in
 //! conjunction with seccompiler-bin.

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Provides version tolerant serialization and deserialization facilities and
 //! implements a persistent storage format for Firecracker state snapshots.

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).
 // More specifically, we are re-exporting modules from `vmm_sys_util` as part

--- a/src/vm-memory/src/lib.rs
+++ b/src/vm-memory/src/lib.rs
@@ -4,7 +4,6 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 use std::io::Error as IoError;
 use std::os::unix::io::AsRawFd;
@@ -103,7 +102,7 @@ fn build_guarded_region(
     // SAFETY: Safe because the parameters are valid.
     unsafe {
         MmapRegionBuilder::new_with_bitmap(size, bitmap)
-            .with_raw_mmap_pointer(region_addr as *mut u8)
+            .with_raw_mmap_pointer(region_addr.cast::<u8>())
             .with_mmap_prot(prot)
             .with_mmap_flags(flags)
             .build()

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -5,11 +5,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#![deny(missing_docs)]
+
 //! Virtual Machine Monitor that leverages the Linux Kernel-based Virtual Machine (KVM),
 //! and other virtualization features to run a single lightweight micro-virtual
 //! machine (microVM).
-#![deny(missing_docs)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -668,7 +668,7 @@ fn guest_memory_from_uffd(
         let host_base_addr = mem_region.as_ptr();
         let size = mem_region.size();
 
-        uffd.register(host_base_addr as _, size as _)
+        uffd.register(host_base_addr.cast(), size as _)
             .map_err(GuestMemoryFromUffdError::Register)?;
         backend_mappings.push(GuestRegionUffdMapping {
             base_host_virt_addr: host_base_addr as u64,

--- a/tests/integration_tests/build/test_clippy.py
+++ b/tests/integration_tests/build/test_clippy.py
@@ -13,6 +13,7 @@ TARGETS = [
     "{}-unknown-linux-gnu".format(MACHINE),
     "{}-unknown-linux-musl".format(MACHINE),
 ]
+CLIPPY_CFG = ["ptr_as_ptr", "undocumented_unsafe_blocks"]
 
 
 @pytest.mark.parametrize("target", TARGETS)
@@ -22,6 +23,8 @@ def test_rust_clippy(target):
 
     @type: build
     """
-    utils.run_cmd(
-        "cargo clippy --target {} --all --profile test" " -- -D warnings".format(target)
-    )
+    cmd = "cargo clippy --target {} --all --profile test" " --".format(target)
+    for clippy_rule in CLIPPY_CFG:
+        cmd += " -D clippy::{}".format(clippy_rule)
+    cmd += " -D warnings"
+    utils.run_cmd(cmd)


### PR DESCRIPTION
## Changes

* move clippy rules from source files to clippy integ test

## Reason

* does not pollute code
* enfroces the clippy rules on all ulterior source files/crates

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
