### PR TITLE
Supress atty cargo audit warning

### DIFF
--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -21,4 +21,7 @@ def test_cargo_audit():
     @type: security
     """
     # Run command and raise exception if non-zero return code
-    utils.run_cmd("cargo audit --deny warnings -q", cwd=defs.FC_WORKSPACE_DIR)
+    utils.run_cmd(
+        "cargo audit --deny warnings -q  --ignore RUSTSEC-2021-0145",
+        cwd=defs.FC_WORKSPACE_DIR,
+    )


### PR DESCRIPTION


Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Suppress the warning `cargo audit` throws about `atty`

## Reason

This warning is currently blocking our PR CI, and there is no remedy available, as there is no patched version of the atty crate available, and we do not know how long it will take for criterion to remove the dependency.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
