### PR TITLE
Doc updates for block device rate limiting and API usage

### DIFF
--- a/docs/api_requests/patch-block.md
+++ b/docs/api_requests/patch-block.md
@@ -46,6 +46,17 @@ curl --unix-socket ${socket} -i \
              \"path_on_host\": \"${ro_drive_path}\",
              \"is_root_device\": false,
              \"is_read_only\": true
+             \"rate_limiter\": {
+                \"bandwidth\": {
+                        \"size\": 100000,
+                        \"one_time_burst\": 4096,
+                        \"refill_time\": 150
+                },
+                \"ops\": {
+                        \"size\": 10,
+                        \"refill_time\": 250
+                }
+            }
          }"
 # Finish configuring and start the microVM. Wait for the guest to boot.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,10 +31,10 @@ The generic requirements are explained below:
 - **KVM**
 
   Please make sure that:
-  1. you have KVM enabled in your Linux kernel, and
-  2. you have read/write access to `/dev/kvm`.
-     If you need help setting up access to `/dev/kvm`, you should check out
-     [Appendix A](#appendix-a-setting-up-kvm-access).
+    1. you have KVM enabled in your Linux kernel, and
+    2. you have read/write access to `/dev/kvm`.
+       If you need help setting up access to `/dev/kvm`, you should check out
+       [Appendix A](#appendix-a-setting-up-kvm-access).
 
 To check if your system meets the requirements to run Firecracker, clone
 the repository and execute `tools/devtool checkenv`.
@@ -83,11 +83,11 @@ Next, you will need an uncompressed Linux kernel binary, and an ext4
 file system image (to use as rootfs).
 
 1. To run an `x86_64` guest you can download such resources from:
-    [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin)
-    and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4).
+   [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin)
+   and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4).
 1. To run an `aarch64` guest, download them from:
-    [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/kernels/vmlinux.bin)
-    and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/rootfs/bionic.rootfs.ext4).
+   [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/kernels/vmlinux.bin)
+   and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/rootfs/bionic.rootfs.ext4).
 
 Now, let's open up two shell prompts: one to run Firecracker, and another one
 to control it (by writing to the API socket). For the purpose of this guide,
@@ -363,6 +363,26 @@ not run on an EC2 .metal instance. You can skip performance tests with:
 ```bash
  ./tools/devtool test -- --ignore integration_tests/performance
  ```
+
+## Troubleshooting
+
+### Errors while using `curl` to access the API
+
+Points to check to confirm the API socket is running and accessible:
+
+- Check that the user running the Firecracker process and the user using `curl`
+  have equivalent privileges. For example, if you run Firecracker with **sudo**
+  that you run `curl` with **sudo** as well.
+- [SELinux](https://man7.org/linux/man-pages/man8/selinux.8.html) can regulate
+  access to sockets on RHEL based distributions. How user's permissions are
+  configured is environmentally specific, but for the purposes of
+  troubleshooting you can check if it is enabled in `/etc/selinux/config`.
+- With the Firecracker process running using `--api-sock /tmp/firecracker.socket`,
+  confirm that the socket is open:
+  - `ss -a | grep '/tmp/firecracker.socket'`
+  - If you have socat available, try `socat - UNIX-CONNECT:/tmp/firecracker.socket`
+    This will throw an explicit error if the socket is inaccessible, or it will pause
+    and wait for input to continue.
 
 ## Appendix A: Setting Up KVM Access
 

--- a/docs/prod-host-setup.md
+++ b/docs/prod-host-setup.md
@@ -216,6 +216,30 @@ containing other qdiscs, most classful qdiscs perform rate control.
   - `connlimit` - restricts the number of connections for a destination IP
     address/from a source IP address, as well as limit the bandwidth
 
+### Mitigating Noisy-Neighbour Storage Device Contention
+
+Data written to storage devices is managed in Linux with a page cache.
+Updates to these pages are written through to their mapped storage
+devices asynchronously at the host operating system's discretion.
+As a result, high storage output can result in this cache being
+filled quickly resulting in a backlog which can slow down I/O of
+other guests on the host.
+
+To protect the resource access of the guests, make sure to tune each Firecracker
+process via the following tools:
+
+- [Jailer](jailer.md): A wrapper environment designed to contain Firecracker
+                       and strictly control what the process and its guest has
+                       access to. Take note of the
+                       [jailer operations guide](jailer.md#jailer-operation),
+                       paying particular note to the `--resource-limit` parameter.
+- Rate limiting: Rate limiting functionality is supported for both networking
+                 and storage devices and is configured by the operator of the
+                 environment that launches the Firecracker process and its
+                 associated guest.
+                 See the [block device documentation](api_requests/patch-block.md)
+                 for examples of calling the API to configure rate limiting.
+
 ### Mitigating Side-Channel Issues
 
 When deploying Firecracker microVMs to handle multi-tenant workloads, the


### PR DESCRIPTION
## Changes

* Add description of block device resource management with an updated API call sample of how to configure the rate limiter on a block device.
* Add some pointers for troubleshooting API usage with `curl`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

