### PR TITLE
chore: Remove `unsafe` checkpoint from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,11 +17,11 @@ the terms of the Apache 2.0 license.
 - [ ] If a specific issue led to this PR, this PR closes the issue.
 - [ ] The description of changes is clear and encompassing.
 - [ ] Any required documentation changes (code and docs) are included in this PR.
-- [ ] New `unsafe` code is documented.
 - [ ] API changes follow the [Runbook for Firecracker API changes][2].
 - [ ] User-facing changes are mentioned in `CHANGELOG.md`.
 - [ ] All added/changed functionality is tested.
 - [ ] New `TODO`s link to an issue.
+- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,6 @@ the terms of the Apache 2.0 license.
 
 ## PR Checklist
 
-- [ ] All commits in this PR are signed (`git commit -s`).
 - [ ] If a specific issue led to this PR, this PR closes the issue.
 - [ ] The description of changes is clear and encompassing.
 - [ ] Any required documentation changes (code and docs) are included in this PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,21 @@ Your contribution needs to meet the following standards:
   Co-authored-by: <B full name> <B email>
   ```
 
+- Usage of `unsafe` should be documented with a justification (over its safe
+  alternative where one exists) and an explanation on why it cannot produce
+  undefined behavior. E.g.
+
+  ```rust
+  // Test creating a resource.
+  // JUSTIFICATION: This cannot be accomplished without unsafe as
+  // `external_function()` returns `RawFd`. An alternative here still uses
+  // unsafe e.g. `drop(unsafe { OwnedFd::from_raw_fd(external_function()) });`.
+  // SAFETY: `external_function()` returns a valid file descriptor.
+  unsafe {
+      libc::close(external_function());
+  }
+  ```
+
 - Document your pull requests. Include the reasoning behind each change, and
   the testing done.
 - Acknowledge Firecracker's [Apache 2.0 license](LICENSE) and certify that no


### PR DESCRIPTION
## Changes

Removed the ``New `unsafe` code is documented.`` checkpoint from the PR template

## Reason

This is covered by the `clippy::undocumented_unsafe_blocks` lint.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] New `unsafe` code is documented.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
