### PR TITLE
Use upstream rand_bytes() merged in vmm-sys-util

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -18,7 +18,7 @@ use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use utils::eventfd::EventFd;
 use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
-use utils::rand_bytes;
+use utils::rand::rand_bytes;
 use virtio_gen::virtio_net::{
     virtio_net_hdr_v1, VIRTIO_F_VERSION_1, VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_UFO,

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -33,32 +33,3 @@ pub fn get_page_size() -> Result<usize, errno::Error> {
         ps => Ok(ps as usize),
     }
 }
-
-// The below fucntions will get merged in rust-vmm function once we will upstream it there
-fn xor_pseudo_rng_u8_bytes(rand_fn: &dyn Fn() -> u32) -> Vec<u8> {
-    let mut r = vec![];
-
-    for n in &rand_fn().to_ne_bytes() {
-        r.push(*n);
-    }
-    r
-}
-
-fn rand_bytes_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut done = 0;
-    loop {
-        for n in xor_pseudo_rng_u8_bytes(rand_fn) {
-            done += 1;
-            buf.push(n);
-            if done >= len {
-                return buf;
-            }
-        }
-    }
-}
-
-/// Get a pseudo random vector of length `len` with bytes.
-pub fn rand_bytes(len: usize) -> Vec<u8> {
-    rand_bytes_impl(&rand::xor_pseudo_rng_u32, len)
-}


### PR DESCRIPTION
Signed-off-by: Vibha Acharya <vibharya@amazon.co.uk>

## Changes
Changes made to use upstream vmm-sys-util's rand_bytes() to generate random bytes for MAC address.


## Reason
PR raised for the function has been merged and released
Related to #3266

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
