### PR TITLE
Have kernel pick tap device name for us in unittests

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -128,12 +128,12 @@ impl Net {
     /// Create a new virtio network device with the given TAP interface.
     pub fn new_with_tap(
         id: String,
-        tap_if_name: String,
+        tap_if_name: &str,
         guest_mac: Option<MacAddr>,
         rx_rate_limiter: RateLimiter,
         tx_rate_limiter: RateLimiter,
     ) -> Result<Self> {
-        let tap = Tap::open_named(&tap_if_name).map_err(Error::TapOpen)?;
+        let tap = Tap::open_named(tap_if_name).map_err(Error::TapOpen)?;
 
         // Set offload flags to match the virtio features below.
         tap.set_offload(

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -113,7 +113,7 @@ impl Persist<'_> for Net {
         let tx_rate_limiter = RateLimiter::restore((), &state.tx_rate_limiter_state)?;
         let mut net = Net::new_with_tap(
             state.id.clone(),
-            state.tap_if_name.clone(),
+            &state.tap_if_name,
             state.config_space.guest_mac_v2,
             rx_rate_limiter,
             tx_rate_limiter,

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -237,6 +237,13 @@ pub mod tests {
         assert_eq!(b"tap0\0\0\0\0\0\0\0\0\0\0\0\0", &tap.if_name);
         assert_eq!("tap0", tap.if_name_as_str());
 
+        // Test using '%d' to have the kernel assign an unused name,
+        // and that we correctly copy back that generated name
+        let tap = Tap::open_named("tap%d").unwrap();
+        // '%d' should be replaced with _some_ number, although we don't know what was the next available one.
+        // Just assert that '%d' definitely isn't there anymore.
+        assert_ne!(b"tap%d", &tap.if_name[..5]);
+
         // 16 characters - too long.
         let name = "a123456789abcdef";
         match Tap::open_named(name) {

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -240,8 +240,8 @@ pub mod tests {
         // Test using '%d' to have the kernel assign an unused name,
         // and that we correctly copy back that generated name
         let tap = Tap::open_named("tap%d").unwrap();
-        // '%d' should be replaced with _some_ number, although we don't know what was the next available one.
-        // Just assert that '%d' definitely isn't there anymore.
+        // '%d' should be replaced with _some_ number, although we don't know what was the next
+        // available one. Just assert that '%d' definitely isn't there anymore.
         assert_ne!(b"tap%d", &tap.if_name[..5]);
 
         // 16 characters - too long.

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -31,13 +31,19 @@ static NEXT_INDEX: AtomicUsize = AtomicUsize::new(1);
 
 pub fn default_net() -> Net {
     let next_tap = NEXT_INDEX.fetch_add(1, Ordering::SeqCst);
-    let tap_dev_name = format!("net-device{}", next_tap);
+    // Id is the firecracker-facing identifier, e.g. local to the FC process. We thus do not need to make sure
+    // it is globally unique
+    let tap_device_id = format!("net-device{}", next_tap);
+    // This is the device name on the host, and thus needs to be unique between all firecracker processes. We
+    // cannot use the above counter to ensure this uniqueness (as it is per-process). Thus, ask the kernel to assign
+    // us a number.
+    let tap_if_name = "net-device%d";
 
     let guest_mac = default_guest_mac();
 
     let mut net = Net::new_with_tap(
-        format!("net-device{}", next_tap),
-        tap_dev_name,
+        tap_device_id,
+        String::from(tap_if_name),
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
@@ -54,13 +60,13 @@ pub fn default_net() -> Net {
 
 pub fn default_net_no_mmds() -> Net {
     let next_tap = NEXT_INDEX.fetch_add(1, Ordering::SeqCst);
-    let tap_dev_name = format!("net-device{}", next_tap);
+    let tap_device_id = format!("net-device{}", next_tap);
 
     let guest_mac = default_guest_mac();
 
-    let net = Net::new_with_tap(
-        format!("net-device{}", next_tap),
-        tap_dev_name,
+    let mut net = Net::new_with_tap(
+        tap_device_id,
+        String::from("net-device%d"),
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -31,19 +31,19 @@ static NEXT_INDEX: AtomicUsize = AtomicUsize::new(1);
 
 pub fn default_net() -> Net {
     let next_tap = NEXT_INDEX.fetch_add(1, Ordering::SeqCst);
-    // Id is the firecracker-facing identifier, e.g. local to the FC process. We thus do not need to make sure
-    // it is globally unique
+    // Id is the firecracker-facing identifier, e.g. local to the FC process. We thus do not need to
+    // make sure it is globally unique
     let tap_device_id = format!("net-device{}", next_tap);
-    // This is the device name on the host, and thus needs to be unique between all firecracker processes. We
-    // cannot use the above counter to ensure this uniqueness (as it is per-process). Thus, ask the kernel to assign
-    // us a number.
+    // This is the device name on the host, and thus needs to be unique between all firecracker
+    // processes. We cannot use the above counter to ensure this uniqueness (as it is
+    // per-process). Thus, ask the kernel to assign us a number.
     let tap_if_name = "net-device%d";
 
     let guest_mac = default_guest_mac();
 
     let mut net = Net::new_with_tap(
         tap_device_id,
-        String::from(tap_if_name),
+        tap_if_name,
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),
@@ -64,9 +64,9 @@ pub fn default_net_no_mmds() -> Net {
 
     let guest_mac = default_guest_mac();
 
-    let mut net = Net::new_with_tap(
+    let net = Net::new_with_tap(
         tap_device_id,
-        String::from("net-device%d"),
+        "net-device%d",
         Some(guest_mac),
         RateLimiter::default(),
         RateLimiter::default(),

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -163,7 +163,7 @@ impl NetBuilder {
         // Create and return the Net device
         devices::virtio::net::Net::new_with_tap(
             cfg.iface_id,
-            cfg.host_dev_name.clone(),
+            &cfg.host_dev_name,
             cfg.guest_mac,
             rx_rate_limiter.unwrap_or_default(),
             tx_rate_limiter.unwrap_or_default(),
@@ -345,7 +345,7 @@ mod tests {
 
         let net = Net::new_with_tap(
             net_id.to_string(),
-            host_dev_name.to_string(),
+            host_dev_name,
             Some(MacAddr::parse_str(guest_mac).unwrap()),
             RateLimiter::default(),
             RateLimiter::default(),

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -23,9 +23,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.95, "AMD": 82.28, "ARM": 82.57}
+    COVERAGE_DICT = {"Intel": 82.95, "AMD": 82.28, "ARM": 82.65}
 else:
-    COVERAGE_DICT = {"Intel": 80.09, "AMD": 79.42, "ARM": 79.69}
+    COVERAGE_DICT = {"Intel": 80.09, "AMD": 79.42, "ARM": 79.76}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Specify the tap name in unittests via `%d` to make the kernel pick a name for us that is ensured to not be in used by a separate process already.

## Reason

spurious failures with "device busy" because of name clashes with tap devices. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
