### PR TITLE
devices: add documentation for legacy devices

### DIFF
--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -113,6 +113,20 @@ impl I8042Device {
         }
     }
 
+    /// Signal a ctrl-alt-del (reset) event.
+    #[inline]
+    pub fn trigger_ctrl_alt_del(&mut self) -> Result<()> {
+        // The CTRL+ALT+DEL sequence is 4 bytes in total (1 extended key + 2 normal keys).
+        // Fail if we don't have room for the whole sequence.
+        if BUF_SIZE - self.buf_len() < 4 {
+            return Err(Error::InternalBufferFull);
+        }
+        self.trigger_key(KEY_CTRL)?;
+        self.trigger_key(KEY_ALT)?;
+        self.trigger_key(KEY_DEL)?;
+        Ok(())
+    }
+
     fn trigger_kbd_interrupt(&self) -> Result<()> {
         if (self.control & CB_KBD_INT) == 0 {
             warn!("Failed to trigger i8042 kbd interrupt (disabled by guest OS)");
@@ -137,20 +151,6 @@ impl I8042Device {
             Ok(_) | Err(Error::KbdInterruptDisabled) => Ok(()),
             Err(err) => Err(err),
         }
-    }
-
-    /// Signal a ctrl-alt-del (reset) event.
-    #[inline]
-    pub fn trigger_ctrl_alt_del(&mut self) -> Result<()> {
-        // The CTRL+ALT+DEL sequence is 4 bytes in total (1 extended key + 2 normal keys).
-        // Fail if we don't have room for the whole sequence.
-        if BUF_SIZE - self.buf_len() < 4 {
-            return Err(Error::InternalBufferFull);
-        }
-        self.trigger_key(KEY_CTRL)?;
-        self.trigger_key(KEY_ALT)?;
-        self.trigger_key(KEY_DEL)?;
-        Ok(())
     }
 
     #[inline]

--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -13,19 +13,20 @@ use utils::eventfd::EventFd;
 
 use crate::bus::BusDevice;
 
+/// Errors thrown by the i8042 device.
 #[derive(Debug)]
 pub enum Error {
-    CloneCpuResetEvt(io::Error),
+    /// Failure in triggering the keyboard interrupt (guest disabled).
     KbdInterruptDisabled,
+    /// Failure in triggering the keyboard interrupt.
     KbdInterruptFailure(io::Error),
+    /// Internal i8042 buffer is full.
     InternalBufferFull,
 }
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::CloneCpuResetEvt(io_err) => {
-                write!(f, "Could not clone CPU reset eventfd: {io_err}.",)
-            }
             Error::KbdInterruptDisabled => {
                 write!(f, "Keyboard interrupt disabled by guest driver.",)
             }
@@ -112,12 +113,7 @@ impl I8042Device {
         }
     }
 
-    /// Returns a clone of the CPU reset event fd
-    pub fn get_reset_evt_clone(&self) -> Result<EventFd> {
-        self.reset_evt.try_clone().map_err(Error::CloneCpuResetEvt)
-    }
-
-    pub fn trigger_kbd_interrupt(&self) -> Result<()> {
+    fn trigger_kbd_interrupt(&self) -> Result<()> {
         if (self.control & CB_KBD_INT) == 0 {
             warn!("Failed to trigger i8042 kbd interrupt (disabled by guest OS)");
             return Err(Error::KbdInterruptDisabled);
@@ -127,7 +123,7 @@ impl I8042Device {
             .map_err(Error::KbdInterruptFailure)
     }
 
-    pub fn trigger_key(&mut self, key: u16) -> Result<()> {
+    fn trigger_key(&mut self, key: u16) -> Result<()> {
         if key & 0xff00 != 0 {
             // Check if there is enough room in the buffer, before pushing an extended (2-byte) key.
             if BUF_SIZE - self.buf_len() < 2 {
@@ -143,6 +139,7 @@ impl I8042Device {
         }
     }
 
+    /// Signal a ctrl-alt-del (reset) event.
     #[inline]
     pub fn trigger_ctrl_alt_del(&mut self) -> Result<()> {
         // The CTRL+ALT+DEL sequence is 4 bytes in total (1 extended key + 2 normal keys).
@@ -337,7 +334,7 @@ mod tests {
             EventFd::new(libc::EFD_NONBLOCK).unwrap(),
             EventFd::new(libc::EFD_NONBLOCK).unwrap(),
         );
-        let reset_evt = i8042.get_reset_evt_clone().unwrap();
+        let reset_evt = i8042.reset_evt.try_clone().unwrap();
 
         // Check if reading in a 2-length array doesn't have side effects.
         let mut data = [1, 2];

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -5,10 +5,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+//! Implements legacy devices (UART, RTC etc).
 mod i8042;
 #[cfg(target_arch = "aarch64")]
 mod rtc_pl031;
-pub mod serial;
+mod serial;
 
 use std::io;
 use std::ops::Deref;
@@ -19,9 +20,11 @@ use vm_superio::Trigger;
 pub use self::i8042::{Error as I8042DeviceError, I8042Device};
 #[cfg(target_arch = "aarch64")]
 pub use self::rtc_pl031::RTCDevice;
-pub use self::serial::{SerialDevice, SerialEventsWrapper, SerialWrapper};
+pub use self::serial::{
+    ReadableFd, SerialDevice, SerialEventsWrapper, SerialWrapper, IER_RDA_BIT, IER_RDA_OFFSET,
+};
 
-/// Newtype for implementing the trigger functionality for `EventFd`.
+/// Wrapper for implementing the trigger functionality for `EventFd`.
 ///
 /// The trigger is used for handling events in the legacy devices.
 pub struct EventFdTrigger(EventFd);
@@ -33,20 +36,26 @@ impl Trigger for EventFdTrigger {
         self.write(1)
     }
 }
+
 impl Deref for EventFdTrigger {
     type Target = EventFd;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
+
 impl EventFdTrigger {
+    /// Clone an `EventFdTrigger`.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(EventFdTrigger((**self).try_clone()?))
     }
+
+    /// Create an `EventFdTrigger`.
     pub fn new(evt: EventFd) -> Self {
         Self(evt)
     }
 
+    /// Get the associated event fd out of an `EventFdTrigger`.
     pub fn get_event(&self) -> EventFd {
         self.0.try_clone().unwrap()
     }

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -11,7 +11,6 @@ use crate::BusDevice;
 pub type RTCDevice = vm_superio::Rtc<Arc<RTCDeviceMetrics>>;
 
 // Implements Bus functions for AMBA PL031 RTC device
-#[cfg(target_arch = "aarch64")]
 impl BusDevice for RTCDevice {
     fn read(&mut self, offset: u64, data: &mut [u8]) {
         if data.len() == 4 {

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+//! Implements a wrapper over an UART serial device.
 use std::io::Write;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
@@ -58,8 +59,11 @@ impl<EV: SerialEvents, W: Write> RawIOHandler for Serial<EventFdTrigger, EV, W> 
     }
 }
 
+/// Wrapper over available events (i.e metrics, buffer ready etc).
 pub struct SerialEventsWrapper {
+    /// Metrics for this serial device.
     pub metrics: Arc<SerialDeviceMetrics>,
+    /// Buffer ready event.
     pub buffer_ready_event_fd: Option<EventFdTrigger>,
 }
 
@@ -91,8 +95,11 @@ impl SerialEvents for SerialEventsWrapper {
     }
 }
 
+/// Wrapper over the imported serial device.
 pub struct SerialWrapper<T: Trigger, EV: SerialEvents, W: Write> {
+    /// Serial device object.
     pub serial: Serial<T, EV, W>,
+    /// Input to the serial device (needs to be readable).
     pub input: Option<Box<dyn ReadableFd + Send>>,
 }
 
@@ -154,7 +161,7 @@ impl<W: Write> SerialWrapper<EventFdTrigger, SerialEventsWrapper, W> {
         self.input.as_ref().map_or(-1, |input| input.as_raw_fd())
     }
 
-    pub fn consume_buffer_ready_event(&self) -> io::Result<u64> {
+    fn consume_buffer_ready_event(&self) -> io::Result<u64> {
         self.serial
             .events()
             .buffer_ready_event_fd
@@ -163,6 +170,7 @@ impl<W: Write> SerialWrapper<EventFdTrigger, SerialEventsWrapper, W> {
     }
 }
 
+/// Type for representing a serial device.
 pub type SerialDevice =
     SerialWrapper<EventFdTrigger, SerialEventsWrapper, Box<dyn io::Write + Send>>;
 

--- a/src/devices/tests/serial_utils/mod.rs
+++ b/src/devices/tests/serial_utils/mod.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::os::raw::c_void;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use devices::legacy::serial::ReadableFd;
+use devices::legacy::ReadableFd;
 
 pub struct MockSerialInput(pub RawFd);
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -12,10 +12,11 @@ use std::sync::{Arc, Mutex};
 use arch::InitrdConfig;
 #[cfg(target_arch = "x86_64")]
 use cpuid::common::is_same_model;
-use devices::legacy::serial::ReadableFd;
 #[cfg(target_arch = "aarch64")]
 use devices::legacy::RTCDevice;
-use devices::legacy::{EventFdTrigger, SerialDevice, SerialEventsWrapper, SerialWrapper};
+use devices::legacy::{
+    EventFdTrigger, ReadableFd, SerialDevice, SerialEventsWrapper, SerialWrapper,
+};
 use devices::virtio::{Balloon, Block, MmioTransport, Net, VirtioDevice, Vsock, VsockUnixBackend};
 use event_manager::{MutEventSubscriber, SubscriberOps};
 use libc::EFD_NONBLOCK;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -41,7 +41,7 @@ use std::time::Duration;
 use std::{fmt, io};
 
 use arch::DeviceType;
-use devices::legacy::serial::{IER_RDA_BIT, IER_RDA_OFFSET};
+use devices::legacy::{IER_RDA_BIT, IER_RDA_OFFSET};
 use devices::virtio::balloon::Error as BalloonError;
 use devices::virtio::{
     Balloon, BalloonConfig, BalloonStats, Block, MmioTransport, Net, BALLOON_DEV_ID, TYPE_BALLOON,

--- a/src/vmm/src/utilities/mock_devices/mod.rs
+++ b/src/vmm/src/utilities/mock_devices/mod.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use devices::legacy::serial::ReadableFd;
+use devices::legacy::ReadableFd;
 
 pub struct MockSerialInput(pub File);
 


### PR DESCRIPTION
## Changes

* add doc (i.e /// comments) for public facing struct for legacy devices

## Reason

* nit improvements

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
