### PR TITLE
Better guest kernel selection

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -463,11 +463,11 @@ class ArtifactCollection:
             keyword=keyword,
         )
 
-        valid_kernels = list(
-            filter(
-                lambda kernel: any(s in kernel.key for s in SUPPORTED_KERNELS), kernels
-            )
-        )
+        supported_kernels = {f"vmlinux-{sup}.bin" for sup in SUPPORTED_KERNELS}
+        valid_kernels = [
+            kernel for kernel in kernels if Path(kernel.key).name in supported_kernels
+        ]
+
         return valid_kernels
 
     def disks(self, keyword=None):


### PR DESCRIPTION
## Changes
Updates kernel selection mechanism in `artifacts.py`

## Reason
Currently guest kernels are selected by searching a sub-string in kernel name.
This can lead to incorrect selection. If we have kernels: [5.10, 5.10-a, 5.10-b] and supported kernel is 5.10 then all 3 kernels will be selected. With this PR only 5.10 kernel will be selected.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
