### PR TITLE
correct dev container image tag

### DIFF
--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -83,7 +83,7 @@ registry. The Firecracker CI suite must also be updated to use the new image.
    you're on.
 
     ```bash
-    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_x86_64
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v27_x86_64
 
     docker images
     REPOSITORY                         TAG          IMAGE ID       CREATED
@@ -125,7 +125,7 @@ Then continue with the above steps:
    you're on.
 
     ```bash
-    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v26_aarch64
+    docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v27_aarch64
 
     docker images
     REPOSITORY                         TAG            IMAGE ID


### PR DESCRIPTION
## Changes
fix incorrect docker images tag


## Reason
As a result of running `docker images` in the document, image `1f9852368efb` is tagged with v27.
Therefore, we should specify the v27 tag when execute `docker tag`.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
