### PR TITLE
[tests][uffd]: uffd/Cargo.lock is dirty

### DIFF
--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +79,12 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "crc64"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
 
 [[package]]
 name = "derive_more"
@@ -340,7 +355,37 @@ dependencies = [
  "libc",
  "net_gen",
  "serde",
+ "versionize",
+ "versionize_derive",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "versionize"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"
+dependencies = [
+ "bincode",
+ "crc64",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+ "versionize_derive",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "versionize_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140aa9fd298f667ea50fa1cb0d8530076924079285c623b18b8f8a1c28386b4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tests/host_tools/uffd/Cargo.lock
+++ b/tests/host_tools/uffd/Cargo.lock
@@ -309,7 +309,6 @@ name = "uffd"
 version = "1.1.0"
 dependencies = [
  "libc",
- "nix",
  "serde",
  "serde_json",
  "userfaultfd",
@@ -324,9 +323,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "userfaultfd"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b738009e099b4ded1ecf19dfb7631f69c24f16e0af6d29fd9b3f54a092aca46"
+checksum = "fee2cdd3f8bdd0b98d7aa9ace35e7214a71888229d60c1cd1cd71b7c09c089d0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",

--- a/tests/host_tools/uffd/Cargo.toml
+++ b/tests/host_tools/uffd/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-utils = { path = "../../../src/utils" }
-
-libc = "0.2.121"
-nix = "0.23.0"
+libc = "0.2.117"
+nix = "0.26.1"
 serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-userfaultfd = "0.4.2"
+serde_json = "1.0.78"
+userfaultfd = "0.5.0"
+
+utils = { path = "../../../src/utils" }
 
 [workspace]
 

--- a/tests/host_tools/uffd/Cargo.toml
+++ b/tests/host_tools/uffd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uffd"
 version = "1.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.117"

--- a/tests/host_tools/uffd/Cargo.toml
+++ b/tests/host_tools/uffd/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.117"
-nix = "0.26.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 userfaultfd = "0.5.0"

--- a/tests/host_tools/uffd/src/bin/valid_handler.rs
+++ b/tests/host_tools/uffd/src/bin/valid_handler.rs
@@ -5,7 +5,6 @@
 //! which loads the whole region from the backing memory file
 //! when a page fault occurs.
 
-use nix::poll::{poll, PollFd, PollFlags};
 use std::os::unix::io::AsRawFd;
 
 use uffd::uffd_utils::{create_pf_handler, MemPageState};
@@ -13,19 +12,27 @@ use uffd::uffd_utils::{create_pf_handler, MemPageState};
 fn main() {
     let mut uffd_handler = create_pf_handler();
 
-    let pollfd = PollFd::new(uffd_handler.uffd.as_raw_fd(), PollFlags::POLLIN);
-
+    let mut pollfd = libc::pollfd {
+        fd: uffd_handler.uffd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
     // Loop, handling incoming events on the userfaultfd file descriptor.
     loop {
         // See what poll() tells us about the userfaultfd.
-        let nready = poll(&mut [pollfd], -1).expect("Failed to poll");
+        let nready = unsafe { libc::poll(&mut pollfd, 1, -1) };
 
-        let revents = pollfd.revents().unwrap();
+        if nready == -1 {
+            panic!("Could not poll for events!")
+        }
+
+        let revents = pollfd.revents;
+
         println!(
             "poll() returns: nready = {}; POLLIN = {}; POLLERR = {}",
             nready,
-            revents.contains(PollFlags::POLLIN),
-            revents.contains(PollFlags::POLLERR),
+            revents & libc::POLLIN,
+            revents & libc::POLLERR,
         );
 
         // Read an event from the userfaultfd.

--- a/tests/integration_tests/security/demo_seccomp/Cargo.toml
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "demo_seccomp"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.117"

--- a/tests/integration_tests/security/demo_seccomp/Cargo.toml
+++ b/tests/integration_tests/security/demo_seccomp/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-libc = "0.2.66"
+libc = "0.2.117"
 
 seccompiler = { path = "../../../../src/seccompiler" }
 


### PR DESCRIPTION
## Changes

* push dirty uffd/Cargo.lock
* Some other small fixes were made that bring the
dependencies in sync with the versions used in
production.

## Reason

The Cargo.lock from the uffd tests appears
as dirty since the "utils" crate depends on Versionize. This happened with the merging of PR #3287.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
