### PR TITLE
Better error message when multi queue net device is in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Improved error message when invalid network backend provided
+
 ## [1.2.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "rate_limiter",
  "serde",
  "snapshot",
+ "thiserror",
  "timerfd",
  "utils",
  "versionize",

--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -4,6 +4,9 @@ This is a very simple quick-start guide to getting a Firecracker guest connected
 to the network. If you're using Firecracker in production, or even want to run
 multiple guests, you'll need to adapt this setup.
 
+**Note**
+Currently firecracker supports only TUN/TAP network backend with no multi queue support.
+
 The simple steps in this guide assume that your internet-facing interface is
 `eth0`, you have nothing else using `tap0` and no other `iptables` rules.
 Check out the *Advanced:* sections if that doesn't work for you.

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 event-manager = "0.3.0"
 libc = "0.2.117"
+thiserror = "1.0.32"
 timerfd = "1.2.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -31,21 +31,25 @@ pub enum NetQueue {
     Tx,
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Open tap device failed.
+    /// Open tap device failed
+    #[error("Open tap device failed: {0}")]
     TapOpen(TapError),
-    /// Setting tap interface offload flags failed.
+    /// Setting tap interface offload flags failed
+    #[error("Setting tap interface offload flags failed: {0}")]
     TapSetOffload(TapError),
-    /// Setting vnet header size failed.
+    /// Setting vnet header size failed
+    #[error("Setting vnet header size failed: {0}")]
     TapSetVnetHdrSize(TapError),
-    /// Enabling tap interface failed.
-    TapEnable(TapError),
-    /// EventFd error.
+    /// EventFd error
+    #[error("EventFd error: {0}")]
     EventFd(io::Error),
-    /// IO error.
+    /// IO error
+    #[error("IO error: {0}")]
     IO(io::Error),
-    /// The VNET header is missing from the frame.
+    /// The VNET header is missing from the frame
+    #[error("The VNET header is missing from the frame")]
     VnetHeaderMissing,
 }
 

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -3,8 +3,8 @@
 
 use std::convert::TryInto;
 use std::ops::Deref;
+use std::result;
 use std::sync::{Arc, Mutex};
-use std::{fmt, result};
 
 use devices::virtio::net::TapError;
 use devices::virtio::Net;
@@ -61,43 +61,23 @@ pub struct NetworkInterfaceUpdateConfig {
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum NetworkInterfaceError {
-    /// Could not create Network Device.
-    CreateNetworkDevice(devices::virtio::net::Error),
-    /// Failed to create a `RateLimiter` object.
-    CreateRateLimiter(std::io::Error),
-    /// The MAC address is already in use.
+    /// Could not create Network Device
+    #[error("Could not create Network Device: {0}")]
+    CreateNetworkDevice(#[from] devices::virtio::net::Error),
+    /// Failed to create a `RateLimiter` object
+    #[error("Failed to create a `RateLimiter` object: {0}")]
+    CreateRateLimiter(#[from] std::io::Error),
+    /// The MAC address is already in use
+    #[error("The MAC address is already in use: {0}")]
     GuestMacAddressInUse(String),
-    /// Error during interface update (patch).
-    DeviceUpdate(VmmError),
-    /// Cannot open/create tap device.
-    OpenTap(TapError),
-}
-
-impl fmt::Display for NetworkInterfaceError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::NetworkInterfaceError::*;
-        match self {
-            CreateNetworkDevice(err) => write!(f, "Could not create Network Device: {:?}", err),
-            CreateRateLimiter(err) => write!(f, "Cannot create RateLimiter: {}", err),
-            GuestMacAddressInUse(mac_addr) => {
-                write!(f, "The guest MAC address {mac_addr} is already in use.")
-            }
-            DeviceUpdate(err) => write!(f, "Error during interface update (patch): {}", err),
-            OpenTap(err) => {
-                // We are propagating the Tap Error. This error can contain
-                // imbricated quotes which would result in an invalid json.
-                let mut tap_err = format!("{:?}", err);
-                tap_err = tap_err.replace('\"', "");
-
-                write!(
-                    f,
-                    "Cannot open TAP device. Invalid name/permissions. {tap_err}",
-                )
-            }
-        }
-    }
+    /// Error during interface update (patch)
+    #[error("Error during interface update (patch): {0}")]
+    DeviceUpdate(#[from] VmmError),
+    /// Cannot open/create tap device
+    #[error("Cannot open/create tap device: {0}")]
+    OpenTap(#[from] TapError),
 }
 
 type Result<T> = result::Result<T, NetworkInterfaceError>;
@@ -172,11 +152,13 @@ impl NetBuilder {
         let rx_rate_limiter = cfg
             .rx_rate_limiter
             .map(super::RateLimiterConfig::try_into)
-            .transpose()?;
+            .transpose()
+            .map_err(NetworkInterfaceError::CreateRateLimiter)?;
         let tx_rate_limiter = cfg
             .tx_rate_limiter
             .map(super::RateLimiterConfig::try_into)
-            .transpose()?;
+            .transpose()
+            .map_err(NetworkInterfaceError::CreateRateLimiter)?;
 
         // Create and return the Net device
         devices::virtio::net::Net::new_with_tap(
@@ -285,10 +267,10 @@ mod tests {
         let guest_mac_2 = "01:23:45:67:89:0b";
 
         let netif_2 = create_netif(id_2, host_dev_name_2, guest_mac_1);
-        let expected_error = format!("The guest MAC address {} is already in use.", guest_mac_1);
+        let expected_error = NetworkInterfaceError::GuestMacAddressInUse(guest_mac_1.into());
         assert_eq!(
             net_builder.build(netif_2).err().unwrap().to_string(),
-            expected_error
+            expected_error.to_string()
         );
         assert_eq!(net_builder.net_devices.len(), 1);
 
@@ -313,10 +295,10 @@ mod tests {
         // Error Cases for UPDATE
         // Error Case: Update netif_2 mac using the same mac as netif_1.
         let netif_2 = create_netif(id_2, host_dev_name_2, guest_mac_1);
-        let expected_error = format!("The guest MAC address {} is already in use.", guest_mac_1);
+        let expected_error = NetworkInterfaceError::GuestMacAddressInUse(guest_mac_1.into());
         assert_eq!(
             net_builder.build(netif_2).err().unwrap().to_string(),
-            expected_error
+            expected_error.to_string()
         );
 
         // Error Case: Update netif_2 dev_host_name using the same dev_host_name as netif_1.
@@ -330,27 +312,6 @@ mod tests {
                 )
             ))
             .to_string()
-        );
-    }
-
-    #[test]
-    fn test_error_display() {
-        // FIXME: use macro
-        let err = NetworkInterfaceError::CreateNetworkDevice(devices::virtio::net::Error::TapOpen(
-            TapError::InvalidIfname,
-        ));
-        let _ = format!("{}{:?}", err, err);
-        let err = NetworkInterfaceError::CreateRateLimiter(std::io::Error::from_raw_os_error(0));
-        let _ = format!("{}{:?}", err, err);
-        let _ = format!(
-            "{}{:?}",
-            NetworkInterfaceError::DeviceUpdate(VmmError::VcpuExit),
-            NetworkInterfaceError::DeviceUpdate(VmmError::VcpuExit)
-        );
-        let _ = format!(
-            "{}{:?}",
-            NetworkInterfaceError::OpenTap(TapError::InvalidIfname),
-            NetworkInterfaceError::OpenTap(TapError::InvalidIfname)
         );
     }
 

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -297,7 +297,10 @@ mod tests {
         assert_eq!(
             net_builder.build(netif_2).err().unwrap().to_string(),
             NetworkInterfaceError::CreateNetworkDevice(devices::virtio::net::Error::TapOpen(
-                TapError::IoctlError(std::io::Error::from_raw_os_error(16))
+                TapError::IfreqExecuteError(
+                    std::io::Error::from_raw_os_error(16),
+                    host_dev_name_1.to_string()
+                )
             ))
             .to_string()
         );
@@ -321,7 +324,10 @@ mod tests {
         assert_eq!(
             net_builder.build(netif_2).err().unwrap().to_string(),
             NetworkInterfaceError::CreateNetworkDevice(devices::virtio::net::Error::TapOpen(
-                TapError::IoctlError(std::io::Error::from_raw_os_error(16))
+                TapError::IfreqExecuteError(
+                    std::io::Error::from_raw_os_error(16),
+                    host_dev_name_1.to_string()
+                )
             ))
             .to_string()
         );

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.51}
+    COVERAGE_DICT = {"Intel": 82.92, "AMD": 82.25, "ARM": 82.42}
 else:
-    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.66}
+    COVERAGE_DICT = {"Intel": 80.02, "AMD": 79.36, "ARM": 79.54}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -253,9 +253,7 @@ def test_net_api_put_update_pre_boot(test_microvm_with_api):
         iface_id="2", host_dev_name=second_if_name, guest_mac=guest_mac
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
-    assert (
-        "The guest MAC address {} is already in use.".format(guest_mac) in response.text
-    )
+    assert f"The MAC address is already in use: {guest_mac}" in response.text
 
     # Updates to a network interface with an available MAC are allowed.
     response = test_microvm.network.put(


### PR DESCRIPTION
So the task is to introduce a proper error message when passing a tap device with multi-queue feature enabled to firecracker. The error itself appears when we try to `TUNSETIFF` on the tap device [here](https://github.com/firecracker-microvm/firecracker/blob/1644b3cb4947b927f29da795492284b4b10f2405/src/devices/src/virtio/net/tap.rs#L126).

- One way to check if a tap device is configured with multi-queue flag is to read `/sys/class/net/{}/tun_flags` file and check it for the flag. The problem is that it does not work when firecracker is run inside the `jailer`, because it can not access that file. 
- So there is another way to check for the flag. We can just try to create tap device twice: one time with usual flags and second time with multi-queue flag set. If the second call successes then we know that device has multi-queue enabled and we can return a proper error. But this solution seems clunky. 
- The last option is just to split existing IoctlError error into separate errors and make messages more explicit.

This PR implements last option.

## Changes
- Split `IoctlError` in `tap.rs` into separate errors and added more descriptive error messages
- Added a note to the network documentation about usage of multi-queue devices
- Added `thiserror::Error` derive to some errors to reduce boilerplate `std::fmt::Display` implementations

## Reason
Fixes: #750

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
