### PR TITLE
Support multiple regions in memory monitor

### DIFF
--- a/tests/integration_tests/functional/test_snapshot_basic.py
+++ b/tests/integration_tests/functional/test_snapshot_basic.py
@@ -534,10 +534,6 @@ def test_create_large_diff_snapshot(test_microvm_with_api):
     """
     vm = test_microvm_with_api
     vm.spawn()
-    # Our memory monitor does not have the necessary logic for dealing
-    # with multiple memory region layout so temporarily disabling it.
-    # GitHub Issue #3349.
-    vm.memory_monitor = None
     vm.basic_config(mem_size_mib=16 * 1024, track_dirty_pages=True)
 
     vm.start()


### PR DESCRIPTION
## Changes

This change adds support for multiple regions in the memory monitor and enables memory monitor for test_create_large_diff_snapshot test.

## Reason

Before the change, the memory monitor could not work with guests with large memory (>3328M) on x86_64.
Resolves: https://github.com/firecracker-microvm/firecracker/issues/3349

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
