### PR TITLE
Fix the documentation in function of dumbo crate

### DIFF
--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -27,11 +27,11 @@ pub trait ByteBuffer: Index<usize, Output = u8> {
     /// Returns the length of the buffer.
     fn len(&self) -> usize;
 
-    /// Reads `buf.len()` bytes from `buf` into the inner buffer, starting at `offset`.
+    /// Reads `buf.len()` bytes from `self` into `buf`, starting at `offset`.
     ///
     /// # Panics
     ///
-    /// Panics if `offset + buf.len()` < `self.len()`.
+    /// Panics if `offset + buf.len()` > `self.len()`.
     fn read_to_slice(&self, offset: usize, buf: &mut [u8]);
 }
 

--- a/src/dumbo/src/pdu/tcp.rs
+++ b/src/dumbo/src/pdu/tcp.rs
@@ -527,6 +527,9 @@ impl<'a, T: NetworkBytesMut> TcpSegment<'a, T> {
                 return Err(Error::EmptyPayload);
             }
 
+            // Copy `room_for_payload` bytes into `payload_buf` using `offset=0`.
+            // Guaranteed not to panic since we checked above that:
+            // `offset + room_for_payload <= payload_buf.len()`.
             payload_buf.read_to_slice(
                 0,
                 &mut segment.bytes[segment_len..segment_len + room_for_payload],


### PR DESCRIPTION
## Changes

Fix the documentation with comment with correct description of functionality and panic condition.
Also, add a comment on to why we cannot cause a panic when reading a TCP payload in a slice.

## Reason

dumbo crate's `ByteBuffer` `read_to_slice` documentation was describing wrong the functionality of the function and the condition under which it may panic.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
