### PR TITLE
[perf] snap resume baselines for m5d and m6i 5.10

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -61,11 +61,13 @@ CREATE_LATENCY_BASELINES = {
     },
 }
 
-# The latencies are pretty high during integration tests and
-# this is tracked here:
+# The latencies for x86 are pretty high due to a design
+# in the cgroups V1 implementation in the kernel. We recommend
+# switching to cgroups v2 for much lower snap resume latencies.
+# More details on this:
 # https://github.com/firecracker-microvm/firecracker/issues/2027
-# TODO: Update the table after fix. Target is < 5ms.
-# since they might be lower.
+# Latencies for snap resume on cgroups V2 can be found in our
+# long-running performance configs (i.e. integration_tests/performance/configs).
 LOAD_LATENCY_BASELINES = {
     "x86_64": {
         "m5d.metal": {
@@ -77,12 +79,12 @@ LOAD_LATENCY_BASELINES = {
             },
             "5.10": {
                 "sync": {
-                    "2vcpu_256mb.json": {"target": 60},
-                    "2vcpu_512mb.json": {"target": 60},
+                    "2vcpu_256mb.json": {"target": 70},
+                    "2vcpu_512mb.json": {"target": 70},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 190},
-                    "2vcpu_512mb.json": {"target": 190},
+                    "2vcpu_256mb.json": {"target": 210},
+                    "2vcpu_512mb.json": {"target": 210},
                 },
             },
         },
@@ -113,12 +115,12 @@ LOAD_LATENCY_BASELINES = {
             },
             "5.10": {
                 "sync": {
-                    "2vcpu_256mb.json": {"target": 60},
-                    "2vcpu_512mb.json": {"target": 60},
+                    "2vcpu_256mb.json": {"target": 70},
+                    "2vcpu_512mb.json": {"target": 70},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 220},
-                    "2vcpu_512mb.json": {"target": 220},
+                    "2vcpu_256mb.json": {"target": 245},
+                    "2vcpu_512mb.json": {"target": 245},
                 },
             },
         },


### PR DESCRIPTION
## Changes

* intermittent failures were noticed on 5.10 x86 platforms (m5d and m6i)

## Reason

* update baselines for m5d and m6i for the snap resume latency test
* update doc to point to the use of cgroups V1 with x86 platforms (which result in high latencies)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] New `unsafe` code is documented.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
