### PR TITLE
[1.0.2] Warn on arm64 snapshots

### DIFF
--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -123,6 +123,10 @@ The baseline for snapshot resume latency target on Intel is under **8ms** with
   deal with cryptographic secrets. Please see [Snapshot security and uniqueness](#snapshot-security-and-uniqueness).
 - Snapshotting on arm64 works for both GICv2 and GICv3 enabled guests.
   However, restoring between different GIC version is not possible.
+- On arm64, the upper 64 bits of the FL/SIMD registers V0-V31 are not saved
+  in snapshots, due to incorrect use of the KVM_GET_ONE_REG ioctl.
+  See [here](https://github.com/firecracker-microvm/firecracker/commit/bdfb24c20330bb82daa919d5b35df4ba31dd43dc)
+  for details. This bug is fixed in Firecracker 1.1.4 and newer.
 
 ## Firecracker Snapshotting characteristics
 

--- a/tests/integration_tests/security/test_sec_audit.py
+++ b/tests/integration_tests/security/test_sec_audit.py
@@ -23,4 +23,6 @@ def test_cargo_audit():
     """
     # Run command and raise exception if non-zero return code
     utils.run_cmd(
-        'cargo audit --deny warnings -q', cwd=defs.FC_WORKSPACE_DIR)
+        "cargo audit --deny warnings -q  --ignore RUSTSEC-2021-0145",
+        cwd=defs.FC_WORKSPACE_DIR,
+    )


### PR DESCRIPTION
## Changes

Print a warning messages about 822009ce3ef521f5c91bcb7c6a36406ed5bdefba whenever a snapshot is created/loaded on arm64 in firecracker 1.0, and update the "Known issues and limitations" section

## Reason

We decided against backporting the fix due to the significant work and the fact that 1.0 goes out of support in a handful of days. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
