### PR TITLE
Fix `bindgen.sh`

### DIFF
--- a/tools/bindgen.sh
+++ b/tools/bindgen.sh
@@ -32,7 +32,7 @@ function fc-bindgen {
     dead_code,
     non_snake_case,
     clippy::ptr_as_ptr,
-    clippy::undocumented_unsafe_blocks
+    clippy::undocumented_unsafe_blocks,
     clippy::cast_lossless
 )]
 


### PR DESCRIPTION
## Changes

Adds comma in `bindgen.sh`.

## Reason

Fixes missing comma in lint settings in `bindgen.sh`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
