### PR TITLE
cpuid: replace transmute with safe version

### DIFF
--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -71,13 +71,13 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
 /// Extracts the CPU vendor id from leaf 0x0.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn get_vendor_id_from_host() -> Result<[u8; 12], Error> {
-    // SAFETY: This is safe because the resulting type has a lower alignment requirement
-    get_cpuid(0, 0).map(|vendor_entry| unsafe {
-        std::mem::transmute::<[u32; 3], [u8; 12]>([
-            vendor_entry.ebx,
-            vendor_entry.edx,
-            vendor_entry.ecx,
-        ])
+    get_cpuid(0, 0).map(|vendor_entry| {
+        let b = vendor_entry.ebx.to_ne_bytes();
+        let d = vendor_entry.edx.to_ne_bytes();
+        let c = vendor_entry.ecx.to_ne_bytes();
+        [
+            b[0], b[1], b[2], b[3], d[0], d[1], d[2], d[3], c[0], c[1], c[2], c[3],
+        ]
     })
 }
 


### PR DESCRIPTION
## Changes

Replaced a transmutation with safe Rust

## Reason

Less unsafe blocks to worry about

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
