### PR TITLE
Selecting targer arch for Firecracker based on the host arch

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,9 +1,10 @@
-[build.'cfg(target_arch = "x86")']
+[build]
 target-dir = "build/cargo_target"
+
+[build.'cfg(target_arch = "x86")']
 target = "x86_64-unknown-linux-musl"
 
 [build.'cfg(target_arch = "aarch64")']
-target-dir = "build/cargo_target"
 target = "aarch64-unknown-linux-musl"
 
 [net]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,10 @@
-[build]
+[build.'cfg(target_arch = "x86")']
 target-dir = "build/cargo_target"
 target = "x86_64-unknown-linux-musl"
+
+[build.'cfg(target_arch = "aarch64")']
+target-dir = "build/cargo_target"
+target = "aarch64-unknown-linux-musl"
 
 [net]
 git-fetch-with-cli = true


### PR DESCRIPTION
## Changes
Modified `.cargo/config` to properly select build tartget depending on the host architecture.
So on `x86` -> `86_64-unknown-linux-musl`
and on `aarch64` -> `aarch64-unknown-linux-musl`
...

## Reason
Fixes: #3221
...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
