### PR TITLE
Backport pipeline pr script to  FC 1.1

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -55,7 +55,8 @@ step_block_unless_maintainer = {
 step_style = {
     "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
     "label": "🪶 Style",
-    # no agent tags, it doesn't matter where this runs
+    # we only install the required dependencies in x86_64
+    "agents": ["platform=x86_64.metal"]
 }
 
 build_grp = group(

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite pipelines dynamically"""
+
+import json
+
+INSTANCES = [
+    "m5d.metal",
+    "m6i.metal",
+    "m6a.metal",
+    "m6gd.metal",
+]
+
+KERNELS = ["4.14", "5.10"]
+
+
+def group(group_name, command, agent_tags=None, priority=0, timeout=30):
+    """
+    Generate a group step with specified parameters, for each instance+kernel
+    combination
+
+    https://buildkite.com/docs/pipelines/group-step
+    """
+    if agent_tags is None:
+        agent_tags = []
+    # Use the 1st character of the group name (should be an emoji)
+    label1 = group_name[0]
+    steps = []
+    for instance in INSTANCES:
+        for kv in KERNELS:
+            agents = [
+                f"type={instance}",
+                f"kv={kv}",
+            ]
+            agents.extend(agent_tags)
+            step = {
+                "command": command,
+                "label": f"{label1} {instance} kv={kv}",
+                "priority": priority,
+                "timeout": timeout,
+                "agents": agents,
+            }
+            steps.append(step)
+
+    return {"group": group_name, "steps": steps}
+
+
+step_block_unless_maintainer = {
+    "block": "Waiting for approval to run",
+    "if": '(build.creator.teams includes "prod-compute-capsule") == false',
+}
+
+step_style = {
+    "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
+    "label": "🪶 Style",
+    # no agent tags, it doesn't matter where this runs
+}
+
+build_grp = group(
+    "📦 Build",
+    "./tools/devtool -y test -- ../tests/integration_tests/build/",
+    priority=1,
+)
+
+functional_1_grp = group(
+    "⚙ Functional [a-n]",
+    "./tools/devtool -y test -- `cd tests; ls integration_tests/functional/test_[a-n]*.py`",
+    priority=1,
+)
+
+functional_2_grp = group(
+    "⚙ Functional [o-z]",
+    "./tools/devtool -y test -- `cd tests; ls integration_tests/functional/test_[o-z]*.py`",
+    priority=1,
+)
+
+security_grp = group(
+    "🔒 Security",
+    "./tools/devtool -y test -- ../tests/integration_tests/security/",
+    priority=1,
+)
+
+performance_grp = group(
+    "⏱ Performance",
+    "./tools/devtool -y test -- ../tests/integration_tests/performance/",
+    priority=1,
+    agent_tags=["ag=1"],
+)
+
+pipeline = {
+    "agents": {"queue": "default"},
+    "steps": [
+        step_block_unless_maintainer,
+        step_style,
+        build_grp,
+        functional_1_grp,
+        functional_2_grp,
+        security_grp,
+        performance_grp,
+    ],
+}
+
+print(json.dumps(pipeline, indent=4, sort_keys=True, ensure_ascii=False))

--- a/tests/integration_tests/style/test_licenses.py
+++ b/tests/integration_tests/style/test_licenses.py
@@ -31,7 +31,7 @@ ALIBABA_LICENSE = (
     "SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause"
 )
 
-EXCLUDE = ["build", ".kernel", ".git"]
+EXCLUDE = ["build", ".kernel", ".git", ".buildkite"]
 
 
 def _has_amazon_copyright(string):

--- a/tests/integration_tests/style/test_python.py
+++ b/tests/integration_tests/style/test_python.py
@@ -32,7 +32,7 @@ def test_python_style():
     python_files = utils.get_files_from(
         find_path="..",
         pattern="*.py",
-        exclude_names=["build", ".kernel"])
+        exclude_names=["build", ".kernel", ".buildkite"])
 
     # Assert if somehow no python files were found
     assert len(python_files) != 0


### PR DESCRIPTION
## Reason

Backporting pipeline-pr.py script to FC 1.1. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
