### PR TITLE
chore(snapshot): clarify snapshot version map

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,5 @@
 [title-max-length]
-line-length=50
+line-length=72
 
 [body-max-line-length]
 line-length=72

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -272,7 +272,7 @@ Details about the required and optional fields can be found in the
 
 *Note*: If the files indicated by `snapshot_path` and `mem_file_path` don't
 exist at the specified paths, then they will be created right before generating
-the snapshot.
+the snapshot. If they exist, the files will be truncated and overwritten.
 
 **Prerequisites**: The microVM is `Paused`.
 

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -293,14 +293,23 @@ the snapshot.
     dirtied page bitmap and marks all pages clean (from a diff snapshot point
     of view).
   - If a `version` is specified, the new snapshot is saved at that version,
-    otherwise it will be saved at the same version of the running Firecracker.
-    The version is only used for the microVM state file as it contains internal
-    state structures for device emulation, vCPUs and others that can change
-    their format from a Firecracker version to another. Versioning is not
-    required for the block and memory files. The separate block device file
-    components of the snapshot have to be handled by the user.
+    otherwise it will be saved at the latest snapshot version of the running
+    Firecracker. The version is only used for the microVM state file as it
+    contains internal state structures for device emulation, vCPUs and others
+    that can change their format from a Firecracker version to another.
+    Versioning is not required for the block and memory files.
 
 - _on failure_: no side-effects.
+
+**Notes**:
+
+- The separate block device file components of the snapshot have to be handled
+  by the user.
+- If specified, `version` must match the firecracker version that introduced a
+  snapshot version, which may differ from the running Firecracker version. For
+  example, if you are running on `1.1.2` and want to target version `1.0.4`, you
+  should specify `1.0.0`. Not specifying `version` uses the latest snapshot
+  version available to that version.
 
 #### Creating diff snapshots
 

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -63,6 +63,15 @@ lazy_static! {
 
     /// Static instance used for creating a 1:1 mapping between Firecracker release version
     /// and snapshot data format version.
+    /// !CAVEAT!
+    /// This map is supposed to be strictly one-to-one (i.e. bijective) because
+    /// describe-snapshot inverts it to look up the release that matches the
+    /// snapshot version. If two version map to the snap_version, the results
+    /// are non-deterministic.
+    /// This means
+    /// - Do not insert patch releases here.
+    /// - Every minor version should be represented here.
+    /// - When requesting a `target_version`, these are the versions we expect.
     pub static ref FC_VERSION_TO_SNAP_VERSION: HashMap<String, u16> = {
         let mut mapping = HashMap::new();
         #[cfg(not(target_arch = "aarch64"))]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,10 +94,11 @@ import host_tools.network as net_tools
 from host_tools import proc
 from framework import utils
 from framework import defs
-from framework.artifacts import ArtifactCollection
+from framework.artifacts import ArtifactCollection, FirecrackerArtifact
 from framework.microvm import Microvm
 from framework.s3fetcher import MicrovmImageS3Fetcher
 from framework.scheduler import PytestScheduler
+from framework.utils import get_firecracker_version_from_toml
 
 # Tests root directory.
 SCRIPT_FOLDER = os.path.dirname(os.path.realpath(__file__))
@@ -501,6 +502,35 @@ def test_spectre_mitigations():
 
     mitigated = x86_64(body) if arch == "x86_64" else aarch64(body)
     assert mitigated, "SPECTREv2 not mitigated {}".format(body)
+
+
+def firecracker_id(fc):
+    """Render a nice ID for pytest parametrize."""
+    if isinstance(fc, FirecrackerArtifact):
+        return f"firecracker-{fc.version}"
+    return None
+
+
+def firecracker_artifacts(*args, **kwargs):
+    """Return all supported firecracker binaries."""
+    params = {
+        "min_version": "1.1.0",
+        "max_version": get_firecracker_version_from_toml(),
+    }
+    params.update(kwargs)
+    return ARTIFACTS_COLLECTION.firecrackers(
+        *args,
+        **params,
+    )
+
+
+@pytest.fixture(params=firecracker_artifacts(), ids=firecracker_id)
+def firecracker_release(request):
+    """Return all supported firecracker binaries."""
+    firecracker = request.param
+    firecracker.download()
+    firecracker.jailer().download()
+    return firecracker
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -7,14 +7,8 @@ import platform
 import tempfile
 import pytest
 from test_balloon import _test_rss_memory_lower
-from conftest import _test_images_s3_bucket
-from framework.artifacts import (
-    ArtifactCollection,
-    FirecrackerArtifact,
-    create_net_devices_configuration,
-)
+from framework.artifacts import create_net_devices_configuration
 from framework.builder import MicrovmBuilder, SnapshotBuilder, SnapshotType
-from framework.utils import get_firecracker_version_from_toml
 import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.drive as drive_tools
 
@@ -25,106 +19,67 @@ net_ifaces = create_net_devices_configuration(4)
 scratch_drives = ["vdb", "vdc", "vdd", "vde", "vdf"]
 
 
-def firecracker_artifacts(*args, **kwargs):
-    """Return all available firecracker binaries."""
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch all firecracker binaries.
-    return artifacts.firecrackers(*args, **kwargs)
-
-
-def firecracker_id(fc):
-    """Render a nice ID for pytest parametrize."""
-    if isinstance(fc, FirecrackerArtifact):
-        return f"firecracker-{fc.version}"
-    return None
-
-
-@pytest.mark.parametrize(
-    "firecracker",
-    firecracker_artifacts(
-        min_version="1.1.0",
-        max_version=get_firecracker_version_from_toml(),
-    ),
-    ids=firecracker_id,
-)
-def test_restore_old_snapshot(bin_cloner_path, firecracker):
+def test_restore_old_to_current(bin_cloner_path, firecracker_release):
     """
-    Restore from snapshots obtained with previous versions of Firecracker.
+    Restore snapshots from previous supported versions of Firecracker.
+
+    For each firecracker release:
+    1. Snapshot with the past release
+    2. Restore with the current build
 
     @type: functional
     """
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
-
-    # With each binary create a snapshot and try to restore in current
-    # version.
-
-    firecracker.download()
-    jailer = firecracker.jailer()
-    jailer.download()
-
-    logger.info("Creating snapshot with Firecracker: %s", firecracker.local_path())
+    jailer = firecracker_release.jailer()
+    logger.info("Using Firecracker: %s", firecracker_release.local_path())
     logger.info("Using Jailer: %s", jailer.local_path())
-
-    target_version = firecracker.base_name()[1:]
-
-    # v0.23 does not support creating diff snapshots.
-    # v0.23 does not support balloon.
-    diff_snapshots = "0.23" not in target_version
-
-    # Create a snapshot.
+    diff_snapshots = True
+    logger.info("Create snapshot")
     snapshot = create_snapshot_helper(
         builder,
         logger,
         drives=scratch_drives,
         ifaces=net_ifaces,
-        fc_binary=firecracker.local_path(),
+        fc_binary=firecracker_release.local_path(),
         jailer_binary=jailer.local_path(),
         diff_snapshots=diff_snapshots,
         balloon=diff_snapshots,
     )
 
-    # Resume microvm using current build of FC/Jailer.
+    logger.info("Resume microvm using current build of FC/Jailer")
     microvm, _ = builder.build_from_snapshot(
         snapshot, resume=True, diff_snapshots=False
     )
+    logger.info("Validate all devices")
     validate_all_devices(logger, microvm, net_ifaces, scratch_drives, diff_snapshots)
     logger.debug("========== Firecracker restore snapshot log ==========")
     logger.debug(microvm.log_data)
 
 
-@pytest.mark.parametrize(
-    "firecracker",
-    firecracker_artifacts(
-        min_version="1.2.0",
-        max_version=get_firecracker_version_from_toml(),
-    ),
-    ids=firecracker_id,
-)
-def test_restore_old_version(bin_cloner_path, firecracker):
+def test_restore_current_to_old(bin_cloner_path, firecracker_release):
     """
     Restore current snapshot with previous versions of Firecracker.
 
-    Current snapshot (i.e a machine snapshotted with current build) is
-    incompatible with any past release due to notification suppression.
+    For each firecracker release:
+    1. Snapshot with the current build
+    2. Restore with the past release
 
     @type: functional
     """
+
+    # Current snapshot (i.e a machine snapshotted with current build) is
+    # incompatible with any past release due to notification suppression.
+    if firecracker_release.version_tuple < (1, 2, 0):
+        pytest.skip("incompatible with Firecracker <1.2.0")
+
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_version_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)
-
-    # Create a snapshot with current build and restore with each FC binary
-    # artifact.
-    firecracker.download()
-    jailer = firecracker.jailer()
-    jailer.download()
-
+    jailer = firecracker_release.jailer()
     logger.info("Creating snapshot with local build")
-
-    # Old version from artifact.
-    target_version = firecracker.base_name()[1:]
+    target_version = firecracker_release.snapshot_version
 
     # Create a snapshot with current FC version targeting the old version.
     snapshot = create_snapshot_helper(
@@ -137,7 +92,9 @@ def test_restore_old_version(bin_cloner_path, firecracker):
         diff_snapshots=True,
     )
 
-    logger.info("Restoring snapshot with Firecracker: %s", firecracker.local_path())
+    logger.info(
+        "Restoring snapshot with Firecracker: %s", firecracker_release.local_path()
+    )
     logger.info("Using Jailer: %s", jailer.local_path())
 
     # Resume microvm using FC/Jailer binary artifacts.
@@ -145,7 +102,7 @@ def test_restore_old_version(bin_cloner_path, firecracker):
         snapshot,
         resume=True,
         diff_snapshots=False,
-        fc_binary=firecracker.local_path(),
+        fc_binary=firecracker_release.local_path(),
         jailer_binary=jailer.local_path(),
     )
     validate_all_devices(logger, vm, net_ifaces, scratch_drives, True)

--- a/tests/integration_tests/functional/test_snapshot_advanced.py
+++ b/tests/integration_tests/functional/test_snapshot_advanced.py
@@ -29,6 +29,15 @@ def test_restore_old_to_current(bin_cloner_path, firecracker_release):
 
     @type: functional
     """
+
+    # due to ARM bug fixed in commit 822009ce
+    if platform.machine() == "aarch64" and firecracker_release.version_tuple < (
+        1,
+        1,
+        4,
+    ):
+        pytest.skip("incompatible with aarch64 and Firecracker <1.1.4")
+
     # Microvm: 2vCPU 256MB RAM, balloon, 4 disks and 4 net devices.
     logger = logging.getLogger("old_snapshot_many_devices")
     builder = MicrovmBuilder(bin_cloner_path)


### PR DESCRIPTION
Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

Fix missing versions in the version to snapshot version map.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
