### PR TITLE
Rename `vm-memory` to `vm-memory-wrapper`

### DIFF
--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -51,7 +51,7 @@ step_style = {
     "command": "./tools/devtool -y test -- ../tests/integration_tests/style/",
     "label": "🪶 Style",
     # we only install the required dependencies in x86_64
-    "agents": ["platform=x86_64.metal"]
+    "agents": ["platform=x86_64.metal"],
 }
 
 build_grp = group(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory 0.3.0",
+ "vm-memory-wrapper",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio_gen",
- "vm-memory 0.3.0",
+ "vm-memory-wrapper",
  "vm-superio",
 ]
 
@@ -599,7 +599,7 @@ dependencies = [
  "libc",
  "proptest",
  "utils",
- "vm-memory 0.3.0",
+ "vm-memory-wrapper",
 ]
 
 [[package]]
@@ -691,7 +691,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
 dependencies = [
- "vm-memory 0.10.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1335,21 +1335,21 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.3.0"
-dependencies = [
- "libc",
- "utils",
- "vm-memory 0.10.0",
-]
-
-[[package]]
-name = "vm-memory"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "vm-memory-wrapper"
+version = "0.3.0"
+dependencies = [
+ "libc",
+ "utils",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ dependencies = [
  "versionize_derive",
  "virtio_gen",
  "vm-allocator",
- "vm-memory 0.3.0",
+ "vm-memory-wrapper",
  "vm-superio",
 ]
 

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "1.3.2"
 arch_gen = { path = "../arch_gen" }
 logger = { path = "../logger" }
 utils = { path = "../utils" }
-vm-memory = { path = "../vm-memory" }
+vm-memory-wrapper = { path = "../vm-memory-wrapper" }
 
 [dev-dependencies]
 device_tree = "1.1.0"

--- a/src/arch/src/aarch64/fdt.rs
+++ b/src/arch/src/aarch64/fdt.rs
@@ -11,7 +11,9 @@ use std::fmt::Debug;
 use std::result;
 
 use vm_fdt::{Error as VmFdtError, FdtWriter, FdtWriterNode};
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{
+    Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
+};
 
 use super::super::{DeviceType, InitrdConfig};
 use super::cache_info::{read_cache_config, CacheEntry};
@@ -457,7 +459,7 @@ mod tests {
     #[test]
     fn test_create_fdt_with_devices() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
 
         let dev_info: HashMap<(DeviceType, std::string::String), MMIODeviceInfo> = [
@@ -497,7 +499,7 @@ mod tests {
     #[test]
     fn test_create_fdt() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
@@ -555,7 +557,7 @@ mod tests {
     #[test]
     fn test_create_fdt_with_initrd() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::fmt::Debug;
 
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 pub use self::fdt::DeviceInfoForFDT;
 use self::gic::GICDevice;
@@ -130,17 +130,17 @@ mod tests {
     #[test]
     fn test_get_fdt_addr() {
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }

--- a/src/arch/src/aarch64/regs.rs
+++ b/src/arch/src/aarch64/regs.rs
@@ -12,7 +12,7 @@ use kvm_bindings::*;
 use kvm_ioctls::VcpuFd;
 use versionize::*;
 use versionize_derive::Versionize;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::get_fdt_addr;
 
@@ -490,7 +490,7 @@ mod tests {
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
         let regions = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
-        let mem = vm_memory::test_utils::create_anon_guest_memory(&regions, false)
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(&regions, false)
             .expect("Cannot initialize memory");
 
         let res = setup_boot_regs(&vcpu, 0, 0x0, &mem);

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -55,7 +55,7 @@ pub enum DeviceType {
 /// Type for passing information about the initrd in the guest memory.
 pub struct InitrdConfig {
     /// Load address of initrd in guest memory
-    pub address: vm_memory::GuestAddress,
+    pub address: vm_memory_wrapper::GuestAddress,
     /// Size of initrd in guest memory
     pub size: usize,
 }

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -19,7 +19,7 @@ pub mod regs;
 use linux_loader::configurator::linux::LinuxBootConfigurator;
 use linux_loader::configurator::{BootConfigurator, BootParams};
 use linux_loader::loader::bootparam::boot_params;
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory_wrapper::{Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
 use crate::InitrdConfig;
 
@@ -215,9 +215,11 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false)
-                .unwrap();
+        let gm = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x10000)],
+            false,
+        )
+        .unwrap();
         let config_err = configure_system(&gm, GuestAddress(0), 0, &None, 1);
         assert!(config_err.is_err());
         assert_eq!(
@@ -228,19 +230,22 @@ mod tests {
         // Now assigning some memory that falls before the 32bit memory hole.
         let mem_size = 128 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = vm_memory::test_utils::create_anon_guest_memory(&arch_mem_regions, false).unwrap();
+        let gm = vm_memory_wrapper::test_utils::create_anon_guest_memory(&arch_mem_regions, false)
+            .unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = vm_memory::test_utils::create_anon_guest_memory(&arch_mem_regions, false).unwrap();
+        let gm = vm_memory_wrapper::test_utils::create_anon_guest_memory(&arch_mem_regions, false)
+            .unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
-        let gm = vm_memory::test_utils::create_anon_guest_memory(&arch_mem_regions, false).unwrap();
+        let gm = vm_memory_wrapper::test_utils::create_anon_guest_memory(&arch_mem_regions, false)
+            .unwrap();
         configure_system(&gm, GuestAddress(0), 0, &None, no_vcpus).unwrap();
     }
 

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -10,7 +10,7 @@ use std::{io, mem, result, slice};
 
 use arch_gen::x86::mpspec;
 use libc::c_char;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 use crate::IRQ_MAX;
 
@@ -296,7 +296,7 @@ pub fn setup_mptable(mem: &GuestMemoryMmap, num_cpus: u8) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::Bytes;
+    use vm_memory_wrapper::Bytes;
 
     use super::*;
 
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn bounds_check() {
         let num_cpus = 4;
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn bounds_check_fails() {
         let num_cpus = 4;
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus) - 1)],
             false,
         )
@@ -338,7 +338,7 @@ mod tests {
     #[test]
     fn mpf_intel_checksum() {
         let num_cpus = 1;
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn mpc_table_checksum() {
         let num_cpus = 4;
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(num_cpus))],
             false,
         )
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn cpu_entry_count() {
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(
                 GuestAddress(MPTABLE_START),
                 compute_mp_size(MAX_SUPPORTED_CPUS as u8),
@@ -430,7 +430,7 @@ mod tests {
     #[test]
     fn cpu_entry_count_max() {
         let cpus = MAX_SUPPORTED_CPUS + 1;
-        let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[(GuestAddress(MPTABLE_START), compute_mp_size(cpus as u8))],
             false,
         )

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -9,7 +9,7 @@ use std::{fmt, mem};
 
 use kvm_bindings::{kvm_fpu, kvm_regs, kvm_sregs};
 use kvm_ioctls::VcpuFd;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 use super::gdt::{gdt_entry, kvm_segment_from_gdt};
 
@@ -263,7 +263,7 @@ fn setup_page_tables(mem: &GuestMemoryMmap, sregs: &mut kvm_sregs) -> Result<()>
 #[cfg(test)]
 mod tests {
     use kvm_ioctls::Kvm;
-    use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::{Bytes, GuestAddress, GuestMemoryMmap};
 
     use super::*;
 
@@ -271,10 +271,13 @@ mod tests {
         let page_size = 0x10000usize;
         let mem_size = mem_size.unwrap_or(page_size as u64) as usize;
         if mem_size % page_size == 0 {
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), mem_size)], false)
-                .unwrap()
+            vm_memory_wrapper::test_utils::create_anon_guest_memory(
+                &[(GuestAddress(0), mem_size)],
+                false,
+            )
+            .unwrap()
         } else {
-            vm_memory::test_utils::create_guest_memory_unguarded(
+            vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
                 &[(GuestAddress(0), mem_size)],
                 false,
             )

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-vm-memory = { path = "../vm-memory" }
+vm-memory-wrapper = { path = "../vm-memory-wrapper" }
 io_uring = { path = "../io_uring" }
 
 [dev-dependencies]

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use timerfd::{ClockId, SetTimeFlags, TimerFd, TimerState};
 use utils::eventfd::EventFd;
 use virtio_gen::virtio_blk::VIRTIO_F_VERSION_1;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 
 use super::super::{ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BALLOON};
 use super::utils::{compact_page_frame_numbers, remove_range};
@@ -587,7 +587,7 @@ impl VirtioDevice for Balloon {
 pub(crate) mod tests {
     use std::u32;
 
-    use vm_memory::GuestAddress;
+    use vm_memory_wrapper::GuestAddress;
 
     use super::super::CONFIG_SPACE_SIZE;
     use super::*;
@@ -1026,7 +1026,7 @@ pub(crate) mod tests {
         assert!(balloon.update_size(1).is_err());
         // Switch the state to active.
         balloon.device_state = DeviceState::Activated(
-            vm_memory::test_utils::create_guest_memory_unguarded(
+            vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
                 &[(GuestAddress(0x0), 0x1)],
                 false,
             )

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -113,7 +113,7 @@ pub mod tests {
     use std::sync::{Arc, Mutex};
 
     use event_manager::{EventManager, SubscriberOps};
-    use vm_memory::GuestAddress;
+    use vm_memory_wrapper::GuestAddress;
 
     use super::*;
     use crate::virtio::balloon::test_utils::set_request;

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -7,7 +7,7 @@ pub mod persist;
 pub mod test_utils;
 mod utils;
 
-use vm_memory::GuestMemoryError;
+use vm_memory_wrapper::GuestMemoryError;
 
 pub use self::device::{Balloon, BalloonConfig, BalloonStats};
 pub use self::event_handler::*;

--- a/src/devices/src/virtio/balloon/persist.rs
+++ b/src/devices/src/virtio/balloon/persist.rs
@@ -11,7 +11,7 @@ use snapshot::Persist;
 use timerfd::{SetTimeFlags, TimerState};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::*;
 use crate::virtio::balloon::device::{BalloonStats, ConfigSpace};

--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -4,7 +4,7 @@
 use std::io;
 
 use logger::error;
-use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory_wrapper::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
 use super::{RemoveRegionError, MAX_PAGE_COMPACT_BUFFER};
 
@@ -118,7 +118,7 @@ pub(crate) fn remove_range(
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::Bytes;
+    use vm_memory_wrapper::Bytes;
 
     use super::*;
 
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_remove_range() {
         let page_size: usize = 0x1000;
-        let mem = vm_memory::test_utils::create_anon_guest_memory(
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[(GuestAddress(0), 2 * page_size)],
             false,
         )
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     fn test_remove_range_on_restored() {
         let page_size: usize = 0x1000;
-        let mem = vm_memory::test_utils::create_anon_guest_memory(
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[(GuestAddress(0), 2 * page_size)],
             false,
         )

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -24,7 +24,7 @@ use virtio_gen::virtio_blk::{
     VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO, VIRTIO_BLK_ID_BYTES, VIRTIO_F_VERSION_1,
 };
 use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::super::{ActivateResult, DeviceState, Queue, VirtioDevice, TYPE_BLOCK};
 use super::io::async_io;
@@ -638,7 +638,7 @@ pub(crate) mod tests {
     use rate_limiter::TokenType;
     use utils::skip_if_io_uring_unsupported;
     use utils::tempfile::TempFile;
-    use vm_memory::{Address, Bytes, GuestAddress};
+    use vm_memory_wrapper::{Address, Bytes, GuestAddress};
 
     use super::*;
     use crate::check_metric_after_block;

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -104,7 +104,7 @@ pub mod tests {
 
     use event_manager::{EventManager, SubscriberOps};
     use virtio_gen::virtio_blk::{VIRTIO_BLK_S_OK, VIRTIO_BLK_T_OUT};
-    use vm_memory::{Bytes, GuestAddress};
+    use vm_memory_wrapper::{Bytes, GuestAddress};
 
     use super::*;
     use crate::virtio::block::device::FileEngineType;

--- a/src/devices/src/virtio/block/io/async_io.rs
+++ b/src/devices/src/virtio/block/io/async_io.rs
@@ -10,7 +10,7 @@ use io_uring::restriction::Restriction;
 use io_uring::{Error as IoUringError, IoUring};
 use logger::log_dev_preview_warning;
 use utils::eventfd::EventFd;
-use vm_memory::{mark_dirty_mem, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{mark_dirty_mem, GuestAddress, GuestMemory, GuestMemoryMmap};
 
 use crate::virtio::block::io::UserDataError;
 use crate::virtio::block::IO_URING_NUM_ENTRIES;
@@ -22,7 +22,7 @@ pub enum Error {
     Submit(std::io::Error),
     SyncAll(std::io::Error),
     EventFd(std::io::Error),
-    GuestMemory(vm_memory::GuestMemoryError),
+    GuestMemory(vm_memory_wrapper::GuestMemoryError),
 }
 
 pub struct AsyncFileEngine<T> {

--- a/src/devices/src/virtio/block/io/mod.rs
+++ b/src/devices/src/virtio/block/io/mod.rs
@@ -6,7 +6,7 @@ pub mod sync_io;
 
 use std::fs::File;
 
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
 pub use self::async_io::AsyncFileEngine;
 pub use self::sync_io::SyncFileEngine;
@@ -180,7 +180,7 @@ pub mod tests {
     use utils::kernel_version::{min_kernel_version_for_io_uring, KernelVersion};
     use utils::tempfile::TempFile;
     use utils::{skip_if_io_uring_supported, skip_if_io_uring_unsupported};
-    use vm_memory::{Bitmap, Bytes, GuestMemory};
+    use vm_memory_wrapper::{Bitmap, Bytes, GuestMemory};
 
     use super::*;
     use crate::virtio::block::device::FileEngineType;
@@ -234,7 +234,7 @@ pub mod tests {
     }
 
     fn create_mem() -> GuestMemoryMmap {
-        vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], true)
+        vm_memory_wrapper::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_LEN)], true)
             .unwrap()
     }
 

--- a/src/devices/src/virtio/block/io/sync_io.rs
+++ b/src/devices/src/virtio/block/io/sync_io.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{Seek, SeekFrom, Write};
 use std::result::Result;
 
-use vm_memory::{Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -8,7 +8,7 @@ pub mod persist;
 pub mod request;
 pub mod test_utils;
 
-use vm_memory::GuestMemoryError;
+use vm_memory_wrapper::GuestMemoryError;
 
 pub use self::device::{Block, CacheType};
 pub use self::event_handler::*;

--- a/src/devices/src/virtio/block/persist.rs
+++ b/src/devices/src/virtio/block/persist.rs
@@ -14,7 +14,7 @@ use utils::kernel_version::min_kernel_version_for_io_uring;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_gen::virtio_blk::VIRTIO_BLK_F_RO;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::*;
 use crate::virtio::block::device::FileEngineType;

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -14,7 +14,7 @@ pub use virtio_gen::virtio_blk::{
     VIRTIO_BLK_ID_BYTES, VIRTIO_BLK_S_IOERR, VIRTIO_BLK_S_OK, VIRTIO_BLK_S_UNSUPP,
     VIRTIO_BLK_T_FLUSH, VIRTIO_BLK_T_GET_ID, VIRTIO_BLK_T_IN, VIRTIO_BLK_T_OUT,
 };
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
 
 use super::super::DescriptorChain;
 use super::{io as block_io, Error, SECTOR_SHIFT};
@@ -402,8 +402,8 @@ impl Request {
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
-    use vm_memory::test_utils::create_anon_guest_memory;
-    use vm_memory::{Address, GuestAddress, GuestMemory};
+    use vm_memory_wrapper::test_utils::create_anon_guest_memory;
+    use vm_memory_wrapper::{Address, GuestAddress, GuestMemory};
 
     use super::*;
     use crate::virtio::queue::tests::*;

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use logger::{error, warn};
 use utils::eventfd::EventFd;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::{ActivateResult, Queue};
 use crate::virtio::{AsAny, VIRTIO_MMIO_INT_CONFIG, VIRTIO_MMIO_INT_VRING};

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use logger::warn;
 use utils::byte_order;
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
 use super::{device_status, *};
 use crate::bus::BusDevice;
@@ -329,7 +329,7 @@ impl BusDevice for MmioTransport {
 pub(crate) mod tests {
     use utils::byte_order::{read_le_u32, write_le_u32};
     use utils::eventfd::EventFd;
-    use vm_memory::GuestMemoryMmap;
+    use vm_memory_wrapper::GuestMemoryMmap;
 
     use super::*;
 
@@ -431,9 +431,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_new() {
-        let m =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)
-                .unwrap();
+        let m = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let mut dummy = DummyDevice::new();
         // Validate reset is no-op.
         assert!(dummy.reset().is_none());
@@ -465,9 +467,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_bus_device_read() {
-        let m =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)
-                .unwrap();
+        let m = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
 
         let mut buf = vec![0xff, 0, 0xfe, 0];
@@ -545,9 +549,11 @@ pub(crate) mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_bus_device_write() {
-        let m =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)
-                .unwrap();
+        let m = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let dummy_dev = Arc::new(Mutex::new(DummyDevice::new()));
         let mut d = MmioTransport::new(m, dummy_dev.clone());
         let mut buf = vec![0; 5];
@@ -706,9 +712,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_bus_device_activate() {
-        let m =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)
-                .unwrap();
+        let m = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
 
         assert!(!d.are_queues_valid());
@@ -826,9 +834,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_bus_device_reset() {
-        let m =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false)
-                .unwrap();
+        let m = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let mut d = MmioTransport::new(m, Arc::new(Mutex::new(DummyDevice::new())));
         let mut buf = vec![0; 4];
 

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -26,7 +26,7 @@ use virtio_gen::virtio_net::{
     VIRTIO_NET_F_MAC,
 };
 use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::{ByteValued, Bytes, GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{ByteValued, Bytes, GuestMemoryError, GuestMemoryMmap};
 
 const FRAME_HEADER_MAX_LEN: usize = PAYLOAD_OFFSET + ETH_IPV4_FRAME_LEN;
 
@@ -832,7 +832,7 @@ pub mod tests {
         VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_TSO4,
         VIRTIO_NET_F_HOST_UFO, VIRTIO_NET_F_MAC,
     };
-    use vm_memory::{Address, GuestMemory};
+    use vm_memory_wrapper::{Address, GuestMemory};
 
     use super::*;
     use crate::check_metric_after_block;

--- a/src/devices/src/virtio/net/iovec.rs
+++ b/src/devices/src/virtio/net/iovec.rs
@@ -4,7 +4,7 @@
 use std::io::IoSlice;
 use std::ops::Deref;
 
-use vm_memory::{GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestMemory, GuestMemoryMmap};
 
 use crate::virtio::DescriptorChain;
 
@@ -15,7 +15,7 @@ pub enum Error {
     WriteOnlyDescriptor,
     /// An error happened with guest memory handling
     #[error("Guest memory error: {0}")]
-    GuestMemory(#[from] vm_memory::GuestMemoryError),
+    GuestMemory(#[from] vm_memory_wrapper::GuestMemoryError),
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -132,8 +132,8 @@ impl<'a> IoVecBuffer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::test_utils::create_anon_guest_memory;
-    use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::test_utils::create_anon_guest_memory;
+    use vm_memory_wrapper::{Bytes, GuestAddress, GuestMemoryMmap};
 
     use super::{IoSlice, IoVecBuffer};
     use crate::virtio::queue::{Queue, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -17,7 +17,7 @@ use snapshot::Persist;
 use utils::net::mac::{MacAddr, MAC_ADDR_LEN};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::device::Net;
 use super::{NUM_QUEUES, QUEUE_SIZE};

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -16,7 +16,7 @@ use mmds::data_store::Mmds;
 use mmds::ns::MmdsNetworkStack;
 use rate_limiter::RateLimiter;
 use utils::net::mac::MacAddr;
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
 #[cfg(test)]
 use crate::virtio::net::device::vnet_hdr_len;
@@ -316,7 +316,7 @@ pub fn default_guest_mac() -> MacAddr {
 }
 
 pub fn default_guest_memory() -> GuestMemoryMmap {
-    vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false)
+    vm_memory_wrapper::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false)
         .expect("Cannot initialize memory")
 }
 
@@ -342,7 +342,7 @@ pub mod test {
     use event_manager::{EventManager, SubscriberId, SubscriberOps};
     use logger::{IncMetric, METRICS};
     use net_gen::ETH_HLEN;
-    use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
     use crate::check_metric_after_block;
     use crate::virtio::net::device::vnet_hdr_len;
@@ -370,7 +370,7 @@ pub mod test {
         pub fn get_default() -> TestHelper<'a> {
             let mut event_manager = EventManager::new().unwrap();
             let mut net = default_net();
-            let mem = vm_memory::test_utils::create_guest_memory_unguarded(
+            let mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
                 &[(GuestAddress(0), MAX_BUFFER_SIZE)],
                 false,
             )

--- a/src/devices/src/virtio/persist.rs
+++ b/src/devices/src/virtio/persist.rs
@@ -11,8 +11,8 @@ use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::address::Address;
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::address::Address;
+use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
 use super::device::*;
 use super::queue::*;

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -11,7 +11,7 @@ use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
 
 use logger::error;
-use vm_memory::{
+use vm_memory_wrapper::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
 };
 
@@ -535,8 +535,8 @@ impl Queue {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use vm_memory::test_utils::create_anon_guest_memory;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::test_utils::create_anon_guest_memory;
+    use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
     pub use super::*;
     use crate::virtio::test_utils::VirtQueue;

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
 use crate::virtio::{Queue, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 
@@ -21,7 +21,8 @@ macro_rules! check_metric_after_block {
 }
 
 pub fn default_mem() -> GuestMemoryMmap {
-    vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap()
+    vm_memory_wrapper::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false)
+        .unwrap()
 }
 
 pub fn initialize_virtqueue(vq: &VirtQueue) {
@@ -82,7 +83,7 @@ pub struct SomeplaceInMemory<'a, T> {
 // The ByteValued trait is required to use mem.read_obj_from_addr and write_obj_at_addr.
 impl<'a, T> SomeplaceInMemory<'a, T>
 where
-    T: vm_memory::ByteValued,
+    T: vm_memory_wrapper::ByteValued,
 {
     fn new(location: GuestAddress, mem: &'a GuestMemoryMmap) -> Self {
         SomeplaceInMemory {
@@ -197,7 +198,7 @@ pub struct VirtqRing<'a, T> {
 
 impl<'a, T> VirtqRing<'a, T>
 where
-    T: vm_memory::ByteValued,
+    T: vm_memory_wrapper::ByteValued,
 {
     fn new(start: GuestAddress, mem: &'a GuestMemoryMmap, qsize: u16, alignment: usize) -> Self {
         assert_eq!(start.0 & (alignment as u64 - 1), 0);
@@ -241,7 +242,7 @@ pub struct VirtqUsedElem {
 }
 
 // SAFETY: `VirtqUsedElem` is a POD and contains no padding.
-unsafe impl vm_memory::ByteValued for VirtqUsedElem {}
+unsafe impl vm_memory_wrapper::ByteValued for VirtqUsedElem {}
 
 pub type VirtqAvail<'a> = VirtqRing<'a, u16>;
 pub type VirtqUsed<'a> = VirtqRing<'a, VirtqUsedElem>;

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -85,7 +85,7 @@ use std::time::{Duration, Instant};
 
 use logger::{debug, error, info, warn, IncMetric, METRICS};
 use utils::epoll::EventSet;
-use vm_memory::{GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestMemoryError, GuestMemoryMmap};
 
 use super::super::defs::uapi;
 use super::super::packet::VsockPacket;

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use logger::{debug, error, warn, IncMetric, METRICS};
 use utils::byte_order;
 use utils::eventfd::EventFd;
-use vm_memory::{Bytes, GuestMemoryMmap};
+use vm_memory_wrapper::{Bytes, GuestMemoryMmap};
 
 use super::super::super::Error as DeviceError;
 use super::defs::uapi;

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -205,7 +205,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use event_manager::{EventManager, SubscriberOps};
-    use vm_memory::Bytes;
+    use vm_memory_wrapper::Bytes;
 
     use super::super::*;
     use super::*;
@@ -410,7 +410,7 @@ mod tests {
     // desc_idx = 0 we are altering the header (first descriptor in the chain), and when
     // desc_idx = 1 we are altering the packet buffer.
     fn vsock_bof_helper(test_ctx: &mut TestContext, desc_idx: usize, addr: u64, len: u32) {
-        use vm_memory::GuestAddress;
+        use vm_memory_wrapper::GuestAddress;
 
         assert!(desc_idx <= 1);
 
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_vsock_bof() {
-        use vm_memory::GuestAddress;
+        use vm_memory_wrapper::GuestAddress;
 
         const GAP_SIZE: usize = 768 << 20;
         const FIRST_AFTER_GAP: usize = 1 << 32;
@@ -458,7 +458,7 @@ mod tests {
         const MIB: usize = 1 << 20;
 
         let mut test_ctx = TestContext::new();
-        test_ctx.mem = vm_memory::test_utils::create_anon_guest_memory(
+        test_ctx.mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[
                 (GuestAddress(0), 8 * MIB),
                 (GuestAddress((GAP_START_ADDR - MIB) as u64), MIB),

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -17,7 +17,7 @@ use std::os::unix::io::AsRawFd;
 
 use packet::VsockPacket;
 use utils::epoll::EventSet;
-use vm_memory::{GuestMemoryError, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestMemoryError, GuestMemoryMmap};
 
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::VSOCK_DEV_ID;

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -16,7 +16,7 @@
 /// to temporary buffers, before passing it on to the vsock backend.
 use std::io::{Read, Write};
 
-use vm_memory::{
+use vm_memory_wrapper::{
     self, Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap,
     GuestMemoryRegion, GuestRegionMmap, MemoryRegionAddress,
 };
@@ -407,7 +407,7 @@ mod tests {
 
     use std::io::Cursor;
 
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
     use super::*;
     use crate::virtio::test_utils::VirtqDesc as GuestQDesc;
@@ -719,7 +719,7 @@ mod tests {
     fn test_buf_region_addr_edge_cases() {
         let mut test_ctx = TestContext::new();
 
-        test_ctx.mem = vm_memory::test_utils::create_guest_memory_unguarded(
+        test_ctx.mem = vm_memory_wrapper::test_utils::create_guest_memory_unguarded(
             &[
                 (GuestAddress(0), 500),
                 (GuestAddress(500), 100),

--- a/src/devices/src/virtio/vsock/persist.rs
+++ b/src/devices/src/virtio/vsock/persist.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::*;
 use crate::virtio::persist::VirtioDeviceState;

--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -7,7 +7,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use utils::epoll::EventSet;
 use utils::eventfd::EventFd;
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
 use crate::virtio::test_utils::VirtQueue as GuestQ;
 use crate::virtio::vsock::device::{RXQ_INDEX, TXQ_INDEX};
@@ -121,9 +121,11 @@ impl TestContext {
     pub fn new() -> Self {
         const CID: u64 = 52;
         const MEM_SIZE: usize = 1024 * 1024 * 128;
-        let mem =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_SIZE)], false)
-                .unwrap();
+        let mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0), MEM_SIZE)],
+            false,
+        )
+        .unwrap();
         Self {
             cid: CID,
             mem,

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -37,7 +37,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 
 use logger::{debug, error, info, warn, IncMetric, METRICS};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::super::csm::ConnState;
 use super::super::defs::uapi;

--- a/src/io_uring/Cargo.toml
+++ b/src/io_uring/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2.117"
 utils = { path = "../utils" }
-vm-memory = { path="../vm-memory" }
+vm-memory-wrapper = { path="../vm-memory-wrapper" }
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 [dev-dependencies]

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -394,7 +394,7 @@ mod tests {
     use utils::skip_if_io_uring_unsupported;
     use utils::syscall::SyscallReturnCode;
     use utils::tempfile::TempFile;
-    use vm_memory::{Bytes, MmapRegion, VolatileMemory};
+    use vm_memory_wrapper::{Bytes, MmapRegion, VolatileMemory};
 
     /// -------------------------------------
     /// BEGIN PROPERTY BASED TESTING

--- a/src/io_uring/src/operation/cqe.rs
+++ b/src/io_uring/src/operation/cqe.rs
@@ -3,7 +3,7 @@
 
 use std::result::Result;
 
-use vm_memory::ByteValued;
+use vm_memory_wrapper::ByteValued;
 
 use crate::bindings::io_uring_cqe;
 

--- a/src/io_uring/src/operation/sqe.rs
+++ b/src/io_uring/src/operation/sqe.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use vm_memory::ByteValued;
+use vm_memory_wrapper::ByteValued;
 
 use crate::bindings::io_uring_sqe;
 

--- a/src/io_uring/src/queue/completion.rs
+++ b/src/io_uring/src/queue/completion.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::RawFd;
 use std::result::Result;
 use std::sync::atomic::Ordering;
 
-use vm_memory::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
+use vm_memory_wrapper::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
 
 use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;

--- a/src/io_uring/src/queue/mmap.rs
+++ b/src/io_uring/src/queue/mmap.rs
@@ -5,7 +5,7 @@ use std::io::Error as IOError;
 use std::os::unix::io::RawFd;
 use std::result::Result;
 
-use vm_memory::{MmapRegion, MmapRegionError};
+use vm_memory_wrapper::{MmapRegion, MmapRegionError};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -9,7 +9,7 @@ use std::result::Result;
 use std::sync::atomic::Ordering;
 
 use utils::syscall::SyscallReturnCode;
-use vm_memory::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
+use vm_memory_wrapper::{Bytes, MmapRegion, VolatileMemory, VolatileMemoryError};
 
 use super::mmap::{mmap, Error as MmapError};
 use crate::bindings;

--- a/src/io_uring/tests/integration_tests.rs
+++ b/src/io_uring/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use utils::eventfd::EventFd;
 use utils::kernel_version::{min_kernel_version_for_io_uring, KernelVersion};
 use utils::skip_if_io_uring_unsupported;
 use utils::tempfile::TempFile;
-use vm_memory::{Bytes, MmapRegion, VolatileMemory};
+use vm_memory_wrapper::{Bytes, MmapRegion, VolatileMemory};
 
 mod test_utils;
 use io_uring::operation::{OpCode, Operation};

--- a/src/io_uring/tests/test_utils/mod.rs
+++ b/src/io_uring/tests/test_utils/mod.rs
@@ -3,7 +3,7 @@
 
 use io_uring::operation::{OpCode, Operation};
 use io_uring::{Error, IoUring, SQueueError};
-use vm_memory::{MmapRegion, VolatileMemory};
+use vm_memory_wrapper::{MmapRegion, VolatileMemory};
 
 fn drain_cqueue(ring: &mut IoUring) {
     while let Some(entry) = unsafe { ring.pop::<usize>().unwrap() } {

--- a/src/vm-memory-wrapper/Cargo.toml
+++ b/src/vm-memory-wrapper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vm-memory-wrapper"
+version = "0.3.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+libc = "0.2.117"
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-bitmap"] }
+
+utils = { path = "../utils" }

--- a/src/vm-memory-wrapper/src/lib.rs
+++ b/src/vm-memory-wrapper/src/lib.rs
@@ -1,0 +1,449 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+#![warn(clippy::undocumented_unsafe_blocks)]
+
+use std::io::Error as IoError;
+use std::os::unix::io::AsRawFd;
+
+use vm_memory::bitmap::AtomicBitmap;
+pub use vm_memory::bitmap::Bitmap;
+use vm_memory::mmap::{check_file_offset, NewBitmap};
+pub use vm_memory::mmap::{MmapRegionBuilder, MmapRegionError};
+pub use vm_memory::{
+    address, Address, ByteValued, Bytes, Error, FileOffset, GuestAddress, GuestMemory,
+    GuestMemoryError, GuestMemoryRegion, GuestUsize, MemoryRegionAddress, MmapRegion,
+    VolatileMemory, VolatileMemoryError,
+};
+
+pub type GuestMemoryMmap = vm_memory::GuestMemoryMmap<Option<AtomicBitmap>>;
+pub type GuestRegionMmap = vm_memory::GuestRegionMmap<Option<AtomicBitmap>>;
+pub type GuestMmapRegion = vm_memory::MmapRegion<Option<AtomicBitmap>>;
+
+const GUARD_PAGE_COUNT: usize = 1;
+
+/// Build a `MmapRegion` surrounded by guard pages.
+///
+/// Initially, we map a `PROT_NONE` guard region of size:
+/// `size` + (GUARD_PAGE_COUNT * 2 * page_size).
+/// The guard region is mapped with `PROT_NONE`, so that any access to this region will cause
+/// a SIGSEGV.
+///
+/// The actual accessible region is going to be nested in the larger guard region.
+/// This is done by mapping over the guard region, starting at an address of
+/// `guard_region_addr + (GUARD_PAGE_COUNT * page_size)`.
+/// This results in a border of `GUARD_PAGE_COUNT` pages on either side of the region, which
+/// acts as a safety net for accessing out-of-bounds addresses that are not allocated for the
+/// guest's memory.
+fn build_guarded_region(
+    maybe_file_offset: Option<FileOffset>,
+    size: usize,
+    prot: i32,
+    flags: i32,
+    track_dirty_pages: bool,
+) -> Result<GuestMmapRegion, MmapRegionError> {
+    let page_size = utils::get_page_size().expect("Cannot retrieve page size.");
+    // Create the guarded range size (received size + X pages),
+    // where X is defined as a constant GUARD_PAGE_COUNT.
+    let guarded_size = size + GUARD_PAGE_COUNT * 2 * page_size;
+
+    // Map the guarded range to PROT_NONE
+    // SAFETY: Safe because the parameters are valid.
+    let guard_addr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            guarded_size,
+            libc::PROT_NONE,
+            libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_NORESERVE,
+            -1,
+            0,
+        )
+    };
+
+    if guard_addr == libc::MAP_FAILED {
+        return Err(MmapRegionError::Mmap(IoError::last_os_error()));
+    }
+
+    let (fd, offset) = match maybe_file_offset {
+        Some(ref file_offset) => {
+            check_file_offset(file_offset, size)?;
+            (file_offset.file().as_raw_fd(), file_offset.start())
+        }
+        None => (-1, 0),
+    };
+
+    let region_start_addr = guard_addr as usize + page_size * GUARD_PAGE_COUNT;
+
+    // Inside the protected range, starting with guard_addr + PAGE_SIZE,
+    // map the requested range with received protection and flags
+    // SAFETY: Safe because the parameters are valid.
+    let region_addr = unsafe {
+        libc::mmap(
+            region_start_addr as *mut libc::c_void,
+            size,
+            prot,
+            flags | libc::MAP_FIXED,
+            fd,
+            offset as libc::off_t,
+        )
+    };
+
+    if region_addr == libc::MAP_FAILED {
+        return Err(MmapRegionError::Mmap(IoError::last_os_error()));
+    }
+
+    let bitmap = match track_dirty_pages {
+        true => Some(AtomicBitmap::with_len(size)),
+        false => None,
+    };
+
+    // SAFETY: Safe because the parameters are valid.
+    unsafe {
+        MmapRegionBuilder::new_with_bitmap(size, bitmap)
+            .with_raw_mmap_pointer(region_addr as *mut u8)
+            .with_mmap_prot(prot)
+            .with_mmap_flags(flags)
+            .build()
+    }
+}
+
+/// Helper for creating the guest memory.
+pub fn create_guest_memory(
+    regions: &[(Option<FileOffset>, GuestAddress, usize)],
+    track_dirty_pages: bool,
+) -> std::result::Result<GuestMemoryMmap, Error> {
+    let prot = libc::PROT_READ | libc::PROT_WRITE;
+    let mut mmap_regions = Vec::with_capacity(regions.len());
+
+    for region in regions {
+        let flags = match region.0 {
+            None => libc::MAP_NORESERVE | libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            Some(_) => libc::MAP_NORESERVE | libc::MAP_PRIVATE,
+        };
+
+        let mmap_region =
+            build_guarded_region(region.0.clone(), region.2, prot, flags, track_dirty_pages)
+                .map_err(Error::MmapRegion)?;
+
+        mmap_regions.push(GuestRegionMmap::new(mmap_region, region.1)?);
+    }
+
+    GuestMemoryMmap::from_regions(mmap_regions)
+}
+
+pub fn mark_dirty_mem(mem: &GuestMemoryMmap, addr: GuestAddress, len: usize) {
+    let _ = mem.try_access(len, addr, |_total, count, caddr, region| {
+        if let Some(bitmap) = region.bitmap() {
+            bitmap.mark_dirty(caddr.0 as usize, count);
+        }
+        Ok(count)
+    });
+}
+
+pub mod test_utils {
+    use super::*;
+
+    /// Test helper used to initialize the guest memory without adding guard pages.
+    /// This is needed because the default `create_guest_memory`
+    /// uses MmapRegionBuilder::build_raw() for setting up the memory with guard pages, which would
+    /// error if the size is not a multiple of the page size.
+    /// There are unit tests which need a custom memory size, not a multiple of the page size.
+    pub fn create_guest_memory_unguarded(
+        regions: &[(GuestAddress, usize)],
+        track_dirty_pages: bool,
+    ) -> std::result::Result<GuestMemoryMmap, Error> {
+        let prot = libc::PROT_READ | libc::PROT_WRITE;
+        let flags = libc::MAP_NORESERVE | libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+        let mut mmap_regions = Vec::with_capacity(regions.len());
+
+        for region in regions {
+            mmap_regions.push(GuestRegionMmap::new(
+                MmapRegionBuilder::new_with_bitmap(
+                    region.1,
+                    match track_dirty_pages {
+                        true => Some(AtomicBitmap::with_len(region.1)),
+                        false => None,
+                    },
+                )
+                .with_mmap_prot(prot)
+                .with_mmap_flags(flags)
+                .build()
+                .map_err(Error::MmapRegion)?,
+                region.0,
+            )?);
+        }
+        GuestMemoryMmap::from_regions(mmap_regions)
+    }
+
+    /// Test helper used to initialize the guest memory, without the option of file-backed mmap.
+    /// It is just a little syntactic sugar that helps deduplicate test code.
+    pub fn create_anon_guest_memory(
+        regions: &[(GuestAddress, usize)],
+        track_dirty_pages: bool,
+    ) -> std::result::Result<GuestMemoryMmap, Error> {
+        create_guest_memory(
+            &regions.iter().map(|r| (None, r.0, r.1)).collect::<Vec<_>>(),
+            track_dirty_pages,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+    use utils::get_page_size;
+    use utils::tempfile::TempFile;
+
+    use super::*;
+
+    enum AddrOp {
+        Read,
+        Write,
+    }
+
+    impl AddrOp {
+        fn apply_on_addr(&self, addr: *mut u8) {
+            match self {
+                AddrOp::Read => {
+                    // We have to do something perform a read_volatile, otherwise
+                    // the Release version will optimize it out, making the test fail.
+                    unsafe { std::ptr::read_volatile(addr) };
+                }
+                AddrOp::Write => unsafe {
+                    std::ptr::write(addr, 0xFF);
+                },
+            }
+        }
+    }
+
+    fn fork_and_run(function: &dyn Fn(), expect_sigsegv: bool) {
+        let pid = unsafe { libc::fork() };
+        match pid {
+            0 => {
+                function();
+            }
+            child_pid => {
+                let mut child_status: i32 = -1;
+                let pid_done = unsafe { libc::waitpid(child_pid, &mut child_status, 0) };
+                assert_eq!(pid_done, child_pid);
+
+                if expect_sigsegv {
+                    // Asserts that the child process terminated because
+                    // it received a signal that was not handled.
+                    assert!(libc::WIFSIGNALED(child_status));
+                    // Signal code should be a SIGSEGV
+                    assert_eq!(libc::WTERMSIG(child_status), libc::SIGSEGV);
+                } else {
+                    assert!(libc::WIFEXITED(child_status));
+                    // Signal code should be a SIGSEGV
+                    assert_eq!(libc::WEXITSTATUS(child_status), 0);
+                }
+            }
+        };
+    }
+
+    fn validate_guard_region(region: &GuestMmapRegion) {
+        let page_size = get_page_size().unwrap();
+
+        // Check that the created range allows us to write inside it
+        let addr = region.as_ptr();
+
+        unsafe {
+            std::ptr::write(addr, 0xFF);
+            assert_eq!(std::ptr::read(addr), 0xFF);
+        }
+
+        // Try a read/write operation against the left guard border of the range
+        let left_border = (addr as usize - page_size) as *mut u8;
+        fork_and_run(&|| AddrOp::Read.apply_on_addr(left_border), true);
+        fork_and_run(&|| AddrOp::Write.apply_on_addr(left_border), true);
+
+        // Try a read/write operation against the right guard border of the range
+        let right_border = (addr as usize + region.size()) as *mut u8;
+        fork_and_run(&|| AddrOp::Read.apply_on_addr(right_border), true);
+        fork_and_run(&|| AddrOp::Write.apply_on_addr(right_border), true);
+    }
+
+    fn loop_guard_region_to_sigsegv(region: &GuestMmapRegion) {
+        let page_size = get_page_size().unwrap();
+        let right_page_guard = region.as_ptr() as usize + region.size();
+
+        fork_and_run(
+            &|| {
+                let mut addr = region.as_ptr() as usize;
+                loop {
+                    if addr >= right_page_guard {
+                        break;
+                    }
+                    AddrOp::Write.apply_on_addr(addr as *mut u8);
+
+                    addr += page_size;
+                }
+            },
+            false,
+        );
+
+        fork_and_run(
+            &|| {
+                AddrOp::Write.apply_on_addr(right_page_guard as *mut u8);
+            },
+            true,
+        );
+    }
+
+    #[test]
+    fn test_build_guarded_region() {
+        // Create anonymous guarded region.
+        {
+            let page_size = get_page_size().unwrap();
+            let size = page_size * 10;
+            let prot = libc::PROT_READ | libc::PROT_WRITE;
+            let flags = libc::MAP_ANONYMOUS | libc::MAP_NORESERVE | libc::MAP_PRIVATE;
+
+            let region = build_guarded_region(None, size, prot, flags, false).unwrap();
+
+            // Verify that the region was built correctly
+            assert_eq!(region.size(), size);
+            assert!(region.file_offset().is_none());
+            assert_eq!(region.prot(), prot);
+            assert_eq!(region.flags(), flags);
+
+            validate_guard_region(&region);
+        }
+
+        // Create guarded region from file.
+        {
+            let file = TempFile::new().unwrap().into_file();
+            let page_size = get_page_size().unwrap();
+
+            let prot = libc::PROT_READ | libc::PROT_WRITE;
+            let flags = libc::MAP_NORESERVE | libc::MAP_PRIVATE;
+            let offset = 0;
+            let size = 10 * page_size;
+            assert_eq!(unsafe { libc::ftruncate(file.as_raw_fd(), 4096 * 10) }, 0);
+
+            let region = build_guarded_region(
+                Some(FileOffset::new(file, offset)),
+                size,
+                prot,
+                flags,
+                false,
+            )
+            .unwrap();
+
+            // Verify that the region was built correctly
+            assert_eq!(region.size(), size);
+            // assert_eq!(region.file_offset().unwrap().start(), offset as u64);
+            assert_eq!(region.prot(), prot);
+            assert_eq!(region.flags(), flags);
+
+            validate_guard_region(&region);
+        }
+    }
+
+    #[test]
+    fn test_create_guest_memory() {
+        // Test that all regions are guarded.
+        {
+            let region_size = 0x10000;
+            let regions = vec![
+                (None, GuestAddress(0x0), region_size),
+                (None, GuestAddress(0x10000), region_size),
+                (None, GuestAddress(0x20000), region_size),
+                (None, GuestAddress(0x30000), region_size),
+            ];
+
+            let guest_memory = create_guest_memory(&regions, false).unwrap();
+            guest_memory.iter().for_each(|region| {
+                validate_guard_region(region);
+                loop_guard_region_to_sigsegv(region);
+            });
+        }
+
+        // Check dirty page tracking is off.
+        {
+            let region_size = 0x10000;
+            let regions = vec![
+                (None, GuestAddress(0x0), region_size),
+                (None, GuestAddress(0x10000), region_size),
+                (None, GuestAddress(0x20000), region_size),
+                (None, GuestAddress(0x30000), region_size),
+            ];
+
+            let guest_memory = create_guest_memory(&regions, false).unwrap();
+            guest_memory.iter().for_each(|region| {
+                assert!(region.bitmap().is_none());
+            });
+        }
+
+        // Check dirty page tracking is on.
+        {
+            let region_size = 0x10000;
+            let regions = vec![
+                (None, GuestAddress(0x0), region_size),
+                (None, GuestAddress(0x10000), region_size),
+                (None, GuestAddress(0x20000), region_size),
+                (None, GuestAddress(0x30000), region_size),
+            ];
+
+            let guest_memory = create_guest_memory(&regions, true).unwrap();
+            guest_memory.iter().for_each(|region| {
+                assert!(region.bitmap().is_some());
+            });
+        }
+    }
+
+    #[test]
+    fn test_mark_dirty_mem() {
+        let page_size = utils::get_page_size().unwrap();
+        let region_size = page_size * 3;
+
+        let regions = vec![
+            (None, GuestAddress(0), region_size), // pages 0-2
+            (None, GuestAddress(region_size as u64), region_size), // pages 3-5
+            (None, GuestAddress(region_size as u64 * 2), region_size), // pages 6-8
+        ];
+        let guest_memory = create_guest_memory(&regions, true).unwrap();
+
+        let dirty_map = [
+            // page 0: not dirty
+            (0, page_size, false),
+            // pages 1-2: dirty range in one region
+            (page_size, page_size * 2, true),
+            // page 3: not dirty
+            (page_size * 3, page_size, false),
+            // pages 4-7: dirty range across 2 regions,
+            (page_size * 4, page_size * 4, true),
+            // page 8: not dirty
+            (page_size * 8, page_size, false),
+        ];
+
+        // Mark dirty memory
+        for (addr, len, dirty) in &dirty_map {
+            if *dirty {
+                mark_dirty_mem(&guest_memory, GuestAddress(*addr as u64), *len);
+            }
+        }
+
+        // Check that the dirty memory was set correctly
+        for (addr, len, dirty) in &dirty_map {
+            guest_memory
+                .try_access(
+                    *len,
+                    GuestAddress(*addr as u64),
+                    |_total, count, caddr, region| {
+                        let offset = caddr.0 as usize;
+                        let bitmap = region.bitmap().as_ref().unwrap();
+                        for i in offset..offset + count {
+                            assert_eq!(bitmap.dirty_at(i), *dirty);
+                        }
+                        Ok(count)
+                    },
+                )
+                .unwrap();
+        }
+    }
+}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -31,7 +31,7 @@ seccompiler = { path = "../seccompiler" }
 snapshot = { path = "../snapshot"}
 utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-vm-memory = { path = "../vm-memory" }
+vm-memory-wrapper = { path = "../vm-memory-wrapper" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -166,15 +166,17 @@ impl PortIODeviceManager {
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::GuestAddress;
+    use vm_memory_wrapper::GuestAddress;
 
     use super::*;
 
     #[test]
     fn test_register_legacy_devices() {
-        let guest_mem =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0x0), 0x1000)], false)
-                .unwrap();
+        let guest_mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
+            &[(GuestAddress(0x0), 0x1000)],
+            false,
+        )
+        .unwrap();
         let mut vm = crate::builder::setup_kvm_vm(&guest_mem, false).unwrap();
         crate::builder::setup_interrupt_controller(&mut vm).unwrap();
         let mut ldm = PortIODeviceManager::new(

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -30,7 +30,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_allocator::{AddressAllocator, AllocPolicy, IdAllocator};
 #[cfg(target_arch = "x86_64")]
-use vm_memory::GuestAddress;
+use vm_memory_wrapper::GuestAddress;
 
 /// Errors for MMIO device manager.
 #[derive(Debug)]
@@ -476,7 +476,7 @@ mod tests {
     use devices::virtio::{ActivateResult, Queue, VirtioDevice};
     use utils::errno;
     use utils::eventfd::EventFd;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
     use super::*;
     use crate::builder;
@@ -581,7 +581,7 @@ mod tests {
     fn test_register_virtio_device() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = vm_memory::test_utils::create_anon_guest_memory(
+        let guest_mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[(start_addr1, 0x1000), (start_addr2, 0x1000)],
             false,
         )
@@ -610,7 +610,7 @@ mod tests {
     fn test_register_too_many_devices() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = vm_memory::test_utils::create_anon_guest_memory(
+        let guest_mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[(start_addr1, 0x1000), (start_addr2, 0x1000)],
             false,
         )
@@ -702,7 +702,7 @@ mod tests {
     fn test_device_info() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x1000);
-        let guest_mem = vm_memory::test_utils::create_anon_guest_memory(
+        let guest_mem = vm_memory_wrapper::test_utils::create_anon_guest_memory(
             &[(start_addr1, 0x1000), (start_addr2, 0x1000)],
             false,
         )

--- a/src/vmm/src/device_manager/persist.rs
+++ b/src/vmm/src/device_manager/persist.rs
@@ -28,7 +28,7 @@ use snapshot::Persist;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_allocator::AllocPolicy;
-use vm_memory::GuestMemoryMmap;
+use vm_memory_wrapper::GuestMemoryMmap;
 
 use super::mmio::*;
 use crate::resources::VmResources;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -56,7 +56,7 @@ use snapshot::Persist;
 use userfaultfd::Uffd;
 use utils::epoll::EventSet;
 use utils::eventfd::EventFd;
-use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory_wrapper::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use vstate::vcpu::{self, KvmVcpuConfigureError, StartThreadedError, VcpuSendEventError};
 
 #[cfg(target_arch = "x86_64")]
@@ -583,7 +583,7 @@ impl Vmm {
         // example, if this function were to be exposed through the VMM controller, the VMM
         // resources should cache the flag.
         self.vm
-            .set_kvm_memory_regions(&self.guest_memory, enable)
+            .set_kvm_memory_ext_regions(&self.guest_memory, enable)
             .map_err(Error::Vm)
     }
 

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -24,7 +24,7 @@ use utils::sock_ctrl_msg::ScmSocket;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_gen::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::{GuestMemory, GuestMemoryMmap};
+use vm_memory_wrapper::{GuestMemory, GuestMemoryMmap};
 
 use crate::builder::{self, BuildMicrovmFromSnapshotError};
 use crate::device_manager::persist::{DeviceStates, Error as DevicePersistError};
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn test_create_snapshot_error_display() {
-        use vm_memory::GuestMemoryError;
+        use vm_memory_wrapper::GuestMemoryError;
 
         use crate::persist::CreateSnapshotError::*;
 

--- a/src/vmm/src/vstate/vcpu/aarch64.rs
+++ b/src/vmm/src/vstate/vcpu/aarch64.rs
@@ -13,7 +13,7 @@ use kvm_ioctls::*;
 use logger::{error, IncMetric, METRICS};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, GuestAddress, GuestMemoryMmap};
 
 use crate::vstate::vcpu::VcpuEmulation;
 use crate::vstate::vm::Vm;
@@ -192,7 +192,7 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
     use std::os::unix::io::AsRawFd;
 
-    use vm_memory::GuestMemoryMmap;
+    use vm_memory_wrapper::GuestMemoryMmap;
 
     use super::*;
     use crate::vstate::vm::tests::setup_vm;

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -669,7 +669,7 @@ mod tests {
     use linux_loader::loader::KernelLoader;
     use utils::errno;
     use utils::signal::validate_signal_num;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory_wrapper::{GuestAddress, GuestMemoryMmap};
 
     use super::*;
     use crate::builder::StartMicrovmError;
@@ -874,7 +874,7 @@ mod tests {
         (vm, vcpu, gm)
     }
 
-    fn load_good_kernel(vm_memory: &GuestMemoryMmap) -> GuestAddress {
+    fn load_good_kernel(vm_memory_wrapper: &GuestMemoryMmap) -> GuestAddress {
         use std::fs::File;
         use std::path::PathBuf;
 
@@ -889,7 +889,7 @@ mod tests {
 
         #[cfg(target_arch = "x86_64")]
         let entry_addr = linux_loader::loader::elf::Elf::load(
-            vm_memory,
+            vm_memory_wrapper,
             Some(GuestAddress(arch::get_kernel_start())),
             &mut kernel_file,
             Some(GuestAddress(arch::get_kernel_start())),
@@ -897,7 +897,7 @@ mod tests {
         .map_err(StartMicrovmError::KernelLoader);
         #[cfg(target_arch = "aarch64")]
         let entry_addr =
-            linux_loader::loader::pe::PE::load(vm_memory, None, &mut kernel_file, None)
+            linux_loader::loader::pe::PE::load(vm_memory_wrapper, None, &mut kernel_file, None)
                 .map_err(StartMicrovmError::KernelLoader);
         entry_addr.unwrap().kernel_load
     }

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -21,7 +21,7 @@ use kvm_ioctls::{VcpuExit, VcpuFd};
 use logger::{error, warn, IncMetric, METRICS};
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+use vm_memory_wrapper::{Address, GuestAddress, GuestMemoryMmap};
 
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation};

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -207,7 +207,7 @@ fn verify_create_snapshot(is_diff: bool) -> (TempFile, TempFile) {
 }
 
 fn verify_load_snapshot(snapshot_file: TempFile, memory_file: TempFile) {
-    use vm_memory::GuestMemoryMmap;
+    use vm_memory_wrapper::GuestMemoryMmap;
     use vmm::memory_snapshot::SnapshotMemory;
 
     let mut event_manager = EventManager::new().unwrap();

--- a/tests/framework/dependencies.txt
+++ b/tests/framework/dependencies.txt
@@ -89,6 +89,7 @@
  'vm-allocator',
  'vm-fdt',
  'vm-memory',
+ 'vm-memory-wrapper',
  'vm-superio',
  'vmm',
  'vmm-sys-util']

--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -34,6 +34,7 @@ from framework.utils import (
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from integration_tests.functional.test_cmd_line_start import _configure_vm_from_json
 import host_tools.network as net_tools  # pylint: disable=import-error
+
 # restore directory
 os.chdir("..")
 


### PR DESCRIPTION
## Changes

Rename `vm-memory` to `vm-memory-wrapper` and remove renaming of `vm-memory` to `vm-memory-upstream`.

## Reason

Renaming dependencies negatively affects readability, one will typically assume when seeing `use some_crate` in the code base it refers to the external crate `some_crate` which could be looked up at `crates.io/crates/some_crate`.

By removing this alias and renaming the local crate, readability is improved.

This was previously a part of https://github.com/firecracker-microvm/firecracker/pull/3079.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
