### PR TITLE
test: add T2S to cross-kernel/CPU snapshot tests

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
+++ b/tests/integration_tests/functional/test_snapshot_restore_cross_kernel.py
@@ -121,7 +121,7 @@ def _test_mmds(vm, mmds_net_iface):
 @pytest.mark.nonci
 @pytest.mark.parametrize(
     "cpu_template",
-    ["C3", "T2", "None"] if get_cpu_vendor() == CpuVendor.INTEL else ["None"],
+    ["C3", "T2", "T2S", "None"] if get_cpu_vendor() == CpuVendor.INTEL else ["None"],
 )
 def test_snap_restore_from_artifacts(
     bin_cloner_path, bin_vsock_path, test_fc_session_root_path, cpu_template

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -203,7 +203,7 @@ def main():
 
     cpu_templates = ["None"]
     if get_cpu_vendor() == CpuVendor.INTEL:
-        cpu_templates.extend(["C3", "T2"])
+        cpu_templates.extend(["C3", "T2", "T2S"])
 
     for cpu_template in cpu_templates:
         # Create a test context.


### PR DESCRIPTION
## Changes

Add T2S template to cross-kernel/CPU snapshot tests.

## Reason

Currently we are testing against C3 and T2 templates.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
