### PR TITLE
chore(tests): add more logs to some intermittently failing tests

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -55,7 +55,8 @@ step_block_unless_maintainer = {
 step_style = {
     "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
     "label": "🪶 Style",
-    # no agent tags, it doesn't matter where this runs
+    # we only install the required dependencies in x86_64
+    "agents": ["platform=x86_64.metal"]
 }
 
 build_grp = group(

--- a/tests/integration_tests/build/test_pylint.py
+++ b/tests/integration_tests/build/test_pylint.py
@@ -20,7 +20,7 @@ def test_python_pylint():
         '--variable-rgx="[a-z_][a-z0-9_]{1,30}$" --disable='
         "fixme,too-many-instance-attributes,import-error,"
         "too-many-locals,too-many-arguments,consider-using-f-string,"
-        "consider-using-with,implicit-str-concat"
+        "consider-using-with,implicit-str-concat,line-too-long"
     )
 
     # Get all *.py files from the project

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -8,7 +8,11 @@ import tempfile
 import pytest
 from test_balloon import _test_rss_memory_lower
 from conftest import _test_images_s3_bucket
-from framework.artifacts import ArtifactCollection, create_net_devices_configuration
+from framework.artifacts import (
+    ArtifactCollection,
+    FirecrackerArtifact,
+    create_net_devices_configuration,
+)
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
 from framework.utils import get_firecracker_version_from_toml
 import host_tools.network as net_tools  # pylint: disable=import-error
@@ -21,7 +25,26 @@ net_ifaces = create_net_devices_configuration(4)
 scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
 
 
-def test_restore_old_snapshot(bin_cloner_path):
+def firecracker_artifacts(*args, **kwargs):
+    """Return all available firecracker binaries."""
+    artifacts = ArtifactCollection(_test_images_s3_bucket())
+    # Fetch all firecracker binaries.
+    return artifacts.firecrackers(*args, **kwargs)
+
+
+def firecracker_id(fc):
+    """Render a nice ID for pytest parametrize."""
+    if isinstance(fc, FirecrackerArtifact):
+        return f"firecracker-{fc.version}"
+    return None
+
+
+@pytest.mark.parametrize(
+    "firecracker",
+    firecracker_artifacts(max_version=get_firecracker_version_from_toml()),
+    ids=firecracker_id,
+)
+def test_restore_old_snapshot(bin_cloner_path, firecracker):
     """
     Restore from snapshots obtained with previous versions of Firecracker.
 
@@ -31,54 +54,57 @@ def test_restore_old_snapshot(bin_cloner_path):
     logger = logging.getLogger("old_snapshot_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
 
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch all firecracker binaries.
     # With each binary create a snapshot and try to restore in current
     # version.
-    firecracker_artifacts = artifacts.firecrackers(
-        max_version=get_firecracker_version_from_toml()
+
+    firecracker.download()
+    jailer = firecracker.jailer()
+    jailer.download()
+
+    logger.info("Creating snapshot with Firecracker: %s", firecracker.local_path())
+    logger.info("Using Jailer: %s", jailer.local_path())
+
+    target_version = firecracker.base_name()[1:]
+
+    # v0.23 does not support creating diff snapshots.
+    # v0.23 does not support balloon.
+    diff_snapshots = "0.23" not in target_version
+
+    # Create a snapshot.
+    snapshot = create_snapshot_helper(
+        builder,
+        logger,
+        drives=scratch_drives,
+        ifaces=net_ifaces,
+        fc_binary=firecracker.local_path(),
+        jailer_binary=jailer.local_path(),
+        diff_snapshots=diff_snapshots,
+        balloon=diff_snapshots,
     )
 
-    for firecracker in firecracker_artifacts:
-        firecracker.download()
-        jailer = firecracker.jailer()
-        jailer.download()
-
-        logger.info("Creating snapshot with Firecracker: %s", firecracker.local_path())
-        logger.info("Using Jailer: %s", jailer.local_path())
-
-        target_version = firecracker.base_name()[1:]
-
-        # v0.23 does not support creating diff snapshots.
-        # v0.23 does not support balloon.
-        diff_snapshots = "0.23" not in target_version
-
-        # Create a snapshot.
-        snapshot = create_snapshot_helper(
-            builder,
-            logger,
-            drives=scratch_drives,
-            ifaces=net_ifaces,
-            fc_binary=firecracker.local_path(),
-            jailer_binary=jailer.local_path(),
-            diff_snapshots=diff_snapshots,
-            balloon=diff_snapshots,
-        )
-
-        # Resume microvm using current build of FC/Jailer.
-        microvm, _ = builder.build_from_snapshot(
-            snapshot, resume=True, diff_snapshots=False
-        )
-        validate_all_devices(
-            logger, microvm, net_ifaces, scratch_drives, diff_snapshots
-        )
-        logger.debug("========== Firecracker restore snapshot log ==========")
-        logger.debug(microvm.log_data)
+    # Resume microvm using current build of FC/Jailer.
+    microvm, _ = builder.build_from_snapshot(
+        snapshot, resume=True, diff_snapshots=False
+    )
+    validate_all_devices(logger, microvm, net_ifaces, scratch_drives, diff_snapshots)
+    logger.debug("========== Firecracker restore snapshot log ==========")
+    logger.debug(microvm.log_data)
 
 
-def test_restore_old_version(bin_cloner_path):
+@pytest.mark.parametrize(
+    "firecracker",
+    firecracker_artifacts(
+        min_version="1.2.0",
+        max_version=get_firecracker_version_from_toml(),
+    ),
+    ids=firecracker_id,
+)
+def test_restore_old_version(bin_cloner_path, firecracker):
     """
     Restore current snapshot with previous versions of Firecracker.
+
+    Current snapshot (i.e a machine snapshotted with current build) is
+    incompatible with any past release due to notification suppression.
 
     @type: functional
     """
@@ -86,51 +112,42 @@ def test_restore_old_version(bin_cloner_path):
     logger = logging.getLogger("old_snapshot_version_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
 
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch all firecracker binaries.
     # Create a snapshot with current build and restore with each FC binary
     # artifact.
-    firecracker_artifacts = artifacts.firecrackers(
-        # current snapshot (i.e a machine snapshotted with current build)
-        # is incompatible with any past release due to notification suppression.
-        min_version="1.2.0",
-        max_version=get_firecracker_version_from_toml(),
+    firecracker.download()
+    jailer = firecracker.jailer()
+    jailer.download()
+
+    logger.info("Creating snapshot with local build")
+
+    # Old version from artifact.
+    target_version = firecracker.base_name()[1:]
+
+    # Create a snapshot with current FC version targeting the old version.
+    snapshot = create_snapshot_helper(
+        builder,
+        logger,
+        target_version=target_version,
+        drives=scratch_drives,
+        ifaces=net_ifaces,
+        balloon=True,
+        diff_snapshots=True,
     )
-    for firecracker in firecracker_artifacts:
-        firecracker.download()
-        jailer = firecracker.jailer()
-        jailer.download()
 
-        logger.info("Creating snapshot with local build")
+    logger.info("Restoring snapshot with Firecracker: %s", firecracker.local_path())
+    logger.info("Using Jailer: %s", jailer.local_path())
 
-        # Old version from artifact.
-        target_version = firecracker.base_name()[1:]
-
-        # Create a snapshot with current FC version targeting the old version.
-        snapshot = create_snapshot_helper(
-            builder,
-            logger,
-            target_version=target_version,
-            drives=scratch_drives,
-            ifaces=net_ifaces,
-            balloon=True,
-            diff_snapshots=True,
-        )
-
-        logger.info("Restoring snapshot with Firecracker: %s", firecracker.local_path())
-        logger.info("Using Jailer: %s", jailer.local_path())
-
-        # Resume microvm using FC/Jailer binary artifacts.
-        vm, _ = builder.build_from_snapshot(
-            snapshot,
-            resume=True,
-            diff_snapshots=False,
-            fc_binary=firecracker.local_path(),
-            jailer_binary=jailer.local_path(),
-        )
-        validate_all_devices(logger, vm, net_ifaces, scratch_drives, True)
-        logger.debug("========== Firecracker restore snapshot log ==========")
-        logger.debug(vm.log_data)
+    # Resume microvm using FC/Jailer binary artifacts.
+    vm, _ = builder.build_from_snapshot(
+        snapshot,
+        resume=True,
+        diff_snapshots=False,
+        fc_binary=firecracker.local_path(),
+        jailer_binary=jailer.local_path(),
+    )
+    validate_all_devices(logger, vm, net_ifaces, scratch_drives, True)
+    logger.debug("========== Firecracker restore snapshot log ==========")
+    logger.debug(vm.log_data)
 
 
 @pytest.mark.skipif(platform.machine() != "x86_64", reason="TSC is x86_64 specific.")

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -8,6 +8,8 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from conftest import _test_images_s3_bucket
 from framework.artifacts import ArtifactCollection, ArtifactSet
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
@@ -40,38 +42,59 @@ def _get_guest_drive_size(ssh_connection, guest_dev_name="/dev/vdb"):
     return stdout.readline().strip()
 
 
-def _test_seq_snapshots(context):
-    logger = context.custom["logger"]
-    seq_len = context.custom["seq_len"]
-    vm_builder = context.custom["builder"]
-    snapshot_type = context.custom["snapshot_type"]
+ARTIFACTS = ArtifactCollection(_test_images_s3_bucket())
+
+# Testing matrix:
+# - Guest kernel: All supported ones
+# - Rootfs: Ubuntu 18.04
+# - Microvm: 2vCPU with 512 MB RAM
+# TODO: Multiple microvm sizes must be tested in the async pipeline.
+@pytest.mark.parametrize(
+    "microvm", ARTIFACTS.microvms(keyword="2vcpu_512mb"), ids=lambda x: x.name()
+)
+@pytest.mark.parametrize("kernel", ARTIFACTS.kernels(), ids=lambda x: x.name())
+@pytest.mark.parametrize(
+    "disk", ARTIFACTS.disks(keyword="ubuntu"), ids=lambda x: x.name()
+)
+@pytest.mark.parametrize("snapshot_type", [SnapshotType.DIFF, SnapshotType.FULL])
+def test_5_snapshots(
+    bin_cloner_path,
+    bin_vsock_path,
+    test_fc_session_root_path,
+    microvm,
+    kernel,
+    disk,
+    snapshot_type,
+):
+    """
+    Create and load 5 snapshots.
+
+    @type: functional
+    """
+    logger = logging.getLogger("snapshot_sequence")
+
+    vm_builder = MicrovmBuilder(bin_cloner_path)
+    seq_len = 5
     diff_snapshots = snapshot_type == SnapshotType.DIFF
 
-    logger.info(
-        'Testing {} with microvm: "{}", kernel {}, disk {} '.format(
-            snapshot_type,
-            context.microvm.name(),
-            context.kernel.name(),
-            context.disk.name(),
-        )
-    )
+    disk.download()
+    kernel.download()
+    microvm.download()
 
     # Create a rw copy artifact.
-    root_disk = context.disk.copy()
+    root_disk = disk.copy()
     # Get ssh key from read-only artifact.
-    ssh_key = context.disk.ssh_key()
+    ssh_key = disk.ssh_key()
     # Create a fresh microvm from artifacts.
     vm_instance = vm_builder.build(
-        kernel=context.kernel,
+        kernel=kernel,
         disks=[root_disk],
         ssh_key=ssh_key,
-        config=context.microvm,
+        config=microvm,
         diff_snapshots=diff_snapshots,
     )
     basevm = vm_instance.vm
-    basevm.vsock.put(
-        vsock_id="vsock0", guest_cid=3, uds_path="/{}".format(VSOCK_UDS_PATH)
-    )
+    basevm.vsock.put(vsock_id="vsock0", guest_cid=3, uds_path=f"/{VSOCK_UDS_PATH}")
 
     basevm.start()
     ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
@@ -80,15 +103,13 @@ def _test_seq_snapshots(context):
     exit_code, _, _ = ssh_connection.execute_command("sync")
     assert exit_code == 0
 
-    test_fc_session_root_path = context.custom["test_fc_session_root_path"]
-    vsock_helper = context.custom["bin_vsock_path"]
     vm_blob_path = "/tmp/vsock/test.blob"
     # Generate a random data file for vsock.
     blob_path, blob_hash = make_blob(test_fc_session_root_path)
     # Copy the data file and a vsock helper to the guest.
-    _copy_vsock_data_to_guest(ssh_connection, blob_path, vm_blob_path, vsock_helper)
+    _copy_vsock_data_to_guest(ssh_connection, blob_path, vm_blob_path, bin_vsock_path)
 
-    logger.info("Create {} #0.".format(snapshot_type))
+    logger.info("Create %s #0.", snapshot_type)
     # Create a snapshot builder from a microvm.
     snapshot_builder = SnapshotBuilder(basevm)
 
@@ -99,7 +120,7 @@ def _test_seq_snapshots(context):
     basevm.kill()
 
     for i in range(seq_len):
-        logger.info("Load snapshot #{}, mem {}".format(i, snapshot.mem))
+        logger.info("Load snapshot #%s, mem %s", i, snapshot.mem)
         microvm, _ = vm_builder.build_from_snapshot(
             snapshot, resume=True, diff_snapshots=diff_snapshots
         )
@@ -117,7 +138,7 @@ def _test_seq_snapshots(context):
         # Check that the root device is not corrupted.
         check_filesystem(ssh_connection, "ext4", "/dev/vda")
 
-        logger.info("Create snapshot #{}.".format(i + 1))
+        logger.info("Create snapshot #%d.", i + 1)
 
         # Create a snapshot builder from the currently running microvm.
         snapshot_builder = SnapshotBuilder(microvm)
@@ -129,7 +150,7 @@ def _test_seq_snapshots(context):
         # If we are testing incremental snapshots we must merge the base with
         # current layer.
         if snapshot_type == SnapshotType.DIFF:
-            logger.info("Base: {}, Layer: {}".format(base_snapshot.mem, snapshot.mem))
+            logger.info("Base: %s, Layer: %s", base_snapshot.mem, snapshot.mem)
             snapshot.rebase_snapshot(base_snapshot)
             # Update the base for next iteration.
             base_snapshot = snapshot
@@ -242,88 +263,6 @@ def test_patch_drive_snapshot(bin_cloner_path):
     assert guest_drive_size == str(scratchdisk1.size())
 
     microvm.kill()
-
-
-def test_5_full_snapshots(
-    network_config, bin_cloner_path, bin_vsock_path, test_fc_session_root_path
-):
-    """
-    Create and load 5 full sequential snapshots.
-
-    @type: functional
-    """
-    logger = logging.getLogger("snapshot_sequence")
-
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Testing matrix:
-    # - Guest kernel: All supported ones
-    # - Rootfs: Ubuntu 18.04
-    # - Microvm: 2vCPU with 512 MB RAM
-    # TODO: Multiple microvm sizes must be tested in the async pipeline.
-    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_512mb"))
-    kernel_artifacts = ArtifactSet(artifacts.kernels())
-    disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
-
-    # Create a test context and add builder, logger, network.
-    test_context = TestContext()
-    test_context.custom = {
-        "builder": MicrovmBuilder(bin_cloner_path),
-        "network_config": network_config,
-        "logger": logger,
-        "snapshot_type": SnapshotType.FULL,
-        "seq_len": 5,
-        "bin_vsock_path": bin_vsock_path,
-        "test_fc_session_root_path": test_fc_session_root_path,
-    }
-
-    # Create the test matrix.
-    test_matrix = TestMatrix(
-        context=test_context,
-        artifact_sets=[microvm_artifacts, kernel_artifacts, disk_artifacts],
-    )
-
-    test_matrix.run_test(_test_seq_snapshots)
-
-
-def test_5_inc_snapshots(
-    network_config, bin_cloner_path, bin_vsock_path, test_fc_session_root_path
-):
-    """
-    Create and load 5 incremental snapshots.
-
-    @type: functional
-    """
-    logger = logging.getLogger("snapshot_sequence")
-
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Testing matrix:
-    # - Guest kernel: All supported ones
-    # - Rootfs: Ubuntu 18.04
-    # - Microvm: 2vCPU with 512MB RAM
-    # TODO: Multiple microvm sizes must be tested in the async pipeline.
-    microvm_artifacts = ArtifactSet(artifacts.microvms(keyword="2vcpu_512mb"))
-    kernel_artifacts = ArtifactSet(artifacts.kernels())
-    disk_artifacts = ArtifactSet(artifacts.disks(keyword="ubuntu"))
-
-    # Create a test context and add builder, logger, network.
-    test_context = TestContext()
-    test_context.custom = {
-        "builder": MicrovmBuilder(bin_cloner_path),
-        "network_config": network_config,
-        "logger": logger,
-        "snapshot_type": SnapshotType.DIFF,
-        "seq_len": 5,
-        "bin_vsock_path": bin_vsock_path,
-        "test_fc_session_root_path": test_fc_session_root_path,
-    }
-
-    # Create the test matrix.
-    test_matrix = TestMatrix(
-        context=test_context,
-        artifact_sets=[microvm_artifacts, kernel_artifacts, disk_artifacts],
-    )
-
-    test_matrix.run_test(_test_seq_snapshots)
 
 
 def test_load_snapshot_failure_handling(test_microvm_with_api):

--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -103,7 +103,6 @@ def _test_seq_snapshots(context):
         microvm, _ = vm_builder.build_from_snapshot(
             snapshot, resume=True, diff_snapshots=diff_snapshots
         )
-
         # Test vsock guest-initiated connections.
         path = os.path.join(
             microvm.path, make_host_port_path(VSOCK_UDS_PATH, ECHO_SERVER_PORT)

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -57,6 +57,8 @@ def _validate_license(filename):
             if line.startswith(("// Copyright", "# Copyright")):
                 copyright_info = line
                 break
+            if line == "":
+                return False
 
         has_amazon_copyright = _has_amazon_copyright(
             copyright_info

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -14,7 +14,7 @@ cache_dir = ../build/pytest_cache
 
 ; Set logger format and level
 log_level = INFO
-log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
+log_format = %(asctime)s.%(msecs)03d %(name)s: %(levelname)s %(message)s
 
 log_cli_level = ERROR
 log_cli = true

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 ; Omit verbose tracebacks, since they tend to pollute the output.
-addopts = --tb=short
+addopts =
+  --tb=short
+  --showlocals
 
 ; Overwrite the default norecurseirs, which includes 'build'.
 norecursedirs = .*


### PR DESCRIPTION
~It would be helpful to have more context on what commands were run and what they returned in the captured logs. This is helpful for troubleshooting.~

Turns out the logging can be megabytes in size, and can hide things like the traceback. So I am pulling that commit but including all the other little quality-of-life improvements I did to support it. 

Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

Increase the verbosity of the logger so that more messages appear in the logs.

## Reason

To help troubleshooting intermittent issues. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
