### PR TITLE
fix: Remove strings from rootfs

### DIFF
--- a/resources/tests/setup_rootfs.sh
+++ b/resources/tests/setup_rootfs.sh
@@ -11,7 +11,7 @@ prepare_fc_rootfs() {
     SSH_DIR="$BUILD_DIR/ssh"
     RESOURCE_DIR="$2"
 
-    packages="udev systemd-sysv openssh-server iproute2 strings"
+    packages="udev systemd-sysv openssh-server iproute2"
 
     # msr-tools is only supported on x86-64.
     arch=$(uname -m)


### PR DESCRIPTION
## Changes

Removes `strings` package from rootfs.

## Reason

`strings` package was added in the part of spectre/meltdown checker test on guests in this commit 42b78fda2a87ebbcdde06f9984d26366d0aea3ce. But actually the installation fails with "E: Unable to locate package strings." error, although it logs "Successfully built rootfs!". Since this package is not the strict requirement for the test, this commit removes the package to prevent rootfs build failures.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] New `unsafe` code is documented.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
