### PR TITLE
Doc fixes and skip builds if doc changes only

### DIFF
--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -82,6 +82,15 @@ also be specifying the supported kernel versions.
   and v3.1 will be patched since were the last two Firecracker releases and
   less than 6 months have passed since release time.
 
+## Release Status
+
+| Release | Release Date | Latest Patch | Min. end of support | Official end of Support        |
+| ------: | -----------: | -----------: | ------------------: | :----------------------------- |
+| v1.2    |   2022-11-30 | v1.2.0       |          2023-05-30 | Supported                      |
+| v1.1    |   2022-05-06 | v1.1.4       |          2022-11-06 | Supported                      |
+| v1.0    |   2022-01-31 | v1.0.2       |          2022-07-31 | 2022-11-30 (v1.2 released)     |
+| v0.25   |   2021-03-13 | v0.25.2      |          2021-09-13 | 2022-03-13 (end of 1y support) |
+
 ## API support
 
 The Firecracker API follows the semantic versioning standard. For a new

--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -66,8 +66,8 @@ lazy_static! {
     /// !CAVEAT!
     /// This map is supposed to be strictly one-to-one (i.e. bijective) because
     /// describe-snapshot inverts it to look up the release that matches the
-    /// snapshot version. If two version map to the snap_version, the results
-    /// are non-deterministic.
+    /// snapshot version. If two versions map to the same snap_version, the
+    /// results are non-deterministic.
     /// This means
     /// - Do not insert patch releases here.
     /// - Every minor version should be represented here.


### PR DESCRIPTION
## Changes

Add a supported releases table and also skip running integration tests if we only have doc changes. This would only work for future PRs, since changing that logic itself is a code change.  

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
