### PR TITLE
fix(tests): fallback to default kernels if IMDSv2 not available

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -30,7 +30,12 @@ def select_supported_kernels():
     """Select kernels supported by the current combination of kernel and instance type."""
     supported_kernels = SUPPORTED_KERNELS
     kernel_version = get_kernel_version(level=1)
-    instance_type = get_instance_type()
+    try:
+        instance_type = get_instance_type()
+    # in case we are not in EC2, return the default
+    # pylint: disable=broad-except
+    except Exception:
+        return supported_kernels
 
     if instance_type == "c7g.metal" and kernel_version == "4.14":
         supported_kernels = SUPPORTED_KERNELS_NO_SVE


### PR DESCRIPTION
Commit 9ac5a5a0f introduced a get_instance_type call before tests start that only works if IMDSv2 is available (i.e. when running in an EC2 instance).

If we are not running in EC2 we catch the exception and returning the default value.

Fixes: 9ac5a5a0f

Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] New `unsafe` code is documented.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
~- [ ] New `TODO`s link to an issue.~

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
