### PR TITLE
Increase snapshot/resume latency target values

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -138,8 +138,8 @@ LOAD_LATENCY_BASELINES = {
                     "2vcpu_512mb.json": {"target": 2},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 125},
-                    "2vcpu_512mb.json": {"target": 130},
+                    "2vcpu_256mb.json": {"target": 320},
+                    "2vcpu_512mb.json": {"target": 310},
                 },
             },
         }

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -65,7 +65,6 @@ CREATE_LATENCY_BASELINES = {
 # this is tracked here:
 # https://github.com/firecracker-microvm/firecracker/issues/2027
 # TODO: Update the table after fix. Target is < 5ms.
-# TODO: we need to actually measure the numbers for m6i
 # since they might be lower.
 LOAD_LATENCY_BASELINES = {
     "x86_64": {
@@ -118,8 +117,8 @@ LOAD_LATENCY_BASELINES = {
                     "2vcpu_512mb.json": {"target": 60},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 190},
-                    "2vcpu_512mb.json": {"target": 190},
+                    "2vcpu_256mb.json": {"target": 220},
+                    "2vcpu_512mb.json": {"target": 220},
                 },
             },
         },


### PR DESCRIPTION
## Changes

Increases the target values of snapshot/resume latency for m6g.metal & m6i.metal.

## Reason

Regarding m6g.metal, along with kernel updates including io_uring change, snapshot/resume latency values on kernel v5.10 increased. In order to not block merging PRs with the updated images, these values need to be updated. We'll keep diving deep into the root cause of this increase even after merging this commit.

Regarding m6i.metal, PR #3235 just copied the target values from m5d.metal and these target values are still TODO. And we have observed several errors for m6i.metal due to this. Replacing them with gathered values will mitigate the CI block.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
