### PR TITLE
Update devtool fcuvm tag to v46

### DIFF
--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v45"
+DEVCTR_IMAGE_TAG="v46"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
v45 was already in use on the v1.1 branch

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
