### PR TITLE
test: remove resource dir when cleaning up microvm_factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -442,8 +442,13 @@ def microvm(test_fc_session_root_path, bin_cloner_path):
 def microvm_factory(tmp_path, bin_cloner_path):
     """Fixture to create microvms simply.
 
-    By using tmp_path, the last 3 runs are kept. This may be a problem when
-    running large number of tests, but it's very handy for debugging.
+    tmp_path is cleaned up by pytest after 3 sessions.
+    However, since we only run one session per docker container execution,
+    tmp_path is never cleaned up by pytest for us.
+    In order to avoid running out of space when instantiating many microvms,
+    we remove the directory manually when the fixture is destroyed
+    (that is after every test).
+    One can comment the removal line, if it helps with debugging.
     """
 
     class MicroVMFactory:
@@ -474,6 +479,7 @@ def microvm_factory(tmp_path, bin_cloner_path):
             """Clean up all built VMs"""
             for vm in self.vms:
                 vm.kill()
+            shutil.rmtree(self.tmp_path)
 
     uvm_factory = MicroVMFactory(tmp_path, bin_cloner_path)
     yield uvm_factory


### PR DESCRIPTION
## Changes

When cleaning up microvm_factory fixture, remove resource directory that contains data related to all microvms created via the factory.

## Reason

If the fixture is called many times within a pytest session, it accumulates artifacts from all microvms it creates, which may lead to running out of space.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] New `unsafe` code is documented.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
