### PR TITLE
remove unnecessary  files from devctr

### DIFF
--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -81,12 +81,15 @@ RUN apt-get update \
 # Update Python to 3.10
 # This method isn't ideal, compiling from source can be dropped
 # once the container definition is based on ubuntu:22.04
-RUN wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
+RUN mkdir "$TMP_BUILD_DIR" && cd "$TMP_BUILD_DIR" \
+    && wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
     && tar -xf Python-3.10.4.tgz \
     && cd ./Python-3.10.4 \
     && ./configure --enable-optimizations \
     && make -j 8 \
-    && make install
+    && make install \
+    && cd / \
+    && rm -rf "$TMP_BUILD_DIR"
 
 RUN python3 -m pip install poetry
 RUN mkdir "$TMP_POETRY_DIR"

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -82,12 +82,15 @@ RUN apt-get update \
 # Update Python to 3.10
 # This method isn't ideal, compiling from source can be dropped
 # once the container definition is based on ubuntu:22.04
-RUN wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
+RUN mkdir "$TMP_BUILD_DIR" && cd "$TMP_BUILD_DIR" \
+    && wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
     && tar -xf Python-3.10.4.tgz \
     && cd ./Python-3.10.4 \
     && ./configure --enable-optimizations \
     && make -j 8 \
-    && make install
+    && make install \
+    && cd / \
+    && rm -rf "$TMP_BUILD_DIR"
 
 RUN python3 -m pip install poetry
 RUN mkdir "$TMP_POETRY_DIR"


### PR DESCRIPTION
## Changes

Remove python's source code and extracted directory from devctr.


## Reason
After complete installation, these files are no longer need.
Container image should be small.

Here is a size comparison with the image built before the fix.

```
$ docker images
REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
public.ecr.aws/firecracker/fcuvm   latest    8ae53ea6a904   14 minutes ago   2.93GB
public.ecr.aws/firecracker/fcuvm   v44       cc02d6a9162c   2 months ago     3.23GB
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
