### PR TITLE
Small documentation/code comment clarifications

### DIFF
--- a/src/devices/src/virtio/net/iovec.rs
+++ b/src/devices/src/virtio/net/iovec.rs
@@ -136,8 +136,8 @@ impl IoVecBuffer {
             // its boundaries) and `start` is less than `seg.iov_len`.
             //
             // The call to `copy_nonoverlapping` is safe because:
-            // 1. `buf_ptr` is a pointer valid for writing `buf_end - buf_start + 1` bytes.
-            // 2. `seg_ptr` is a pointer valid for reading `buf_end - buf_start + 1` bytes.
+            // 1. `buf_ptr` is a pointer valid for writing `buf_end - buf_start` bytes.
+            // 2. `seg_ptr` is a pointer valid for reading `buf_end - buf_start` bytes.
             // 3. Both pointers pointers are pointing to `u8`, so they are properly aligned.
             // 4. The memory regions these pointers point to are not overlapping. `seg_ptr` points
             //    to guest physical memory, whereas `buf_ptr` to Firecracaker-owned memory.

--- a/src/dumbo/src/tcp/connection.rs
+++ b/src/dumbo/src/tcp/connection.rs
@@ -150,6 +150,10 @@ pub enum WriteNextError {
 /// user to supply an opaque `u64` timestamp value when invoking send or receive functionality. The
 /// timestamps must be non-decreasing, and are mainly used for retransmission timeouts.
 ///
+/// See https://github.com/firecracker-microvm/firecracker/blob/main/docs/mmds/mmds-design.md#dumbo
+/// for why we are able to make these simplifications. Specifically, we want to stress that no
+/// traffic handled by dumbo ever leaves a microVM.
+///
 /// [`close`]: #method.close
 #[cfg_attr(test, derive(Clone))]
 pub struct Connection {


### PR DESCRIPTION
See #3402 for reference.

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Changes

Link to MMDS documentation in dumbo and fix a safety comment in iovec.rs

## Reason

The only reason we are able to simplify our TCP/IP stack in the way we do it because the traffic handled by it never leaves the microVM. However, the current comments in the code do not provide this justification. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
