### PR TITLE
Backport Release Automation to Firecracker v1.0

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -79,11 +79,9 @@ DEVCTR_IMAGE_TAG="v39"
 # (Yet another step on our way to reproducible builds.)
 DEVCTR_IMAGE="${DEVCTR_IMAGE_NO_TAG}:${DEVCTR_IMAGE_TAG}"
 
-# Naming things is hard
-MY_NAME="Firecracker $(basename "$0")"
-
 # Full path to the Firecracker tools dir on the host.
 FC_TOOLS_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$FC_TOOLS_DIR/functions"
 
 # Full path to the Firecracker sources dir on the host.
 FC_ROOT_DIR=$(cd "${FC_TOOLS_DIR}/.." && pwd)
@@ -153,57 +151,6 @@ DEFAULT_TEST_SESSION_ROOT_PATH=/srv
 DEFAULT_RAMDISK_PATH=/mnt/devtool-ramdisk
 
 
-# Send a decorated message to stdout, followed by a new line
-#
-say() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
-        || echo "[$MY_NAME] $*"
-}
-
-# Send a decorated message to stdout, without a trailing new line
-#
-say_noln() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo -n "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
-        || echo "[$MY_NAME] $*"
-}
-
-# Send a text message to stderr
-#
-say_err() {
-    [ -t 2 ] && [ -n "$TERM" ] \
-        && echo -e "$(tput setaf 1)[$MY_NAME] $*$(tput sgr0)" 1>&2 \
-        || echo -e "[$MY_NAME] $*" 1>&2
-}
-
-# Send a warning-highlighted text to stdout
-say_warn() {
-    [ -t 1 ] && [ -n "$TERM" ] \
-        && echo "$(tput setaf 3)[$MY_NAME] $*$(tput sgr0)" \
-        || echo "[$MY_NAME] $*"
-}
-
-# Exit with an error message and (optional) code
-# Usage: die [-c <error code>] <error message>
-#
-die() {
-    code=1
-    [[ "$1" = "-c" ]] && {
-        code="$2"
-        shift 2
-    }
-    say_err "$@"
-    exit $code
-}
-
-# Exit with an error message if the last exit code is not 0
-#
-ok_or_die() {
-    code=$?
-    [[ $code -eq 0 ]] || die -c $code "$@"
-}
-
 # Check if Docker is available and exit if it's not.
 # Upon returning from this call, the caller can be certain Docker is available.
 #
@@ -270,14 +217,6 @@ ensure_devctr() {
 
         ok_or_die "Error pulling docker image. Aborting."
     }
-}
-
-# Check if /dev/kvm exists. Exit if it doesn't.
-# Upon returning from this call, the caller can be certain /dev/kvm is
-# available.
-#
-ensure_kvm() {
-    [[ -c /dev/kvm ]] || die "/dev/kvm not found. Aborting."
 }
 
 # Make sure the build/ dirs are available. Exit if we can't create them.
@@ -363,50 +302,6 @@ cmd_build_devctr() {
     # Copy back the lockfile, since a new dependency or version would have
     # updated it.
     copy_poetry_lockfile
-}
-
-# Prompt the user for confirmation before proceeding.
-# Args:
-#   $1  prompt text.
-#       Default: Continue? (y/n)
-#   $2  confirmation input.
-#       Default: y
-# Return:
-#   exit code 0 for successful confirmation
-#   exit code != 0 if the user declined
-#
-get_user_confirmation() {
-
-    # Pass if running unattended
-    [[ "$OPT_UNATTENDED" = true ]] && return 0
-
-    # Fail if STDIN is not a terminal (there's no user to confirm anything)
-    [[ -t 0 ]] || return 1
-
-    # Otherwise, ask the user
-    #
-    msg=$([ -n "$1" ] && echo -n "$1" || echo -n "Continue? (y/n) ")
-    yes=$([ -n "$2" ] && echo -n "$2" || echo -n "y")
-    say_noln "$msg"
-    read c && [ "$c" = "$yes" ] && return 0
-    return 1
-}
-
-# Validate the user supplied version number.
-# It must start with 3 groups of integers separated by dot and
-# must not contain `wip` or `dirty`.
-validate_version() {
-    declare version_regex="^([0-9]+\.){2}[0-9]+"
-    version="$1"
-
-    if [ -z "$version" ]; then
-        die "Version cannot be empty."
-    elif [[ ! "$version" =~ $version_regex ]]; then
-        die "Invalid version number: $version. Version should start with \$Major.\$Minor.\$Build, see
-        https://github.com/firecracker-microvm/firecracker/blob/main/docs/RELEASE_POLICY.md for more information."
-    elif [[ "$version" == *"wip"* ]] || [[ "$version" == *"dirty"* ]]; then
-        die "Invalid version number: $version. Version should not contain \`wip\` or \`dirty\`."
-    fi
 }
 
 # Validate that the repo targetted for a release exists.
@@ -940,6 +835,16 @@ cmd_build() {
     return $ret
 }
 
+function cmd_make_release {
+    cmd_test || die "Tests failed!"
+
+    run_devctr \
+        --user "$(id -u):$(id -g)" \
+        --workdir "$CTR_FC_ROOT_DIR" \
+        -- \
+        ./tools/release.sh --libc musl --profile release --make-release
+}
+
 cmd_distclean() {
     # List of folders to remove.
     dirs=("build" "test_results")
@@ -1140,11 +1045,6 @@ copy_release_artifact() {
     elif [[ -d "$from_path" ]]; then
         cp -r "$from_path" "$to_path"
     fi
-}
-
-get_swagger_version() {
-    local file="$1"
-    grep -oP 'version: \K.*' "$file"
 }
 
 mount_ramdisk() {

--- a/tools/functions
+++ b/tools/functions
@@ -1,0 +1,153 @@
+# -*- shell-script[bash] -*-
+
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+###################
+# Logging helpers #
+###################
+
+# Naming things is hard
+ARG0=${BASH_SOURCE[-1]}
+MY_NAME="Firecracker $(basename "$ARG0")"
+
+# Send a decorated message to stdout, followed by a new line
+#
+say() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
+        || echo "[$MY_NAME] $*"
+}
+
+# Send a decorated message to stdout, without a trailing new line
+#
+say_noln() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo -n "$(tput setaf 2)[$MY_NAME]$(tput sgr0) $*" \
+        || echo "[$MY_NAME] $*"
+}
+
+# Send a text message to stderr
+#
+say_err() {
+    [ -t 2 ] && [ -n "$TERM" ] \
+        && echo -e "$(tput setaf 1)[$MY_NAME] $*$(tput sgr0)" 1>&2 \
+        || echo -e "[$MY_NAME] $*" 1>&2
+}
+
+# Send a warning-highlighted text to stdout
+say_warn() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo "$(tput setaf 3)[$MY_NAME] $*$(tput sgr0)" \
+        || echo "[$MY_NAME] $*"
+}
+
+# Exit with an error message and (optional) code
+# Usage: die [-c <error code>] <error message>
+#
+die() {
+    code=1
+    [[ "$1" = "-c" ]] && {
+        code="$2"
+        shift 2
+    }
+    say_err "$@"
+    exit $code
+}
+
+# Exit with an error message if the last exit code is not 0
+#
+ok_or_die() {
+    code=$?
+    [[ $code -eq 0 ]] || die -c $code "$@"
+}
+
+# ANSI output helper
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+function SGR {
+    local codes=$*
+    printf "\e[%sm" "${codes// /;}"
+}
+
+# Prompt the user for confirmation before proceeding.
+# Args:
+#   $1  prompt text.
+#       Default: Continue? (y/n)
+#   $2  confirmation input.
+#       Default: y
+# Return:
+#   exit code 0 for successful confirmation
+#   exit code != 0 if the user declined
+#
+OPT_UNATTENDED=false
+get_user_confirmation() {
+
+    # Pass if running unattended
+    [[ "$OPT_UNATTENDED" = true ]] && return 0
+
+    # Fail if STDIN is not a terminal (there's no user to confirm anything)
+    [[ -t 0 ]] || return 1
+
+    # Otherwise, ask the user
+    #
+    msg=$([ -n "${1:-}" ] && echo -n "$1" || echo -n "Continue? (y/n) ")
+    yes=$([ -n "${2:-}" ] && echo -n "$2" || echo -n "y")
+    say_noln "$msg"
+    read c && [ "$c" = "$yes" ] && return 0
+    return 1
+}
+
+#######################################
+# Release automation common functions #
+#######################################
+
+# Get version from the swagger file
+function get_swagger_version {
+    local file=${1:-"$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"}
+    grep -oP 'version: \K.*' "$file"
+}
+
+function check_local_branch_is_release_branch {
+    local LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    local RELEASE_BRANCH=firecracker-v$(echo "$version" |cut -d. -f-2)
+
+    if [ "$LOCAL_BRANCH" != "$RELEASE_BRANCH" ]; then
+        cat <<EOF
+ERROR: The current branch '$LOCAL_BRANCH' should be '$RELEASE_BRANCH'
+Bailing out.
+You can fix this by checking out the expected release branch and rerunning:
+
+    git checkout -B $RELEASE_BRANCH
+EOF
+        exit 1
+    fi
+}
+
+# Validate the user supplied version number.
+# It must start with 3 groups of integers separated by dot and
+# must not contain `wip` or `dirty`.
+function validate_version {
+    declare version_regex="^([0-9]+\.){2}[0-9]+"
+    local version="$1"
+
+    if [ -z "$version" ]; then
+        die "Version cannot be empty."
+    elif [[ ! "$version" =~ $version_regex ]]; then
+        die "Invalid version number: $version. Version should start with \$Major.\$Minor.\$Build, see
+        https://github.com/firecracker-microvm/firecracker/blob/main/docs/RELEASE_POLICY.md for more information."
+    elif [[ "$version" == *"wip"* ]] || [[ "$version" == *"dirty"* ]]; then
+        die "Invalid version number: $version. Version should not contain \`wip\` or \`dirty\`."
+    fi
+}
+
+#########################
+# Firecracker functions #
+#########################
+
+# Check if /dev/kvm exists. Exit if it doesn't.
+# Upon returning from this call, the caller can be certain /dev/kvm is
+# available.
+#
+ensure_kvm() {
+    [[ -c /dev/kvm ]] || die "/dev/kvm not found. Aborting."
+}

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu -o pipefail
+
+FC_TOOLS_DIR=$(dirname $(realpath $0))
+FC_ROOT_DIR=$FC_TOOLS_DIR/..
+
+
+if [ $# -ne 2 ]; then
+    cat <<EOF
+Compose the text for a new release using the information in the changelog,
+between the two specified releases.
+
+$0 <previous_version> <version>
+
+    Example: $0 1.1.1 1.1.2
+EOF
+    exit 1;
+fi
+
+prev_ver="$1"
+curr_ver="$2"
+changelog="$FC_ROOT_DIR/CHANGELOG.md"
+
+if [[ ! $prev_ver < $curr_ver ]]; then
+    echo "$prev_ver >= $curr_ver. Did you switch the argument order?"
+    exit 1
+fi
+
+# Patterns for the sections in the changelog corresponding to the versions.
+pat_curr="^##\s\[$curr_ver\]"
+pat_prev="^##\s\[$prev_ver\]"
+# Extract the section enclosed between the 2 headers and strip off the first
+# 2 and last 2 lines (one is blank and one contains the header `## [A.B.C]`).
+# Then, replace `-` with `*` and remove section headers.
+sed "/$pat_curr/,/$pat_prev/!d" "$changelog" \
+    | sed '1,2d;$d' \
+    | sed "s/^-/*/g" \
+    | sed "s/^###\s//g"

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu -o pipefail
+
+FC_TOOLS_DIR=$(dirname $(realpath $0))
+source "$FC_TOOLS_DIR/functions"
+FC_ROOT_DIR=$FC_TOOLS_DIR/..
+
+if [ $# -ne 1 ]; then
+    cat <<EOF
+$0 <version>
+
+    Example: $0 0.42.0
+
+    Prepare a new Firecracker release:
+    1. Update the version number
+    2. Update Crate dependencies
+    3. Generate CREDITS.md and CHANGELOG.md
+    4. Commit the result
+    5. Create a link to PR the changes
+EOF
+    exit 1
+fi
+version=$1
+validate_version "$version"
+
+check_local_branch_is_release_branch
+
+# Create GitHub PR link
+ORIGIN_URL=$(git config --get remote.origin.url)
+GH_USER=$(git config --get github.user)
+REPO=$(basename "$ORIGIN_URL" .git)
+LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RELEASE_BRANCH=firecracker-v$(echo "$version" |cut -d. -f-2)
+UPSTREAM=upstream
+# In which branch should the change go, in the main repo?
+TARGET_BRANCH=main
+PATCH=$(echo "$version" |cut -d. -f3)
+# If this is a patch release, the target branch should be the release branch
+if [ "$PATCH" -gt 0 ]; then
+    TARGET_BRANCH=$RELEASE_BRANCH
+fi
+PR_URL="https://github.com/firecracker-microvm/$REPO/compare/$TARGET_BRANCH...$GH_USER:$REPO:$LOCAL_BRANCH?expand=1"
+
+# Get current version from the swagger spec.
+prev_ver=$(get_swagger_version)
+
+say "Updating from $prev_ver to $version ..."
+# Update version in files.
+files_to_change=(
+    "$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
+    "$FC_ROOT_DIR/src/firecracker/Cargo.toml"
+    "$FC_ROOT_DIR/src/jailer/Cargo.toml"
+    "$FC_ROOT_DIR/src/rebase-snap/Cargo.toml"
+    "$FC_ROOT_DIR/src/seccompiler/Cargo.toml"
+)
+say "Updating source files:"
+for file in "${files_to_change[@]}"; do
+    say "- $file"
+    # Dirty hack to make this work on both macOS/BSD and Linux.
+    # FIXME This is very hacky and can unintentionally bump other versions, so
+    # only do the replacement *once*.
+    sed -i "s/$prev_ver/$version/" "$file"
+done
+
+# Run `cargo check` to update firecracker and jailer versions in
+# `Cargo.lock`.
+say "Updating lockfile..."
+cargo check
+
+# Update credits.
+say "Updating credits..."
+$FC_TOOLS_DIR/update-credits.sh
+
+# Update changelog.
+say "Updating changelog..."
+sed -i "s/\[Unreleased\]/\[$version\]/g" "$FC_ROOT_DIR/CHANGELOG.md"
+
+git add "${files_to_change[@]}" Cargo.lock CREDITS.md CHANGELOG.md
+git commit -s -m "Releasing v$version"
+
+
+# pretty print code
+function pp-code {
+    # grey background
+    echo "$(SGR 0 48 5 242)$*$(SGR 0)"
+}
+
+# pretty print a list item
+function pp-li {
+    bullet=$1; shift
+    # reset bg-color-5 bold
+    echo "$(SGR 0 48 5 101)$bullet$(SGR 0 1) $*$(SGR 0)"
+}
+
+cat <<EOF
+🎉 Almost done!
+
+$(pp-li 1. Check the changes made to the repo:)
+
+   $(pp-code git log --patch HEAD~1..HEAD)
+
+$(pp-li 2. Preview the release notes)
+
+   $(pp-code ./tools/release-notes.sh "$prev_ver" "$version")
+
+$(pp-li 3. If you want to undo the changes, run)
+
+   $(pp-code git reset --keep HEAD~1)
+
+$(pp-li 4. Review and merge this change)
+
+   $(pp-code git push --force -u origin HEAD)
+   $PR_URL
+
+$(pp-li 5. Once it is reviewed and merged, run the tag script)
+   $(pp-code ./tools/release-tag.sh $prev_ver $version)
+EOF

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -70,16 +70,24 @@ done
 # `Cargo.lock`.
 say "Updating lockfile..."
 cargo check
+CHANGED=(Cargo.lock)
+
+cd tests/integration_tests/security/demo_seccomp
+cargo check
+cd -
+CHANGED+=(tests/integration_tests/security/demo_seccomp/Cargo.lock)
 
 # Update credits.
 say "Updating credits..."
 $FC_TOOLS_DIR/update-credits.sh
+CHANGED+=(CREDITS.md)
 
 # Update changelog.
 say "Updating changelog..."
 sed -i "s/\[Unreleased\]/\[$version\]/g" "$FC_ROOT_DIR/CHANGELOG.md"
+CHANGED+=(CHANGELOG.md)
 
-git add "${files_to_change[@]}" Cargo.lock CREDITS.md CHANGELOG.md
+git add "${files_to_change[@]}" "${CHANGED[@]}"
 git commit -s -m "Releasing v$version"
 
 

--- a/tools/release-prepare.sh
+++ b/tools/release-prepare.sh
@@ -54,7 +54,6 @@ files_to_change=(
     "$FC_ROOT_DIR/src/api_server/swagger/firecracker.yaml"
     "$FC_ROOT_DIR/src/firecracker/Cargo.toml"
     "$FC_ROOT_DIR/src/jailer/Cargo.toml"
-    "$FC_ROOT_DIR/src/rebase-snap/Cargo.toml"
     "$FC_ROOT_DIR/src/seccompiler/Cargo.toml"
 )
 say "Updating source files:"

--- a/tools/release-tag.sh
+++ b/tools/release-tag.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu -o pipefail
+
+FC_TOOLS_DIR=$(dirname $(realpath $0))
+source "$FC_TOOLS_DIR/functions"
+FC_ROOT_DIR=$FC_TOOLS_DIR/..
+
+# Create a tag for the specified release.
+# The tag text will be composed from the changelog contents enclosed between the
+# specified release number and the previous one.
+function create_local_tag {
+    version="$1"
+    prev_ver="$2"
+    branch="$3"
+
+    say "Obtaining tag description for local tag v$version..."
+    tag_text=$($FC_TOOLS_DIR/release-notes.sh "$prev_ver" "$version")
+    say "Tag description for v$version:"
+    echo "$tag_text"
+    # Create tag.
+    git tag -a v"$version" "$branch" -m "$tag_text" || die "Could not create local tag v$version."
+    say "Local tag v$version created."
+}
+
+
+# # # # MAIN # # # #
+
+if [ $# -ne 2 ]; then
+    cat <<EOF
+$0 <previous_version> <version>
+
+    Example: $0 1.1.1 1.1.2
+
+    It will create a local git tag and push it to the upstream
+EOF
+    exit 1
+fi
+prev_version=$1
+version=$2
+validate_version "$prev_version"
+validate_version "$version"
+
+LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RELEASE_BRANCH=firecracker-v$(echo "$version" |cut -d. -f-2)
+UPSTREAM=upstream
+UPSTREAM_URL=$(git remote get-url $UPSTREAM)
+check_local_branch_is_release_branch
+
+# Start by creating a local tag and associate to it a description.
+say "Creating local tag..."
+create_local_tag "$version" "$prev_version" "$LOCAL_BRANCH"
+
+# pretty print a warning
+function warn {
+    # reset reverse yellow
+    echo "$(SGR 0 7 33)$*$(SGR 0)"
+}
+
+warn "!WARNING! The next step will modify upstream: $UPSTREAM_URL by running:"
+echo "    git push $UPSTREAM v$version"
+echo "    git push $UPSTREAM $RELEASE_BRANCH"
+get_user_confirmation || die "Cancelling tag push"
+git push $UPSTREAM "v$version"
+git push $UPSTREAM "$RELEASE_BRANCH"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -90,6 +90,12 @@ PROFILE_DIR=$(get-profile-dir "$PROFILE")
 CARGO_TARGET=$ARCH-unknown-linux-$LIBC
 CARGO_TARGET_DIR=build/cargo_target/$CARGO_TARGET/$PROFILE_DIR
 
+if [[ $VERSION =~ "-dirty$" ]]; then
+    say_warn "Building dirty version.. dirty because:"
+    git status -s --untracked-files=no
+    git diff
+fi
+
 CARGO_REGISTRY_DIR="build/cargo_registry"
 CARGO_GIT_REGISTRY_DIR="build/cargo_git_registry"
 for dir in "$CARGO_REGISTRY_DIR" "$CARGO_GIT_REGISTRY_DIR"; do

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# fail if we encounter an error, uninitialized variable or a pipe breaks
+set -eu -o pipefail
+
+FC_TOOLS_DIR=$(dirname $(realpath $0))
+source "$FC_TOOLS_DIR/functions"
+FC_ROOT_DIR=$FC_TOOLS_DIR/..
+
+function get-profile-dir {
+    case $1 in
+        dev)
+            echo debug
+        ;;
+        *)
+            echo "$1"
+        ;;
+    esac
+}
+
+function check_swagger_artifact {
+    # Validate swagger version against target version.
+    local swagger_path version swagger_ver
+    swagger_path=$1
+    version=$2
+    swagger_ver=$(get_swagger_version "$swagger_path")
+    if [[ $version =~ v$swagger_ver.* ]]; then
+        die "Artifact $swagger_path's version: $swagger_ver does not match release version $version."
+    fi
+}
+
+function check_bin_artifact {
+    # Validate binary version against target version.
+    local bin_path version bin_version
+    bin_path=$1
+    version=$2
+    bin_version=$($bin_path --version | head -1 | grep -oP ' \Kv.*')
+    if [[ "$bin_version" != "$version" ]]; then
+        die "Artifact $bin_path's version: $bin_version does not match release version $version."
+    fi
+}
+
+#### MAIN ####
+
+# defaults
+LIBC=musl
+PROFILE=dev
+MAKE_RELEASE=
+
+#### Option parsing
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+      --help)
+          cat <<EOF
+$0 - Build Firecracker
+
+   --profile PROFILE  - Build with the specified Rust profile (default: dev)
+   --libc [musl|gnu]  - Build with the specified libc (default: musl)
+   --make-release     - Make release artifacts
+EOF
+          exit 0
+      ;;
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --libc)
+      LIBC="$2"
+      shift 2
+      ;;
+    --make-release)
+      MAKE_RELEASE=true
+      shift 1
+      ;;
+    *)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+
+ARCH=$(uname -m)
+VERSION=$(git describe --tags --dirty)
+PROFILE_DIR=$(get-profile-dir "$PROFILE")
+CARGO_TARGET=$ARCH-unknown-linux-$LIBC
+CARGO_TARGET_DIR=build/cargo_target/$CARGO_TARGET/$PROFILE_DIR
+
+CARGO_REGISTRY_DIR="build/cargo_registry"
+CARGO_GIT_REGISTRY_DIR="build/cargo_git_registry"
+for dir in "$CARGO_REGISTRY_DIR" "$CARGO_GIT_REGISTRY_DIR"; do
+    mkdir -pv "$dir"
+done
+
+
+CARGO_OPTS=""
+# We could use Cargo's --profile when that's stable
+if [ "$PROFILE" = "release" ]; then
+    CARGO_OPTS+=" --release"
+fi
+
+# Artificially trigger a re-run of the build script,
+# to make sure that `firecracker --version` reports the latest changes.
+touch build.rs
+
+ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap)
+
+if [ "$LIBC" == "gnu" ]; then
+    # Don't build jailer. See commit 3bf285c8f
+    echo "Not building jailer because glibc selected instead of musl"
+    CARGO_OPTS+=" --exclude jailer"
+    ARTIFACTS=(firecracker seccompiler-bin rebase-snap)
+fi
+
+say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."
+# shellcheck disable=SC2086
+cargo build --target "$CARGO_TARGET" $CARGO_OPTS --workspace
+
+say "Binaries placed under $CARGO_TARGET_DIR"
+
+# # # # Make a release
+if [ -z "$MAKE_RELEASE" ]; then
+    exit 0
+fi
+
+if [ "$LIBC" != "musl" ]; then
+    die "Releases using a libc other than musl not supported"
+fi
+
+SUFFIX=$VERSION-$ARCH
+RELEASE_DIR=release-$SUFFIX
+mkdir "$RELEASE_DIR"
+for file in "${ARTIFACTS[@]}"; do
+    check_bin_artifact "$CARGO_TARGET_DIR/$file" "$VERSION"
+    cp -v "$CARGO_TARGET_DIR/$file" "$RELEASE_DIR/$file-$SUFFIX"
+    echo "STRIP $RELEASE_DIR/$file-$SUFFIX"
+    strip --strip-debug "$RELEASE_DIR/$file-$SUFFIX"
+done
+cp -v "resources/seccomp/$CARGO_TARGET.json" "$RELEASE_DIR/seccomp-filter-$SUFFIX.json"
+# Copy over arch independent assets
+cp -v -t "$RELEASE_DIR" LICENSE NOTICE THIRD-PARTY
+check_swagger_artifact src/api_server/swagger/firecracker.yaml "$VERSION"
+cp -v src/api_server/swagger/firecracker.yaml "$RELEASE_DIR/firecracker_spec-$VERSION.yaml"
+
+cp -r test_results "$RELEASE_DIR/test_results-$SUFFIX"
+
+(
+    cd "$RELEASE_DIR"
+    find . -type f -not -name "SHA256SUMS" |sort |xargs sha256sum >SHA256SUMS
+)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -27,7 +27,7 @@ function check_swagger_artifact {
     swagger_path=$1
     version=$2
     swagger_ver=$(get_swagger_version "$swagger_path")
-    if [[ $version =~ v$swagger_ver.* ]]; then
+    if [[ ! $version =~ v$swagger_ver.* ]]; then
         die "Artifact $swagger_path's version: $swagger_ver does not match release version $version."
     fi
 }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -113,13 +113,13 @@ fi
 # to make sure that `firecracker --version` reports the latest changes.
 touch build.rs
 
-ARTIFACTS=(firecracker jailer seccompiler-bin rebase-snap)
+ARTIFACTS=(firecracker jailer seccompiler-bin)
 
 if [ "$LIBC" == "gnu" ]; then
     # Don't build jailer. See commit 3bf285c8f
     echo "Not building jailer because glibc selected instead of musl"
     CARGO_OPTS+=" --exclude jailer"
-    ARTIFACTS=(firecracker seccompiler-bin rebase-snap)
+    ARTIFACTS=(firecracker seccompiler-bin)
 fi
 
 say "Building version=$VERSION, profile=$PROFILE, target=$CARGO_TARGET..."


### PR DESCRIPTION
## Changes

Backport release automation changes to v1.0 branch

Original PR: https://github.com/firecracker-microvm/firecracker/pull/3139

## Reason

To simplify future patch releases

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
