### PR TITLE
Increase snapshot target for 512mb VM on aarch64/amd64

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -138,7 +138,7 @@ LOAD_LATENCY_BASELINES = {
                 },
                 "async": {
                     "2vcpu_256mb.json": {"target": 320},
-                    "2vcpu_512mb.json": {"target": 310},
+                    "2vcpu_512mb.json": {"target": 330},
                 },
             },
         }

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -90,7 +90,7 @@ LOAD_LATENCY_BASELINES = {
             "4.14": {
                 "sync": {
                     "2vcpu_256mb.json": {"target": 15},
-                    "2vcpu_512mb.json": {"target": 15},
+                    "2vcpu_512mb.json": {"target": 19},
                 }
             },
             "5.10": {

--- a/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
+++ b/tests/integration_tests/performance/test_versioned_serialization_benchmark.py
@@ -68,8 +68,8 @@ def _check_statistics(directory, mean):
         attribute = "no-crc"
 
     measure = BASELINES[proc_model[0]][bench][attribute]
-    low = measure["target"] - measure["delta"]
-    high = measure["target"] + measure["delta"]
+    low = round(measure["target"] - measure["delta"], 3)
+    high = round(measure["target"] + measure["delta"], 3)
     assert low <= mean <= high, "Benchmark result {} has changed!".format(directory)
 
     return directory, f"{mean} ms", f"{low} <= result <= {high}"


### PR DESCRIPTION
## Changes

* Increase the snapshot load test performance target on aarch64 hosts for Kernel 5.10 using the async file engine.
* Increase the snapshot load test performance target on amd hosts for Kernel 4.14 using the sync file engine.
* Adding rounding of some floating point values in the serialization benchmark test

## Reason

Test failure for continuous integration seen in Buildkite ([ARM test](https://buildkite.com/firecracker/firecracker-pr/builds/242#01853975-5022-42eb-8f76-cb78fff3fb7d), [AMD test](https://buildkite.com/firecracker/firecracker-pr/builds/257#01853ec2-3e6a-496f-be2a-bd04ccc47e88)). This follows recent tweaks to that target in [PR/3291](https://github.com/firecracker-microvm/firecracker/pull/3291). A slightly increased time between the 256MB guest and the 512MB guest was not maintained when the previous update was made, however it isn't unreasonable to expect a slightly slower snapshot load for a larger guest.

Regarding the rounding added to the serialization benchmark. This was added as a result of arithmetic inaccuracy in Python (see a [test failure as a result](https://buildkite.com/firecracker/firecracker-pr/builds/244#018539a9-287e-49da-91f4-44a91a3155cahttps://buildkite.com/firecracker/firecracker-pr/builds/244#018539a9-287e-49da-91f4-44a91a3155ca)) which results in incorrectly failing tests. This is due to a binary representation of floating point numbers which results in values that are slightly off what was configured to be tested against. See [this guide](https://floating-point-gui.de/basic/) for more context. Another alternative is to use the `Decimal` type explicitly but is more verbose and does not seem necessary given the floating point resolution that the test requires.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

