### PR TITLE
fix(tests): mark monitoring threads as daemonic

### DIFF
--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -934,6 +934,7 @@ class Microvm:
         self.logging_thread = utils.StoppableThread(
             target=monitor_fd, args=(weakref.ref(self), log_fifo.path), daemon=True
         )
+        self.logging_thread.daemon = True
         self.logging_thread.start()
 
     def __del__(self):

--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -41,6 +41,7 @@ class MemoryMonitor(Thread):
         self._should_stop = False
         self._current_rss = 0
         self._lock = Lock()
+        self.daemon = True
 
     @property
     def pid(self):

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -232,7 +232,8 @@ def _g2h_send_ping(context):
     # Gather results and verify pass criteria.
     try:
         result = st_core.run_exercise()
+        file_dumper.dump(result)
     except core.CoreException as err:
         handle_failure(file_dumper, err)
-
-    file_dumper.dump(result)
+    finally:
+        basevm.kill()


### PR DESCRIPTION
Due to some recent change, pytest can hang waiting for monitoring threads to run.

We fix it by:

1. Marking those threads as daemonic, which will help pytest finish [1]
2. Explicitly kill the VM of the affected test

With those fixes (only 1. may be required), pytest finishes as expected.

[1]: https://stackoverflow.com/questions/19219596/py-test-hangs-after-showing-test-results

Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
