### PR TITLE
Update build_devctr with hint about version choice

### DIFF
--- a/docs/devctr-image.md
+++ b/docs/devctr-image.md
@@ -79,8 +79,26 @@ registry. The Firecracker CI suite must also be updated to use the new image.
     public.ecr.aws/firecracker/fcuvm   v26       8d00deb17f7a     2 weeks ago   2.41GB
     ```
 
-1. Tag the new image with the next available version and the architecture
-   you're on.
+1. Tag the new image with the next available version `X` and the architecture
+   you're on. Note that this will not always be "current version in devtool + 1",
+   as sometimes that version might already be used on feature branches. Always
+   check the "Image Tags" on [the fcuvm repository](https://gallery.ecr.aws/firecracker/fcuvm)
+   to make sure you do not accidentally overwrite an existing image.
+
+   As a sanity check, run:
+
+   ```bash
+   docker pull public.ecr.aws/firecracker/fcuvm:vX
+   ```
+
+   and verify that you get an error message along the lines of
+
+   ```
+   Error response from daemon: manifest for public.ecr.aws/firecracker/fcuvm:vX not
+   found: manifest unknown: Requested image not found
+   ```
+
+   This means the version you've chosen does not exist yet, and you are good to go.
 
     ```bash
     docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v27_x86_64
@@ -121,8 +139,26 @@ Then continue with the above steps:
     public.ecr.aws/firecracker/fcuvm   v26        8d00deb17f7a        2 weeks ago
     ```
 
-1. Tag the new image with the next available version and the architecture
-   you're on.
+1. Tag the new image with the next available version `X` and the architecture
+   you're on. Note that this will not always be "current version in devtool + 1",
+   as sometimes that version might already be used on feature branches. Always
+   check the "Image Tags" on [the fcuvm repository](https://gallery.ecr.aws/firecracker/fcuvm)
+   to make sure you do not accidentally overwrite an existing image.
+
+   As a sanity check, run:
+
+   ```bash
+   docker pull public.ecr.aws/firecracker/fcuvm:vX
+   ```
+
+   and verify that you get an error message along the lines of
+
+   ```
+   Error response from daemon: manifest for public.ecr.aws/firecracker/fcuvm:vX not
+   found: manifest unknown: Requested image not found
+   ```
+
+   This means the version you've chosen does not exist yet, and you are good to go.
 
     ```bash
     docker tag 1f9852368efb public.ecr.aws/firecracker/fcuvm:v27_aarch64


### PR DESCRIPTION

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Add instructions to make sure that we do not accidentally overwrite existing images when publishing new versions of the devctr

## Reason

We accidentally overwrote some images the other day

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
