### PR TITLE
chore: Update snap/restore baseline

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -2182,350 +2182,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.179,
-                                                    "delta_percentage": 12
+                                                    "target": 12.847,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.681,
-                                                    "delta_percentage": 21
+                                                    "target": 13.303,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.277,
-                                                    "delta_percentage": 12
+                                                    "target": 13.035,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.835,
-                                                    "delta_percentage": 24
+                                                    "target": 13.483,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.385,
+                                                    "target": 13.284,
                                                     "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.881,
-                                                    "delta_percentage": 29
+                                                    "target": 13.764,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.493,
-                                                    "delta_percentage": 14
+                                                    "target": 13.524,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.006,
-                                                    "delta_percentage": 22
+                                                    "target": 14.008,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.605,
-                                                    "delta_percentage": 15
+                                                    "target": 13.787,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.116,
-                                                    "delta_percentage": 25
+                                                    "target": 14.226,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.724,
-                                                    "delta_percentage": 17
+                                                    "target": 14.061,
+                                                    "delta_percentage": 21
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.259,
-                                                    "delta_percentage": 26
+                                                    "target": 14.483,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.811,
-                                                    "delta_percentage": 18
+                                                    "target": 14.326,
+                                                    "delta_percentage": 23
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.382,
-                                                    "delta_percentage": 33
+                                                    "target": 14.916,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.986,
-                                                    "delta_percentage": 20
+                                                    "target": 14.7,
+                                                    "delta_percentage": 23
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.644,
-                                                    "delta_percentage": 106
+                                                    "target": 15.253,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.211,
-                                                    "delta_percentage": 20
+                                                    "target": 15.143,
+                                                    "delta_percentage": 25
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.983,
-                                                    "delta_percentage": 94
+                                                    "target": 15.81,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.388,
-                                                    "delta_percentage": 21
+                                                    "target": 15.344,
+                                                    "delta_percentage": 26
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.338,
-                                                    "delta_percentage": 131
+                                                    "target": 15.98,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.136,
-                                                    "delta_percentage": 13
+                                                    "target": 12.827,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.642,
-                                                    "delta_percentage": 22
+                                                    "target": 13.467,
+                                                    "delta_percentage": 44
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.174,
-                                                    "delta_percentage": 12
+                                                    "target": 12.869,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.677,
-                                                    "delta_percentage": 19
+                                                    "target": 13.221,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.294,
+                                                    "target": 13.002,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.873,
-                                                    "delta_percentage": 22
+                                                    "target": 13.574,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.469,
+                                                    "target": 13.262,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.064,
-                                                    "delta_percentage": 20
+                                                    "target": 13.928,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.246,
-                                                    "delta_percentage": 13
+                                                    "target": 14.031,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.999,
-                                                    "delta_percentage": 25
+                                                    "target": 14.763,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.504,
-                                                    "delta_percentage": 17
+                                                    "target": 14.905,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.444,
-                                                    "delta_percentage": 33
+                                                    "target": 15.575,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.346,
-                                                    "delta_percentage": 17
+                                                    "target": 16.351,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 11.321,
-                                                    "delta_percentage": 27
+                                                    "target": 17.305,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 13.732,
-                                                    "delta_percentage": 17
+                                                    "target": 19.187,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 14.627,
-                                                    "delta_percentage": 26
+                                                    "target": 20.217,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.821,
-                                                    "delta_percentage": 20
+                                                    "target": 13.508,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.617,
-                                                    "delta_percentage": 36
+                                                    "target": 14.211,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.426,
-                                                    "delta_percentage": 12
+                                                    "target": 13.939,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.071,
-                                                    "delta_percentage": 25
+                                                    "target": 14.659,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 9.027,
-                                                    "delta_percentage": 14
+                                                    "target": 14.532,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.619,
-                                                    "delta_percentage": 22
+                                                    "target": 15.143,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.245,
-                                                    "delta_percentage": 13
+                                                    "target": 12.91,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.852,
-                                                    "delta_percentage": 28
+                                                    "target": 13.44,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.288,
+                                                    "target": 12.991,
                                                     "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.903,
-                                                    "delta_percentage": 31
+                                                    "target": 13.625,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.326,
+                                                    "target": 13.046,
                                                     "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.94,
-                                                    "delta_percentage": 21
+                                                    "target": 13.718,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.302,
-                                                    "delta_percentage": 13
+                                                    "target": 12.995,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.877,
-                                                    "delta_percentage": 22
+                                                    "target": 13.562,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         }
@@ -2536,350 +2536,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.158,
-                                                    "delta_percentage": 13
+                                                    "target": 12.8,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.718,
-                                                    "delta_percentage": 24
+                                                    "target": 13.366,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.278,
+                                                    "target": 13.005,
                                                     "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.831,
-                                                    "delta_percentage": 26
+                                                    "target": 13.53,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.392,
-                                                    "delta_percentage": 14
+                                                    "target": 13.283,
+                                                    "delta_percentage": 15
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.958,
-                                                    "delta_percentage": 31
+                                                    "target": 13.761,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.513,
-                                                    "delta_percentage": 15
+                                                    "target": 13.496,
+                                                    "delta_percentage": 17
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.091,
-                                                    "delta_percentage": 26
+                                                    "target": 14.297,
+                                                    "delta_percentage": 40
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.611,
-                                                    "delta_percentage": 16
+                                                    "target": 13.738,
+                                                    "delta_percentage": 19
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.225,
-                                                    "delta_percentage": 35
+                                                    "target": 14.271,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.739,
-                                                    "delta_percentage": 17
+                                                    "target": 14.045,
+                                                    "delta_percentage": 21
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.327,
-                                                    "delta_percentage": 44
+                                                    "target": 14.594,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.87,
-                                                    "delta_percentage": 17
+                                                    "target": 14.287,
+                                                    "delta_percentage": 23
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.465,
-                                                    "delta_percentage": 24
+                                                    "target": 14.934,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.019,
-                                                    "delta_percentage": 20
+                                                    "target": 14.61,
+                                                    "delta_percentage": 24
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.703,
-                                                    "delta_percentage": 50
+                                                    "target": 15.494,
+                                                    "delta_percentage": 32
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.231,
-                                                    "delta_percentage": 19
+                                                    "target": 15.05,
+                                                    "delta_percentage": 25
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.07,
-                                                    "delta_percentage": 138
+                                                    "target": 15.837,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.401,
-                                                    "delta_percentage": 20
+                                                    "target": 15.361,
+                                                    "delta_percentage": 26
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.15,
-                                                    "delta_percentage": 94
+                                                    "target": 15.99,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.23,
-                                                    "delta_percentage": 12
+                                                    "target": 12.78,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.71,
-                                                    "delta_percentage": 28
+                                                    "target": 13.203,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.244,
-                                                    "delta_percentage": 13
+                                                    "target": 12.789,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.748,
-                                                    "delta_percentage": 25
+                                                    "target": 13.128,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.324,
-                                                    "delta_percentage": 16
+                                                    "target": 12.991,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.807,
-                                                    "delta_percentage": 28
+                                                    "target": 13.35,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.482,
-                                                    "delta_percentage": 13
+                                                    "target": 13.256,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.138,
-                                                    "delta_percentage": 28
+                                                    "target": 13.913,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.258,
-                                                    "delta_percentage": 15
+                                                    "target": 14.086,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.018,
-                                                    "delta_percentage": 23
+                                                    "target": 14.688,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.434,
-                                                    "delta_percentage": 24
+                                                    "target": 14.882,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.36,
-                                                    "delta_percentage": 40
+                                                    "target": 15.438,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 10.223,
-                                                    "delta_percentage": 14
+                                                    "target": 16.169,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 11.032,
-                                                    "delta_percentage": 25
+                                                    "target": 16.596,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 13.561,
-                                                    "delta_percentage": 12
+                                                    "target": 19.049,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 14.275,
-                                                    "delta_percentage": 30
+                                                    "target": 19.709,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.746,
+                                                    "target": 13.427,
                                                     "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.271,
-                                                    "delta_percentage": 20
+                                                    "target": 13.887,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.398,
-                                                    "delta_percentage": 11
+                                                    "target": 13.959,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.908,
-                                                    "delta_percentage": 22
+                                                    "target": 14.391,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 9.024,
-                                                    "delta_percentage": 11
+                                                    "target": 14.506,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 9.516,
-                                                    "delta_percentage": 19
+                                                    "target": 14.878,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.214,
-                                                    "delta_percentage": 13
+                                                    "target": 12.875,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.737,
-                                                    "delta_percentage": 22
+                                                    "target": 13.286,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.256,
-                                                    "delta_percentage": 12
+                                                    "target": 12.927,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.79,
-                                                    "delta_percentage": 21
+                                                    "target": 13.318,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.316,
-                                                    "delta_percentage": 13
+                                                    "target": 12.996,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.841,
-                                                    "delta_percentage": 23
+                                                    "target": 13.392,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 7.289,
+                                                    "target": 12.957,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 7.773,
-                                                    "delta_percentage": 22
+                                                    "target": 13.329,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Updates baselines for snapshot/restore tests on kernel 4.14 + m6a.metal (AMD).

## Reason

The snapshot/restore performance test continued to fail since 2022-10-30. 

As a result of investigation, `ioctl()` for `KVM_CREATE_VM` and the first `KVM_CREATE_VCPU` takes much time and most of the elapsed time for `ioctl()` was spent on sending IPIs to all-but-self.

The reasons why we see this issue only on the combination of kernel 4.14 and m6a.metal (AMD) are:
- m6a.metal (AMD) uses xAPIC and needs to send 1 IPI for each CPU thread, while m5d.metal (Intel) uses 2xAPIC support cluster configuration and just need to send 1 IPI for each cluster.
- [This patch](https://lwn.net/Articles/793065/) is available on kernel 5.10 and it reduces the time to send IPIs to all-buf-self by using the destination shorthand feature.

As described above, the latency seems to come from the available APIC (xAPIC or x2APIC) and this is out of control from us. Thus, this commit just updates the performance baseline.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
