### PR TITLE
Update rust vmm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,11 +607,11 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8242360c7d79a7713a28043c994b815e9820b0e97e44b228ec9bd913c16bdfe"
+checksum = "1c30882b410003a8e7c288ede492d6b8ddfb2ea13a5e9c2d27356954067d81cb"
 dependencies = [
- "vm-memory 0.9.0",
+ "vm-memory 0.10.0",
 ]
 
 [[package]]
@@ -1244,14 +1244,14 @@ version = "0.3.0"
 dependencies = [
  "libc",
  "utils",
- "vm-memory 0.9.0",
+ "vm-memory 0.10.0",
 ]
 
 [[package]]
 name = "vm-memory"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
+checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,9 +429,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "event-manager"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
+checksum = "2bbb5f730c95a458654dee0afb13f1ebb4fc3d7b772789d5f30713ec68fed75d"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,8 +558,8 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.5.0"
-source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.5.0-1#4569d3f5b7746b66fc58a14cd05e5dbf9368932b"
+version = "0.6.0"
+source = "git+https://github.com/firecracker-microvm/kvm-bindings?tag=v0.6.0-1#e8359204b41d5c2e7c5af9ae5c26283b62337740"
 dependencies = [
  "versionize",
  "versionize_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
+checksum = "c3a321cabd827642499c77e27314f388dd83a717a5ca716b86476fb947f73ae4"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -1192,9 +1192,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "versionize"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7429cf68de8f091b667d27323ed323afd39584a56d533995b12ddd748e5e6ca9"
+checksum = "d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"
 dependencies = [
  "bincode",
  "crc64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "vm-superio"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b5231d334edbc03b22704caa1a022e4c07491d6df736593f26094df8b04a51"
+checksum = "6de3dc0146d78558327419fac388850fc6cbf197e924c4659a4863db20b5af64"
 
 [[package]]
 name = "vmm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?rev=0a58eb1#0a58eb1ece68e326e68365c4297d0a7c08ecd9bc"
+source = "git+https://github.com/firecracker-microvm/micro-http?rev=4b18a04#4b18a043e997da5b5f679e3defc279fec908753e"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ panic = "abort"
 lto = true
 
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.5.0-1", features = ["fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/firecracker-microvm/kvm-bindings", tag = "v0.6.0-1", features = ["fam-wrappers"] }

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -14,7 +14,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 thiserror = "1.0.32"
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
 mmds = { path = "../mmds" }
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 libc = ">=0.2.39"
-linux-loader = ">=0.4.0"
+linux-loader = "0.8.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
 vm-fdt = "0.1.0"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.9.0"
+kvm-ioctls = "0.12.0"
 libc = ">=0.2.39"
 linux-loader = ">=0.4.0"
 versionize = ">=0.1.6"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 libc = ">=0.2.39"
 linux-loader = ">=0.4.0"

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.9.0"
+kvm-ioctls = "0.12.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-event-manager = ">=0.2.1"
+event-manager = "0.3.0"
 libc = ">=0.2.39"
 timerfd = ">=1.0"
 versionize = ">=0.1.6"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -11,7 +11,7 @@ libc = ">=0.2.39"
 timerfd = ">=1.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
-vm-superio = ">=0.4.0"
+vm-superio = "0.7.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 dumbo = { path = "../dumbo" }

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -10,7 +10,7 @@ bitflags = ">=1.0.4"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/src/firecracker/Cargo.toml
+++ b/src/firecracker/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://firecracker-microvm.github.io/"
 license = "Apache-2.0"
 
 [dependencies]
-event-manager = ">=0.2.1"
+event-manager = "0.3.0"
 libc = ">=0.2.39"
 serde_json = ">=1.0.68"
 timerfd = ">=1.0"

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -11,7 +11,7 @@ libc = ">=0.2.39"
 log = { version = ">=0.4", features = ["std"] }
 serde = { version = ">=1.0.27", features = ["derive", "rc"] }
 serde_json = ">=1.0.9"
-vm-superio = ">=0.4.0"
+vm-superio = "0.7.0"
 
 utils = { path = "../utils" }
 

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -17,6 +17,6 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "0a58eb1" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }

--- a/src/vm-memory/Cargo.toml
+++ b/src/vm-memory/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 libc = ">=0.2.80"
-vm-memory-upstream = { package = "vm-memory",  version = ">=0.9.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory-upstream = { package = "vm-memory",  version = "0.10.0", features = ["backend-mmap", "backend-bitmap"] }
 
 utils = { path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-kvm-ioctls = ">=0.9.0"
+kvm-ioctls = "0.12.0"
 lazy_static = ">=1.4.0"
 libc = ">=0.2.39"
 linux-loader = ">=0.4.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,7 @@ kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 lazy_static = ">=1.4.0"
 libc = ">=0.2.39"
-linux-loader = ">=0.4.0"
+linux-loader = "0.8.0"
 serde = { version = ">=1.0.27", features = ["derive"] }
 serde_json = ">=1.0.9"
 userfaultfd = ">=0.4.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 event-manager = ">=0.2.1"
-kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 lazy_static = ">=1.4.0"
 libc = ">=0.2.39"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = ">=1.0.9"
 userfaultfd = ">=0.4.0"
 versionize = ">=0.1.6"
 versionize_derive = ">=0.1.3"
-vm-superio = ">=0.4.0"
+vm-superio = "0.7.0"
 vm-allocator = "0.1.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 thiserror = "1.0.32"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-event-manager = ">=0.2.1"
+event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.9.0"
 lazy_static = ">=1.4.0"

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -459,7 +459,7 @@ fn test_snapshot_cpu_vendor_mismatch() {
     for state in microvm_state.vcpu_states.as_mut_slice().iter_mut() {
         for reg in state.regs.as_mut_slice().iter_mut() {
             if reg.id == MIDR_EL1 {
-                reg.addr = 0x710FD081;
+                reg.value = 0x710FD081;
             }
         }
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,7 +23,7 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.4}
+    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.42}
 else:
     COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.6}
 

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -737,7 +737,7 @@ def test_mmds_older_snapshot(bin_cloner_path):
     artifacts = ArtifactCollection(_test_images_s3_bucket())
     # Fetch all firecracker binaries.
     firecracker_artifacts = artifacts.firecrackers(
-        max_version=get_firecracker_version_from_toml()
+        min_version="1.1.0", max_version=get_firecracker_version_from_toml()
     )
     for firecracker in firecracker_artifacts:
         firecracker.download()

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -41,7 +41,10 @@ def firecracker_id(fc):
 
 @pytest.mark.parametrize(
     "firecracker",
-    firecracker_artifacts(max_version=get_firecracker_version_from_toml()),
+    firecracker_artifacts(
+        min_version="1.1.0",
+        max_version=get_firecracker_version_from_toml(),
+    ),
     ids=firecracker_id,
 )
 def test_restore_old_snapshot(bin_cloner_path, firecracker):

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -646,7 +646,9 @@ def test_older_snapshot_resume_latency(bin_cloner_path, results_file_dumper, io_
     # With each binary create a snapshot and try to restore in current
     # version.
     firecracker_artifacts = ArtifactSet(
-        artifacts.firecrackers(max_version=get_firecracker_version_from_toml())
+        artifacts.firecrackers(
+            min_version="1.1.0", max_version=get_firecracker_version_from_toml()
+        )
     )
     assert len(firecracker_artifacts) > 0
 


### PR DESCRIPTION
## Changes

Bump all rust-vmm dependencies to the newest release and specify their versions using caret requirements (we update all our other dependencies in #3248). The only crate where the version bump also introduces API changes is kvm-ioctl,  but these are minimal and this PR adjusts for them. 

## Reason

Recently, all rust-vmm crates received major version bumps to fix the way intra-rust-vmm dependencies are specified. See https://github.com/rust-vmm/community/issues/136#issuecomment-1314184934 for details

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
