### PR TITLE
Backport fix intermittent serial_after_snapshot

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -899,7 +899,7 @@ class Microvm:
 class Serial:
     """Class for serial console communication with a Microvm."""
 
-    RX_TIMEOUT_S = 5
+    RX_TIMEOUT_S = 20
 
     def __init__(self, vm):
         """Initialize a new Serial object."""
@@ -952,6 +952,7 @@ class Serial:
             if rx_str.endswith(token):
                 break
             if (time.time() - start) >= self.RX_TIMEOUT_S:
+                self._vm.kill()
                 assert False
 
         return rx_str

--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -17,6 +17,8 @@ from framework import utils
 import host_tools.logging as log_tools
 import host_tools.network as net_tools
 
+PLATFORM = platform.machine()
+
 
 class WaitTerminal(TestState):  # pylint: disable=too-few-public-methods
     """Initial state when we wait for the login prompt."""
@@ -55,20 +57,19 @@ def test_serial_after_snapshot(bin_cloner_path):
     """
     vm_builder = MicrovmBuilder(bin_cloner_path)
     vm_instance = vm_builder.build_vm_nano(
-        diff_snapshots=False,
         daemonize=False,
     )
     microvm = vm_instance.vm
     root_disk = vm_instance.disks[0]
     ssh_key = vm_instance.ssh_key
 
-    microvm.start()
     serial = Serial(microvm)
     serial.open()
+    microvm.start()
 
     # Image used for tests on aarch64 has autologon
-    if platform.machine() == "x86_64":
-        serial.rx(token='login: ')
+    if PLATFORM == "x86_64":
+        serial.rx(token="login: ")
         serial.tx("root")
         serial.rx("Password: ")
         serial.tx("root")
@@ -76,19 +77,18 @@ def test_serial_after_snapshot(bin_cloner_path):
     serial.rx("#")
 
     snapshot_builder = SnapshotBuilder(microvm)
-    disks = [root_disk.local_path()]
-    # Create diff snapshot.
-    snapshot = snapshot_builder.create(disks,
-                                       ssh_key,
-                                       SnapshotType.FULL)
+
+    # Create snapshot.
+    snapshot = snapshot_builder.create(
+        [root_disk.local_path()], ssh_key, SnapshotType.FULL
+    )
     # Kill base microVM.
     microvm.kill()
 
     # Load microVM clone from snapshot.
-    test_microvm, _ = vm_builder.build_from_snapshot(snapshot,
-                                                     resume=True,
-                                                     diff_snapshots=False,
-                                                     daemonize=False)
+    test_microvm, _ = vm_builder.build_from_snapshot(
+        snapshot, resume=True, daemonize=False
+    )
     serial = Serial(test_microvm)
     serial.open()
     # We need to send a newline to signal the serial to flush

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -23,4 +23,6 @@ def test_cargo_audit():
     """
     # Run command and raise exception if non-zero return code
     utils.run_cmd(
-        'cargo audit --deny warnings -q', cwd=defs.FC_WORKSPACE_DIR)
+        "cargo audit --deny warnings -q  --ignore RUSTSEC-2021-0145",
+        cwd=defs.FC_WORKSPACE_DIR,
+    )


### PR DESCRIPTION
The test started failling after latest AMI
update on 4.14. Seems that reading from the
screen log file the output of the microVM
became slower.

Signed-off-by: Diana Popa <dpopa@amazon.com>
(cherry picked from commit e779c545025e40d6c56371b0f97cbc2f30c1c518)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
