### PR TITLE
perf: vsock: update baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -78,27 +78,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6749,
-                                                    "delta_percentage": 6
+                                                    "target": 6827,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6801,
+                                                    "target": 6885,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2143,
-                                                    "delta_percentage": 7
+                                                    "target": 2190,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5228,
+                                                    "target": 5265,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5101,
-                                                    "delta_percentage": 7
+                                                    "target": 5141,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1791,
+                                                    "target": 1805,
                                                     "delta_percentage": 6
                                                 }
                                             }
@@ -106,40 +106,40 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 7171,
-                                                    "delta_percentage": 7
+                                                    "target": 7087,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 7187,
-                                                    "delta_percentage": 7
+                                                    "target": 7089,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2801,
+                                                    "target": 2802,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5858,
+                                                    "target": 5895,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5798,
+                                                    "target": 5821,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2565,
-                                                    "delta_percentage": 4
-                                                },
-                                                "vsock-p1024K-bd": {
-                                                    "target": 5789,
+                                                    "target": 2539,
                                                     "delta_percentage": 5
                                                 },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 5833,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 5738,
+                                                    "target": 5789,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2605,
-                                                    "delta_percentage": 8
+                                                    "target": 2202,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -150,27 +150,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 12281,
+                                                    "target": 12436,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 12381,
+                                                    "target": 12564,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2317,
+                                                    "target": 2330,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5321,
+                                                    "target": 5394,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5163,
+                                                    "target": 5223,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2194,
+                                                    "target": 2204,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -178,39 +178,39 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 16467,
+                                                    "target": 16531,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 16736,
+                                                    "target": 16791,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2762,
-                                                    "delta_percentage": 8
+                                                    "target": 2756,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 6110,
-                                                    "delta_percentage": 5
+                                                    "target": 6156,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5902,
-                                                    "delta_percentage": 5
+                                                    "target": 5926,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2665,
+                                                    "target": 2694,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6110,
-                                                    "delta_percentage": 6
-                                                },
-                                                "vsock-pDEFAULT-bd": {
-                                                    "target": 6057,
+                                                    "target": 6143,
                                                     "delta_percentage": 5
                                                 },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 6096,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2797,
+                                                    "target": 2650,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -229,7 +229,7 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
@@ -260,31 +260,31 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 91,
+                                                    "target": 92,
                                                     "delta_percentage": 13
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 133,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 133,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 177,
+                                                    "target": 179,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 121,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 121,
-                                                    "delta_percentage": 7
+                                                    "target": 122,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 196,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -328,19 +328,19 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 198,
-                                                    "delta_percentage": 6
+                                                    "target": 197,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 83,
-                                                    "delta_percentage": 13
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 119,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 119,
+                                                    "target": 120,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -349,15 +349,15 @@
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 141,
-                                                    "delta_percentage": 8
+                                                    "target": 148,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -370,35 +370,35 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 54,
+                                                    "target": 53,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 54,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 55,
+                                                    "target": 54,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 61,
+                                                    "target": 59,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 9
+                                                    "target": 59,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 48,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 66,
+                                                    "target": 67,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -415,22 +415,22 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 78,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 69,
-                                                    "delta_percentage": 7
+                                                    "target": 67,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 64,
+                                                    "target": 63,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 65,
-                                                    "delta_percentage": 8
+                                                    "target": 63,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 75,
+                                                    "target": 69,
                                                     "delta_percentage": 7
                                                 }
                                             }
@@ -446,20 +446,20 @@
                                                     "delta_percentage": 10
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 42,
-                                                    "delta_percentage": 9
+                                                    "target": 41,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 57,
-                                                    "delta_percentage": 9
+                                                    "target": 56,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 62,
+                                                    "target": 61,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 62,
-                                                    "delta_percentage": 9
+                                                    "target": 60,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 50,
@@ -471,7 +471,7 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 49,
-                                                    "delta_percentage": 11
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 50,
@@ -479,31 +479,31 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 76,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 69,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 69,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 61,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 61,
-                                                    "delta_percentage": 8
+                                                    "target": 60,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 61,
-                                                    "delta_percentage": 7
+                                                    "target": 59,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 69,
-                                                    "delta_percentage": 10
+                                                    "target": 68,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }
@@ -521,68 +521,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 5403,
-                                                    "delta_percentage": 5
+                                                    "target": 5421,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 5459,
+                                                    "target": 5469,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 1380,
-                                                    "delta_percentage": 10
+                                                    "target": 1316,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 3450,
-                                                    "delta_percentage": 5
+                                                    "target": 3434,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 3375,
+                                                    "target": 3359,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 799,
-                                                    "delta_percentage": 32
+                                                    "target": 728,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 6179,
-                                                    "delta_percentage": 4
+                                                    "target": 6097,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 6208,
-                                                    "delta_percentage": 4
+                                                    "target": 6082,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2138,
-                                                    "delta_percentage": 7
+                                                    "target": 2153,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4262,
-                                                    "delta_percentage": 8
+                                                    "target": 4236,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4177,
+                                                    "target": 4163,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1616,
+                                                    "target": 1574,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 3885,
-                                                    "delta_percentage": 4
+                                                    "target": 3842,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 3863,
-                                                    "delta_percentage": 5
+                                                    "target": 3820,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 1413,
-                                                    "delta_percentage": 5
+                                                    "target": 1402,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -593,27 +593,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 10422,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 10744,
+                                                    "target": 10482,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 10918,
+                                                    "delta_percentage": 5
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 1544,
+                                                    "target": 1565,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 3519,
+                                                    "target": 3500,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 3409,
-                                                    "delta_percentage": 5
+                                                    "target": 3405,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1335,
+                                                    "target": 1339,
                                                     "delta_percentage": 4
                                                 }
                                             }
@@ -621,40 +621,40 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 15511,
+                                                    "target": 15650,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 15605,
-                                                    "delta_percentage": 6
+                                                    "target": 15671,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2350,
-                                                    "delta_percentage": 7
+                                                    "target": 2366,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 4209,
+                                                    "target": 4199,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 4066,
+                                                    "target": 4052,
                                                     "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 1950,
-                                                    "delta_percentage": 8
+                                                    "target": 1864,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 4116,
-                                                    "delta_percentage": 4
-                                                },
-                                                "vsock-pDEFAULT-bd": {
-                                                    "target": 4090,
+                                                    "target": 4083,
                                                     "delta_percentage": 5
                                                 },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 4036,
+                                                    "delta_percentage": 6
+                                                },
                                                 "vsock-p1024-bd": {
-                                                    "target": 1576,
-                                                    "delta_percentage": 7
+                                                    "target": 1639,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -684,50 +684,50 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 99,
-                                                    "delta_percentage": 6
+                                                    "target": 100,
+                                                    "delta_percentage": 4
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 97,
-                                                    "delta_percentage": 9
+                                                    "target": 100,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 123,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 123,
+                                                    "target": 122,
                                                     "delta_percentage": 5
                                                 },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 180,
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 124,
                                                     "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 182,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 115,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 115,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 198,
+                                                    "target": 197,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -744,63 +744,63 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 99,
-                                                    "delta_percentage": 7
+                                                    "target": 100,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 100,
+                                                    "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 197,
+                                                    "target": 196,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 197,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 107,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 113,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 114,
-                                                    "delta_percentage": 7
+                                                    "target": 115,
+                                                    "delta_percentage": 4
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 163,
-                                                    "delta_percentage": 6
+                                                    "target": 168,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 104,
-                                                    "delta_percentage": 5
+                                                    "target": 105,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 105,
+                                                    "target": 104,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 135,
-                                                    "delta_percentage": 6
+                                                    "target": 139,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -814,63 +814,63 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 56,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 57,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 52,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 69,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 68,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 38,
-                                                    "delta_percentage": 12
+                                                    "target": 39,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 66,
-                                                    "delta_percentage": 7
+                                                    "target": 67,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 66,
-                                                    "delta_percentage": 8
+                                                    "target": 67,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 72,
-                                                    "delta_percentage": 8
+                                                    "target": 74,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 79,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 80,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 62,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 71,
-                                                    "delta_percentage": 6
+                                                    "target": 70,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 72,
-                                                    "delta_percentage": 6
+                                                    "target": 70,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 72,
@@ -885,20 +885,20 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 41,
-                                                    "delta_percentage": 8
+                                                    "target": 40,
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 43,
+                                                    "target": 42,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 54,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 70,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 69,
@@ -906,7 +906,7 @@
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 42,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
@@ -918,35 +918,35 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 56,
-                                                    "delta_percentage": 11
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 77,
-                                                    "delta_percentage": 12
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 76,
-                                                    "delta_percentage": 6
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 75,
                                                     "delta_percentage": 9
                                                 },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 60,
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 75,
                                                     "delta_percentage": 7
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 76,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 8
+                                                },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 70,
+                                                    "target": 69,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 68,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 59,
-                                                    "delta_percentage": 8
+                                                    "target": 60,
+                                                    "delta_percentage": 7
                                                 }
                                             }
                                         }
@@ -968,27 +968,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 8198,
-                                                    "delta_percentage": 5
+                                                    "target": 8254,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 8293,
-                                                    "delta_percentage": 5
+                                                    "target": 8341,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2686,
+                                                    "target": 2707,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5956,
+                                                    "target": 6006,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5800,
+                                                    "target": 5845,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2148,
+                                                    "target": 2160,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -996,39 +996,39 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 9658,
-                                                    "delta_percentage": 5
+                                                    "target": 9670,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 9584,
-                                                    "delta_percentage": 6
+                                                    "target": 9608,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 3483,
-                                                    "delta_percentage": 6
+                                                    "target": 3428,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 7095,
+                                                    "target": 7132,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 6976,
+                                                    "target": 7008,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2997,
-                                                    "delta_percentage": 9
+                                                    "target": 2994,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6852,
+                                                    "target": 6880,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6776,
+                                                    "target": 6798,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2924,
+                                                    "target": 2962,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -1040,27 +1040,27 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 14148,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 14342,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 2880,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 6121,
+                                                    "target": 14166,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 14348,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2882,
+                                                    "delta_percentage": 6
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 6157,
+                                                    "delta_percentage": 5
+                                                },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5958,
-                                                    "delta_percentage": 7
+                                                    "target": 5983,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2629,
+                                                    "target": 2636,
                                                     "delta_percentage": 5
                                                 }
                                             }
@@ -1068,40 +1068,40 @@
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 19888,
+                                                    "target": 19986,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 20231,
+                                                    "target": 20311,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 3547,
-                                                    "delta_percentage": 6
+                                                    "target": 3507,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 7425,
+                                                    "target": 7457,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 7119,
+                                                    "target": 7138,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 3215,
+                                                    "target": 3253,
                                                     "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 7157,
-                                                    "delta_percentage": 6
+                                                    "target": 7178,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 7097,
+                                                    "target": 7111,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2840,
-                                                    "delta_percentage": 14
+                                                    "target": 2805,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1115,27 +1115,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
@@ -1150,8 +1150,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 140,
-                                                    "delta_percentage": 10
+                                                    "target": 133,
+                                                    "delta_percentage": 21
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 130,
@@ -1159,23 +1159,23 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 131,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 172,
-                                                    "delta_percentage": 7
+                                                    "target": 173,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 120,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 121,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 190,
-                                                    "delta_percentage": 7
+                                                    "target": 188,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         }
@@ -1195,7 +1195,7 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
@@ -1203,11 +1203,11 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
@@ -1222,32 +1222,32 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 130,
-                                                    "delta_percentage": 8
+                                                    "target": 115,
+                                                    "delta_percentage": 35
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 122,
-                                                    "delta_percentage": 6
+                                                    "target": 123,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 121,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 163,
+                                                    "target": 162,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 114,
-                                                    "delta_percentage": 21
+                                                    "target": 112,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         }
@@ -1261,23 +1261,23 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 54,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 54,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 53,
-                                                    "delta_percentage": 9
+                                                    "target": 54,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 58,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 58,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 49,
@@ -1289,11 +1289,11 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 63,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 63,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 70,
@@ -1305,11 +1305,11 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 74,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 68,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 61,
@@ -1320,8 +1320,8 @@
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 72,
-                                                    "delta_percentage": 8
+                                                    "target": 71,
+                                                    "delta_percentage": 7
                                                 }
                                             }
                                         }
@@ -1332,12 +1332,12 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 40,
+                                                    "target": 41,
                                                     "delta_percentage": 10
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 41,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 58,
@@ -1345,15 +1345,15 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 59,
-                                                    "delta_percentage": 9
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 60,
+                                                    "target": 59,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 52,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
@@ -1364,36 +1364,36 @@
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 49,
-                                                    "delta_percentage": 9
+                                                    "target": 50,
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 70,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 68,
-                                                    "delta_percentage": 8
+                                                    "target": 67,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 67,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 62,
-                                                    "delta_percentage": 8
+                                                    "target": 63,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 59,
+                                                    "target": 58,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 58,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 54,
-                                                    "delta_percentage": 22
+                                                    "target": 52,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Changes

Update performance baselines for vsock throughput.

## Reason

AMI update.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [X] All commits in this PR are signed (`git commit -s`).
- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [X] The description of changes is clear and encompassing.
- ~[ ] Any required documentation changes (code and docs) are included in this PR.~
- ~[ ] New `unsafe` code is documented.~
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- ~[ ] All added/changed functionality is tested.~
- ~[ ] New `TODO`s link to an issue.~

---

- ~[ ] This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
