### PR TITLE
perf: add scripts to compare performance baselines

### DIFF
--- a/tools/compare_baselines/interactive.py
+++ b/tools/compare_baselines/interactive.py
@@ -1,0 +1,177 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare gathered baselines interactively."""
+
+import sys
+import json
+import enum
+import questionary
+
+from utils.comparator import BaseComparator
+from utils.defs import DEFAULT_BASELINE_DIRECTORY
+from utils.fetcher import BaselineDirectoryFetcher
+
+
+class Command(enum.Enum):
+    """List of commands"""
+
+    LOAD = "Load baseline JSON files"
+    COMPARE = "Compare baseline values"
+    QUIT = "Quit"
+
+
+class InteractiveComparator(BaseComparator):
+    """Class for comparing baselines interactively"""
+
+    def __init__(self):
+        super().__init__()
+        self._fetchers = {}
+
+    @property
+    def fethcers(self):
+        """Return fetchers"""
+        return self._fetchers
+
+    def cmd_loop(self):
+        """Main loop to receive command"""
+        while True:
+            cmd = questionary.select(
+                "Select command:",
+                choices=[c.value for c in Command],
+            ).ask()
+
+            if cmd == Command.LOAD.value:
+                self.cmd_load()
+            elif cmd == Command.COMPARE.value:
+                self.cmd_compare()
+            elif cmd == Command.QUIT.value:
+                print("Bye.")
+                break
+
+    def cmd_load(self):
+        """Load command"""
+        dpath = questionary.path(
+            "Enter directory path to load JSON:",
+            default=DEFAULT_BASELINE_DIRECTORY,
+        ).ask()
+        if not dpath:
+            return
+
+        dfetcher = BaselineDirectoryFetcher(dpath)
+        self._fetchers.update(dfetcher.fetchers)
+
+    def cmd_compare(self):
+        """Compare command"""
+        # select
+        path1, instance1, model1 = self._select("source")
+        if path1 is None:
+            return
+
+        test = self._fetchers[path1].test
+        path2, instance2, model2 = self._select("target", test)
+        if path2 is None:
+            return
+
+        # calculate diff
+        diff = self.calc_diff(
+            self._fetchers[path1].get_baseline(instance1, model1),
+            self._fetchers[path2].get_baseline(instance2, model2),
+        )
+
+        # calculate stats
+        stats = self.calc_stats(diff)
+
+        # print to stdout
+        print(
+            f"Test: {test}\n"
+            f"Source:\n"
+            f"  Instance type: {instance1}\n"
+            f"  CPU model: {model1}\n"
+            f"  JSON path: {path1}\n"
+            f"Target:\n"
+            f"  Instance type: {instance2}\n"
+            f"  CPU model: {model2}\n"
+            f"  JSON path: {path2}\n"
+            f"Stats:\n"
+            f"{json.dumps(stats, indent=4)}"
+        )
+
+        # dump results
+        data = {
+            "test": test,
+            "source": {
+                "path": path1,
+                "instance": instance1,
+                "model": model1,
+            },
+            "target": {"path": path1, "instance": instance2, "model": model2},
+            "diff": diff,
+            "stats": stats,
+        }
+        self._dump(data)
+
+    def _select(self, sample, test=None):
+        """Select a baseline"""
+        # select file
+        if test:
+            choices = [f.fpath for f in self._fetchers.values() if f.test == test]
+        else:
+            choices = self._fetchers.keys()
+
+        if len(choices) == 0:
+            print(
+                "No available data. Please import JSON files.",
+                file=sys.stderr,
+            )
+            return None, None, None
+
+        path = questionary.select(
+            f"Select path for {sample} sample:",
+            choices=sorted(choices),
+        ).ask()
+        if not path:
+            return None, None, None
+
+        # select instance type
+        instance = questionary.select(
+            f"Select instance type for {sample} sample:",
+            choices=self._fetchers[path].get_instances(),
+        ).ask()
+        if not instance:
+            return None, None, None
+
+        # select CPU model
+        models = self._fetchers[path].get_models(instance)
+        if len(models) == 1:
+            model = models[0]
+        else:
+            model = questionary.select(
+                f"Select CPU for {sample} sample:",
+                choices=models,
+            ).ask()
+            if not model:
+                return None, None, None
+
+        return path, instance, model
+
+    def _dump(self, data):
+        """Dump results"""
+        ofile = questionary.text(
+            "Enter file path to dump (Keep empty not to dump):"
+        ).ask()
+        if not ofile:
+            return
+
+        dumped = json.dumps(data, indent=4)
+        with open(ofile, "w", encoding="utf-8") as file:
+            file.write(dumped)
+
+
+def main():
+    """Main function"""
+    comp = InteractiveComparator()
+    comp.cmd_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_baselines/main.py
+++ b/tools/compare_baselines/main.py
@@ -1,0 +1,222 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare gathered baselines"""
+
+import os
+import argparse
+import subprocess
+
+from utils.comparator import DirectoryComparator, CpuComparator
+from utils.defs import (
+    DEFAULT_BASELINE_DIRECTORY,
+    DEFAULT_RESULT_FILEPATH,
+    CODENAME2DICT,
+    TESTS,
+    KERNELS,
+)
+
+
+def cmd_cpu(args):
+    """Compare baselines between CPUs"""
+    comp = CpuComparator(
+        args.directory,
+        args.tests,
+        args.kernels,
+        args.codenames,
+    )
+    comp.compare()
+    comp.dump_json(args.output)
+
+
+def cmd_directory(args):
+    """Comparre baselines between two directories"""
+    comp = DirectoryComparator(
+        args.source,
+        args.target,
+        args.tests,
+        args.kernels,
+        args.codenames,
+    )
+    comp.compare(args.auxiliary)
+    comp.dump_json(args.output)
+
+
+def cmd_commit(args):
+    """Compare baselines between two commit hashes"""
+    if args.target is None:
+        args.target = (
+            subprocess.check_output(["git", "show", "--format='%H'", "--no-patch"])[:-1]
+            .decode()
+            .strip("'")
+        )
+
+    subprocess.run(["git", "worktree", "add", args.source, args.source], check=True)
+    subprocess.run(["git", "worktree", "add", args.target, args.target], check=True)
+
+    comp = DirectoryComparator(
+        os.path.join(args.source, args.directory),
+        os.path.join(args.target, args.directory),
+        args.tests,
+        args.kernels,
+        args.codenames,
+    )
+
+    subprocess.run(["git", "worktree", "remove", args.source], check=True)
+    subprocess.run(["git", "worktree", "remove", args.target], check=True)
+
+    comp.compare(args.auxiliary)
+    comp.dump_json(args.output)
+
+
+def cmd_latest(args):
+    """Compare baselines with the latest commit"""
+    latest_hash = (
+        subprocess.check_output(["git", "show", "--format='%H'", "--no-patch"])[:-1]
+        .decode()
+        .strip("'")
+    )
+
+    subprocess.run(["git", "worktree", "add", latest_hash, latest_hash], check=True)
+
+    comp = DirectoryComparator(
+        os.path.join(latest_hash, args.directory),
+        os.path.join(args.directory),
+        args.tests,
+        args.kernels,
+        args.codenames,
+    )
+
+    subprocess.run(["git", "worktree", "remove", latest_hash], check=True)
+
+    comp.compare(args.auxiliary)
+    comp.dump_json(args.output)
+
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(description="Compare gathered baselines")
+
+    # Shared options for all subcommands
+    shared_parser = argparse.ArgumentParser(add_help=False)
+    shared_parser.add_argument(
+        "--tests",
+        help="List of test types",
+        nargs="+",
+        action="store",
+        choices=TESTS,
+        default=TESTS,
+    )
+    shared_parser.add_argument(
+        "--kernels",
+        help="List of host kernel versions",
+        nargs="+",
+        action="store",
+        choices=KERNELS,
+        default=KERNELS,
+    )
+    shared_parser.add_argument(
+        "--codenames",
+        help="List of CPU codenames. The first one is used as basis.",
+        action="store",
+        nargs="+",
+        choices=list(CODENAME2DICT.keys()),
+        default=list(CODENAME2DICT.keys()),
+    )
+    shared_parser.add_argument(
+        "-o",
+        "--output",
+        help="Path of output file.",
+        action="store",
+        default=DEFAULT_RESULT_FILEPATH,
+    )
+    shared_parser.add_argument(
+        "-a",
+        "--auxiliary",
+        help="Include auxiliary information",
+        action="store_true",
+    )
+
+    subparsers = parser.add_subparsers(title="modes")
+
+    # Subcommand options for comparing baselines between CPUs
+    parser_cpu = subparsers.add_parser(
+        "cpu", parents=[shared_parser], help="Compare between CPUs."
+    )
+    parser_cpu.set_defaults(handler=cmd_cpu)
+    parser_cpu.add_argument(
+        "-d",
+        "--directory",
+        help="Path of directory containing JSON files of baselines.",
+        action="store",
+        default=DEFAULT_BASELINE_DIRECTORY,
+    )
+
+    # Subcommand options for comparing baselines between directories
+    parser_dir = subparsers.add_parser(
+        "directory", parents=[shared_parser], help="Compare between two directories."
+    )
+    parser_dir.set_defaults(handler=cmd_directory)
+    parser_dir.add_argument(
+        "-s",
+        "--source",
+        help="Path of source directory containing JSON files of baselines.",
+        action="store",
+        required=True,
+    )
+    parser_dir.add_argument(
+        "-t",
+        "--target",
+        help="Path of target directory containing JSON files of baselines.",
+        action="store",
+        required=True,
+    )
+
+    # Subcommand options for comparing baselines between commit hashes
+    parser_commit = subparsers.add_parser(
+        "commit", parents=[shared_parser], help="Compare between two commit hashes."
+    )
+    parser_commit.set_defaults(handler=cmd_commit)
+    parser_commit.add_argument(
+        "-d",
+        "--directory",
+        help="Path of directory containing JSON files of baselines.",
+        action="store",
+        default=DEFAULT_BASELINE_DIRECTORY,
+    )
+    parser_commit.add_argument(
+        "-s",
+        "--source",
+        help="Source commit hash.",
+        action="store",
+        required=True,
+    )
+    parser_commit.add_argument(
+        "-t",
+        "--target",
+        help="Target commit hash.",
+        action="store",
+    )
+
+    # Subcommand options for comparing baselines with the latest commit
+    parser_latest = subparsers.add_parser(
+        "latest", parents=[shared_parser], help="Compare with the latest commit."
+    )
+    parser_latest.set_defaults(handler=cmd_latest)
+    parser_latest.add_argument(
+        "-d",
+        "--directory",
+        help="Path of directory containing JSON files of baselines.",
+        action="store",
+        default=DEFAULT_BASELINE_DIRECTORY,
+    )
+
+    # Parse arguments
+    args = parser.parse_args()
+    if hasattr(args, "handler"):
+        args.handler(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_baselines/utils/__init__.py
+++ b/tools/compare_baselines/utils/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for comparing performance baselines"""
+
+from . import comparator
+from . import defs
+from . import fetcher

--- a/tools/compare_baselines/utils/comparator.py
+++ b/tools/compare_baselines/utils/comparator.py
@@ -1,0 +1,285 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utility classes to compare baseline data"""
+
+import sys
+import math
+import json
+
+from utils.defs import CODENAME2DICT, BASELINE_FILENAME_FORMAT
+from utils.fetcher import BaselineDirectoryFetcher
+
+
+EPS = sys.float_info.epsilon
+
+
+class BaseComparator:
+    """Base class for comparing baselines"""
+
+    def __init__(self):
+        self._result = {}
+
+    @property
+    def result(self):
+        """Return result"""
+        return self._result
+
+    def calc_diff(self, bl1, bl2):
+        """Calculate difference between two baselines."""
+        diff = {}
+        self._calc_diff(bl1, bl2, diff)
+        return diff
+
+    def _calc_diff(self, bl1, bl2, diff):
+        """Go down nested structure and populate difference."""
+        for key in bl1.keys() & bl2.keys():
+            if key == "target":
+                diff["target_diff_percentage"] = (
+                    (bl2[key] + EPS) / (bl1[key] + EPS) - 1.0
+                ) * 100.0
+            elif key == "delta_percentage":
+                diff["delta_percentage_diff"] = (
+                    bl2["delta_percentage"] - bl1["delta_percentage"]
+                )
+            else:
+                diff.setdefault(key, {})
+                self._calc_diff(bl1[key], bl2[key], diff[key])
+
+    def calc_stats(self, diff):
+        """Calculate mean and unbiased standard deviation for each metric."""
+        stats = {}
+
+        for metric in diff.keys():
+            stats[metric] = {}
+
+            for key in ["target_diff_percentage", "delta_percentage_diff"]:
+                aggregated = []
+                self._aggregate_data(diff[metric], key, aggregated)
+
+                mean = self._calc_mean(aggregated)
+                stdev = self._calc_stdev(aggregated, mean)
+
+                stats[metric][key] = {
+                    "mean": mean,
+                    "stdev": stdev,
+                }
+
+        return stats
+
+    def _aggregate_data(self, data, key, result):
+        """Aggregate data into list"""
+        for value in data.values():
+            if key in value:
+                result.append(value[key])
+            else:
+                self._aggregate_data(value, key, result)
+
+    def _calc_mean(self, data):
+        """Calculate mean for given list."""
+        if len(data) == 0:
+            return None
+
+        total = 0
+        for value in data:
+            total += value
+        return total / len(data)
+
+    def _calc_stdev(self, data, mean):
+        """Calculate unbiased standard deviation for given list."""
+        if len(data) == 0 or mean is None:
+            return None
+
+        var = 0
+        for value in data:
+            var += (value - mean) * (value - mean)
+        return math.sqrt(var / (len(data) - 1))
+
+    def dump_json(self, fpath):
+        """Dump results to JSON file"""
+        dumped = json.dumps(self._result, indent=4)
+        with open(fpath, "w", encoding="utf-8") as file:
+            file.write(dumped)
+
+
+class DirectoryComparator(BaseComparator):
+    """Class for comparing baselines between directories"""
+
+    def __init__(self, dpath1, dpath2, tests, kernels, codenames):
+        """Initialize 2 BaselineDirectoryFetcher"""
+        super().__init__()
+        self._dfetcher1 = BaselineDirectoryFetcher(dpath1)
+        self._dfetcher2 = BaselineDirectoryFetcher(dpath2)
+        self._tests = tests
+        self._kernels = kernels
+        self._codenames = codenames
+
+    def compare(self, auxiliary=False):
+        """Compare data between directories"""
+        result = {
+            "source": self._dfetcher1.dpath,
+            "target": self._dfetcher2.dpath,
+        }
+
+        for test in self._tests:
+            for kernel in self._kernels:
+                fname = BASELINE_FILENAME_FORMAT.format(test=test, kernel=kernel)
+
+                fetcher1 = self._dfetcher1.get_fetcher(test, kernel)
+                if fetcher1 is None:
+                    print(
+                        f"{fname} not found in {self._dfetcher1.dpath}",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                fetcher2 = self._dfetcher2.get_fetcher(test, kernel)
+                if fetcher2 is None:
+                    print(
+                        f"{fname} not found in {self._dfetcher2.dpath}",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                result[fname] = {
+                    "test": test,
+                    "kernel": kernel,
+                    "cpus": [],
+                }
+
+                for codename in self._codenames:
+                    cpu = CODENAME2DICT[codename]
+
+                    baseline1 = fetcher1.get_baseline(cpu["instance"], cpu["model"])
+                    if baseline1 is None:
+                        print(
+                            f"Baseline for {cpu['instance']} / {cpu['model']} not found"
+                            f" in {fetcher1.fpath}.",
+                            file=sys.stderr,
+                        )
+                        continue
+
+                    baseline2 = fetcher2.get_baseline(cpu["instance"], cpu["model"])
+                    if baseline2 is None:
+                        print(
+                            f"Baseline for {cpu['instance']} / {cpu['model']} not found"
+                            f" in {fetcher2.fpath}.",
+                            file=sys.stderr,
+                        )
+                        continue
+
+                    diff = self.calc_diff(baseline1, baseline2)
+                    stats = self.calc_stats(diff)
+
+                    cpu_result = {
+                        "instance": cpu["instance"],
+                        "model": cpu["model"],
+                        "stats": stats,
+                    }
+                    if auxiliary:
+                        cpu_result["diff"] = diff
+
+                    result[fname]["cpus"].append(cpu_result)
+
+        self._result = result
+
+
+class CpuComparator(BaseComparator):
+    """Class for comparing baselines between CPUs"""
+
+    def __init__(self, dpath, tests, kernels, codenames):
+        """Initialize CPU comparator"""
+        super().__init__()
+        self._dpath = dpath
+        self._tests = tests
+        self._kernels = kernels
+        self._codenames = codenames
+        self._dfetcher = BaselineDirectoryFetcher(dpath)
+
+    def compare(self, auxiliary=False):
+        """Calculate differences and statistics based on the first CPU."""
+        result = {}
+
+        for test in self._tests:
+            for kernel in self._kernels:
+                fname = BASELINE_FILENAME_FORMAT.format(test=test, kernel=kernel)
+
+                fetcher = self._dfetcher.get_fetcher(test, kernel)
+                if fetcher is None:
+                    print(
+                        f"{fname} not found in {self._dfetcher.dpath}",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                base_cpu = CODENAME2DICT[self._codenames[0]]
+                base_instance = base_cpu["instance"]
+                base_model = base_cpu["model"]
+                base_baseline = fetcher.get_baseline(base_instance, base_model)
+                if base_baseline is None:
+                    print(
+                        f"Baseline for {base_instance} / {base_model} not found"
+                        f" in {fetcher.fpath}.",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                # fmt: off
+                result[fetcher.fpath] = {
+                    "test": fetcher.test,
+                    "kernel": fetcher.kernel,
+                    "base": {
+                        "instance": base_instance,
+                        "model": base_cpu,
+                    },
+                    "stats": {},
+                }
+                if auxiliary:
+                    result[fetcher.fpath]["diff"] = []
+                # fmt: on
+
+                for codename in self._codenames:
+                    target_cpu = CODENAME2DICT[codename]
+                    target_instance = target_cpu["instance"]
+                    target_model = target_cpu["model"]
+
+                    target_baseline = fetcher.get_baseline(
+                        target_instance, target_model
+                    )
+                    if target_baseline is None:
+                        print(
+                            f"Baseline for {target_instance} / {target_model} not found"
+                            f" in {fetcher.fpath}.",
+                            file=sys.stderr,
+                        )
+                        continue
+
+                    diff = self.calc_diff(base_baseline, target_baseline)
+                    if auxiliary:
+                        result[fetcher.fpath]["diff"].append(
+                            {
+                                "instance": target_instance,
+                                "model": target_model,
+                                "value": diff,
+                            }
+                        )
+
+                    stats = self.calc_stats(diff)
+                    for metric, data in stats.items():
+                        result[fetcher.fpath]["stats"].setdefault(
+                            metric,
+                            {
+                                "target_diff_percentage": [],
+                                "delta_percentage_diff": [],
+                            },
+                        )
+
+                        for key in ["target_diff_percentage", "delta_percentage_diff"]:
+                            result[fetcher.fpath]["stats"][metric][key].append(
+                                {
+                                    "instance": target_instance,
+                                    "model": target_model,
+                                    "value": data[key],
+                                }
+                            )
+
+        self._result = result

--- a/tools/compare_baselines/utils/defs.py
+++ b/tools/compare_baselines/utils/defs.py
@@ -1,0 +1,58 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Some common definitions used in different modules"""
+
+
+# fmt: off
+CODENAME2DICT = {
+    "skylake": {
+        "instance": "m5d.metal",
+        "model": "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",
+    },
+    "cascadelake": {
+        "instance": "m5d.metal",
+        "model": "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz",
+    },
+    "icelake": {
+        "instance": "m6i.metal",
+        "model": "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+    },
+    "milan": {
+        "instance": "m6a.metal",
+        "model": "AMD EPYC 7R13 48-Core Processor"
+    },
+    "graviton2": {
+        "instance": "m6g.metal",
+        "model": "ARM_NEOVERSE_N1"
+    },
+}
+# fmt: on
+
+MODEL2SHORT = {
+    "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz": "m5d/SL",
+    "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz": "m5d/CL",
+    "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz": "m6i",
+    "AMD EPYC 7R13 48-Core Processor": "m6a",
+    "ARM_NEOVERSE_N1": "m6g",
+}
+
+DEFAULT_BASELINE_DIRECTORY = "tests/integration_tests/performance/configs/"
+
+BASELINE_FILENAME_PATTERN = r"^test_(.+)_config_(.+).json"
+
+BASELINE_FILENAME_FORMAT = "test_{test}_config_{kernel}.json"
+
+DEFAULT_RESULT_FILEPATH = "comparison_result.json"
+
+TESTS = [
+    "block_performance",
+    "network_latency",
+    "network_tcp_throughput",
+    "snap_restore_performance",
+    "vsock_throughput",
+]
+
+KERNELS = [
+    "4.14",
+    "5.10",
+]

--- a/tools/compare_baselines/utils/fetcher.py
+++ b/tools/compare_baselines/utils/fetcher.py
@@ -1,0 +1,139 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Utility classes to fetch baseline data"""
+
+
+import os
+import re
+import json
+import glob
+
+from utils.defs import BASELINE_FILENAME_PATTERN
+
+
+class InvalidFilenameError(Exception):
+    """Error for invalid file name"""
+
+    def __init__(self, fname):
+        self._message = (
+            f"{fname} does not match the pattern " f"`{BASELINE_FILENAME_PATTERN}`."
+        )
+        super().__init__(self._message)
+
+    def __str__(self):
+        return self._message
+
+
+class BaselineFileFetcher:
+    """Class for fetching baselines from file."""
+
+    def __init__(self, fpath):
+        """Initialize baseline fetcher"""
+        fname = os.path.basename(fpath)
+        match = re.match(BASELINE_FILENAME_PATTERN, fname)
+        if match is None:
+            raise InvalidFilenameError(fname)
+
+        self._fpath = fpath
+        self._fname = fname
+        self._test = match.group(1)
+        self._kernel = match.group(2)
+        with open(fpath, "r", encoding="utf-8") as file:
+            self._raw = json.load(file)
+
+    @property
+    def fpath(self):
+        """Return path of baseline file"""
+        return self._fpath
+
+    @property
+    def fname(self):
+        """Return file name of baseline file"""
+        return self._fname
+
+    @property
+    def test(self):
+        """Return test type"""
+        return self._test
+
+    @property
+    def kernel(self):
+        """Return kernel version"""
+        return self._kernel
+
+    def get_baseline(self, instance, model):
+        """Get baseline values by instance type and CPU model"""
+        if instance not in self._raw["hosts"]["instances"]:
+            return None
+
+        baselines = list(
+            filter(
+                lambda cpu_baseline: cpu_baseline["model"] == model,
+                self._raw["hosts"]["instances"][instance]["cpus"],
+            )
+        )
+
+        if len(baselines) == 0:
+            return None
+
+        return baselines[0]["baselines"]
+
+    def get_instances(self):
+        """Get list of instances"""
+        return list(self._raw["hosts"]["instances"].keys())
+
+    def get_models(self, instance):
+        """Get list of CPU models"""
+        return [m["model"] for m in self._raw["hosts"]["instances"][instance]["cpus"]]
+
+    def get_cpus(self):
+        """Get list of CPUs"""
+        result = []
+        for instance, value in self._raw["hosts"]["instances"].items():
+            cpus = value["cpus"]
+            for cpu in cpus:
+                result.append(
+                    {
+                        "instance": instance,
+                        "model": cpu["model"],
+                    }
+                )
+        return result
+
+
+class BaselineDirectoryFetcher:
+    """Class for fetching baselines from directory."""
+
+    def __init__(self, dpath):
+        paths = sorted(glob.glob(os.path.join(dpath, "*.json")))
+        pattern = re.compile(BASELINE_FILENAME_PATTERN)
+        paths = [path for path in paths if pattern.match(os.path.basename(path))]
+
+        self._dpath = dpath
+        self._fetchers = {}
+        for path in paths:
+            self._fetchers[path] = BaselineFileFetcher(path)
+
+    @property
+    def dpath(self):
+        """Return path of directory"""
+        return self._dpath
+
+    @property
+    def fetchers(self):
+        """Return lists of fetchers"""
+        return self._fetchers
+
+    def get_fetcher(self, test, kernel):
+        """Get fetcher with test type and kernel version"""
+        fetchers = list(
+            filter(
+                lambda f: f.test == test and f.kernel == kernel,
+                self._fetchers.values(),
+            )
+        )
+
+        if len(fetchers) == 0:
+            return None
+
+        return fetchers[0]


### PR DESCRIPTION
## Changes

Adds scripts to compare performance baselines

## Reason

There are several situations to compare gathered performance baselines:
- when we encounter some performance regressions
- when we support new instance types / CPUs

Currently, we don't have any tools to evaluate gathered baselines and we have no choices but to compare them one by one.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
