### PR TITLE
Update bumpalo 3.9.1 -> 3.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"

--- a/tests/integration_tests/performance/test_boottime.py
+++ b/tests/integration_tests/performance/test_boottime.py
@@ -4,13 +4,34 @@
 
 import re
 import platform
+from framework.utils_cpuid import get_instance_type, get_cpu_model_name
 
 # The maximum acceptable boot time in us.
 MAX_BOOT_TIME_US = 150000
-# NOTE: for aarch64 most of the boot time is spent by the kernel to unpack the
+# NOTE: For aarch64 most of the boot time is spent by the kernel to unpack the
 # initramfs in RAM. This time is influenced by the size and the compression
-# method of the used initrd image.
-INITRD_BOOT_TIME_US = 180000 if platform.machine() == "x86_64" else 205000
+# method of the used initrd image. The boot time for Skylake is greater than
+# other x86-64 CPUs, since L1TF mitigation (unconditional L1D cache flush) is
+# enabled.
+INITRD_BOOT_TIME_US = {
+    "x86_64": {
+        "m5d.metal": {
+            "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz": 230000,
+            "Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz": 180000,
+        },
+        "m6i.metal": {
+            "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz": 180000,
+        },
+        "m6a.metal": {
+            "AMD EPYC 7R13 48-Core Processor": 180000,
+        },
+    },
+    "aarch64": {
+        "m6g.metal": {
+            "ARM_NEOVERSE_N1": 205000,
+        }
+    },
+}
 # TODO: Keep a `current` boot time in S3 and validate we don't regress
 # Regex for obtaining boot time from some string.
 TIMESTAMP_LOG_REGEX = r"Guest-boot-time\s+\=\s+(\d+)\s+us"
@@ -69,10 +90,14 @@ def test_initrd_boottime(test_microvm_with_initrd):
     vm = test_microvm_with_initrd
     vm.jailer.extra_args.update({"boot-timer": None})
     _tap = _configure_and_run_vm(vm, initrd=True)
-    boottime_us = _test_microvm_boottime(vm, max_time_us=INITRD_BOOT_TIME_US)
+    max_time_us = INITRD_BOOT_TIME_US[platform.machine()][get_instance_type()][
+        get_cpu_model_name()
+    ]
+    boottime_us = _test_microvm_boottime(vm, max_time_us=max_time_us)
+
     print("Boot time with initrd is: " + str(boottime_us) + " us")
 
-    return f"{boottime_us} us", f"< {INITRD_BOOT_TIME_US} us"
+    return f"{boottime_us} us", f"< {max_time_us} us"
 
 
 def _test_microvm_boottime(vm, max_time_us=MAX_BOOT_TIME_US):


### PR DESCRIPTION
We do not use bumpalo in production code, as its only a transitive dependency of criterion (and there, only for web assembly targets). Nevertheless, cargo audit reports a vulnerability in it, and since we block our CI on cargo audit reports, this needs to be fixed as 1.1 is still support (so we need to be able to merge PRs)

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
