### PR TITLE
perf: net: update AMD baselines for TCP throughput

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -2507,128 +2507,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4181,
-                                                    "delta_percentage": 6
+                                                    "target": 3854,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 31026,
-                                                    "delta_percentage": 29
+                                                    "target": 24662,
+                                                    "delta_percentage": 84
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 43625,
-                                                    "delta_percentage": 36
+                                                    "target": 32534,
+                                                    "delta_percentage": 126
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4179,
-                                                    "delta_percentage": 7
+                                                    "target": 3821,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 29993,
-                                                    "delta_percentage": 27
+                                                    "target": 20281,
+                                                    "delta_percentage": 138
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 40741,
-                                                    "delta_percentage": 36
+                                                    "target": 43336,
+                                                    "delta_percentage": 34
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3645,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 23831,
-                                                    "delta_percentage": 23
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 64631,
+                                                    "target": 3392,
                                                     "delta_percentage": 25
                                                 },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 23525,
+                                                    "delta_percentage": 24
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 38466,
+                                                    "delta_percentage": 163
+                                                },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3615,
-                                                    "delta_percentage": 9
+                                                    "target": 3378,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 23779,
-                                                    "delta_percentage": 27
+                                                    "target": 22814,
+                                                    "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 60296,
-                                                    "delta_percentage": 32
+                                                    "target": 36885,
+                                                    "delta_percentage": 152
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 7158,
-                                                    "delta_percentage": 8
+                                                    "target": 6795,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 38643,
-                                                    "delta_percentage": 26
+                                                    "target": 42947,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 44826,
-                                                    "delta_percentage": 37
+                                                    "target": 57170,
+                                                    "delta_percentage": 31
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 7090,
-                                                    "delta_percentage": 7
+                                                    "target": 6729,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 38378,
-                                                    "delta_percentage": 29
+                                                    "target": 43777,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 44956,
-                                                    "delta_percentage": 32
-                                                },
-                                                "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 6203,
-                                                    "delta_percentage": 11
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 45429,
-                                                    "delta_percentage": 33
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 56817,
-                                                    "delta_percentage": 39
-                                                },
-                                                "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 6199,
-                                                    "delta_percentage": 12
-                                                },
-                                                "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 44559,
-                                                    "delta_percentage": 29
-                                                },
-                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 53477,
-                                                    "delta_percentage": 44
-                                                },
-                                                "tcp-p1024K-ws16K-bd": {
-                                                    "target": 6258,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 40953,
+                                                    "target": 54722,
                                                     "delta_percentage": 27
                                                 },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 47874,
-                                                    "delta_percentage": 46
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 6232,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 38063,
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 5885,
                                                     "delta_percentage": 25
                                                 },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 43990,
+                                                    "delta_percentage": 40
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 49439,
+                                                    "delta_percentage": 41
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 5903,
+                                                    "delta_percentage": 25
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 41781,
+                                                    "delta_percentage": 25
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 49753,
+                                                    "delta_percentage": 38
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 5905,
+                                                    "delta_percentage": 21
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 43069,
+                                                    "delta_percentage": 26
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 56887,
+                                                    "delta_percentage": 36
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 5889,
+                                                    "delta_percentage": 21
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 39777,
+                                                    "delta_percentage": 28
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 48190,
-                                                    "delta_percentage": 33
+                                                    "target": 56004,
+                                                    "delta_percentage": 32
                                                 }
                                             }
                                         }
@@ -2639,128 +2639,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 2928,
-                                                    "delta_percentage": 13
+                                                    "target": 2944,
+                                                    "delta_percentage": 24
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 24731,
-                                                    "delta_percentage": 18
+                                                    "target": 19961,
+                                                    "delta_percentage": 73
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 41090,
-                                                    "delta_percentage": 34
+                                                    "target": 46161,
+                                                    "delta_percentage": 54
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 2885,
-                                                    "delta_percentage": 11
+                                                    "target": 2842,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 24507,
-                                                    "delta_percentage": 18
+                                                    "target": 17795,
+                                                    "delta_percentage": 120
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 41157,
-                                                    "delta_percentage": 35
+                                                    "target": 46084,
+                                                    "delta_percentage": 44
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 2915,
-                                                    "delta_percentage": 6
+                                                    "target": 2831,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 25350,
-                                                    "delta_percentage": 18
+                                                    "target": 25379,
+                                                    "delta_percentage": 19
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 62673,
-                                                    "delta_percentage": 35
+                                                    "target": 37917,
+                                                    "delta_percentage": 158
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 2899,
-                                                    "delta_percentage": 6
+                                                    "target": 2820,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 20674,
-                                                    "delta_percentage": 7
+                                                    "target": 20404,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 40997,
-                                                    "delta_percentage": 87
+                                                    "target": 31568,
+                                                    "delta_percentage": 128
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4539,
+                                                    "target": 4592,
                                                     "delta_percentage": 8
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 34434,
-                                                    "delta_percentage": 27
+                                                    "target": 36893,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 44490,
-                                                    "delta_percentage": 36
+                                                    "target": 51348,
+                                                    "delta_percentage": 34
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4488,
-                                                    "delta_percentage": 9
-                                                },
-                                                "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 34506,
-                                                    "delta_percentage": 24
-                                                },
-                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 43567,
-                                                    "delta_percentage": 28
-                                                },
-                                                "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 4926,
+                                                    "target": 4552,
                                                     "delta_percentage": 8
                                                 },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 36823,
+                                                    "delta_percentage": 23
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-g2h": {
+                                                    "target": 50766,
+                                                    "delta_percentage": 27
+                                                },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 4803,
+                                                    "delta_percentage": 22
+                                                },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 36704,
-                                                    "delta_percentage": 16
+                                                    "target": 35941,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 61138,
-                                                    "delta_percentage": 48
+                                                    "target": 55595,
+                                                    "delta_percentage": 58
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 4947,
-                                                    "delta_percentage": 6
+                                                    "target": 4821,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 32395,
-                                                    "delta_percentage": 11
+                                                    "target": 32046,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 55088,
-                                                    "delta_percentage": 57
+                                                    "target": 56771,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 4296,
-                                                    "delta_percentage": 10
+                                                    "target": 4297,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 37146,
-                                                    "delta_percentage": 12
+                                                    "target": 37309,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 52912,
-                                                    "delta_percentage": 38
+                                                    "target": 58481,
+                                                    "delta_percentage": 37
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 4320,
-                                                    "delta_percentage": 7
+                                                    "target": 4285,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 36602,
-                                                    "delta_percentage": 11
+                                                    "target": 36938,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 52436,
-                                                    "delta_percentage": 39
+                                                    "target": 62507,
+                                                    "delta_percentage": 38
                                                 }
                                             }
                                         }
@@ -2781,20 +2781,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 96,
-                                                    "delta_percentage": 17
+                                                    "target": 89,
+                                                    "delta_percentage": 39
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 69,
-                                                    "delta_percentage": 89
+                                                    "target": 81,
+                                                    "delta_percentage": 57
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
@@ -2806,7 +2806,7 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 99,
@@ -2814,11 +2814,11 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
@@ -2833,20 +2833,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 115,
-                                                    "delta_percentage": 16
+                                                    "target": 162,
+                                                    "delta_percentage": 63
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 119,
-                                                    "delta_percentage": 13
+                                                    "target": 150,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2857,11 +2857,11 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 196,
+                                                    "target": 197,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
@@ -2869,11 +2869,11 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 195,
-                                                    "delta_percentage": 8
+                                                    "target": 197,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
@@ -2881,8 +2881,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 171,
-                                                    "delta_percentage": 27
+                                                    "target": 186,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 198,
@@ -2893,8 +2893,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 185,
-                                                    "delta_percentage": 19
+                                                    "target": 189,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         }
@@ -2922,15 +2922,15 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 99,
@@ -2946,11 +2946,11 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
@@ -2965,20 +2965,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 115,
-                                                    "delta_percentage": 18
+                                                    "target": 153,
+                                                    "delta_percentage": 61
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 118,
-                                                    "delta_percentage": 15
+                                                    "target": 151,
+                                                    "delta_percentage": 56
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2989,19 +2989,19 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 192,
-                                                    "delta_percentage": 11
+                                                    "target": 197,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 198,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
@@ -3013,11 +3013,11 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 122,
-                                                    "delta_percentage": 11
+                                                    "target": 170,
+                                                    "delta_percentage": 66
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
@@ -3025,8 +3025,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 125,
-                                                    "delta_percentage": 13
+                                                    "target": 164,
+                                                    "delta_percentage": 57
                                                 }
                                             }
                                         }
@@ -3039,128 +3039,128 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 49,
-                                                    "delta_percentage": 13
+                                                    "target": 48,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 72,
-                                                    "delta_percentage": 17
+                                                    "target": 59,
+                                                    "delta_percentage": 67
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 89,
-                                                    "delta_percentage": 12
+                                                    "target": 66,
+                                                    "delta_percentage": 75
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 48,
-                                                    "delta_percentage": 15
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 73,
-                                                    "delta_percentage": 16
+                                                    "target": 51,
+                                                    "delta_percentage": 89
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 85,
-                                                    "delta_percentage": 11
-                                                },
-                                                "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 33,
-                                                    "delta_percentage": 14
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 47,
+                                                    "target": 79,
                                                     "delta_percentage": 25
                                                 },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 34,
+                                                    "delta_percentage": 22
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 45,
+                                                    "delta_percentage": 24
+                                                },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 80,
-                                                    "delta_percentage": 7
+                                                    "target": 64,
+                                                    "delta_percentage": 66
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 13
+                                                    "target": 33,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 56,
-                                                    "delta_percentage": 17
+                                                    "target": 54,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 84,
-                                                    "delta_percentage": 11
+                                                    "target": 66,
+                                                    "delta_percentage": 74
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 65,
-                                                    "delta_percentage": 13
-                                                },
-                                                "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 82,
-                                                    "delta_percentage": 9
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 89,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 64,
                                                     "delta_percentage": 11
                                                 },
-                                                "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 81,
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 78,
                                                     "delta_percentage": 10
                                                 },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 90,
+                                                    "delta_percentage": 13
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 64,
+                                                    "delta_percentage": 13
+                                                },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 77,
+                                                    "delta_percentage": 11
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
+                                                    "target": 87,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 45,
+                                                    "target": 46,
                                                     "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 86,
-                                                    "delta_percentage": 18
+                                                    "target": 83,
+                                                    "delta_percentage": 30
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 85,
-                                                    "delta_percentage": 12
+                                                    "target": 82,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 45,
+                                                    "target": 46,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 89,
-                                                    "delta_percentage": 15
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
+                                                    "target": 86,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 54,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
                                                     "target": 81,
-                                                    "delta_percentage": 11
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
                                                     "target": 88,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 54,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "target": 79,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
                                                     "target": 89,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }
@@ -3171,128 +3171,128 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 33,
-                                                    "delta_percentage": 12
+                                                    "target": 35,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 63,
-                                                    "delta_percentage": 14
+                                                    "target": 46,
+                                                    "delta_percentage": 84
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 88,
-                                                    "delta_percentage": 11
+                                                    "target": 82,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 32,
-                                                    "delta_percentage": 14
+                                                    "target": 34,
+                                                    "delta_percentage": 54
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 62,
-                                                    "delta_percentage": 19
+                                                    "target": 45,
+                                                    "delta_percentage": 81
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 84,
-                                                    "delta_percentage": 12
+                                                    "target": 82,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 29,
-                                                    "delta_percentage": 13
+                                                    "target": 30,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 52,
-                                                    "delta_percentage": 32
+                                                    "target": 48,
+                                                    "delta_percentage": 27
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 83,
-                                                    "delta_percentage": 9
+                                                    "target": 62,
+                                                    "delta_percentage": 85
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 29,
-                                                    "delta_percentage": 13
+                                                    "target": 30,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 52,
-                                                    "delta_percentage": 30
+                                                    "target": 49,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 67,
-                                                    "delta_percentage": 62
+                                                    "target": 59,
+                                                    "delta_percentage": 71
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 43,
-                                                    "delta_percentage": 11
+                                                    "target": 44,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 75,
-                                                    "delta_percentage": 13
+                                                    "target": 69,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
+                                                    "target": 85,
                                                     "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 43,
-                                                    "delta_percentage": 13
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 74,
-                                                    "delta_percentage": 12
+                                                    "target": 67,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 37,
-                                                    "delta_percentage": 14
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 70,
-                                                    "delta_percentage": 11
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 89,
+                                                    "target": 84,
                                                     "delta_percentage": 9
                                                 },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 39,
+                                                    "delta_percentage": 15
+                                                },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 71,
+                                                    "delta_percentage": 15
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 83,
+                                                    "delta_percentage": 28
+                                                },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 38,
-                                                    "delta_percentage": 12
+                                                    "target": 39,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 70,
-                                                    "delta_percentage": 19
+                                                    "target": 72,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 89,
-                                                    "delta_percentage": 12
+                                                    "target": 86,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 45,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 79,
-                                                    "delta_percentage": 26
+                                                    "target": 74,
+                                                    "delta_percentage": 19
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 93,
-                                                    "delta_percentage": 7
+                                                    "target": 91,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 45,
-                                                    "delta_percentage": 13
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 80,
-                                                    "delta_percentage": 26
+                                                    "target": 74,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 94,
-                                                    "delta_percentage": 8
+                                                    "target": 95,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
@@ -2507,128 +2507,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4252,
-                                                    "delta_percentage": 7
+                                                    "target": 4246,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 33485,
-                                                    "delta_percentage": 26
+                                                    "target": 23518,
+                                                    "delta_percentage": 123
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 49144,
-                                                    "delta_percentage": 37
+                                                    "target": 34392,
+                                                    "delta_percentage": 138
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4228,
+                                                    "target": 4200,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 33248,
-                                                    "delta_percentage": 24
+                                                    "target": 21346,
+                                                    "delta_percentage": 139
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 46047,
-                                                    "delta_percentage": 33
+                                                    "target": 50891,
+                                                    "delta_percentage": 44
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3763,
+                                                    "target": 3740,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 24337,
-                                                    "delta_percentage": 19
+                                                    "target": 24199,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 66060,
-                                                    "delta_percentage": 11
+                                                    "target": 39656,
+                                                    "delta_percentage": 166
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3763,
+                                                    "target": 3729,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 24976,
-                                                    "delta_percentage": 22
+                                                    "target": 24003,
+                                                    "delta_percentage": 24
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 61922,
-                                                    "delta_percentage": 29
+                                                    "target": 38042,
+                                                    "delta_percentage": 160
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 7041,
+                                                    "target": 7037,
                                                     "delta_percentage": 8
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 42692,
-                                                    "delta_percentage": 28
+                                                    "target": 44775,
+                                                    "delta_percentage": 24
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 51470,
-                                                    "delta_percentage": 31
+                                                    "target": 58338,
+                                                    "delta_percentage": 42
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 6979,
-                                                    "delta_percentage": 7
+                                                    "target": 6981,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 41864,
+                                                    "target": 43716,
                                                     "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 49508,
-                                                    "delta_percentage": 27
+                                                    "target": 55738,
+                                                    "delta_percentage": 40
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 6440,
-                                                    "delta_percentage": 8
+                                                    "target": 6399,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 45389,
+                                                    "target": 45215,
                                                     "delta_percentage": 32
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 58972,
-                                                    "delta_percentage": 37
+                                                    "target": 52187,
+                                                    "delta_percentage": 54
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 6467,
-                                                    "delta_percentage": 8
+                                                    "target": 6416,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 43503,
-                                                    "delta_percentage": 27
+                                                    "target": 43363,
+                                                    "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 54187,
-                                                    "delta_percentage": 44
+                                                    "target": 52325,
+                                                    "delta_percentage": 40
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 6380,
-                                                    "delta_percentage": 6
+                                                    "target": 6353,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 43005,
-                                                    "delta_percentage": 22
+                                                    "target": 42800,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 53703,
-                                                    "delta_percentage": 32
+                                                    "target": 59347,
+                                                    "delta_percentage": 40
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 6377,
+                                                    "target": 6350,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 39714,
-                                                    "delta_percentage": 20
+                                                    "target": 40491,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 50767,
-                                                    "delta_percentage": 28
+                                                    "target": 58262,
+                                                    "delta_percentage": 42
                                                 }
                                             }
                                         }
@@ -2639,128 +2639,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 3043,
-                                                    "delta_percentage": 14
+                                                    "target": 3017,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 27466,
-                                                    "delta_percentage": 20
+                                                    "target": 21530,
+                                                    "delta_percentage": 89
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 48850,
-                                                    "delta_percentage": 39
+                                                    "target": 55357,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 3017,
-                                                    "delta_percentage": 15
+                                                    "target": 2999,
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 26877,
-                                                    "delta_percentage": 19
+                                                    "target": 18321,
+                                                    "delta_percentage": 124
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 45088,
-                                                    "delta_percentage": 36
+                                                    "target": 50745,
+                                                    "delta_percentage": 53
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3052,
+                                                    "target": 3060,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 25921,
-                                                    "delta_percentage": 18
+                                                    "target": 24424,
+                                                    "delta_percentage": 27
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 67913,
-                                                    "delta_percentage": 7
+                                                    "target": 40509,
+                                                    "delta_percentage": 170
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3036,
-                                                    "delta_percentage": 7
+                                                    "target": 3048,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 21735,
-                                                    "delta_percentage": 10
+                                                    "target": 21729,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 33721,
-                                                    "delta_percentage": 29
+                                                    "target": 28232,
+                                                    "delta_percentage": 74
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4453,
+                                                    "target": 4472,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 37807,
+                                                    "target": 38601,
                                                     "delta_percentage": 27
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 49635,
-                                                    "delta_percentage": 35
+                                                    "target": 54883,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4413,
+                                                    "target": 4430,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 37796,
-                                                    "delta_percentage": 26
+                                                    "target": 37487,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 47868,
-                                                    "delta_percentage": 27
+                                                    "target": 53550,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 5156,
-                                                    "delta_percentage": 7
+                                                    "target": 5147,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 36495,
-                                                    "delta_percentage": 20
+                                                    "target": 36017,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 67051,
-                                                    "delta_percentage": 40
+                                                    "target": 53331,
+                                                    "delta_percentage": 64
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 5166,
+                                                    "target": 5143,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 33282,
-                                                    "delta_percentage": 12
+                                                    "target": 32981,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 60868,
-                                                    "delta_percentage": 53
+                                                    "target": 55756,
+                                                    "delta_percentage": 54
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 3907,
+                                                    "target": 3955,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 38712,
-                                                    "delta_percentage": 10
+                                                    "target": 38760,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 56578,
-                                                    "delta_percentage": 35
+                                                    "target": 54059,
+                                                    "delta_percentage": 40
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 3903,
+                                                    "target": 3946,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 37510,
-                                                    "delta_percentage": 9
+                                                    "target": 37211,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 55382,
-                                                    "delta_percentage": 37
+                                                    "target": 60160,
+                                                    "delta_percentage": 44
                                                 }
                                             }
                                         }
@@ -2778,23 +2778,23 @@
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 99,
-                                                    "delta_percentage": 6
+                                                    "target": 90,
+                                                    "delta_percentage": 43
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 85,
-                                                    "delta_percentage": 69
+                                                    "target": 83,
+                                                    "delta_percentage": 72
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
@@ -2818,7 +2818,7 @@
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
@@ -2833,8 +2833,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 119,
-                                                    "delta_percentage": 13
+                                                    "target": 163,
+                                                    "delta_percentage": 68
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
@@ -2845,8 +2845,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 121,
-                                                    "delta_percentage": 11
+                                                    "target": 150,
+                                                    "delta_percentage": 58
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2865,12 +2865,12 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 196,
-                                                    "delta_percentage": 7
+                                                    "target": 197,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 198,
@@ -2881,20 +2881,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 184,
-                                                    "delta_percentage": 16
+                                                    "target": 186,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 198,
-                                                    "delta_percentage": 5
-                                                },
-                                                "tcp-pDEFAULT-ws256K-bd": {
                                                     "target": 197,
                                                     "delta_percentage": 5
                                                 },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 191,
-                                                    "delta_percentage": 13
+                                                    "target": 187,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         }
@@ -2906,15 +2906,15 @@
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 99,
@@ -2957,16 +2957,16 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 118,
-                                                    "delta_percentage": 16
+                                                    "target": 156,
+                                                    "delta_percentage": 67
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
@@ -2977,8 +2977,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 122,
-                                                    "delta_percentage": 14
+                                                    "target": 147,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2993,7 +2993,7 @@
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
@@ -3013,11 +3013,11 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 123,
-                                                    "delta_percentage": 11
+                                                    "target": 169,
+                                                    "delta_percentage": 67
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
@@ -3025,8 +3025,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 126,
-                                                    "delta_percentage": 15
+                                                    "target": 163,
+                                                    "delta_percentage": 62
                                                 }
                                             }
                                         }
@@ -3043,48 +3043,48 @@
                                                     "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 71,
-                                                    "delta_percentage": 19
+                                                    "target": 53,
+                                                    "delta_percentage": 88
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
-                                                    "delta_percentage": 15
+                                                    "target": 65,
+                                                    "delta_percentage": 87
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 48,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 71,
-                                                    "delta_percentage": 17
+                                                    "target": 51,
+                                                    "delta_percentage": 91
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 84,
-                                                    "delta_percentage": 10
+                                                    "target": 81,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 12
+                                                    "target": 35,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 46,
+                                                    "target": 47,
                                                     "delta_percentage": 24
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 83,
-                                                    "delta_percentage": 6
+                                                    "target": 64,
+                                                    "delta_percentage": 77
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 15
+                                                    "target": 35,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 56,
-                                                    "delta_percentage": 17
+                                                    "target": 57,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 86,
-                                                    "delta_percentage": 10
+                                                    "target": 66,
+                                                    "delta_percentage": 85
                                                 }
                                             }
                                         },
@@ -3095,67 +3095,67 @@
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 80,
-                                                    "delta_percentage": 10
+                                                    "target": 79,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
+                                                    "target": 90,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 65,
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 81,
-                                                    "delta_percentage": 11
+                                                    "target": 78,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "target": 88,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 47,
-                                                    "delta_percentage": 10
+                                                    "target": 48,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 89,
+                                                    "target": 86,
                                                     "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 88,
-                                                    "delta_percentage": 9
+                                                    "target": 85,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 47,
-                                                    "delta_percentage": 12
+                                                    "target": 48,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 92,
+                                                    "target": 91,
                                                     "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 90,
-                                                    "delta_percentage": 7
+                                                    "target": 88,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 55,
-                                                    "delta_percentage": 10
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 81,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 56,
                                                     "delta_percentage": 10
                                                 },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 80,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 79,
+                                                    "target": 81,
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
@@ -3172,51 +3172,51 @@
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "target": 33,
-                                                    "delta_percentage": 15
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 59,
-                                                    "delta_percentage": 24
+                                                    "target": 45,
+                                                    "delta_percentage": 87
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 13
+                                                    "target": 82,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 33,
-                                                    "delta_percentage": 13
+                                                    "target": 34,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 59,
-                                                    "delta_percentage": 25
+                                                    "target": 44,
+                                                    "delta_percentage": 83
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 83,
-                                                    "delta_percentage": 12
+                                                    "target": 80,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 31,
-                                                    "delta_percentage": 18
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 52,
-                                                    "delta_percentage": 31
+                                                    "target": 45,
+                                                    "delta_percentage": 58
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 87,
-                                                    "delta_percentage": 8
+                                                    "target": 65,
+                                                    "delta_percentage": 94
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 31,
-                                                    "delta_percentage": 19
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 54,
+                                                    "target": 53,
                                                     "delta_percentage": 29
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 61,
-                                                    "delta_percentage": 35
+                                                    "target": 57,
+                                                    "delta_percentage": 50
                                                 }
                                             }
                                         },
@@ -3224,75 +3224,75 @@
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "target": 44,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 73,
-                                                    "delta_percentage": 12
+                                                    "target": 67,
+                                                    "delta_percentage": 30
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
-                                                    "delta_percentage": 8
+                                                    "target": 86,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 44,
-                                                    "delta_percentage": 11
-                                                },
-                                                "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 74,
                                                     "delta_percentage": 12
                                                 },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 68,
+                                                    "delta_percentage": 26
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 8
+                                                    "target": 85,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 39,
-                                                    "delta_percentage": 13
+                                                    "target": 40,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 73,
-                                                    "delta_percentage": 19
+                                                    "target": 74,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 94,
-                                                    "delta_percentage": 7
+                                                    "target": 85,
+                                                    "delta_percentage": 40
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 39,
-                                                    "delta_percentage": 13
+                                                    "target": 40,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 74,
+                                                    "target": 77,
                                                     "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 94,
-                                                    "delta_percentage": 10
+                                                    "target": 89,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 43,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 77,
-                                                    "delta_percentage": 25
+                                                    "target": 74,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 92,
-                                                    "delta_percentage": 7
+                                                    "target": 88,
+                                                    "delta_percentage": 19
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 43,
-                                                    "delta_percentage": 12
+                                                    "target": 44,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 80,
-                                                    "delta_percentage": 29
+                                                    "target": 76,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 95,
-                                                    "delta_percentage": 7
+                                                    "target": 96,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Changes
Update AMD performance baselines for TCP throughput tests.

## Reason
We have recently merged some network improvements (see #2958) and only ARM and Intel performance baselines were updated.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [X] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] New `unsafe` code is documented.~
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~

---

- ~[ ] This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
