### PR TITLE
chore: snap_restore_performance 4.14. m6i baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_4.14.json
@@ -1463,167 +1463,167 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.657,
-                                                    "delta_percentage": 14
+                                                    "target": 3.706,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.149,
-                                                    "delta_percentage": 34
+                                                    "target": 4.297,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.779,
-                                                    "delta_percentage": 10
+                                                    "target": 3.833,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.083,
-                                                    "delta_percentage": 13
+                                                    "target": 4.199,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.859,
-                                                    "delta_percentage": 14
+                                                    "target": 3.921,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.153,
-                                                    "delta_percentage": 15
+                                                    "target": 4.252,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.968,
-                                                    "delta_percentage": 13
+                                                    "target": 3.993,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.276,
-                                                    "delta_percentage": 21
+                                                    "target": 4.299,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.104,
-                                                    "delta_percentage": 16
+                                                    "target": 4.149,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.464,
-                                                    "delta_percentage": 19
+                                                    "target": 4.459,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.164,
-                                                    "delta_percentage": 12
+                                                    "target": 4.239,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.515,
-                                                    "delta_percentage": 18
+                                                    "target": 4.604,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.301,
-                                                    "delta_percentage": 16
+                                                    "target": 4.374,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.717,
-                                                    "delta_percentage": 27
+                                                    "target": 4.76,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.454,
-                                                    "delta_percentage": 16
+                                                    "target": 4.491,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.86,
-                                                    "delta_percentage": 14
+                                                    "target": 4.849,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.57,
-                                                    "delta_percentage": 13
+                                                    "target": 4.628,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.937,
-                                                    "delta_percentage": 16
+                                                    "target": 5.012,
+                                                    "delta_percentage": 17
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.696,
-                                                    "delta_percentage": 17
+                                                    "target": 4.753,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.18,
-                                                    "delta_percentage": 19
+                                                    "target": 5.147,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.711,
-                                                    "delta_percentage": 13
+                                                    "target": 3.743,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.11,
-                                                    "delta_percentage": 14
+                                                    "target": 4.143,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.957,
-                                                    "delta_percentage": 12
+                                                    "target": 4.033,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.408,
+                                                    "target": 4.45,
                                                     "delta_percentage": 17
                                                 }
                                             }
@@ -1631,111 +1631,111 @@
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.523,
-                                                    "delta_percentage": 11
+                                                    "target": 4.625,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.955,
-                                                    "delta_percentage": 20
+                                                    "target": 5.185,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.68,
-                                                    "delta_percentage": 10
+                                                    "target": 5.753,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.069,
-                                                    "delta_percentage": 16
+                                                    "target": 6.474,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.204,
-                                                    "delta_percentage": 8
+                                                    "target": 8.252,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 8.646,
-                                                    "delta_percentage": 15
+                                                    "target": 8.92,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 13.005,
-                                                    "delta_percentage": 14
+                                                    "target": 13.229,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 14.216,
-                                                    "delta_percentage": 56
+                                                    "target": 15.374,
+                                                    "delta_percentage": 134
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 21.707,
+                                                    "target": 22.061,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 23.296,
-                                                    "delta_percentage": 57
+                                                    "target": 23.444,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 38.884,
+                                                    "target": 39.406,
                                                     "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 39.98,
-                                                    "delta_percentage": 12
+                                                    "target": 42.679,
+                                                    "delta_percentage": 75
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.109,
+                                                    "target": 4.248,
                                                     "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.609,
-                                                    "delta_percentage": 19
+                                                    "target": 5.021,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.62,
-                                                    "delta_percentage": 13
+                                                    "target": 4.74,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.09,
+                                                    "target": 5.288,
                                                     "delta_percentage": 17
                                                 }
                                             }
@@ -1743,70 +1743,70 @@
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.2,
+                                                    "target": 5.254,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.638,
-                                                    "delta_percentage": 20
+                                                    "target": 5.838,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.584,
-                                                    "delta_percentage": 16
+                                                    "target": 3.573,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.025,
-                                                    "delta_percentage": 24
+                                                    "target": 4.155,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.589,
-                                                    "delta_percentage": 12
+                                                    "target": 3.673,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.011,
-                                                    "delta_percentage": 21
+                                                    "target": 4.273,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.703,
-                                                    "delta_percentage": 12
+                                                    "target": 3.793,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.238,
-                                                    "delta_percentage": 41
+                                                    "target": 4.402,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.714,
-                                                    "delta_percentage": 12
+                                                    "target": 3.746,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.135,
-                                                    "delta_percentage": 23
+                                                    "target": 4.2,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         }
@@ -1817,350 +1817,350 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.554,
-                                                    "delta_percentage": 12
+                                                    "target": 3.577,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.982,
-                                                    "delta_percentage": 18
+                                                    "target": 4.232,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.627,
-                                                    "delta_percentage": 10
+                                                    "target": 3.731,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.053,
-                                                    "delta_percentage": 18
+                                                    "target": 4.352,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.794,
-                                                    "delta_percentage": 13
+                                                    "target": 3.87,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.197,
-                                                    "delta_percentage": 21
+                                                    "target": 4.351,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.931,
-                                                    "delta_percentage": 11
+                                                    "target": 3.981,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.451,
-                                                    "delta_percentage": 27
+                                                    "target": 4.631,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.079,
-                                                    "delta_percentage": 14
+                                                    "target": 4.157,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.48,
-                                                    "delta_percentage": 29
+                                                    "target": 4.743,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.231,
-                                                    "delta_percentage": 17
+                                                    "target": 4.263,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.641,
-                                                    "delta_percentage": 20
+                                                    "target": 4.779,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.322,
-                                                    "delta_percentage": 14
+                                                    "target": 4.363,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.793,
-                                                    "delta_percentage": 19
+                                                    "target": 4.97,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.435,
-                                                    "delta_percentage": 16
+                                                    "target": 4.502,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.902,
-                                                    "delta_percentage": 15
+                                                    "target": 5.019,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.569,
-                                                    "delta_percentage": 14
+                                                    "target": 4.679,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.985,
-                                                    "delta_percentage": 17
+                                                    "target": 5.14,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.691,
-                                                    "delta_percentage": 17
+                                                    "target": 4.771,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.116,
-                                                    "delta_percentage": 20
+                                                    "target": 5.272,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.694,
+                                                    "target": 3.737,
                                                     "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.047,
-                                                    "delta_percentage": 13
+                                                    "target": 4.122,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         },
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.936,
+                                                    "target": 4.032,
                                                     "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.32,
-                                                    "delta_percentage": 19
+                                                    "target": 4.511,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.486,
-                                                    "delta_percentage": 12
+                                                    "target": 4.638,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.902,
-                                                    "delta_percentage": 17
+                                                    "target": 5.057,
+                                                    "delta_percentage": 18
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.703,
-                                                    "delta_percentage": 13
+                                                    "target": 5.778,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 6.417,
-                                                    "delta_percentage": 40
+                                                    "target": 6.699,
+                                                    "delta_percentage": 27
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 8.241,
-                                                    "delta_percentage": 10
+                                                    "target": 8.353,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
                                                     "target": 9.048,
-                                                    "delta_percentage": 39
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 13.1,
-                                                    "delta_percentage": 9
+                                                    "target": 13.099,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 13.818,
-                                                    "delta_percentage": 17
+                                                    "target": 13.98,
+                                                    "delta_percentage": 28
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 21.647,
-                                                    "delta_percentage": 10
+                                                    "target": 21.64,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 23.511,
-                                                    "delta_percentage": 57
+                                                    "target": 23.048,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 38.559,
+                                                    "target": 38.947,
                                                     "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 40.368,
-                                                    "delta_percentage": 51
+                                                    "target": 43.025,
+                                                    "delta_percentage": 69
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.035,
-                                                    "delta_percentage": 13
+                                                    "target": 4.102,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.433,
-                                                    "delta_percentage": 14
+                                                    "target": 4.526,
+                                                    "delta_percentage": 19
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 4.574,
-                                                    "delta_percentage": 11
+                                                    "target": 4.676,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.019,
-                                                    "delta_percentage": 23
+                                                    "target": 5.052,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 5.134,
+                                                    "target": 5.261,
                                                     "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 5.57,
-                                                    "delta_percentage": 21
+                                                    "target": 5.751,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.529,
-                                                    "delta_percentage": 13
+                                                    "target": 3.594,
+                                                    "delta_percentage": 12
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.949,
-                                                    "delta_percentage": 25
+                                                    "target": 3.975,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.583,
-                                                    "delta_percentage": 11
+                                                    "target": 3.61,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.965,
-                                                    "delta_percentage": 14
+                                                    "target": 4.054,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.63,
-                                                    "delta_percentage": 11
+                                                    "target": 3.692,
+                                                    "delta_percentage": 13
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.028,
-                                                    "delta_percentage": 14
+                                                    "target": 4.132,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.653,
-                                                    "delta_percentage": 12
+                                                    "target": 3.694,
+                                                    "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 4.088,
-                                                    "delta_percentage": 17
+                                                    "target": 4.129,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Re-gathered baselines for `snap_restore_performance` for m6i kernel 4.14.

## Changes

Updates `snap_restore_performance` baselines for the 4.14 kernel on the m6i instance.

## Reason

The P90 values with m6i kernel 4.14 for the intermittently failing tests are as follows:

`(x)` represents `x` samples.

case|32c7f1e220bf46f988301b915bb5f995772a31aa (original 40)|32c7f1e220bf46f988301b915bb5f995772a31aa (80) (https://pastebin.com/uLUVtM7r)|866ad25014ad55a82c113cf0c7ab8ed0f2d1f675 (80) (https://pastebin.com/WqBZZtK1)|01ecbccdc5140014e62f6fb600ff647f087d2af5 (80) (https://pastebin.com/q9XnPvGy)
---|---|---|---|---
1vcpu 8192mb|14.216±56%|14.471±149%|14.491±148%|15.374±134%
1vcpu 1024mb|4.902±17%|4.955±15%|4.966±22%|5.057±19%
1vcpu 3278mb|39.88±12%|42.044±87%|41.513±80%|42.679±75%
1vcpu 256mb|4.047±13%|4.103±27%|4.106±27%|4.122±16%
1vcpu 2048mb|6.069±16%|6.296±42%|6.315±36%|6.474±30%

The likely circumstance is that the gathering of previous baselines was too small a sample set and missed outliers which dramatically increases the delta for P90.

By comparing the commits with a larger sample set we can see their is no difference in Firecracker which caused performance changes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
