### PR TITLE
ci: remove block step from buildkite script

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -47,11 +47,6 @@ def group(group_name, command, agent_tags=None, priority=0, timeout=30):
     return {"group": group_name, "steps": steps}
 
 
-step_block_unless_maintainer = {
-    "block": "Waiting for approval to run",
-    "if": '(build.creator.teams includes "prod-compute-capsule") == false',
-}
-
 step_style = {
     "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
     "label": "🪶 Style",
@@ -93,7 +88,6 @@ performance_grp = group(
 pipeline = {
     "agents": {"queue": "default"},
     "steps": [
-        step_block_unless_maintainer,
         step_style,
         build_grp,
         functional_1_grp,


### PR DESCRIPTION
## Changes

Remove the block step from the script that creates the buildkite pipeline steps for PRs.

## Reason

The block-if-not-maintainer step should not be part of the generated pipeline, as someone might open a PR which removes it (exactly as this commit does) and, even worse, launch arbitrary stuff on our CI.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
