### PR TITLE
perf: update snapshot baselines for ARM 5.10

### DIFF
--- a/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_snap_restore_performance_config_5.10.json
@@ -2901,153 +2901,153 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.808,
-                                                    "delta_percentage": 9
+                                                    "target": 1.658,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.836,
-                                                    "delta_percentage": 10
+                                                    "target": 1.679,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.923,
-                                                    "delta_percentage": 9
+                                                    "target": 1.774,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.946,
-                                                    "delta_percentage": 9
+                                                    "target": 1.8,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.064,
-                                                    "delta_percentage": 9
+                                                    "target": 1.917,
+                                                    "delta_percentage": 14
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.097,
-                                                    "delta_percentage": 10
+                                                    "target": 1.953,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.195,
-                                                    "delta_percentage": 9
+                                                    "target": 2.052,
+                                                    "delta_percentage": 20
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.219,
-                                                    "delta_percentage": 10
+                                                    "target": 2.079,
+                                                    "delta_percentage": 23
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.325,
-                                                    "delta_percentage": 9
+                                                    "target": 2.164,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.36,
-                                                    "delta_percentage": 9
+                                                    "target": 2.191,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.456,
-                                                    "delta_percentage": 9
+                                                    "target": 2.298,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.486,
-                                                    "delta_percentage": 10
+                                                    "target": 2.325,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.608,
-                                                    "delta_percentage": 9
+                                                    "target": 2.413,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.651,
-                                                    "delta_percentage": 10
+                                                    "target": 2.438,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.747,
-                                                    "delta_percentage": 9
+                                                    "target": 2.559,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.791,
-                                                    "delta_percentage": 12
+                                                    "target": 2.59,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.902,
-                                                    "delta_percentage": 11
+                                                    "target": 2.707,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.937,
-                                                    "delta_percentage": 12
+                                                    "target": 2.735,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.038,
-                                                    "delta_percentage": 10
+                                                    "target": 2.841,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.095,
-                                                    "delta_percentage": 13
+                                                    "target": 2.869,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.838,
-                                                    "delta_percentage": 10
+                                                    "target": 1.69,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.859,
+                                                    "target": 1.712,
                                                     "delta_percentage": 9
                                                 }
                                             }
@@ -3055,196 +3055,196 @@
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.844,
-                                                    "delta_percentage": 12
+                                                    "target": 1.693,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.875,
-                                                    "delta_percentage": 14
+                                                    "target": 1.72,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.848,
-                                                    "delta_percentage": 10
+                                                    "target": 1.698,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.883,
-                                                    "delta_percentage": 14
+                                                    "target": 1.733,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.85,
-                                                    "delta_percentage": 10
+                                                    "target": 1.72,
+                                                    "delta_percentage": 30
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.878,
-                                                    "delta_percentage": 11
+                                                    "target": 1.756,
+                                                    "delta_percentage": 56
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.85,
-                                                    "delta_percentage": 10
+                                                    "target": 1.707,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.877,
-                                                    "delta_percentage": 11
+                                                    "target": 1.729,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.855,
-                                                    "delta_percentage": 10
+                                                    "target": 1.704,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.88,
-                                                    "delta_percentage": 10
+                                                    "target": 1.729,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.855,
-                                                    "delta_percentage": 10
+                                                    "target": 1.707,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.883,
-                                                    "delta_percentage": 10
+                                                    "target": 1.733,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.862,
-                                                    "delta_percentage": 10
+                                                    "target": 1.712,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.89,
-                                                    "delta_percentage": 10
+                                                    "target": 1.741,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.42,
-                                                    "delta_percentage": 8
+                                                    "target": 2.255,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.453,
-                                                    "delta_percentage": 8
+                                                    "target": 2.293,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.029,
+                                                    "target": 2.854,
                                                     "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.066,
-                                                    "delta_percentage": 8
+                                                    "target": 2.937,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.628,
-                                                    "delta_percentage": 7
+                                                    "target": 3.444,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.667,
-                                                    "delta_percentage": 7
+                                                    "target": 3.521,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.83,
-                                                    "delta_percentage": 9
+                                                    "target": 1.677,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.856,
-                                                    "delta_percentage": 10
+                                                    "target": 1.698,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.853,
-                                                    "delta_percentage": 9
+                                                    "target": 1.698,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.883,
-                                                    "delta_percentage": 11
+                                                    "target": 1.718,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.878,
+                                                    "target": 1.741,
                                                     "delta_percentage": 10
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.909,
-                                                    "delta_percentage": 10
+                                                    "target": 1.762,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.965,
-                                                    "delta_percentage": 10
+                                                    "target": 1.789,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.992,
-                                                    "delta_percentage": 12
+                                                    "target": 1.815,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }
@@ -3255,153 +3255,153 @@
                                         "1vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.82,
-                                                    "delta_percentage": 10
+                                                    "target": 1.656,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.845,
-                                                    "delta_percentage": 12
+                                                    "target": 1.676,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "2vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.937,
+                                                    "target": 1.77,
                                                     "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.968,
-                                                    "delta_percentage": 9
+                                                    "target": 1.805,
+                                                    "delta_percentage": 25
                                                 }
                                             }
                                         },
                                         "3vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.077,
-                                                    "delta_percentage": 9
+                                                    "target": 1.915,
+                                                    "delta_percentage": 16
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.108,
-                                                    "delta_percentage": 9
+                                                    "target": 1.95,
+                                                    "delta_percentage": 24
                                                 }
                                             }
                                         },
                                         "4vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.211,
-                                                    "delta_percentage": 9
+                                                    "target": 2.043,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.237,
-                                                    "delta_percentage": 10
+                                                    "target": 2.071,
+                                                    "delta_percentage": 11
                                                 }
                                             }
                                         },
                                         "5vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.342,
-                                                    "delta_percentage": 9
+                                                    "target": 2.167,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.367,
-                                                    "delta_percentage": 10
+                                                    "target": 2.197,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "6vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.466,
-                                                    "delta_percentage": 9
+                                                    "target": 2.299,
+                                                    "delta_percentage": 7
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.493,
-                                                    "delta_percentage": 9
+                                                    "target": 2.328,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "7vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.612,
-                                                    "delta_percentage": 9
+                                                    "target": 2.412,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.641,
-                                                    "delta_percentage": 9
+                                                    "target": 2.436,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "8vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.74,
-                                                    "delta_percentage": 9
+                                                    "target": 2.562,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.776,
-                                                    "delta_percentage": 9
+                                                    "target": 2.599,
+                                                    "delta_percentage": 14
                                                 }
                                             }
                                         },
                                         "9vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.887,
-                                                    "delta_percentage": 9
+                                                    "target": 2.712,
+                                                    "delta_percentage": 18
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.919,
-                                                    "delta_percentage": 11
+                                                    "target": 2.75,
+                                                    "delta_percentage": 26
                                                 }
                                             }
                                         },
                                         "10vcpu_128mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.031,
-                                                    "delta_percentage": 10
+                                                    "target": 2.84,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.087,
-                                                    "delta_percentage": 11
+                                                    "target": 2.897,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "1vcpu_256mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.845,
-                                                    "delta_percentage": 10
+                                                    "target": 1.705,
+                                                    "delta_percentage": 11
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.874,
+                                                    "target": 1.727,
                                                     "delta_percentage": 11
                                                 }
                                             }
@@ -3409,167 +3409,167 @@
                                         "1vcpu_512mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.848,
-                                                    "delta_percentage": 9
+                                                    "target": 1.697,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.877,
-                                                    "delta_percentage": 10
+                                                    "target": 1.723,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "1vcpu_1024mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.859,
-                                                    "delta_percentage": 10
+                                                    "target": 1.714,
+                                                    "delta_percentage": 27
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.887,
-                                                    "delta_percentage": 11
+                                                    "target": 1.747,
+                                                    "delta_percentage": 34
                                                 }
                                             }
                                         },
                                         "1vcpu_2048mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.862,
-                                                    "delta_percentage": 9
+                                                    "target": 1.716,
+                                                    "delta_percentage": 25
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.889,
-                                                    "delta_percentage": 10
+                                                    "target": 1.751,
+                                                    "delta_percentage": 45
                                                 }
                                             }
                                         },
                                         "1vcpu_4096mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.866,
-                                                    "delta_percentage": 10
+                                                    "target": 1.709,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.896,
-                                                    "delta_percentage": 9
+                                                    "target": 1.761,
+                                                    "delta_percentage": 47
                                                 }
                                             }
                                         },
                                         "1vcpu_8192mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.88,
-                                                    "delta_percentage": 15
+                                                    "target": 1.713,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.947,
-                                                    "delta_percentage": 44
+                                                    "target": 1.734,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_16384mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.881,
-                                                    "delta_percentage": 9
+                                                    "target": 1.714,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.92,
-                                                    "delta_percentage": 11
+                                                    "target": 1.738,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "1vcpu_32768mb": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.883,
-                                                    "delta_percentage": 10
+                                                    "target": 1.717,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.913,
-                                                    "delta_percentage": 9
+                                                    "target": 2.039,
+                                                    "delta_percentage": 219
                                                 }
                                             }
                                         },
                                         "2net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 2.43,
-                                                    "delta_percentage": 8
+                                                    "target": 2.264,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 2.461,
-                                                    "delta_percentage": 8
+                                                    "target": 2.293,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         },
                                         "3net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.032,
-                                                    "delta_percentage": 7
+                                                    "target": 2.857,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.067,
-                                                    "delta_percentage": 8
+                                                    "target": 2.95,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "4net_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 3.632,
-                                                    "delta_percentage": 7
+                                                    "target": 3.454,
+                                                    "delta_percentage": 9
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 3.673,
-                                                    "delta_percentage": 7
+                                                    "target": 3.514,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         },
                                         "2block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.843,
-                                                    "delta_percentage": 9
+                                                    "target": 1.693,
+                                                    "delta_percentage": 22
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.869,
-                                                    "delta_percentage": 9
+                                                    "target": 1.724,
+                                                    "delta_percentage": 33
                                                 }
                                             }
                                         },
                                         "3block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.861,
-                                                    "delta_percentage": 9
+                                                    "target": 1.704,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.882,
+                                                    "target": 1.725,
                                                     "delta_percentage": 9
                                                 }
                                             }
@@ -3577,28 +3577,28 @@
                                         "4block_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.886,
-                                                    "delta_percentage": 9
+                                                    "target": 1.727,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.912,
-                                                    "delta_percentage": 9
+                                                    "target": 1.75,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         },
                                         "all_dev": {
                                             "P50": {
                                                 "restore": {
-                                                    "target": 1.96,
-                                                    "delta_percentage": 9
+                                                    "target": 1.794,
+                                                    "delta_percentage": 8
                                                 }
                                             },
                                             "P90": {
                                                 "restore": {
-                                                    "target": 1.984,
-                                                    "delta_percentage": 9
+                                                    "target": 1.816,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Update the baselines.

## Reason

There is an improvement in snapshot/restore performance of about 7% on ARM, 5.10 kernel:

```
{
    "source": "dcf56c3a59168b47a435089d47b27a7945cc86db/tests/integration_tests/performance/configs/",
    "target": "tests/integration_tests/performance/configs/",
    "test_snap_restore_performance_config_5.10.json": {
        "test": "snap_restore_performance",
        "kernel": "5.10",
        "cpus": [
            {
                "instance": "m6g.metal",
                "model": "ARM_NEOVERSE_N1",
                "stats": {
                    "latency": {
                        "target_diff_percentage": {
                            "mean": -7.308976464469347,
                            "stdev": 1.8383303612453021
                        },
                        "delta_percentage_diff": {
                            "mean": 4.62,
                            "stdev": 22.954403639925967
                        }
                    }
                }
            }
        ]
    }
}
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
``