### PR TITLE
fix: upgrade to latest linux loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c30882b410003a8e7c288ede492d6b8ddfb2ea13a5e9c2d27356954067d81cb"
+checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
 dependencies = [
  "vm-memory 0.10.0",
 ]

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 libc = "0.2.117"
-linux-loader = "0.8.0"
+linux-loader = "0.8.1"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-fdt = "0.2.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
-linux-loader = "0.8.0"
+linux-loader = "0.8.1"
 vm-superio = "0.7.0"
 lazy_static = "1.4.0"
 libc = "0.2.117"

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.92, "AMD": 82.25, "ARM": 82.42}
+    COVERAGE_DICT = {"Intel": 82.92, "AMD": 82.25, "ARM": 82.35}
 else:
-    COVERAGE_DICT = {"Intel": 80.02, "AMD": 79.36, "ARM": 79.54}
+    COVERAGE_DICT = {"Intel": 80.02, "AMD": 79.36, "ARM": 79.45}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

* upgrade to linux loader 0.8.1

## Reason

* consume latest fix: https://github.com/rust-vmm/linux-loader/pull/125/files#diff-c7c03aafbb71ffde8c782644097d85eba96f762dfb2e2fc870613f4071f57c35L220

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
