### PR TITLE
fix(virtio): undefined behaviour in net `writev` implementation

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -632,7 +632,7 @@ impl Net {
 
     #[cfg(not(test))]
     fn write_tap(tap: &mut Tap, buf: &IoVecBuffer) -> std::io::Result<usize> {
-        tap.write_vectored(buf)
+        tap.write_iovec(buf)
     }
 
     pub fn process_rx_queue_event(&mut self) {
@@ -876,7 +876,7 @@ pub mod tests {
 
         pub(crate) fn write_tap(tap: &mut Tap, buf: &IoVecBuffer) -> io::Result<usize> {
             match tap.mocks.write_tap {
-                WriteTapMock::Success => tap.write_vectored(buf),
+                WriteTapMock::Success => tap.write_iovec(buf),
                 WriteTapMock::Failure => Err(io::Error::new(
                     io::ErrorKind::Other,
                     "Write tap mock failure.",

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.82, "AMD": 81.86, "ARM": 82.36}
+    COVERAGE_DICT = {"Intel": 82.88, "AMD": 81.86, "ARM": 82.36}
 else:
-    COVERAGE_DICT = {"Intel": 79.96, "AMD": 78.99, "ARM": 79.27}
+    COVERAGE_DICT = {"Intel": 80.02, "AMD": 78.99, "ARM": 79.27}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Avoid making a slice out of raw guest physical memory for `IoVecBuffer`s. Instead use directly `libc::iovec` to describe the buffers and, in order to have vectored writes for tap devices, call directly `libc::writev`.

## Reason

The way we implemented `IoVecBuffer` was leading to potentially undefined behaviour. We were creating a normal slice from guest physical memory. Although, with well-behaved drivers this should be fine, a driver that touches that memory after adding the buffer in the queue and before the device adds it in the used queue, would cause undefined behaviour due to the aliasing requirements of Rust for slices.
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
