### PR TITLE
Api server thread clean shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?rev=4b18a04#4b18a043e997da5b5f679e3defc279fec908753e"
+source = "git+https://github.com/firecracker-microvm/micro-http#0d0fdcd50ea10c1b4777f9a958873fc848a5b7bb"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.78"
 thiserror = "1.0.32"
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 mmds = { path = "../mmds" }
 seccompiler = { path = "../seccompiler" }
 utils = { path = "../utils" }

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -97,6 +97,11 @@ impl ApiServer {
         loop {
             let request_vec = match server.requests() {
                 Ok(vec) => vec,
+                Err(ServerError::ShutdownEvent) => {
+                    server.flush_outgoing_writes();
+                    debug!("shutdown request received, API server thread ending.");
+                    return;
+                }
                 Err(err) => {
                     // print request error, but keep server running
                     error!("API Server error on retrieving incoming request: {}", err);

--- a/src/api_server/src/parsed_request.rs
+++ b/src/api_server/src/parsed_request.rs
@@ -32,7 +32,6 @@ use crate::ApiServer;
 #[derive(Debug)]
 pub(crate) enum RequestAction {
     Sync(Box<VmmAction>),
-    ShutdownInternal, // !!! not an API, used by shutdown to thread::join the API thread
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -96,9 +95,6 @@ impl TryFrom<&Request> for ParsedRequest {
             (Method::Put, "mmds", Some(body)) => parse_put_mmds(body, path_tokens.next()),
             (Method::Put, "network-interfaces", Some(body)) => {
                 parse_put_net(body, path_tokens.next())
-            }
-            (Method::Put, "shutdown-internal", None) => {
-                Ok(ParsedRequest::new(RequestAction::ShutdownInternal))
             }
             (Method::Put, "snapshot", Some(body)) => parse_put_snapshot(body, path_tokens.next()),
             (Method::Put, "vsock", Some(body)) => parse_put_vsock(body),
@@ -350,7 +346,6 @@ pub mod tests {
                 (RequestAction::Sync(ref sync_req), RequestAction::Sync(ref other_sync_req)) => {
                     sync_req == other_sync_req
                 }
-                _ => false,
             }
         }
     }
@@ -358,7 +353,6 @@ pub mod tests {
     pub(crate) fn vmm_action_from_request(req: ParsedRequest) -> VmmAction {
         match req.action {
             RequestAction::Sync(vmm_action) => *vmm_action,
-            _ => panic!("Invalid request"),
         }
     }
 
@@ -371,7 +365,6 @@ pub mod tests {
                 assert_eq!(req_msg, msg);
                 *vmm_action
             }
-            _ => panic!("Invalid request"),
         }
     }
 
@@ -881,21 +874,6 @@ pub mod tests {
         assert!(connection.try_read().is_ok());
         let req = connection.pop_parsed_request().unwrap();
         assert!(ParsedRequest::try_from(&req).is_ok());
-    }
-
-    #[test]
-    fn test_try_from_put_shutdown() {
-        let (mut sender, receiver) = UnixStream::pair().unwrap();
-        let mut connection = HttpConnection::new(receiver);
-        sender
-            .write_all(http_request("PUT", "/shutdown-internal", None).as_bytes())
-            .unwrap();
-        assert!(connection.try_read().is_ok());
-        let req = connection.pop_parsed_request().unwrap();
-        match ParsedRequest::try_from(&req).unwrap().into_parts() {
-            (RequestAction::ShutdownInternal, _) => (),
-            _ => panic!("wrong parsed request"),
-        };
     }
 
     #[test]

--- a/src/dumbo/Cargo.toml
+++ b/src/dumbo/Cargo.toml
@@ -13,7 +13,7 @@ bitflags = "1.3.2"
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 utils = { path = "../utils" }
 
 [dev-dependencies]

--- a/src/firecracker/src/api_server_adapter.rs
+++ b/src/firecracker/src/api_server_adapter.rs
@@ -1,9 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::Write;
 use std::os::unix::io::AsRawFd;
-use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex};
@@ -241,19 +239,7 @@ pub(crate) fn run_with_api(
         )
     });
 
-    // We want to tell the API thread to shut down for a clean exit. But this is after
-    // the Vmm.stop() has been called, so it's a moment of internal finalization (as
-    // opposed to be something the client might call to shut the Vm down).  Since it's
-    // an internal signal implementing it with an HTTP request is probably not the ideal
-    // way to do it...but having another way would involve multiplexing micro-http server
-    // with some other communication mechanism, or enhancing micro-http with exit
-    // conditions.
-
-    // We also need to make sure the socket path is ready.
-    let mut sock = UnixStream::connect(bind_path).unwrap();
-    sock.write_all(b"PUT /shutdown-internal HTTP/1.1\r\n\r\n")
-        .unwrap();
-
+    api_kill_switch.write(1).unwrap();
     // This call to thread::join() should block until the API thread has processed the
     // shutdown-internal and returns from its function.
     api_thread.join().expect("Api thread should join");

--- a/src/mmds/Cargo.toml
+++ b/src/mmds/Cargo.toml
@@ -21,6 +21,6 @@ versionize_derive = "0.1.5"
 
 dumbo = { path = "../dumbo" }
 logger = { path = "../logger" }
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "4b18a04" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http" }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }


### PR DESCRIPTION
## Changes

Use dedicated kill switch mechanism to break out of micro-http loop and gracefully shutdown the API server thread.

Remove hacky "/shutdown-internal" HTTP request which was externally exposing a way to bring down parts of firecracker components.

## Dependencies

Ideally needs https://github.com/firecracker-microvm/micro-http/pull/33 merged first, then point the dependency there.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] ~If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] ~New `unsafe` code is documented.~
- [x] ~API changes follow the [Runbook for Firecracker API changes][2].~
- [x] ~User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
- [x] ~New `TODO`s link to an issue.~

---

- [x] ~This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
