### PR TITLE
fix: Exclude CPUID templates on Arm

### DIFF
--- a/src/cpuid-templates/Cargo.toml
+++ b/src/cpuid-templates/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "cpuid-templates"
-version = "0.1.0"
-authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2021"
-license = "Apache-2.0"
-
-[dependencies]
-cpuid = { path="../cpuid" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -35,7 +35,6 @@ vm-memory = { path = "../vm-memory" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }
-cpuid-templates = { path = "../cpuid-templates" }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/vmm/src/vstate/vcpu/x86_64/cpuid_templates.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64/cpuid_templates.rs
@@ -1418,7 +1418,6 @@ pub fn t2() -> Cpuid {
 ///    0x80860000 0x00: eax=0x00000000 ebx=0x00000000 ecx=0x00000000 edx=0x00000000
 ///    0xc0000000 0x00: eax=0x00000000 ebx=0x00000000 ecx=0x00000000 edx=0x00000000
 /// ```
-
 pub fn t2s() -> Cpuid {
     Cpuid::Intel(IntelCpuid({
         let mut map = std::collections::BTreeMap::new();
@@ -2754,6 +2753,7 @@ pub fn t2cl() -> Cpuid {
         map
     }))
 }
+
 /// This is translated from `cpuid -r` within a T2A guest microVM on an ec2 m6a.metal instance:
 ///
 /// ```text

--- a/src/vmm/src/vstate/vcpu/x86_64/mod.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64/mod.rs
@@ -24,6 +24,8 @@ use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation};
 use crate::vstate::vm::Vm;
 
+mod cpuid_templates;
+
 // Tolerance for TSC frequency expected variation.
 // The value of 250 parts per million is based on
 // the QEMU approach, more details here:

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 77.81, "AMD": 78.54, "ARM": 63.68}
+    COVERAGE_DICT = {"Intel": 77.81, "AMD": 78.54, "ARM": 72.26}
 else:
-    COVERAGE_DICT = {"Intel": 75.53, "AMD": 76.26, "ARM": 61.31}
+    COVERAGE_DICT = {"Intel": 75.53, "AMD": 76.26, "ARM": 69.58}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Apply `#[cfg(target_arch = "x86_64")]` to CPUID template to avoid compiling them on Arm.

## Reason

Minimizes negative impact on Arm coverage.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
