### PR TITLE
Fix off-by-one in iovec.rs

### DIFF
--- a/src/devices/src/virtio/net/iovec.rs
+++ b/src/devices/src/virtio/net/iovec.rs
@@ -143,7 +143,7 @@ impl IoVecBuffer {
             //    to guest physical memory, whereas `buf_ptr` to Firecracaker-owned memory.
             unsafe {
                 let seg_ptr = (seg.iov_base as *const u8).add(start);
-                std::ptr::copy_nonoverlapping(seg_ptr, buf_ptr, buf_end - buf_start + 1);
+                std::ptr::copy_nonoverlapping(seg_ptr, buf_ptr, buf_end - buf_start);
             }
 
             buf_start = buf_end;
@@ -258,6 +258,9 @@ mod tests {
         let iovec = IoVecBuffer::from_descriptor_chain(&mem, head).unwrap();
 
         let mut buf = vec![0; 5];
+        assert_eq!(iovec.read_at(&mut buf[..4], 0), Some(4));
+        assert_eq!(buf, vec![0u8, 1, 2, 3, 0]);
+
         assert_eq!(iovec.read_at(&mut buf, 0), Some(5));
         assert_eq!(buf, vec![0u8, 1, 2, 3, 4]);
 


### PR DESCRIPTION




Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

We adjust the `len` parameter passed to `std::ptr::copy_nonoverlapping` to `end - start`, and add a tests that verifies that no bytes are written beyond the end of the slice passed to `read_at`.

## Reason

The std::ptr::copy_nonoverlapping call used to copy into buf[buf_start..buf_end] was instructed to copy `end - start + 1` bytes, however `buf_end - buf_start` is exactly `end - start` (without the +1) long, since the upper bound of the slice is not inclusive. This would lead to either 1 byte being written past the end of `buf`, or 1 byte being read past the end of the last iovec.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
