### PR TITLE
Make test_logging correctly handle case where threadname has space

### DIFF
--- a/tests/integration_tests/functional/test_logging.py
+++ b/tests/integration_tests/functional/test_logging.py
@@ -48,7 +48,7 @@ def check_log_message_format(log_str, instance_id, level, show_level, show_origi
     e.g. with THREAD NAME as TN
     `2018-09-09T12:52:00.123456789 [MYID:TN:WARN:/path/to/file.rs:52] warning`
     """
-    (timestamp, tag, _) = log_str.split(" ")[:3]
+    timestamp, tag_and_msg = log_str.split(" ", maxsplit=1)
     timestamp = timestamp[:-10]
     strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
 
@@ -58,9 +58,9 @@ def check_log_message_format(log_str, instance_id, level, show_level, show_origi
         pattern += ":(" + "|".join(LOG_LEVELS) + ")"
     if show_origin:
         pattern += ":([^:]+/[^:]+):([0-9]+)"
-    pattern += "\\]"
+    pattern += "\\].*"
 
-    mo = re.match(pattern, tag)
+    mo = re.match(pattern, tag_and_msg)
     assert mo is not None
 
     if show_level:


### PR DESCRIPTION
Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Now, it doesn't tear apart the tag anymore if there's a space in it, meaning we no longer get spurious failures in the above case.

## Reason

Occasionally, the first logging message from a VM would be from a vcpu thread, which is named `fc_vpu 0` or similar. The previous logic would then split on spaces, assuming that the "tag" part of the message doesnt contain a space. This could lead to spurious failures, such as https://buildkite.com/firecracker/firecracker-pr/builds/326#01855e8c-a886-471b-8b1d-b9f7db3f9595

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
