### PR TITLE
use thiserror::Error for more packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "thiserror",
  "utils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snapshot",
+ "thiserror",
  "utils",
  "versionize",
  "versionize_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ version = "1.2.0"
 dependencies = [
  "libc",
  "regex",
+ "thiserror",
  "utils",
 ]
 

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -255,41 +255,23 @@ pub(crate) fn method_to_error(method: Method) -> Result<ParsedRequest, Error> {
     }
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, thiserror::Error)]
 pub(crate) enum Error {
     // The resource ID is empty.
+    #[error("The ID cannot be empty.")]
     EmptyID,
     // A generic error, with a given status code and message to be turned into a fault message.
+    #[error("{1}")]
     Generic(StatusCode, String),
     // The resource ID must only contain alphanumeric characters and '_'.
+    #[error("API Resource IDs can only contain alphanumeric characters and underscores.")]
     InvalidID,
     // The HTTP method & request path combination is not valid.
+    #[error("Invalid request method and/or path: {} {0}.", std::str::from_utf8(.1.raw()).expect("Cannot convert from UTF-8"))]
     InvalidPathMethod(String, Method),
     // An error occurred when deserializing the json body of a request.
+    #[error("An error occurred when deserializing the json body of a request: {0}.")]
     SerdeJson(serde_json::Error),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::EmptyID => write!(f, "The ID cannot be empty."),
-            Error::Generic(_, ref desc) => write!(f, "{desc}"),
-            Error::InvalidID => write!(
-                f,
-                "API Resource IDs can only contain alphanumeric characters and underscores."
-            ),
-            Error::InvalidPathMethod(ref path, ref method) => write!(
-                f,
-                "Invalid request method and/or path: {} {}.",
-                std::str::from_utf8(method.raw()).expect("Cannot convert from UTF-8"),
-                path
-            ),
-            Error::SerdeJson(ref err) => write!(
-                f,
-                "An error occurred when deserializing the json body of a request: {err}."
-            ),
-        }
-    }
 }
 
 // It's convenient to turn errors into HTTP responses directly.

--- a/src/devices/src/bus.rs
+++ b/src/devices/src/bus.rs
@@ -9,8 +9,8 @@
 
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::collections::btree_map::BTreeMap;
+use std::result;
 use std::sync::{Arc, Mutex};
-use std::{fmt, result};
 
 use crate::virtio::AsAny;
 
@@ -26,20 +26,11 @@ pub trait BusDevice: AsAny + Send {
     fn write(&mut self, offset: u64, data: &[u8]) {}
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// The insertion failed because the new device overlapped with an old device.
+    #[error("New device overlaps with an old device.")]
     Overlap,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            Overlap => write!(f, "New device overlaps with an old device."),
-        }
-    }
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -6,7 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::num::Wrapping;
-use std::{fmt, io, result};
+use std::{io, result};
 
 use logger::{error, warn, IncMetric, METRICS};
 use utils::eventfd::EventFd;
@@ -14,28 +14,17 @@ use utils::eventfd::EventFd;
 use crate::bus::BusDevice;
 
 /// Errors thrown by the i8042 device.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Failure in triggering the keyboard interrupt (guest disabled).
-    KbdInterruptDisabled,
-    /// Failure in triggering the keyboard interrupt.
-    KbdInterruptFailure(io::Error),
     /// Internal i8042 buffer is full.
+    #[error("i8042 internal buffer full.")]
     InternalBufferFull,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::KbdInterruptDisabled => {
-                write!(f, "Keyboard interrupt disabled by guest driver.",)
-            }
-            Error::KbdInterruptFailure(io_err) => {
-                write!(f, "Could not trigger keyboard interrupt: {io_err}.",)
-            }
-            Error::InternalBufferFull => write!(f, "i8042 internal buffer full."),
-        }
-    }
+    /// Failure in triggering the keyboard interrupt.
+    #[error("Keyboard interrupt disabled by guest driver.")]
+    KbdInterruptDisabled,
+    /// Failure in triggering the keyboard interrupt (guest disabled).
+    #[error("Could not trigger keyboard interrupt: {0}.")]
+    KbdInterruptFailure(io::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/src/devices/src/virtio/vsock/csm/mod.rs
+++ b/src/devices/src/virtio/vsock/csm/mod.rs
@@ -6,8 +6,6 @@
 mod connection;
 mod txbuf;
 
-use std::fmt;
-
 pub use connection::VsockConnection;
 
 pub mod defs {
@@ -25,35 +23,18 @@ pub mod defs {
     pub const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Attempted to push data to a full TX buffer.
+    #[error("Attempted to push data to a full TX buffer")]
     TxBufFull,
     /// An I/O error occurred, when attempting to flush the connection TX buffer.
+    #[error("An I/O error occurred, when attempting to flush the connection TX buffer: {0}")]
     TxBufFlush(std::io::Error),
     /// An I/O error occurred, when attempting to write data to the host-side stream.
+    #[error("An I/O error occurred, when attempting to write data to the host-side stream: {0}")]
     StreamWrite(std::io::Error),
 }
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::TxBufFull => write!(f, "Attempted to push data to a full TX buffer"),
-            Self::TxBufFlush(err) => write!(
-                f,
-                "An I/O error occurred, when attempting to flush the connection TX buffer: {}",
-                err
-            ),
-            Self::StreamWrite(err) => write!(
-                f,
-                "An I/O error occurred, when attempting to write data to the host-side stream: {}",
-                err
-            ),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 type Result<T> = std::result::Result<T, Error>;
 

--- a/src/jailer/Cargo.toml
+++ b/src/jailer/Cargo.toml
@@ -11,5 +11,6 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2.117"
 regex = { version = "1.5.5", default-features = false, features = ["std"] }
+thiserror = "1.0.32"
 
 utils = { path = "../utils" }

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -11,7 +11,7 @@ mod env;
 mod resource_limits;
 use std::ffi::{CString, NulError, OsString};
 use std::path::{Path, PathBuf};
-use std::{env as p_env, fmt, fs, io, process, result};
+use std::{env as p_env, fs, io, process, result};
 
 use utils::arg_parser::{ArgParser, Argument, Error as ParsingError};
 use utils::validators;
@@ -19,234 +19,122 @@ use utils::validators;
 use crate::env::Env;
 
 const JAILER_VERSION: &str = env!("FIRECRACKER_VERSION");
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Failed to parse arguments: {0}")]
     ArgumentParsing(ParsingError),
+    #[error("{}", format!("Failed to canonicalize path {:?}: {}", .0, .1).replace('\"', ""))]
     Canonicalize(PathBuf, io::Error),
+    #[error("{}", format!("Failed to inherit cgroups configurations from file {} in path {:?}", .1, .0).replace('\"', ""))]
     CgroupInheritFromParent(PathBuf, String),
+    #[error("{1} configurations not found in {0}")]
     CgroupLineNotFound(String, String),
+    #[error("Cgroup invalid file: {0}")]
     CgroupInvalidFile(String),
+    #[error("Expected value {0} for {2}. Current value: {1}")]
     CgroupWrite(String, String, String),
+    #[error("Invalid format for cgroups: {0}")]
     CgroupFormat(String),
+    #[error("Hierarchy not found: {0}")]
     CgroupHierarchyMissing(String),
+    #[error("Controller {0} is unavailable")]
     CgroupControllerUnavailable(String),
+    #[error("{0} is an invalid cgroup version specifier")]
     CgroupInvalidVersion(String),
+    #[error("Parent cgroup path is invalid. Path should not be absolute or contain '..' or '.'")]
     CgroupInvalidParentPath(),
+    #[error("Failed to change owner for {0:?}: {1}")]
     ChangeFileOwner(PathBuf, io::Error),
+    #[error("Failed to chdir into chroot directory: {0}")]
     ChdirNewRoot(io::Error),
+    #[error("Failed to change permissions on {0:?}: {1}")]
     Chmod(PathBuf, io::Error),
+    #[error("Failed cloning into a new child process: {0}")]
     Clone(io::Error),
+    #[error("Failed to close netns fd: {0}")]
     CloseNetNsFd(io::Error),
+    #[error("Failed to close /dev/null fd: {0}")]
     CloseDevNullFd(io::Error),
+    #[error("{}", format!("Failed to copy {:?} to {:?}: {}", .0, .1, .2).replace('\"', ""))]
     Copy(PathBuf, PathBuf, io::Error),
+    #[error("{}", format!("Failed to create directory {:?}: {}", .0, .1).replace('\"', ""))]
     CreateDir(PathBuf, io::Error),
+    #[error("Encountered interior \\0 while parsing a string")]
     CStringParsing(NulError),
+    #[error("Failed to duplicate fd: {0}")]
     Dup2(io::Error),
+    #[error("Failed to exec into Firecracker: {0}")]
     Exec(io::Error),
+    #[error(
+        "Invalid filename. The filename of `--exec-file` option must contain \"firecracker\": {0}"
+    )]
     ExecFileName(String),
+    #[error("{}", format!("Failed to extract filename from path {:?}", .0).replace('\"', ""))]
     ExtractFileName(PathBuf),
+    #[error("{}", format!("Failed to open file {:?}: {}", .0, .1).replace('\"', ""))]
     FileOpen(PathBuf, io::Error),
+    #[error("Failed to decode string from byte array: {0}")]
     FromBytesWithNul(std::ffi::FromBytesWithNulError),
+    #[error("Failed to get flags from fd: {0}")]
     GetOldFdFlags(io::Error),
+    #[error("Invalid gid: {0}")]
     Gid(String),
+    #[error("Invalid instance ID: {0}")]
     InvalidInstanceId(validators::Error),
+    #[error("{}", format!("File {:?} doesn't have a parent", .0).replace('\"', ""))]
     MissingParent(PathBuf),
+    #[error("Failed to create the jail root directory before pivoting root: {0}")]
     MkdirOldRoot(io::Error),
+    #[error("Failed to create {1} via mknod inside the jail: {0}")]
     MknodDev(io::Error, &'static str),
+    #[error("Failed to bind mount the jail root directory: {0}")]
     MountBind(io::Error),
+    #[error("Failed to change the propagation type to slave: {0}")]
     MountPropagationSlave(io::Error),
+    #[error("{}", format!("{:?} is not a file", .0).replace('\"', ""))]
     NotAFile(PathBuf),
+    #[error("{}", format!("{:?} is not a directory", .0).replace('\"', ""))]
     NotADirectory(PathBuf),
+    #[error("Failed to open /dev/null: {0}")]
     OpenDevNull(io::Error),
+    #[error("{}", format!("Failed to parse path {:?} into an OsString", .0).replace('\"', ""))]
     OsStringParsing(PathBuf, OsString),
+    #[error("Failed to pivot root: {0}")]
     PivotRoot(io::Error),
+    #[error("{}", format!("Failed to read line from {:?}: {}", .0, .1).replace('\"', ""))]
     ReadLine(PathBuf, io::Error),
+    #[error("{}", format!("Failed to read file {:?} into a string: {}", .0, .1).replace('\"', ""))]
     ReadToString(PathBuf, io::Error),
+    #[error("Regex failed: {0:?}")]
     RegEx(regex::Error),
+    #[error("Invalid resource argument: {0}")]
     ResLimitArgument(String),
+    #[error("Invalid format for resources limits: {0}")]
     ResLimitFormat(String),
+    #[error("Invalid limit value for resource: {0}: {1}")]
     ResLimitValue(String, String),
+    #[error("Failed to remove old jail root directory: {0}")]
     RmOldRootDir(io::Error),
+    #[error("Failed to change current directory: {0}")]
     SetCurrentDir(io::Error),
+    #[error("Failed to join network namespace: netns: {0}")]
     SetNetNs(io::Error),
+    #[error("Failed to set limit for resource: {0}")]
     Setrlimit(String),
+    #[error("Failed to daemonize: setsid: {0}")]
     SetSid(io::Error),
+    #[error("Invalid uid: {0}")]
     Uid(String),
+    #[error("Failed to unmount the old jail root: {0}")]
     UmountOldRoot(io::Error),
+    #[error("Unexpected value for the socket listener fd: {0}")]
     UnexpectedListenerFd(i32),
+    #[error("Failed to unshare into new mount namespace: {0}")]
     UnshareNewNs(io::Error),
+    #[error("Failed to unset the O_CLOEXEC flag on the socket fd: {0}")]
     UnsetCloexec(io::Error),
+    #[error("{}", format!("Failed to write to {:?}: {}", .0, .1).replace('\"', ""))]
     Write(PathBuf, io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            ArgumentParsing(ref err) => write!(f, "Failed to parse arguments: {}", err),
-            Canonicalize(ref path, ref io_err) => write!(
-                f,
-                "{}",
-                format!("Failed to canonicalize path {:?}: {}", path, io_err).replace('\"', "")
-            ),
-            Chmod(ref path, ref err) => {
-                write!(f, "Failed to change permissions on {:?}: {}", path, err)
-            }
-            CgroupInheritFromParent(ref path, ref filename) => write!(
-                f,
-                "{}",
-                format!(
-                    "Failed to inherit cgroups configurations from file {} in path {:?}",
-                    filename, path
-                )
-                .replace('\"', "")
-            ),
-            CgroupLineNotFound(ref proc_mounts, ref controller) => write!(
-                f,
-                "{} configurations not found in {}",
-                controller, proc_mounts
-            ),
-            CgroupInvalidFile(ref file) => write!(f, "Cgroup invalid file: {}", file,),
-            CgroupWrite(ref evalue, ref rvalue, ref file) => write!(
-                f,
-                "Expected value {} for {}. Current value: {}",
-                evalue, file, rvalue
-            ),
-            CgroupFormat(ref arg) => write!(f, "Invalid format for cgroups: {}", arg,),
-            CgroupHierarchyMissing(ref arg) => write!(f, "Hierarchy not found: {}", arg,),
-            CgroupControllerUnavailable(ref arg) => write!(f, "Controller {} is unavailable", arg,),
-            CgroupInvalidVersion(ref arg) => {
-                write!(f, "{} is an invalid cgroup version specifier", arg,)
-            }
-            CgroupInvalidParentPath() => {
-                write!(
-                    f,
-                    "Parent cgroup path is invalid. Path should not be absolute or contain '..' \
-                     or '.'",
-                )
-            }
-            ChangeFileOwner(ref path, ref err) => {
-                write!(f, "Failed to change owner for {:?}: {}", path, err)
-            }
-            ChdirNewRoot(ref err) => write!(f, "Failed to chdir into chroot directory: {}", err),
-            Clone(ref err) => write!(f, "Failed cloning into a new child process: {}", err),
-            CloseNetNsFd(ref err) => write!(f, "Failed to close netns fd: {}", err),
-            CloseDevNullFd(ref err) => write!(f, "Failed to close /dev/null fd: {}", err),
-            Copy(ref file, ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to copy {:?} to {:?}: {}", file, path, err).replace('\"', "")
-            ),
-            CreateDir(ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to create directory {:?}: {}", path, err).replace('\"', "")
-            ),
-            CStringParsing(_) => write!(f, "Encountered interior \\0 while parsing a string"),
-            Dup2(ref err) => write!(f, "Failed to duplicate fd: {}", err),
-            Exec(ref err) => write!(f, "Failed to exec into Firecracker: {}", err),
-            ExecFileName(ref filename) => write!(
-                f,
-                "Invalid filename. The filename of `--exec-file` option must contain \
-                 \"firecracker\": {}",
-                filename
-            ),
-            ExtractFileName(ref path) => write!(
-                f,
-                "{}",
-                format!("Failed to extract filename from path {:?}", path).replace('\"', "")
-            ),
-            FileOpen(ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to open file {:?}: {}", path, err).replace('\"', "")
-            ),
-            FromBytesWithNul(ref err) => {
-                write!(f, "Failed to decode string from byte array: {}", err)
-            }
-            GetOldFdFlags(ref err) => write!(f, "Failed to get flags from fd: {}", err),
-            Gid(ref gid) => write!(f, "Invalid gid: {}", gid),
-            InvalidInstanceId(ref err) => write!(f, "Invalid instance ID: {}", err),
-            MissingParent(ref path) => write!(
-                f,
-                "{}",
-                format!("File {:?} doesn't have a parent", path).replace('\"', "")
-            ),
-            MkdirOldRoot(ref err) => write!(
-                f,
-                "Failed to create the jail root directory before pivoting root: {}",
-                err
-            ),
-            MknodDev(ref err, ref devname) => write!(
-                f,
-                "Failed to create {} via mknod inside the jail: {}",
-                devname, err
-            ),
-            MountBind(ref err) => {
-                write!(f, "Failed to bind mount the jail root directory: {}", err)
-            }
-            MountPropagationSlave(ref err) => {
-                write!(f, "Failed to change the propagation type to slave: {}", err)
-            }
-            NotAFile(ref path) => write!(
-                f,
-                "{}",
-                format!("{:?} is not a file", path).replace('\"', "")
-            ),
-            NotADirectory(ref path) => write!(
-                f,
-                "{}",
-                format!("{:?} is not a directory", path).replace('\"', "")
-            ),
-            OpenDevNull(ref err) => write!(f, "Failed to open /dev/null: {}", err),
-            OsStringParsing(ref path, _) => write!(
-                f,
-                "{}",
-                format!("Failed to parse path {:?} into an OsString", path).replace('\"', "")
-            ),
-            PivotRoot(ref err) => write!(f, "Failed to pivot root: {}", err),
-            ReadLine(ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to read line from {:?}: {}", path, err).replace('\"', "")
-            ),
-            ReadToString(ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to read file {:?} into a string: {}", path, err).replace('\"', "")
-            ),
-            RegEx(ref err) => write!(f, "Regex failed: {:?}", err),
-            ResLimitArgument(ref arg) => write!(f, "Invalid resource argument: {}", arg,),
-            ResLimitFormat(ref arg) => write!(f, "Invalid format for resources limits: {}", arg,),
-            ResLimitValue(ref arg, ref err) => {
-                write!(f, "Invalid limit value for resource: {}: {}", arg, err)
-            }
-            RmOldRootDir(ref err) => write!(f, "Failed to remove old jail root directory: {}", err),
-            SetCurrentDir(ref err) => write!(f, "Failed to change current directory: {}", err),
-            SetNetNs(ref err) => write!(f, "Failed to join network namespace: netns: {}", err),
-            Setrlimit(ref err) => write!(f, "Failed to set limit for resource: {}", err),
-            SetSid(ref err) => write!(f, "Failed to daemonize: setsid: {}", err),
-            Uid(ref uid) => write!(f, "Invalid uid: {}", uid),
-            UmountOldRoot(ref err) => write!(f, "Failed to unmount the old jail root: {}", err),
-            UnexpectedListenerFd(fd) => {
-                write!(f, "Unexpected value for the socket listener fd: {}", fd)
-            }
-            UnshareNewNs(ref err) => {
-                write!(f, "Failed to unshare into new mount namespace: {}", err)
-            }
-            UnsetCloexec(ref err) => write!(
-                f,
-                "Failed to unset the O_CLOEXEC flag on the socket fd: {}",
-                err
-            ),
-            Write(ref path, ref err) => write!(
-                f,
-                "{}",
-                format!("Failed to write to {:?}: {}", path, err).replace('\"', "")
-            ),
-        }
-    }
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.13.0"
 bincode = "1.2.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
+thiserror = "1.0.32"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }

--- a/src/mmds/src/data_store.rs
+++ b/src/mmds/src/data_store.rs
@@ -46,28 +46,18 @@ pub enum OutputFormat {
     Imds,
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, thiserror::Error)]
 pub enum Error {
+    #[error("The MMDS patch request doesn't fit.")]
     DataStoreLimitExceeded,
+    #[error("The MMDS resource does not exist.")]
     NotFound,
+    #[error("The MMDS data store is not initialized.")]
     NotInitialized,
+    #[error("Token Authority error: {0}")]
     TokenAuthority(TokenError),
+    #[error("Cannot retrieve value. The value has an unsupported type.")]
     UnsupportedValueType,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::DataStoreLimitExceeded => write!(f, "The MMDS patch request doesn't fit."),
-            Error::NotFound => write!(f, "The MMDS resource does not exist."),
-            Error::NotInitialized => write!(f, "The MMDS data store is not initialized."),
-            Error::TokenAuthority(err) => write!(f, "Token Authority error: {}", err),
-            Error::UnsupportedValueType => write!(
-                f,
-                "Cannot retrieve value. The value has an unsupported type."
-            ),
-        }
-    }
 }
 
 // Used for ease of use in tests.

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -11,7 +11,6 @@ pub mod persist;
 mod token;
 pub mod token_headers;
 
-use std::fmt;
 use std::sync::{Arc, Mutex};
 
 use micro_http::{
@@ -24,36 +23,23 @@ use crate::data_store::{Error as MmdsError, Mmds, MmdsVersion, OutputFormat};
 use crate::token::PATH_TO_TOKEN;
 use crate::token_headers::REJECTED_HEADER;
 
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("MMDS token not valid.")]
     InvalidToken,
+    #[error("Invalid URI.")]
     InvalidURI,
+    #[error("Not allowed HTTP method.")]
     MethodNotAllowed,
+    #[error("No MMDS token provided. Use `X-metadata-token` header to specify the session token.")]
     NoTokenProvided,
+    #[error(
+        "Token time to live value not found. Use `X-metadata-token-ttl-seconds` header to specify \
+         the token's lifetime."
+    )]
     NoTtlProvided,
+    #[error("Resource not found: {0}.")]
     ResourceNotFound(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::InvalidToken => write!(f, "MMDS token not valid."),
-            Error::InvalidURI => write!(f, "Invalid URI."),
-            Error::MethodNotAllowed => write!(f, "Not allowed HTTP method."),
-            Error::NoTokenProvided => write!(
-                f,
-                "No MMDS token provided. Use `X-metadata-token` header to specify the session \
-                 token."
-            ),
-            Error::NoTtlProvided => write!(
-                f,
-                "Token time to live value not found. Use `X-metadata-token-ttl-seconds` header to \
-                 specify the token's lifetime."
-            ),
-            Error::ResourceNotFound(ref uri) => {
-                write!(f, "Resource not found: {uri}.")
-            }
-        }
-    }
 }
 
 impl From<MediaType> for OutputFormat {

--- a/src/seccompiler/Cargo.toml
+++ b/src/seccompiler/Cargo.toml
@@ -14,9 +14,10 @@ path = "src/seccompiler_bin.rs"
 
 [dependencies]
 bincode = "1.2.1"
+derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 libc = "0.2.117"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
-derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
+thiserror = "1.0.32"
 
 utils = { path = "../utils" }

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -97,36 +97,23 @@ impl<'de> Deserialize<'de> for Comment {
 }
 
 /// Seccomp errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub(crate) enum Error {
     /// Attempting to add an empty vector of rules to the rule chain of a syscall.
+    #[error("The seccomp rules vector is empty.")]
     EmptyRulesVector,
     /// Filter exceeds the maximum number of instructions that a BPF program can have.
+    #[error("The seccomp filter contains too many BPF instructions.")]
     FilterTooLarge,
     /// Argument number that exceeds the maximum value.
+    #[error("The seccomp rule contains an invalid argument number.")]
     InvalidArgumentNumber,
     /// Error related to the target arch.
+    #[error("{0:?}")]
     Arch(TargetArchError),
     /// Conflicting rules in filter.
+    #[error("Syscall {0} has conflicting rules.")]
     ConflictingRules(i64),
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            EmptyRulesVector => write!(f, "The seccomp rules vector is empty."),
-            FilterTooLarge => write!(f, "The seccomp filter contains too many BPF instructions."),
-            InvalidArgumentNumber => {
-                write!(f, "The seccomp rule contains an invalid argument number.")
-            }
-            Arch(ref err) => write!(f, "{:?}", err),
-            ConflictingRules(ref syscall_number) => {
-                write!(f, "Syscall {} has conflicting rules.", syscall_number)
-            }
-        }
-    }
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/src/seccompiler/src/compiler.rs
+++ b/src/seccompiler/src/compiler.rs
@@ -34,30 +34,17 @@ use crate::syscall_table::SyscallTable;
 type Result<T> = result::Result<T, Error>;
 
 /// Errors compiling Filters into BPF.
-#[derive(Debug, PartialEq, derive_more::From)]
+#[derive(Debug, PartialEq, derive_more::From, thiserror::Error)]
 pub(crate) enum Error {
     /// Filter and default actions are equal.
+    #[error("`filter_action` and `default_action` are equal.")]
     IdenticalActions,
     /// Error from the SeccompFilter.
+    #[error("{0}")]
     SeccompFilter(SeccompFilterError),
     /// Invalid syscall name for the given arch.
+    #[error("Invalid syscall name: {0} for given arch: {1:?}.")]
     SyscallName(String, TargetArch),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match *self {
-            IdenticalActions => write!(f, "`filter_action` and `default_action` are equal."),
-            SeccompFilter(ref err) => write!(f, "{}", err),
-            SyscallName(ref syscall_name, ref arch) => write!(
-                f,
-                "Invalid syscall name: {} for given arch: {:?}.",
-                syscall_name, arch
-            ),
-        }
-    }
 }
 
 /// Deserializable object that represents the Json filter file.

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.95, "AMD": 82.28, "ARM": 82.65}
+    COVERAGE_DICT = {"Intel": 82.90, "AMD": 82.23, "ARM": 82.50}
 else:
-    COVERAGE_DICT = {"Intel": 80.09, "AMD": 79.42, "ARM": 79.76}
+    COVERAGE_DICT = {"Intel": 79.98, "AMD": 79.35, "ARM": 79.63}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

changed these packages implementation to use thiserror::Error instead implements fmt::Display.

- api_server
- mmds
- devices
- seccompiler
- jailer

## Reason

This PR will fix partof https://github.com/firecracker-microvm/firecracker/issues/3278


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
