### PR TITLE
chore: check that repo is not dirty

### DIFF
--- a/tests/integration_tests/style/test_repo.py
+++ b/tests/integration_tests/style/test_repo.py
@@ -5,6 +5,8 @@
 
 import subprocess
 
+from framework.utils import run_cmd
+
 
 def test_repo_no_spaces_in_paths():
     """
@@ -21,3 +23,13 @@ def test_repo_no_spaces_in_paths():
     )
     # If grep doesn't find any, it will exit with status 1. Otherwise 0
     assert res.returncode == 1, "Some files have spaces:\n" + res.stdout.decode()
+
+
+def test_repo_not_dirty():
+    """
+    Ensure there are no dirty files in repo.
+
+    @type: style
+    """
+    _, stdout, _ = run_cmd("git diff --stat")
+    assert stdout == "", "Repository is dirty: \n{}".format(stdout)


### PR DESCRIPTION
## Changes

Added an integration test that checks all files
impacted by changes are checked in.

## Reason

Ensure that repo is not dirty. Fixes #3317.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
