### PR TITLE
test: Update Arm start-up time

### DIFF
--- a/tests/integration_tests/performance/test_process_startup_time.py
+++ b/tests/integration_tests/performance/test_process_startup_time.py
@@ -10,7 +10,7 @@ import platform
 import host_tools.logging as log_tools
 from host_tools.cargo_build import run_seccompiler_bin
 
-MAX_STARTUP_TIME_CPU_US = {"x86_64": 5500, "aarch64": 3400}
+MAX_STARTUP_TIME_CPU_US = {"x86_64": 5500, "aarch64": 3800}
 """ The maximum acceptable startup time in CPU us. """
 # TODO: Keep a `current` startup time in S3 and validate we don't regress
 


### PR DESCRIPTION
Signed-off-by: Jonathan Woollett-Light <jcawl@amazon.co.uk>

## Changes

Updates Arm start-up time.

## Reason

There appears to have been a regression in Arm start-up.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
