### PR TITLE
Removing MAC address random generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@
   and restore on a host that has a Skylake CPU.
 - Added a new CLI option `--metrics-path PATH`. It accepts a file parameter
   where metrics will be sent to.
-- A MAC address is generated if one is not explicitly specified while adding
-  network interfaces. This address can be obtained as part of the GET
-  `/vm/config`.
 - Added baselines for m6i.metal and m6a.metal for all long running performance
   tests.
 
@@ -30,10 +27,8 @@
 - Make the `T2` template more robust by explicitly disabling additional
   CPUID flags that should be off but were missed initially or that were
   not available in the spec when the template was created.
-- When MAC address was left unspecified, GET `/vm/config` would report the
-  interface MAC address incorrectly as `null`, and post snapshot restore as
-  `00:00:00:00:00:00`. It now correctly reports the code generated MAC address
-  when queried in both cases.
+- Now MAC address is correctly displayed when queried with GET `/vm/config`
+  if left unspecified in both pre and post snapshot states.
 - Fixed a self-DoS scenario in the virtio-queue code by reporting and
   terminating execution when the number of available descriptors reported
   by the driver is higher than the queue size.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,8 @@ dependencies = [
  "net_gen",
  "serde",
  "serde_json",
+ "versionize",
+ "versionize_derive",
  "vmm-sys-util",
 ]
 

--- a/docs/network-setup.md
+++ b/docs/network-setup.md
@@ -76,10 +76,6 @@ to your configuration file like this:
 Alternatively, if you are using firectl, add
 --tap-device=tap0/AA:FC:00:00:00:01` to your command line.
 
-*Note:* When `guest_mac` is not explicitely specified, a MAC address is generated
-and assigned to the network interface. This address is included in the result of
-GET `/vm/config`.
-
 ## In The Guest
 
 Once you have booted the guest, bring up networking within the guest:

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -4,6 +4,7 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
+
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
 use std::sync::atomic::AtomicUsize;
@@ -17,8 +18,7 @@ use mmds::data_store::Mmds;
 use mmds::ns::MmdsNetworkStack;
 use rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use utils::eventfd::EventFd;
-use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
-use utils::rand_bytes;
+use utils::net::mac::MacAddr;
 use virtio_gen::virtio_net::{
     virtio_net_hdr_v1, VIRTIO_F_VERSION_1, VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_UFO,
@@ -47,9 +47,6 @@ enum FrontendError {
     ReadOnlyDescriptor,
 }
 
-// KVM OUI MAC address is 52:54:00:xx:xx:xx
-const KVM_OUI: [u8; 3] = [0x52, 0x54, 0x00];
-
 pub(crate) fn vnet_hdr_len() -> usize {
     mem::size_of::<virtio_net_hdr_v1>()
 }
@@ -75,31 +72,12 @@ fn frame_bytes_from_buf_mut(buf: &mut [u8]) -> Result<&mut [u8]> {
 // This initializes to all 0 the VNET hdr part of a buf.
 fn init_vnet_hdr(buf: &mut [u8]) {
     // The buffer should be larger than vnet_hdr_len.
-    // TODO: any better way to set all these bytes to 0? Or is this optimized by the compiler?
-    for i in &mut buf[0..vnet_hdr_len()] {
-        *i = 0;
-    }
+    buf[0..vnet_hdr_len()].fill(0);
 }
 
-fn generate_mac_address() -> MacAddr {
-    let mut random_mac: [u8; MAC_ADDR_LEN] = [0; MAC_ADDR_LEN];
-    let (left, right) = random_mac.split_at_mut(3);
-    left.copy_from_slice(&KVM_OUI);
-    right.copy_from_slice(rand_bytes(3).as_slice());
-    MacAddr::from_bytes_unchecked(&random_mac)
-}
-
-#[derive(Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ConfigSpace {
-    pub guest_mac: [u8; MAC_ADDR_LEN],
-}
-
-impl Default for ConfigSpace {
-    fn default() -> ConfigSpace {
-        ConfigSpace {
-            guest_mac: [0; MAC_ADDR_LEN],
-        }
-    }
+    pub guest_mac: MacAddr,
 }
 
 // SAFETY: `ConfigSpace` contains only PODs.
@@ -130,7 +108,7 @@ pub struct Net {
     pub(crate) irq_trigger: IrqTrigger,
 
     pub(crate) config_space: ConfigSpace,
-    pub(crate) guest_mac: MacAddr,
+    pub(crate) guest_mac: Option<MacAddr>,
 
     pub(crate) device_state: DeviceState,
     pub(crate) activate_evt: EventFd,
@@ -146,7 +124,7 @@ impl Net {
     pub fn new_with_tap(
         id: String,
         tap_if_name: String,
-        guest_mac: Option<&MacAddr>,
+        guest_mac: Option<MacAddr>,
         rx_rate_limiter: RateLimiter,
         tx_rate_limiter: RateLimiter,
     ) -> Result<Self> {
@@ -172,18 +150,12 @@ impl Net {
             | 1 << VIRTIO_RING_F_EVENT_IDX;
 
         let mut config_space = ConfigSpace::default();
-        // Enable feature to configure a MAC address
-        // If not enabled, the driver generates a random MAC address.
-        avail_features |= 1 << VIRTIO_NET_F_MAC;
-        let mac_addr = {
-            if let Some(some_mac_adrr) = guest_mac {
-                *some_mac_adrr
-            } else {
-                // When the MAC address is not specified explicitly, generate one and assign it.
-                generate_mac_address()
-            }
-        };
-        config_space.guest_mac.copy_from_slice(mac_addr.get_bytes());
+        if let Some(mac) = guest_mac {
+            config_space.guest_mac = mac;
+            // Enabling feature for MAC address configuration
+            // If not set, the driver will generates a random MAC address
+            avail_features |= 1 << VIRTIO_NET_F_MAC;
+        }
 
         let mut queue_evts = Vec::new();
         let mut queues = Vec::new();
@@ -207,11 +179,11 @@ impl Net {
             tx_frame_buf: [0u8; MAX_BUFFER_SIZE],
             tx_iovec: Vec::with_capacity(QUEUE_SIZE as usize),
             irq_trigger: IrqTrigger::new().map_err(Error::EventFd)?,
+            config_space,
+            guest_mac,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?,
-            config_space,
             mmds_ns: None,
-            guest_mac: mac_addr,
 
             #[cfg(test)]
             mocks: Mocks::default(),
@@ -224,8 +196,8 @@ impl Net {
     }
 
     /// Provides the MAC of this net device.
-    pub fn guest_mac(&self) -> &MacAddr {
-        &self.guest_mac
+    pub fn guest_mac(&self) -> Option<&MacAddr> {
+        self.guest_mac.as_ref()
     }
 
     /// Provides the host IFACE name of this net device.
@@ -429,7 +401,7 @@ impl Net {
         rate_limiter: &mut RateLimiter,
         frame_buf: &[u8],
         tap: &mut Tap,
-        guest_mac: MacAddr,
+        guest_mac: Option<MacAddr>,
     ) -> Result<bool> {
         let checked_frame = |frame_buf| {
             frame_bytes_from_buf(frame_buf).map_err(|err| {
@@ -454,11 +426,13 @@ impl Net {
         // This frame goes to the TAP.
 
         // Check for guest MAC spoofing.
-        let _ = EthernetFrame::from_bytes(checked_frame(frame_buf)?).map(|eth_frame| {
-            if guest_mac != eth_frame.src_mac() {
-                METRICS.net.tx_spoofed_mac_count.inc();
-            }
-        });
+        if let Some(mac) = guest_mac {
+            let _ = EthernetFrame::from_bytes(checked_frame(frame_buf)?).map(|eth_frame| {
+                if mac != eth_frame.src_mac() {
+                    METRICS.net.tx_spoofed_mac_count.inc();
+                }
+            });
+        }
 
         match tap.write(frame_buf) {
             Ok(_) => {
@@ -844,8 +818,7 @@ impl VirtioDevice for Net {
         }
 
         config_space_bytes[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
-        self.guest_mac =
-            MacAddr::from_bytes_unchecked(&self.config_space.guest_mac[..MAC_ADDR_LEN]);
+        self.guest_mac = Some(self.config_space.guest_mac);
         METRICS.net.mac_address_updates.inc();
     }
 
@@ -881,6 +854,7 @@ pub mod tests {
     use dumbo::pdu::ethernet::ETHERTYPE_ARP;
     use logger::{IncMetric, METRICS};
     use rate_limiter::{RateLimiter, TokenBucket, TokenType};
+    use utils::net::mac::MAC_ADDR_LEN;
     use virtio_gen::virtio_net::{
         virtio_net_hdr_v1, VIRTIO_F_VERSION_1, VIRTIO_NET_F_CSUM, VIRTIO_NET_F_GUEST_CSUM,
         VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4,
@@ -995,11 +969,11 @@ pub mod tests {
         let mac = MacAddr::parse_str("11:22:33:44:55:66").unwrap();
         let mut config_mac = [0u8; MAC_ADDR_LEN];
         net.read_config(0, &mut config_mac);
-        assert_eq!(config_mac, mac.get_bytes());
+        assert_eq!(&config_mac, mac.get_bytes());
 
         // Invalid read.
         config_mac = [0u8; MAC_ADDR_LEN];
-        net.read_config(MAC_ADDR_LEN as u64 + 1, &mut config_mac);
+        net.read_config(MAC_ADDR_LEN as u64, &mut config_mac);
         assert_eq!(config_mac, [0u8, 0u8, 0u8, 0u8, 0u8, 0u8]);
     }
 
@@ -1008,15 +982,15 @@ pub mod tests {
         let mut net = default_net();
         set_mac(&mut net, MacAddr::parse_str("11:22:33:44:55:66").unwrap());
 
-        let new_config: [u8; 6] = [0x66, 0x55, 0x44, 0x33, 0x22, 0x11];
+        let new_config: [u8; MAC_ADDR_LEN] = [0x66, 0x55, 0x44, 0x33, 0x22, 0x11];
         net.write_config(0, &new_config);
-        let mut new_config_read = [0u8; 6];
+        let mut new_config_read = [0u8; MAC_ADDR_LEN];
         net.read_config(0, &mut new_config_read);
         assert_eq!(new_config, new_config_read);
 
         // Check that the guest MAC was updated.
         let expected_guest_mac = MacAddr::from_bytes_unchecked(&new_config);
-        assert_eq!(expected_guest_mac, net.guest_mac);
+        assert_eq!(expected_guest_mac, net.guest_mac.unwrap());
         assert_eq!(METRICS.net.mac_address_updates.count(), 1);
 
         // Partial write (this is how the kernel sets a new mac address) - byte by byte.
@@ -1030,7 +1004,7 @@ pub mod tests {
         // Invalid write.
         net.write_config(5, &new_config);
         // Verify old config was untouched.
-        new_config_read = [0u8; 6];
+        new_config_read = [0u8; MAC_ADDR_LEN];
         net.read_config(0, &mut new_config_read);
         assert_eq!(new_config, new_config_read);
     }
@@ -1483,7 +1457,7 @@ pub mod tests {
                 &mut net.tx_rate_limiter,
                 &frame_buf[..frame_len],
                 &mut net.tap,
-                src_mac,
+                Some(src_mac),
             )
             .unwrap())
         );
@@ -1517,7 +1491,7 @@ pub mod tests {
                 &mut net.tx_rate_limiter,
                 &frame_buf[..frame_len],
                 &mut net.tap,
-                guest_mac,
+                Some(guest_mac),
             )
         );
 
@@ -1530,7 +1504,7 @@ pub mod tests {
                 &mut net.tx_rate_limiter,
                 &frame_buf[..frame_len],
                 &mut net.tap,
-                not_guest_mac,
+                Some(not_guest_mac),
             )
         );
     }

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -7,6 +7,7 @@ use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
+use logger::warn;
 use mmds::data_store::Mmds;
 use mmds::ns::MmdsNetworkStack;
 use mmds::persist::MmdsNetworkStackState;
@@ -23,10 +24,39 @@ use super::{NUM_QUEUES, QUEUE_SIZE};
 use crate::virtio::persist::{Error as VirtioStateError, VirtioDeviceState};
 use crate::virtio::{DeviceState, TYPE_NET};
 
-#[derive(Clone, Versionize)]
+#[derive(Debug, Default, Clone, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
 pub struct NetConfigSpaceState {
+    #[version(end = 2, default_fn = "def_guest_mac_old")]
     guest_mac: [u8; MAC_ADDR_LEN],
+    #[version(start = 2, de_fn = "de_guest_mac_v2", ser_fn = "ser_guest_mac_v2")]
+    guest_mac_v2: Option<MacAddr>,
+}
+
+impl NetConfigSpaceState {
+    fn de_guest_mac_v2(&mut self, version: u16) -> VersionizeResult<()> {
+        // v1.1 and older versions do not have optional MAC address.
+        warn!("Optional MAC address will be set to older version.");
+        if version < 2 {
+            self.guest_mac_v2 = Some(self.guest_mac.into());
+        }
+        Ok(())
+    }
+
+    fn ser_guest_mac_v2(&mut self, _target_version: u16) -> VersionizeResult<()> {
+        // v1.1 and older versions do not have optional MAC address.
+        warn!("Saving to older snapshot version, optional MAC address will not be saved.");
+        match self.guest_mac_v2 {
+            Some(mac) => self.guest_mac = mac.into(),
+            None => self.guest_mac = Default::default(),
+        }
+        Ok(())
+    }
+
+    fn def_guest_mac_old(_: u16) -> [u8; MAC_ADDR_LEN] {
+        // v1.2 and newer don't use this field anyway
+        Default::default()
+    }
 }
 
 #[derive(Clone, Versionize)]
@@ -67,7 +97,8 @@ impl Persist<'_> for Net {
             tx_rate_limiter_state: self.tx_rate_limiter.save(),
             mmds_ns: self.mmds_ns.as_ref().map(|mmds| mmds.save()),
             config_space: NetConfigSpaceState {
-                guest_mac: self.config_space.guest_mac,
+                guest_mac_v2: self.guest_mac,
+                guest_mac: Default::default(),
             },
             virtio_state: VirtioDeviceState::from_device(self),
         }
@@ -83,10 +114,7 @@ impl Persist<'_> for Net {
         let mut net = Net::new_with_tap(
             state.id.clone(),
             state.tap_if_name.clone(),
-            Some(MacAddr::from_bytes_unchecked(
-                &state.config_space.guest_mac[..MAC_ADDR_LEN],
-            ))
-            .as_ref(),
+            state.config_space.guest_mac_v2,
             rx_rate_limiter,
             tx_rate_limiter,
         )?;

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -38,7 +38,7 @@ pub fn default_net() -> Net {
     let mut net = Net::new_with_tap(
         format!("net-device{}", next_tap),
         tap_dev_name,
-        Some(&guest_mac),
+        Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
     )
@@ -61,7 +61,7 @@ pub fn default_net_no_mmds() -> Net {
     let net = Net::new_with_tap(
         format!("net-device{}", next_tap),
         tap_dev_name,
-        Some(&guest_mac),
+        Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
     )
@@ -307,8 +307,8 @@ pub fn default_guest_memory() -> GuestMemoryMmap {
 }
 
 pub fn set_mac(net: &mut Net, mac: MacAddr) {
-    net.guest_mac = mac;
-    net.config_space.guest_mac.copy_from_slice(mac.get_bytes());
+    net.guest_mac = Some(mac);
+    net.config_space.guest_mac = mac;
 }
 
 // Assigns "guest virtio driver" activated queues to the net device.

--- a/src/mmds/src/token.rs
+++ b/src/mmds/src/token.rs
@@ -378,12 +378,16 @@ mod tests {
         // We allow a deviation of 20ms to account for the gap
         // between the two calls to `get_time_ms()`.
         let deviation = 20;
-        assert!(ttl >= MILLISECONDS_PER_SECOND - deviation && ttl <= MILLISECONDS_PER_SECOND);
+        assert!(
+            ttl >= MILLISECONDS_PER_SECOND && ttl <= MILLISECONDS_PER_SECOND + deviation,
+            "ttl={ttl} not within [{MILLISECONDS_PER_SECOND}, \
+             {MILLISECONDS_PER_SECOND}+{deviation}]",
+        );
 
         let time_now = get_time_ms(ClockType::Monotonic);
         let expiry = TokenAuthority::compute_expiry(0);
         let ttl = expiry - time_now;
-        assert!(ttl <= deviation);
+        assert!(ttl <= deviation, "ttl={ttl} is greater than {deviation}");
     }
 
     #[test]

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -8,6 +8,8 @@ license = "Apache-2.0"
 [dependencies]
 libc = ">=0.2.39"
 serde = { version = ">=1.0.27", features = ["derive"] }
+versionize = "0.1.6"
+versionize_derive = "0.1.3"
 vmm-sys-util = ">=0.8.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -34,32 +34,3 @@ pub fn get_page_size() -> Result<usize, errno::Error> {
         ps => Ok(ps as usize),
     }
 }
-
-// The below fucntions will get merged in rust-vmm function once we will upstream it there
-fn xor_pseudo_rng_u8_bytes(rand_fn: &dyn Fn() -> u32) -> Vec<u8> {
-    let mut r = vec![];
-
-    for n in &rand_fn().to_ne_bytes() {
-        r.push(*n);
-    }
-    r
-}
-
-fn rand_bytes_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut done = 0;
-    loop {
-        for n in xor_pseudo_rng_u8_bytes(rand_fn) {
-            done += 1;
-            buf.push(n);
-            if done >= len {
-                return buf;
-            }
-        }
-    }
-}
-
-/// Get a pseudo random vector of length `len` with bytes.
-pub fn rand_bytes(len: usize) -> Vec<u8> {
-    rand_bytes_impl(&rand::xor_pseudo_rng_u32, len)
-}

--- a/src/utils/src/net/mac.rs
+++ b/src/utils/src/net/mac.rs
@@ -106,33 +106,12 @@ impl MacAddr {
         MacAddr { bytes }
     }
 
-    /// Create a `MacAddr` from a slice.
-    /// This method will return None if the slice length is different from `MAC_ADDR_LEN`.
-    /// # Arguments
-    ///
-    /// * `src` - slice from which to copy MAC address content.
-    /// # Example
-    ///
-    /// ```
-    /// use self::utils::net::mac::MacAddr;
-    /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
-    /// println!("{}", mac.to_string());
-    /// ```
-    /// TODO this is unused, do we need it?
-    #[inline]
-    pub fn from_bytes(src: &[u8]) -> Option<MacAddr> {
-        if src.len() != MAC_ADDR_LEN {
-            return None;
-        }
-        Some(MacAddr::from_bytes_unchecked(src))
-    }
-
     /// Return the underlying content of this `MacAddr` in bytes.
     /// # Example
     ///
     /// ```
     /// use self::utils::net::mac::MacAddr;
-    /// let mac = MacAddr::from_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]).unwrap();
+    /// let mac = MacAddr::from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
     /// assert_eq!([0x01, 0x02, 0x03, 0x04, 0x05, 0x06], mac.get_bytes());
     /// ```
     #[inline]
@@ -184,20 +163,6 @@ mod tests {
 
         let bytes = mac.get_bytes();
         assert_eq!(bytes, [0x12u8, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
-    }
-
-    #[test]
-    fn test_from_bytes() {
-        let src1 = [0x01, 0x02, 0x03, 0x04, 0x05];
-        let src2 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
-        let src3 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-
-        assert!(MacAddr::from_bytes(&src1[..]).is_none());
-
-        let x = MacAddr::from_bytes(&src2[..]).unwrap();
-        assert_eq!(x.to_string(), String::from("01:02:03:04:05:06"));
-
-        assert!(MacAddr::from_bytes(&src3[..]).is_none());
     }
 
     #[test]

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -50,9 +50,9 @@ pub enum Error {
     MmdsConfig(MmdsConfigError),
 }
 
-#[derive(Clone, Versionize)]
 /// Holds the state of a balloon device connected to the MMIO space.
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Clone, Versionize)]
 pub struct ConnectedBalloonState {
     /// Device identifier.
     pub device_id: String,
@@ -64,9 +64,9 @@ pub struct ConnectedBalloonState {
     pub device_info: MMIODeviceInfo,
 }
 
-#[derive(Clone, Versionize)]
 /// Holds the state of a block device connected to the MMIO space.
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Clone, Versionize)]
 pub struct ConnectedBlockState {
     /// Device identifier.
     pub device_id: String,
@@ -78,9 +78,9 @@ pub struct ConnectedBlockState {
     pub device_info: MMIODeviceInfo,
 }
 
-#[derive(Clone, Versionize)]
 /// Holds the state of a net device connected to the MMIO space.
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Clone, Versionize)]
 pub struct ConnectedNetState {
     /// Device identifier.
     pub device_id: String,
@@ -92,9 +92,9 @@ pub struct ConnectedNetState {
     pub device_info: MMIODeviceInfo,
 }
 
-#[derive(Clone, Versionize)]
 /// Holds the state of a vsock device connected to the MMIO space.
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Clone, Versionize)]
 pub struct ConnectedVsockState {
     /// Device identifier.
     pub device_id: String,
@@ -106,9 +106,9 @@ pub struct ConnectedVsockState {
     pub device_info: MMIODeviceInfo,
 }
 
+/// Holds the state of a legacy device connected to the MMIO space.
 #[cfg(target_arch = "aarch64")]
 #[derive(Clone, Versionize)]
-/// Holds the state of a legacy device connected to the MMIO space.
 pub struct ConnectedLegacyState {
     /// Device identifier.
     pub type_: DeviceType,
@@ -117,8 +117,8 @@ pub struct ConnectedLegacyState {
 }
 
 /// Holds the MMDS data store version.
-#[derive(Debug, Clone, PartialEq, Eq, Versionize)]
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Debug, Clone, PartialEq, Eq, Versionize)]
 pub enum MmdsVersionState {
     V1,
     V2,
@@ -142,9 +142,9 @@ impl From<MmdsVersion> for MmdsVersionState {
     }
 }
 
-#[derive(Clone, Versionize)]
 /// Holds the device states.
 // NOTICE: Any changes to this structure require a snapshot version bump.
+#[derive(Clone, Versionize)]
 pub struct DeviceStates {
     #[cfg(target_arch = "aarch64")]
     // State of legacy devices in MMIO space.
@@ -534,7 +534,7 @@ impl<'a> Persist<'a> for MMIODeviceManager {
 #[cfg(test)]
 mod tests {
     use devices::virtio::block::CacheType;
-    use utils::net::mac::MacAddr;
+    use devices::virtio::net::persist::NetConfigSpaceState;
     use utils::tempfile::TempFile;
 
     use super::*;
@@ -704,7 +704,7 @@ mod tests {
             let network_interface = NetworkInterfaceConfig {
                 iface_id: String::from("netif"),
                 host_dev_name: String::from("hostname"),
-                guest_mac: Some(MacAddr::parse_str("00:00:00:00:00:00").unwrap()),
+                guest_mac: None,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
             };
@@ -743,7 +743,8 @@ mod tests {
 
             version_map
                 .new_version()
-                .set_type_version(DeviceStates::type_id(), 3);
+                .set_type_version(DeviceStates::type_id(), 3)
+                .set_type_version(NetConfigSpaceState::type_id(), 2);
 
             // For snapshot versions that not support persisting the mmds version, it should be
             // deserialized as None. The MMIODeviceManager will initialise it as the default if
@@ -824,7 +825,7 @@ mod tests {
     {{
       "iface_id": "netif",
       "host_dev_name": "hostname",
-      "guest_mac": "00:00:00:00:00:00",
+      "guest_mac": null,
       "rx_rate_limiter": null,
       "tx_rate_limiter": null
     }}

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -3,7 +3,6 @@
 
 //! Defines state structures for saving/restoring a Firecracker microVM.
 
-use std::fmt::{Display, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::os::unix::io::AsRawFd;
@@ -174,71 +173,45 @@ pub enum MicrovmStateError {
 }
 
 /// Errors associated with creating a snapshot.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CreateSnapshotError {
     /// Failed to get dirty bitmap.
+    #[error("Cannot get dirty bitmap: {0}")]
     DirtyBitmap(VmmError),
     /// The virtio devices uses a features that is incompatible with older versions of Firecracker.
+    #[error(
+        "The virtio devices use a features that is incompatible with older versions of \
+         Firecracker: {0}"
+    )]
     IncompatibleVirtioFeature(&'static str),
     /// Invalid microVM version format
+    #[error("Invalid microVM version format")]
     InvalidVersionFormat,
     /// MicroVM version does not support snapshot.
+    #[error("Cannot translate microVM version to snapshot data version")]
     UnsupportedVersion,
     /// Failed to write memory to snapshot.
+    #[error("Cannot write memory file: {0}")]
     Memory(memory_snapshot::Error),
     /// Failed to open memory backing file.
+    #[error("Cannot perform {0} on the memory backing file: {1}")]
     MemoryBackingFile(&'static str, io::Error),
     /// Failed to save MicrovmState.
+    #[error("Cannot save the microVM state: {0}")]
     MicrovmState(MicrovmStateError),
     /// Failed to serialize microVM state.
+    #[error("Cannot serialize the microVM state: {0}")]
     SerializeMicrovmState(snapshot::Error),
     /// Failed to open the snapshot backing file.
+    #[error("Cannot perform {0} on the snapshot backing file: {1}")]
     SnapshotBackingFile(&'static str, io::Error),
-    #[cfg(target_arch = "x86_64")]
     /// Number of devices exceeds the maximum supported devices for the snapshot data version.
+    #[cfg(target_arch = "x86_64")]
+    #[error(
+        "Too many devices attached: {0}. The maximum number allowed for the snapshot data version \
+         requested is {FC_V0_23_MAX_DEVICES}."
+    )]
     TooManyDevices(usize),
-}
-
-impl Display for CreateSnapshotError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::CreateSnapshotError::*;
-        match self {
-            DirtyBitmap(err) => write!(f, "Cannot get dirty bitmap: {}", err),
-            IncompatibleVirtioFeature(feature) => write!(
-                f,
-                "The virtio devices use a features that is incompatible with older versions of \
-                 Firecracker: {}",
-                feature
-            ),
-            InvalidVersionFormat => write!(f, "Invalid microVM version format"),
-            UnsupportedVersion => write!(
-                f,
-                "Cannot translate microVM version to snapshot data version",
-            ),
-            Memory(err) => write!(f, "Cannot write memory file: {}", err),
-            MemoryBackingFile(action, err) => write!(
-                f,
-                "Cannot perform {} on the memory backing file: {}",
-                action, err
-            ),
-            MicrovmState(err) => write!(f, "Cannot save the microVM state: {}", err),
-            SerializeMicrovmState(err) => {
-                write!(f, "Cannot serialize the microVM state: {:?}", err)
-            }
-            SnapshotBackingFile(action, err) => write!(
-                f,
-                "Cannot perform {} on the snapshot backing file: {}",
-                action, err
-            ),
-            #[cfg(target_arch = "x86_64")]
-            TooManyDevices(val) => write!(
-                f,
-                "Too many devices attached: {}. The maximum number allowed for the snapshot data \
-                 version requested is {}.",
-                val, FC_V0_23_MAX_DEVICES
-            ),
-        }
-    }
 }
 
 /// Creates a Microvm snapshot.

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -250,6 +250,7 @@ fn snapshot_state_to_file(
     let mut snapshot_file = OpenOptions::new()
         .create(true)
         .write(true)
+        .truncate(true)
         .open(snapshot_path)
         .map_err(|err| SnapshotBackingFile("open", err))?;
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -1087,13 +1087,11 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9",
-                            "guest_mac": "06:00:c0:00:32:de"
+                            "host_dev_name": "hostname9"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10",
-                            "guest_mac": "0a:00:20:00:a2:de"
+                            "host_dev_name": "hostname10"
                         }}
                     ],
                     "machine-config": {{
@@ -1164,13 +1162,11 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9",
-                            "guest_mac": "06:00:00:00:32:de"
+                            "host_dev_name": "hostname9"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10",
-                            "guest_mac": "06:00:00:00:a2:de"
+                            "host_dev_name": "hostname10"
                         }}
                     ],
                     "machine-config": {{
@@ -1225,13 +1221,11 @@ mod tests {
                     "network-interfaces": [
                         {{
                             "iface_id": "netif1",
-                            "host_dev_name": "hostname9",
-                            "guest_mac": "06:00:00:00:32:de"
+                            "host_dev_name": "hostname9"
                         }},
                         {{
                             "iface_id": "netif2",
-                            "host_dev_name": "hostname10",
-                            "guest_mac": "06:00:00:00:a2:de"
+                            "host_dev_name": "hostname10"
                         }}
                     ],
                     "machine-config": {{

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use devices::virtio::block::persist::BlockState;
+use devices::virtio::net::persist::NetConfigSpaceState;
 use devices::virtio::QueueState;
 use lazy_static::lazy_static;
 use versionize::{VersionMap, Versionize};
@@ -53,6 +54,7 @@ lazy_static! {
 
         // v1.2 state change mappings.
         version_map.new_version().set_type_version(VmInfo::type_id(), 2);
+        version_map.set_type_version(NetConfigSpaceState::type_id(), 2);
         #[cfg(target_arch = "x86_64")]
         version_map.set_type_version(VcpuState::type_id(), 3);
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.42}
+    COVERAGE_DICT = {"Intel": 82.99, "AMD": 82.31, "ARM": 82.37}
 else:
-    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.6}
+    COVERAGE_DICT = {"Intel": 80.15, "AMD": 79.48, "ARM": 79.54}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
Signed-off-by: Egor Lazarchuk <yegorlz@amazon.co.uk>

This PR:
- Removes random MAC address generation introduced by [this](https://github.com/firecracker-microvm/firecracker/pull/3121) commit
- fixes an issue in `GET /vm/config` which returned invalid `00:00:00:00:00:00` MAC address if it was not previously specified by the user.

Additionally fixes snapshot files not being truncated when saved.

## Reason
Fixes #2943 second time

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
