### PR TITLE
fix: `htons_unchecked` and `htonl_unchecked`

### DIFF
--- a/src/dumbo/src/pdu/bytes.rs
+++ b/src/dumbo/src/pdu/bytes.rs
@@ -112,9 +112,11 @@ pub trait NetworkBytesMut: NetworkBytes + DerefMut<Target = [u8]> {
     ///
     /// # Panics
     ///
-    /// This method will panic if `offset` is invalid.
+    /// If `value` cannot be written into `self` at the given `offset` (e.g. if `offset > self.len()
+    /// - size_of::<u16>()`).
     #[inline]
     fn htons_unchecked(&mut self, offset: usize, value: u16) {
+        assert!(offset <= self.len() - std::mem::size_of::<u16>());
         byte_order::write_be_u16(&mut self[offset..], value)
     }
 
@@ -122,9 +124,11 @@ pub trait NetworkBytesMut: NetworkBytes + DerefMut<Target = [u8]> {
     ///
     /// # Panics
     ///
-    /// This method will panic if `offset` is invalid.
+    /// If `value` cannot be written into `self` at the given `offset` (e.g. if `offset > self.len()
+    /// - size_of::<u32>()`).
     #[inline]
     fn htonl_unchecked(&mut self, offset: usize, value: u32) {
+        assert!(offset <= self.len() - std::mem::size_of::<u32>());
         byte_order::write_be_u32(&mut self[offset..], value)
     }
 }
@@ -191,6 +195,22 @@ impl<'a, T: NetworkBytesMut> NetworkBytesMut for InnerBytes<'a, T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_htons_unchecked() {
+        let mut buf = [u8::default(); std::mem::size_of::<u16>()];
+        let mut a = buf.as_mut();
+        a.htons_unchecked(1, u16::default());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_htonl_unchecked() {
+        let mut buf = [u8::default(); std::mem::size_of::<u32>()];
+        let mut a = buf.as_mut();
+        a.htonl_unchecked(1, u32::default());
+    }
 
     #[test]
     fn test_network_bytes() {


### PR DESCRIPTION
Previously indexing only checked that `offset` was within the range of `self` but not that the given `value` could fit within the range of `self` starting from `offset`. This could previously lead to bytes not being written and the function not panicking,

## Changes

Restricts assertions on `htons_unchecked` and `htonl_unchecked`.

## Reason

Previously indexing only checked that `offset` was within the range of `self` but not that the given `value` could fit within the range of `self` starting from `offset`. This could previously lead to bytes not being written and the function not panicking.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
