### PR TITLE
fix(create-snapshot): workaround tests directory

### DIFF
--- a/tools/create_snapshot_artifact/main.py
+++ b/tools/create_snapshot_artifact/main.py
@@ -15,6 +15,8 @@ from functools import partial
 sys.path.append(os.path.join(os.getcwd(), "tests"))  # noqa: E402
 
 # pylint: disable=wrong-import-position
+# The test infra assumes it is running from the `tests` directory.
+os.chdir("tests")
 from conftest import _test_images_s3_bucket, _gcc_compile, init_microvm
 from framework.artifacts import (
     ArtifactCollection,
@@ -32,6 +34,8 @@ from framework.utils import (
 from framework.utils_cpuid import CpuVendor, get_cpu_vendor
 from integration_tests.functional.test_cmd_line_start import _configure_vm_from_json
 import host_tools.network as net_tools  # pylint: disable=import-error
+# restore directory
+os.chdir("..")
 
 DEST_KERNEL_NAME = "vmlinux.bin"
 ROOTFS_KEY = "ubuntu-18.04"


### PR DESCRIPTION
The test infra assumes CWD is 'ROOT/tests'. create_snapshot_artifact runs from the root '.', so some functions can fail.

Workaround by changing to tests while doing the imports.

Original error:

```
[12] Command:
cd ../src/firecracker && cargo pkgid | cut -d# -f2 | cut -d: -f2
[12] stdout:

[12] stderr:
/bin/sh: 1: cd: can't cd to ../src/firecracker

Returned error code: 2
stderr:
/bin/sh: 1: cd: can't cd to ../src/firecracker
```

Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
