### PR TITLE
Increase max commit title length to 72 characters

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,5 @@
 [title-max-length]
-line-length=50
+line-length=72
 
 [body-max-line-length]
 line-length=72


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

## Changes

Increase max commit title length to 72 characters

## Reason

50 is excessively restrictive, often preventing including code identifiers which describe the change like long function names.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
