### PR TITLE
fix: CPUID pass-through

### DIFF
--- a/src/vmm/src/cpuid/amd/mod.rs
+++ b/src/vmm/src/cpuid/amd/mod.rs
@@ -27,6 +27,24 @@ mod registers;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AmdCpuid(pub std::collections::BTreeMap<CpuidKey, CpuidEntry>);
 
+impl AmdCpuid {
+    /// Include leaves from `other` that are not present in `self`.
+    #[inline]
+    #[must_use]
+    pub fn include_leaves_from(mut self, other: Self) -> Self {
+        let leaves = self
+            .0
+            .iter()
+            .map(|x| x.0.leaf)
+            .collect::<std::collections::HashSet<_>>();
+
+        self.0
+            .extend(other.0.into_iter().filter(|x| !leaves.contains(&x.0.leaf)));
+
+        self
+    }
+}
+
 impl CpuidTrait for AmdCpuid {
     /// Gets a given sub-leaf.
     #[inline]
@@ -91,5 +109,137 @@ mod tests {
             }),
             None
         );
+    }
+
+    #[allow(clippy::too_many_lines)]
+    #[test]
+    fn include_leaves_from() {
+        let first = AmdCpuid(
+            [
+                (
+                    CpuidKey {
+                        leaf: 0,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 1,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 3,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let second = AmdCpuid(
+            [
+                (
+                    CpuidKey {
+                        leaf: 0,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 2,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 2,
+                        subleaf: 1,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 4,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let expected = AmdCpuid(
+            [
+                // First
+                (
+                    CpuidKey {
+                        leaf: 0,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 1,
+                        subleaf: 1,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 3,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+                // Second
+                (
+                    CpuidKey {
+                        leaf: 2,
+                        subleaf: 1,
+                    },
+                    CpuidEntry::default(),
+                ),
+                (
+                    CpuidKey {
+                        leaf: 4,
+                        subleaf: 0,
+                    },
+                    CpuidEntry::default(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        assert_eq!(first.include_leaves_from(second), expected);
     }
 }

--- a/src/vmm/src/cpuid/cpuid_ffi.rs
+++ b/src/vmm/src/cpuid/cpuid_ffi.rs
@@ -491,6 +491,14 @@ bit_fields::bitfield!(
     }
 );
 
+#[allow(clippy::derivable_impls)]
+impl Default for KvmCpuidFlags {
+    #[inline]
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
 /// CPUID entry (a mimic of <https://elixir.bootlin.com/linux/v5.10.129/source/arch/x86/include/uapi/asm/kvm.h#L232>).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(C)]

--- a/src/vmm/src/cpuid/mod.rs
+++ b/src/vmm/src/cpuid/mod.rs
@@ -350,6 +350,11 @@ pub enum Cpuid {
     Amd(AmdCpuid),
 }
 
+/// Error type for [`Cpuid::join`].
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+#[error("Failed to join CPUIDs as they belong to different manufactures.")]
+pub struct CpuidJoinError;
+
 impl Cpuid {
     /// Returns `Some(&mut IntelCpuid)` if `Self == Self::Intel(_)` else returns `None`.
     #[inline]
@@ -388,6 +393,20 @@ impl Cpuid {
         match self {
             Self::Intel(_) => None,
             Self::Amd(amd) => Some(amd),
+        }
+    }
+
+    /// Include leaves from `other` that are not present in `self`.
+    ///
+    /// # Errors
+    ///
+    /// When CPUIDs have different manufacturer IDs.
+    #[inline]
+    pub fn include_leaves_from(self, other: Self) -> Result<Self, CpuidJoinError> {
+        match (self, other) {
+            (Self::Intel(a), Self::Intel(b)) => Ok(Self::Intel(a.include_leaves_from(b))),
+            (Self::Amd(a), Self::Amd(b)) => Ok(Self::Amd(a.include_leaves_from(b))),
+            _ => Err(CpuidJoinError),
         }
     }
 }
@@ -493,7 +512,7 @@ impl std::cmp::Ord for CpuidKey {
 }
 
 /// CPUID entry information stored for each leaf of [`IntelCpuid`].
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CpuidEntry {
     /// The KVM requires a `flags` parameter which indicates if a given CPUID leaf has sub-leaves.
     /// This does not change at runtime so we can save memory by not storing this under every
@@ -549,7 +568,7 @@ pub struct CpuidEntry {
 /// To transmute this into leaves such that we can return mutable reference to it with leaf specific
 /// accessors, requires this to have a consistent member ordering. [`core::arch::x86::CpuidResult`]
 /// is not `repr(C)`.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[repr(C)]
 pub struct CpuidRegisters {
     /// EAX
@@ -619,7 +638,21 @@ impl From<RawKvmCpuidEntry> for (CpuidKey, CpuidEntry) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
+
+    #[test]
+    fn include_leaves_from() {
+        let first = Cpuid::Amd(AmdCpuid(BTreeMap::new()));
+        let second = Cpuid::Intel(IntelCpuid(BTreeMap::new()));
+
+        assert_eq!(
+            first.clone().include_leaves_from(second.clone()),
+            Err(CpuidJoinError)
+        );
+        assert_eq!(second.include_leaves_from(first), Err(CpuidJoinError));
+    }
 
     #[test]
     fn get() {

--- a/src/vmm/src/vstate/vcpu/x86_64/mod.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64/mod.rs
@@ -218,6 +218,10 @@ pub enum KvmVcpuConfigureError {
     /// Failed to construct `crate::cpuid::Cpuid` from snapshot.
     #[error("Failed to construct `crate::cpuid::RawCpuid` from `kvm_bindings::CpuId`")]
     SnapshotCpuid(crate::cpuid::CpuidTryFromRawCpuid),
+    /// Failed to join given cpuid and specified CPUID template (specified template is for
+    /// different manufacturer than the given cpuid).
+    #[error("Failed to join given `cpuid` and specified CPUID template: {0}")]
+    Join(#[from] crate::cpuid::CpuidJoinError),
     /// Failed to apply modifications to CPUID.
     #[error("Failed to apply modifications to CPUID: {0}")]
     NormalizeCpuidError(crate::cpuid::NormalizeCpuidError),
@@ -282,6 +286,10 @@ impl KvmVcpu {
         vcpu_config: &VcpuConfig,
         cpuid: CpuId,
     ) -> std::result::Result<(), KvmVcpuConfigureError> {
+        // We use the given `cpuid` as the base.
+        let cpuid = crate::cpuid::Cpuid::try_from(crate::cpuid::RawCpuid::from(cpuid))
+            .map_err(KvmVcpuConfigureError::SnapshotCpuid)?;
+
         // If a template is specified, get the CPUID template, else use `cpuid`.
         let mut config_cpuid = match vcpu_config.cpu_template {
             CpuFeaturesTemplate::C3 => cpuid_templates::c3(),
@@ -291,7 +299,7 @@ impl KvmVcpu {
             CpuFeaturesTemplate::T2A => cpuid_templates::t2a(),
             // If a template is not supplied we use the given `cpuid` as the base.
             CpuFeaturesTemplate::None => {
-                crate::cpuid::Cpuid::try_from(crate::cpuid::RawCpuid::from(cpuid))
+                crate::cpuid::Cpuid::try_from(crate::cpuid::RawCpuid::from(cpuid.clone()))
                     .map_err(KvmVcpuConfigureError::SnapshotCpuid)?
             }
         };
@@ -308,8 +316,11 @@ impl KvmVcpu {
             )
             .map_err(KvmVcpuConfigureError::NormalizeCpuidError)?;
 
+        // Include leaves from host that are not present in CPUID template.
+        let joined_cpuid = config_cpuid.include_leaves_from(cpuid)?;
+
         // Set CPUID.
-        let kvm_cpuid = kvm_bindings::CpuId::from(config_cpuid);
+        let kvm_cpuid = kvm_bindings::CpuId::from(joined_cpuid);
 
         // Set CPUID in the KVM
         self.fd

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.08, "AMD": 78.92, "ARM": 82.09}
+    COVERAGE_DICT = {"Intel": 78.14, "AMD": 78.92, "ARM": 82.09}
 else:
-    COVERAGE_DICT = {"Intel": 75.81, "AMD": 76.64, "ARM": 79.04}
+    COVERAGE_DICT = {"Intel": 75.87, "AMD": 76.64, "ARM": 79.04}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Passes portions of the host CPUID through to the guest depending on the CPUID template.

## Reason

In setting CPUID a user will typically want to pass-through most values and only specify a few. These values can relate to cache topology and be very tricky to specify in a template. In this case we need CPUID to support setting specific leaves and passing-through others.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
