### PR TITLE
fix: cargo audit timeout

### DIFF
--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -107,7 +107,11 @@ RUN cd "$TMP_POETRY_DIR" \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN" \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add llvm-tools-preview \
-    && cargo install --version $GRCOV_VERSION grcov
+    && cargo install --version $GRCOV_VERSION grcov \
+    && rm -rf "$CARGO_HOME/registry" \
+    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
+    && rm -rf "$CARGO_HOME/git" \
+    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
 
 RUN ln -s /usr/bin/musl-gcc /usr/bin/aarch64-linux-musl-gcc
 

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -114,7 +114,11 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_TOOL
     && rustup component add llvm-tools-preview \
     && cargo install cargo-audit \
     && cargo install --locked cargo-deny \
-    && cargo install --version $GRCOV_VERSION grcov
+    && cargo install --version $GRCOV_VERSION grcov \
+    && rm -rf "$CARGO_HOME/registry" \
+    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
+    && rm -rf "$CARGO_HOME/git" \
+    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
 
 # help musl-gcc find linux headers
 RUN cd /usr/include/x86_64-linux-musl \

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG="v50"
+DEVCTR_IMAGE_TAG="v51"
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

## Changes

Reverts removed of:
```
    && rm -rf "$CARGO_HOME/registry" \
    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
    && rm -rf "$CARGO_HOME/git" \
    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
```
made in cbc073800c701294025372ea10ba6dfce6731e3d

## Reason

`cargo audit` was timing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
