### PR TITLE
Test utils cleanup

### DIFF
--- a/src/devices/src/virtio/balloon/utils.rs
+++ b/src/devices/src/virtio/balloon/utils.rs
@@ -178,11 +178,7 @@ mod tests {
     #[test]
     fn test_remove_range() {
         let page_size: usize = 0x1000;
-        let mem = vm_memory::test_utils::create_anon_guest_memory(
-            &[(GuestAddress(0), 2 * page_size)],
-            false,
-        )
-        .unwrap();
+        let mem = single_region_mem(2 * page_size);
 
         // Fill the memory with ones.
         let ones = vec![1u8; 2 * page_size];
@@ -223,11 +219,7 @@ mod tests {
     #[test]
     fn test_remove_range_on_restored() {
         let page_size: usize = 0x1000;
-        let mem = vm_memory::test_utils::create_anon_guest_memory(
-            &[(GuestAddress(0), 2 * page_size)],
-            false,
-        )
-        .unwrap();
+        let mem = single_region_mem(2 * page_size);
 
         // Fill the memory with ones.
         let ones = vec![1u8; 2 * page_size];
@@ -268,6 +260,8 @@ mod tests {
     /// -------------------------------------
     /// BEGIN PROPERTY BASED TESTING
     use proptest::prelude::*;
+
+    use crate::virtio::test_utils::single_region_mem;
 
     fn random_pfn_u32_max() -> impl Strategy<Value = Vec<u32>> {
         // Create a randomly sized vec (max MAX_PAGE_COMPACT_BUFFER elements) filled with random u32

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -643,12 +643,12 @@ pub(crate) mod tests {
     use super::*;
     use crate::check_metric_after_block;
     use crate::virtio::block::test_utils::{
-        default_block, default_engine_type_for_kv, set_queue, set_rate_limiter,
-        simulate_async_completion_event, simulate_queue_and_async_completion_events,
-        simulate_queue_event,
+        default_block, default_engine_type_for_kv, read_blk_req_descriptors, set_queue,
+        set_rate_limiter, simulate_async_completion_event,
+        simulate_queue_and_async_completion_events, simulate_queue_event,
     };
     use crate::virtio::queue::tests::*;
-    use crate::virtio::test_utils::{default_mem, initialize_virtqueue, VirtQueue};
+    use crate::virtio::test_utils::{default_mem, VirtQueue};
     use crate::virtio::IO_URING_NUM_ENTRIES;
 
     #[test]
@@ -764,7 +764,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
 
@@ -790,7 +790,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
 
         // Read at out of bounds address.
@@ -851,7 +851,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
 
@@ -900,7 +900,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let status_addr = GuestAddress(vq.dtable[2].addr.get());
@@ -929,7 +929,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
         vq.dtable[1].set(0xf000, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -963,7 +963,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let data_addr = GuestAddress(vq.dtable[1].addr.get());
@@ -1003,7 +1003,7 @@ pub(crate) mod tests {
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
             block.activate(mem.clone()).unwrap();
-            initialize_virtqueue(&vq);
+            read_blk_req_descriptors(&vq);
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
 
             vq.dtable[1].set(0xff00, 0x1000, VIRTQ_DESC_F_NEXT, 2);
@@ -1220,7 +1220,7 @@ pub(crate) mod tests {
             let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
             set_queue(&mut block, 0, vq.create_queue());
             block.activate(mem.clone()).unwrap();
-            initialize_virtqueue(&vq);
+            read_blk_req_descriptors(&vq);
             vq.dtable[1].set(0xff00, 0x1000, VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE, 2);
 
             let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
@@ -1259,7 +1259,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let status_addr = GuestAddress(vq.dtable[2].addr.get());
@@ -1303,7 +1303,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let data_addr = GuestAddress(vq.dtable[1].addr.get());
@@ -1507,7 +1507,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let data_addr = GuestAddress(vq.dtable[1].addr.get());
@@ -1573,7 +1573,7 @@ pub(crate) mod tests {
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
         block.activate(mem.clone()).unwrap();
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let request_type_addr = GuestAddress(vq.dtable[0].addr.get());
         let data_addr = GuestAddress(vq.dtable[1].addr.get());

--- a/src/devices/src/virtio/block/event_handler.rs
+++ b/src/devices/src/virtio/block/event_handler.rs
@@ -109,10 +109,10 @@ pub mod tests {
     use super::*;
     use crate::virtio::block::device::FileEngineType;
     use crate::virtio::block::test_utils::{
-        default_block, set_queue, simulate_async_completion_event,
+        default_block, read_blk_req_descriptors, set_queue, simulate_async_completion_event,
     };
     use crate::virtio::queue::tests::*;
-    use crate::virtio::test_utils::{default_mem, initialize_virtqueue, VirtQueue};
+    use crate::virtio::test_utils::{default_mem, VirtQueue};
 
     #[test]
     fn test_event_handler() {
@@ -121,7 +121,7 @@ pub mod tests {
         let mem = default_mem();
         let vq = VirtQueue::new(GuestAddress(0), &mem, 16);
         set_queue(&mut block, 0, vq.create_queue());
-        initialize_virtqueue(&vq);
+        read_blk_req_descriptors(&vq);
 
         let block = Arc::new(Mutex::new(block));
         let _id = event_manager.add_subscriber(block.clone());

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -407,13 +407,13 @@ mod tests {
 
     use super::*;
     use crate::virtio::queue::tests::*;
-    use crate::virtio::test_utils::{VirtQueue, VirtqDesc};
+    use crate::virtio::test_utils::{default_mem, single_region_mem, VirtQueue, VirtqDesc};
 
     const NUM_DISK_SECTORS: u64 = 1024;
 
     #[test]
     fn test_read_request_header() {
-        let mem = create_anon_guest_memory(&[(GuestAddress(0), 0x1000)], false).unwrap();
+        let mem = single_region_mem(0x1000);
         let addr = GuestAddress(0);
         let sector = 123_454_321;
 
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_parse_generic() {
-        let mem = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let mem = &default_mem();
         let mut queue = RequestVirtQueue::new(GuestAddress(0), mem);
 
         // Write only request type descriptor.
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_parse_in() {
-        let mem = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let mem = &default_mem();
         let mut queue = RequestVirtQueue::new(GuestAddress(0), mem);
 
         let request_header = RequestHeader::new(VIRTIO_BLK_T_IN, 99);
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_parse_out() {
-        let mem = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let mem = &default_mem();
         let mut queue = RequestVirtQueue::new(GuestAddress(0), mem);
 
         let request_header = RequestHeader::new(VIRTIO_BLK_T_OUT, 100);
@@ -653,7 +653,7 @@ mod tests {
 
     #[test]
     fn test_parse_flush() {
-        let mem = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let mem = &default_mem();
         let mut queue = RequestVirtQueue::new(GuestAddress(0), mem);
 
         // Flush request with a data descriptor.
@@ -673,7 +673,7 @@ mod tests {
 
     #[test]
     fn test_parse_get_id() {
-        let mem = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let mem = &default_mem();
         let mut queue = RequestVirtQueue::new(GuestAddress(0), mem);
 
         let request_header = RequestHeader::new(VIRTIO_BLK_T_GET_ID, 15);

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -11,15 +11,16 @@ use std::time::Duration;
 use rate_limiter::RateLimiter;
 use utils::kernel_version::{min_kernel_version_for_io_uring, KernelVersion};
 use utils::tempfile::TempFile;
+use vm_memory::{Bytes, GuestAddress};
 
 use crate::virtio::block::device::FileEngineType;
 #[cfg(test)]
 use crate::virtio::block::io::FileEngine;
 use crate::virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
-use crate::virtio::test_utils::VirtQueue;
+use crate::virtio::test_utils::{VirtQueue, VirtqDesc};
 #[cfg(test)]
 use crate::virtio::IrqType;
-use crate::virtio::{Block, CacheType, Queue};
+use crate::virtio::{Block, CacheType, Queue, RequestHeader};
 
 /// Create a default Block instance to be used in tests.
 pub fn default_block(file_engine_type: FileEngineType) -> Block {
@@ -108,6 +109,49 @@ pub fn simulate_queue_and_async_completion_events(b: &mut Block, expected_irq: b
         FileEngine::Sync(_) => {
             simulate_queue_event(b, Some(expected_irq));
         }
+    }
+}
+
+/// Structure encapsulating the virtq descriptors of a single request to the block device
+pub struct RequestDescriptorChain<'a, 'b> {
+    pub driver_queue: &'b VirtQueue<'a>,
+
+    pub header_desc: &'b VirtqDesc<'a>,
+    pub data_desc: &'b VirtqDesc<'a>,
+    pub status_desc: &'b VirtqDesc<'a>,
+}
+
+impl<'a, 'b> RequestDescriptorChain<'a, 'b> {
+    /// Creates a new [`RequestDescriptor´] chain in the given [`VirtQueue`]
+    ///
+    /// The header, data and status descriptors are put into the first three indices in
+    /// the queue's descriptor table. They point to address 0x1000, 0x2000 and 0x3000 in guest
+    /// memory, respectively, and each have their `len` set to 0x1000.
+    ///
+    /// The data descriptor is initialized to be write_only
+    pub fn new(vq: &'b VirtQueue<'a>) -> Self {
+        read_blk_req_descriptors(vq);
+
+        RequestDescriptorChain {
+            driver_queue: vq,
+            header_desc: &vq.dtable[0],
+            data_desc: &vq.dtable[1],
+            status_desc: &vq.dtable[2],
+        }
+    }
+
+    pub fn header(&self) -> RequestHeader {
+        self.header_desc
+            .memory()
+            .read_obj(GuestAddress(self.header_desc.addr.get()))
+            .unwrap()
+    }
+
+    pub fn set_header(&self, header: RequestHeader) {
+        self.header_desc
+            .memory()
+            .write_obj(header, GuestAddress(self.header_desc.addr.get()))
+            .unwrap()
     }
 }
 

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -19,7 +19,7 @@ pub mod persist;
 mod tap;
 pub mod test_utils;
 
-pub use tap::Error as TapError;
+pub use tap::{Error as TapError, Tap};
 
 pub use self::device::Net;
 pub use self::event_handler::*;

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -161,10 +161,11 @@ mod tests {
 
     use super::*;
     use crate::virtio::device::VirtioDevice;
-    use crate::virtio::net::test_utils::{default_guest_memory, default_net, default_net_no_mmds};
+    use crate::virtio::net::test_utils::{default_net, default_net_no_mmds};
+    use crate::virtio::test_utils::default_mem;
 
     fn validate_save_and_restore(net: Net, mmds_ds: Option<Arc<Mutex<Mmds>>>) {
-        let guest_mem = default_guest_memory();
+        let guest_mem = default_mem();
         let mut mem = vec![0; 4096];
         let version_map = VersionMap::new();
 

--- a/src/devices/src/virtio/net/persist.rs
+++ b/src/devices/src/virtio/net/persist.rs
@@ -111,7 +111,7 @@ impl Persist<'_> for Net {
         // RateLimiter::restore() can fail at creating a timerfd.
         let rx_rate_limiter = RateLimiter::restore((), &state.rx_rate_limiter_state)?;
         let tx_rate_limiter = RateLimiter::restore((), &state.tx_rate_limiter_state)?;
-        let mut net = Net::new_with_tap(
+        let mut net = Net::new(
             state.id.clone(),
             &state.tap_if_name,
             state.config_space.guest_mac_v2,

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -315,11 +315,6 @@ pub fn default_guest_mac() -> MacAddr {
     MacAddr::parse_str("11:22:33:44:55:66").unwrap()
 }
 
-pub fn default_guest_memory() -> GuestMemoryMmap {
-    vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false)
-        .expect("Cannot initialize memory")
-}
-
 pub fn set_mac(net: &mut Net, mac: MacAddr) {
     net.guest_mac = Some(mac);
     net.config_space.guest_mac = mac;

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -41,7 +41,7 @@ pub fn default_net() -> Net {
 
     let guest_mac = default_guest_mac();
 
-    let mut net = Net::new_with_tap(
+    let mut net = Net::new(
         tap_device_id,
         tap_if_name,
         Some(guest_mac),
@@ -64,7 +64,7 @@ pub fn default_net_no_mmds() -> Net {
 
     let guest_mac = default_guest_mac();
 
-    let net = Net::new_with_tap(
+    let net = Net::new(
         tap_device_id,
         "net-device%d",
         Some(guest_mac),

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -539,7 +539,7 @@ pub(crate) mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
     pub use super::*;
-    use crate::virtio::test_utils::VirtQueue;
+    use crate::virtio::test_utils::{default_mem, single_region_mem, VirtQueue};
     use crate::virtio::QueueError::{DescIndexOutOfBounds, UsedRing};
 
     impl Queue {
@@ -604,7 +604,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_queue_validation() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
@@ -673,7 +673,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_queue_processing() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
@@ -775,7 +775,7 @@ pub(crate) mod tests {
         // with valid available ring indexes while it produces an error with invalid
         // indexes.
         // No notification suppression enabled.
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x6000)], false).unwrap();
+        let m = &single_region_mem(0x6000);
 
         // We set up a queue of size 4.
         let vq = VirtQueue::new(GuestAddress(0), m, 4);
@@ -825,7 +825,7 @@ pub(crate) mod tests {
         // with valid available ring indexes while it produces an error with invalid
         // indexes.
         // Notification suppression is enabled.
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x6000)], false).unwrap();
+        let m = &single_region_mem(0x6000);
 
         // We set up a queue of size 4.
         let vq = VirtQueue::new(GuestAddress(0), m, 4);
@@ -854,7 +854,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_used() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
@@ -898,7 +898,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_used_event() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let q = vq.create_queue();
@@ -913,7 +913,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_set_avail_event() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
         let mut q = vq.create_queue();
@@ -928,7 +928,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_needs_kick() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 
@@ -976,7 +976,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_try_enable_notification() {
-        let m = &create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap();
+        let m = &default_mem();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
         let mut q = vq.create_queue();
 

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
 
-use crate::virtio::{Queue, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+use crate::virtio::Queue;
 
 #[macro_export]
 macro_rules! check_metric_after_block {
@@ -22,42 +22,6 @@ macro_rules! check_metric_after_block {
 
 pub fn default_mem() -> GuestMemoryMmap {
     vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap()
-}
-
-pub fn initialize_virtqueue(vq: &VirtQueue) {
-    let request_type_desc: usize = 0;
-    let data_desc: usize = 1;
-    let status_desc: usize = 2;
-
-    let request_addr: u64 = 0x1000;
-    let data_addr: u64 = 0x2000;
-    let status_addr: u64 = 0x3000;
-    let len = 0x1000;
-
-    // Set the request type descriptor.
-    vq.avail.ring[request_type_desc].set(request_type_desc as u16);
-    vq.dtable[request_type_desc].set(request_addr, len, VIRTQ_DESC_F_NEXT, data_desc as u16);
-
-    // Set the data descriptor.
-    vq.avail.ring[data_desc].set(data_desc as u16);
-    vq.dtable[data_desc].set(
-        data_addr,
-        len,
-        VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE,
-        status_desc as u16,
-    );
-
-    // Set the status descriptor.
-    vq.avail.ring[status_desc].set(status_desc as u16);
-    vq.dtable[status_desc].set(
-        status_addr,
-        len,
-        VIRTQ_DESC_F_WRITE,
-        (status_desc + 1) as u16,
-    );
-
-    // Mark the next available descriptor.
-    vq.avail.idx.set(1);
 }
 
 pub struct InputData {

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -140,6 +140,10 @@ impl<'a> VirtqDesc<'a> {
         self.next.set(next);
     }
 
+    pub fn memory(&self) -> &'a GuestMemoryMmap {
+        self.addr.mem
+    }
+
     pub fn set_data(&mut self, data: &[u8]) {
         assert!(self.len.get() as usize >= data.len());
         let mem = self.addr.mem;
@@ -257,6 +261,10 @@ impl<'a> VirtQueue<'a> {
             avail,
             used,
         }
+    }
+
+    pub fn memory(&self) -> &'a GuestMemoryMmap {
+        self.used.flags.mem
     }
 
     pub fn size(&self) -> u16 {

--- a/src/devices/src/virtio/test_utils.rs
+++ b/src/devices/src/virtio/test_utils.rs
@@ -20,8 +20,17 @@ macro_rules! check_metric_after_block {
     }};
 }
 
+/// Creates a [`GuestMemoryMmap`] with a single region of the given size starting at guest physical
+/// address 0
+pub fn single_region_mem(region_size: usize) -> GuestMemoryMmap {
+    vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), region_size)], false)
+        .unwrap()
+}
+
+/// Creates a [`GuestMemoryMmap`] with a single region  of size 65536 (= 0x10000 hex) starting at
+/// guest physical address 0
 pub fn default_mem() -> GuestMemoryMmap {
-    vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), 0x10000)], false).unwrap()
+    single_region_mem(0x10000)
 }
 
 pub struct InputData {

--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -9,7 +9,7 @@ use utils::epoll::EventSet;
 use utils::eventfd::EventFd;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 
-use crate::virtio::test_utils::VirtQueue as GuestQ;
+use crate::virtio::test_utils::{single_region_mem, VirtQueue as GuestQ};
 use crate::virtio::vsock::device::{RXQ_INDEX, TXQ_INDEX};
 use crate::virtio::vsock::packet::{VsockPacket, VSOCK_PKT_HDR_SIZE};
 use crate::virtio::{
@@ -121,9 +121,7 @@ impl TestContext {
     pub fn new() -> Self {
         const CID: u64 = 52;
         const MEM_SIZE: usize = 1024 * 1024 * 128;
-        let mem =
-            vm_memory::test_utils::create_anon_guest_memory(&[(GuestAddress(0), MEM_SIZE)], false)
-                .unwrap();
+        let mem = single_region_mem(MEM_SIZE);
         Self {
             cid: CID,
             mem,

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -161,7 +161,7 @@ impl NetBuilder {
             .map_err(NetworkInterfaceError::CreateRateLimiter)?;
 
         // Create and return the Net device
-        devices::virtio::net::Net::new_with_tap(
+        devices::virtio::net::Net::new(
             cfg.iface_id,
             &cfg.host_dev_name,
             cfg.guest_mac,
@@ -343,7 +343,7 @@ mod tests {
         let host_dev_name = "dev";
         let guest_mac = "01:23:45:67:89:0b";
 
-        let net = Net::new_with_tap(
+        let net = Net::new(
             net_id.to_string(),
             host_dev_name,
             Some(MacAddr::parse_str(guest_mac).unwrap()),

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -39,7 +39,7 @@ TARGET = f"{ARCH}-unknown-linux-gnu"
 
 # We allow coverage to have a max difference of `COVERAGE_MAX_DELTA` as percentage before failing
 # the test (currently 0.05%).
-COVERAGE_MAX_DELTA = 0.0005
+COVERAGE_MAX_DELTA = 0.05
 
 
 @pytest.mark.timeout(400)
@@ -96,19 +96,11 @@ def test_coverage(monkeypatch, record_property):
     coverage_str = index_contents[start + 1 : end]
     coverage = float(coverage_str)
 
-    # Compare coverage.
-    high = coverage_target * (1.0 + COVERAGE_MAX_DELTA)
-    low = coverage_target * (1.0 - COVERAGE_MAX_DELTA)
-
     # Record coverage.
     record_property(
-        "coverage", f"{coverage}% {coverage_target}% ±{COVERAGE_MAX_DELTA:.2%}%"
+        "coverage", f"{coverage}% {coverage_target}% ±{COVERAGE_MAX_DELTA:.2f}%"
     )
 
-    # Assert coverage within delta.
-    assert (
-        coverage >= low
-    ), f"Current code coverage ({coverage:.2f}%) is more than {COVERAGE_MAX_DELTA:.2%}% below the target ({coverage_target:.2f}%)"
-    assert (
-        coverage <= high
-    ), f"Current code coverage ({coverage:.2f}%) is more than {COVERAGE_MAX_DELTA:.2%}% above the target ({coverage_target:.2f}%)"
+    assert coverage == pytest.approx(
+        coverage_target, abs=COVERAGE_MAX_DELTA
+    ), f"Current code coverage ({coverage:.2f}%) deviates more than {COVERAGE_MAX_DELTA:.2f}% from target ({coverage_target:.2f})"


### PR DESCRIPTION
## Changes

Refractors some of the virtio test_utils code to deduplicate it. 

## Reason

Improving maintainability of our test code

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
