### PR TITLE
virtio: use same impl member order from the trait

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -498,6 +498,18 @@ impl Balloon {
 }
 
 impl VirtioDevice for Balloon {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features;
+    }
+
     fn device_type(&self) -> u32 {
         TYPE_BALLOON
     }
@@ -520,18 +532,6 @@ impl VirtioDevice for Balloon {
 
     fn interrupt_status(&self) -> Arc<AtomicUsize> {
         self.irq_trigger.irq_status.clone()
-    }
-
-    fn avail_features(&self) -> u64 {
-        self.avail_features
-    }
-
-    fn acked_features(&self) -> u64 {
-        self.acked_features
-    }
-
-    fn set_acked_features(&mut self, acked_features: u64) {
-        self.acked_features = acked_features;
     }
 
     fn read_config(&self, offset: u64, mut data: &mut [u8]) {
@@ -562,10 +562,6 @@ impl VirtioDevice for Balloon {
         config_space_bytes[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
     }
 
-    fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
-    }
-
     fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {
         self.device_state = DeviceState::Activated(mem);
         if self.activate_evt.write(1).is_err() {
@@ -580,6 +576,10 @@ impl VirtioDevice for Balloon {
         }
 
         Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
     }
 }
 

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -528,6 +528,18 @@ impl Block {
 }
 
 impl VirtioDevice for Block {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features;
+    }
+
     fn device_type(&self) -> u32 {
         TYPE_BLOCK
     }
@@ -551,18 +563,6 @@ impl VirtioDevice for Block {
     /// Returns the current device interrupt status.
     fn interrupt_status(&self) -> Arc<AtomicUsize> {
         self.irq_trigger.irq_status.clone()
-    }
-
-    fn avail_features(&self) -> u64 {
-        self.avail_features
-    }
-
-    fn acked_features(&self) -> u64 {
-        self.acked_features
-    }
-
-    fn set_acked_features(&mut self, acked_features: u64) {
-        self.acked_features = acked_features;
     }
 
     fn read_config(&self, offset: u64, mut data: &mut [u8]) {
@@ -591,10 +591,6 @@ impl VirtioDevice for Block {
         self.config_space[offset as usize..(offset + data_len) as usize].copy_from_slice(data);
     }
 
-    fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
-    }
-
     fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
@@ -609,6 +605,10 @@ impl VirtioDevice for Block {
         }
         self.device_state = DeviceState::Activated(mem);
         Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
     }
 }
 

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -367,20 +367,6 @@ pub(crate) mod tests {
     }
 
     impl VirtioDevice for DummyDevice {
-        fn device_type(&self) -> u32 {
-            123
-        }
-
-        fn read_config(&self, offset: u64, data: &mut [u8]) {
-            data.copy_from_slice(&self.config_bytes[offset as usize..]);
-        }
-
-        fn write_config(&mut self, offset: u64, data: &[u8]) {
-            for (i, item) in data.iter().enumerate() {
-                self.config_bytes[offset as usize + i] = *item;
-            }
-        }
-
         fn avail_features(&self) -> u64 {
             self.avail_features
         }
@@ -393,9 +379,8 @@ pub(crate) mod tests {
             self.acked_features = acked_features;
         }
 
-        fn activate(&mut self, _: GuestMemoryMmap) -> ActivateResult {
-            self.device_activated = true;
-            Ok(())
+        fn device_type(&self) -> u32 {
+            123
         }
 
         fn queues(&self) -> &[Queue] {
@@ -416,6 +401,21 @@ pub(crate) mod tests {
 
         fn interrupt_status(&self) -> Arc<AtomicUsize> {
             self.interrupt_status.clone()
+        }
+
+        fn read_config(&self, offset: u64, data: &mut [u8]) {
+            data.copy_from_slice(&self.config_bytes[offset as usize..]);
+        }
+
+        fn write_config(&mut self, offset: u64, data: &[u8]) {
+            for (i, item) in data.iter().enumerate() {
+                self.config_bytes[offset as usize + i] = *item;
+            }
+        }
+
+        fn activate(&mut self, _: GuestMemoryMmap) -> ActivateResult {
+            self.device_activated = true;
+            Ok(())
         }
 
         fn is_activated(&self) -> bool {

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -754,6 +754,18 @@ impl Net {
 }
 
 impl VirtioDevice for Net {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features;
+    }
+
     fn device_type(&self) -> u32 {
         TYPE_NET
     }
@@ -776,18 +788,6 @@ impl VirtioDevice for Net {
 
     fn interrupt_status(&self) -> Arc<AtomicUsize> {
         self.irq_trigger.irq_status.clone()
-    }
-
-    fn avail_features(&self) -> u64 {
-        self.avail_features
-    }
-
-    fn acked_features(&self) -> u64 {
-        self.acked_features
-    }
-
-    fn set_acked_features(&mut self, acked_features: u64) {
-        self.acked_features = acked_features;
     }
 
     fn read_config(&self, offset: u64, mut data: &mut [u8]) {
@@ -822,10 +822,6 @@ impl VirtioDevice for Net {
         METRICS.net.mac_address_updates.inc();
     }
 
-    fn is_activated(&self) -> bool {
-        self.device_state.is_activated()
-    }
-
     fn activate(&mut self, mem: GuestMemoryMmap) -> ActivateResult {
         let event_idx = self.has_feature(u64::from(VIRTIO_RING_F_EVENT_IDX));
         if event_idx {
@@ -840,6 +836,10 @@ impl VirtioDevice for Net {
         }
         self.device_state = DeviceState::Activated(mem);
         Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
     }
 }
 


### PR DESCRIPTION
## Changes

* virtio trait functions are ordered in implementation functions

## Reason

* This is to avoid a linting warning in my
IDE space.
* It is also good practice.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
