### PR TITLE
fix: Documenting `unsafe` in CPUID

### DIFF
--- a/src/vmm/src/cpuid/amd/indexing.rs
+++ b/src/vmm/src/cpuid/amd/indexing.rs
@@ -6,7 +6,7 @@ use std::mem::transmute;
 
 #[allow(clippy::wildcard_imports)]
 use super::leaves::*;
-use crate::cpuid::{index_leaf, transmute_vec, AmdCpuid, CpuidKey, IndexLeaf, IndexLeafMut};
+use crate::cpuid::{index_leaf, AmdCpuid, CpuidEntry, CpuidKey, IndexLeaf, IndexLeafMut};
 
 index_leaf!(0x7, Leaf7, AmdCpuid);
 
@@ -21,14 +21,18 @@ impl IndexLeaf<0x8000001d> for AmdCpuid {
 
     #[inline]
     fn index_leaf<'a>(&'a self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            Leaf8000001d(transmute_vec(
+            Leaf8000001d(
                 self.0
                     .range(CpuidKey::leaf(0x8000001d)..CpuidKey::leaf(0x8000001e))
-                    .map(|(_, v)| transmute::<_, &'a Leaf8000001dSubleaf>(&v.result))
+                    .map(|(_, v): (_, &'a CpuidEntry)| {
+                        transmute::<_, &'a Leaf8000001dSubleaf>(&v.result)
+                    })
                     .collect(),
-            ))
+            )
         }
     }
 }
@@ -38,14 +42,18 @@ impl IndexLeafMut<0x8000001d> for AmdCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            Leaf8000001dMut(transmute_vec(
+            Leaf8000001dMut(
                 self.0
                     .range_mut(CpuidKey::leaf(0x8000001d)..CpuidKey::leaf(0x8000001e))
-                    .map(|(_, v)| transmute::<_, &'a mut Leaf8000001dSubleaf>(&mut v.result))
+                    .map(|(_, v): (_, &'a mut CpuidEntry)| {
+                        transmute::<_, &'a mut Leaf8000001dSubleaf>(&mut v.result)
+                    })
                     .collect(),
-            ))
+            )
         }
     }
 }

--- a/src/vmm/src/cpuid/amd/normalize.rs
+++ b/src/vmm/src/cpuid/amd/normalize.rs
@@ -155,19 +155,13 @@ impl super::AmdCpuid {
                 CpuidKey::leaf(0x8000001e),
                 CpuidEntry {
                     flags: KvmCpuidFlags::empty(),
-                    // SAFETY: Safe as `cfg(cpuid)` ensure CPUID is supported.
-                    result: CpuidRegisters::from(unsafe {
-                        core::arch::x86_64::__cpuid(0x8000001e)
-                    }),
+                    result: CpuidRegisters::from(crate::cpuid::cpuid(0x8000001e)),
                 },
             );
 
             // 0x8000001d - Cache Topology Information
             for subleaf in 0.. {
-                // SAFETY: Safe as `cfg(cpuid)` ensure CPUID is supported.
-                let result = CpuidRegisters::from(unsafe {
-                    core::arch::x86_64::__cpuid_count(0x8000001d, subleaf)
-                });
+                let result = CpuidRegisters::from(crate::cpuid::cpuid_count(0x8000001d, subleaf));
                 // From 'AMD64 Architecture Programmer’s Manual Volume 3: General-Purpose and System
                 // Instructions':
                 //
@@ -201,6 +195,7 @@ impl super::AmdCpuid {
         let leaf_80000000 = self
             .leaf_mut::<0x80000000>()
             .ok_or(NormalizeCpuidError::MissingLeaf0x80000000)?;
+
         // SAFETY: Safe, as `0x8000_001f` is within the known range.
         unsafe {
             leaf_80000000

--- a/src/vmm/src/cpuid/indexing.rs
+++ b/src/vmm/src/cpuid/indexing.rs
@@ -24,17 +24,46 @@ pub trait IndexLeafMut<const INDEX: usize> {
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a>;
 }
 
-/// Transmutes `Vec<T>` into `Vec<U>` where `size::<T>() == size::<U>()`.
-pub(crate) unsafe fn transmute_vec<T, U>(from: Vec<T>) -> Vec<U> {
-    let mut intermediate = std::mem::ManuallyDrop::new(from);
-    Vec::from_raw_parts(
-        intermediate.as_mut_ptr().cast(),
-        intermediate.len(),
-        intermediate.capacity(),
-    )
-}
-
 /// Convenience macro for indexing leaves.
+///
+/// # Justification
+///
+/// `get`  and `get_mut` is a common Rust pattern, these functions typically return `&T`  and
+/// `&mut T`  respectively. In the case of `get` it is preferable to return a reference over a copy,
+/// a reference can be optimized to a copy (while a copy cannot be optimized to a reference). To
+/// return a reference in either case requires `std::mem::transmute` (or casting the reference as a
+/// pointer, to the same affect). This is why `std::mem::transmute` and `unsafe` is used here.
+///
+/// # Safety
+///
+/// The lifetime 'a as defined on `index_leaf<'a>(&'a self) -> Self::Output<'a>` informs the borrow
+/// checker that `Self::Output` immutably borrows `self`. This prevents dropping or mutating `self`
+/// before dropping `Self::Output`.
+///
+/// E.g.
+/// ```ignore
+/// fn main() {
+///     let mut a: Vec<i32> = vec![1, 2, 3, 4];
+///     let b = tester(&a);
+///
+///     // drop(a);
+///     // drop(b); // Attempting to drop b after a errors.
+///
+///     // a[0] += 2;
+///     // drop(b); // Attempting to mutably borrow a before dropping b errors.
+/// }
+///
+/// #[derive(Debug)]
+/// struct Wrapper<'a>(Vec<&'a u32>);
+///
+/// fn tester<'a>(vec: &'a Vec<i32>) -> Wrapper<'a> {
+///     Wrapper(
+///         vec.iter()
+///             .map(|x: &'a i32| unsafe { std::mem::transmute::<&'a i32, &'a u32>(x) })
+///             .collect::<Vec<_>>(),
+///     )
+/// }
+/// ```
 macro_rules! index_leaf {
     ($index: literal, $leaf: ty, $cpuid: ty) => {
         impl $crate::cpuid::IndexLeaf<$index> for $cpuid {
@@ -43,8 +72,12 @@ macro_rules! index_leaf {
             fn index_leaf<'a>(&'a self) -> Self::Output<'a> {
                 self.0
                     .get(&$crate::cpuid::CpuidKey::leaf($index))
-                    // SAFETY: Transmuting reference to same sized types is safe.
-                    .map(|entry| unsafe { std::mem::transmute::<_, &$leaf>(&entry.result) })
+                    // JUSTIFICATION: There is no safe alternative.
+                    // SAFETY: Transmuting references to same size and alignment types is safe. For
+                    // further information See `index_leaf!`.
+                    .map(|entry: &'a crate::cpuid::CpuidEntry| unsafe {
+                        std::mem::transmute::<_, &'a $leaf>(&entry.result)
+                    })
             }
         }
         impl $crate::cpuid::IndexLeafMut<$index> for $cpuid {
@@ -53,8 +86,12 @@ macro_rules! index_leaf {
             fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
                 self.0
                     .get_mut(&$crate::cpuid::CpuidKey::leaf($index))
-                    // SAFETY: Transmuting reference to same sized types is safe.
-                    .map(|entry| unsafe { std::mem::transmute::<_, &mut $leaf>(&mut entry.result) })
+                    // JUSTIFICATION: There is no safe alternative.
+                    // SAFETY: Transmuting references to same size and alignment types is safe. For
+                    // further information See `index_leaf!`.
+                    .map(|entry: &'a mut crate::cpuid::CpuidEntry| unsafe {
+                        std::mem::transmute::<_, &'a mut $leaf>(&mut entry.result)
+                    })
             }
         }
     };

--- a/src/vmm/src/cpuid/intel/indexing.rs
+++ b/src/vmm/src/cpuid/intel/indexing.rs
@@ -6,7 +6,7 @@ use std::mem::transmute;
 
 #[allow(clippy::wildcard_imports)]
 use super::leaves::*;
-use crate::cpuid::{index_leaf, transmute_vec, CpuidKey, IndexLeaf, IndexLeafMut, IntelCpuid};
+use crate::cpuid::{index_leaf, CpuidEntry, CpuidKey, IndexLeaf, IndexLeafMut, IntelCpuid};
 
 index_leaf!(0x2, Leaf2, IntelCpuid);
 
@@ -17,14 +17,16 @@ impl IndexLeaf<0x4> for IntelCpuid {
 
     #[inline]
     fn index_leaf<'a>(&'a self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            Leaf4(transmute_vec(
+            Leaf4(
                 self.0
                     .range(CpuidKey::leaf(0x4)..CpuidKey::leaf(0x5))
-                    .map(|(_, v)| transmute::<_, &'a Leaf4Subleaf>(&v.result))
+                    .map(|(_, v): (_, &'a CpuidEntry)| transmute::<_, &'a Leaf4Subleaf>(&v.result))
                     .collect(),
-            ))
+            )
         }
     }
 }
@@ -34,14 +36,18 @@ impl IndexLeafMut<0x4> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            Leaf4Mut(transmute_vec(
+            Leaf4Mut(
                 self.0
                     .range_mut(CpuidKey::leaf(0x4)..CpuidKey::leaf(0x5))
-                    .map(|(_, v)| transmute::<_, &'a mut Leaf4Subleaf>(&mut v.result))
+                    .map(|(_, v): (_, &'a mut CpuidEntry)| {
+                        transmute::<_, &'a mut Leaf4Subleaf>(&mut v.result)
+                    })
                     .collect(),
-            ))
+            )
         }
     }
 }
@@ -58,12 +64,20 @@ impl IndexLeaf<0x7> for IntelCpuid {
         Leaf7(
             self.0
                 .get(&CpuidKey::subleaf(0x7, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf7Subleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf7Subleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x7, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf7Subleaf1>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf7Subleaf1>(&entry.result)
+                }),
         )
     }
 }
@@ -73,14 +87,21 @@ impl IndexLeafMut<0x7> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf7Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x7, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf7Subleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x7, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf7Subleaf1>(&mut entry.result) }),
         )
     }
@@ -95,14 +116,16 @@ impl IndexLeaf<0xB> for IntelCpuid {
 
     #[inline]
     fn index_leaf<'a>(&'a self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            LeafB(transmute_vec(
+            LeafB(
                 self.0
                     .range(CpuidKey::leaf(0xB)..CpuidKey::leaf(0xC))
-                    .map(|(_, v)| transmute::<_, &'a LeafBSubleaf>(&v.result))
+                    .map(|(_, v): (_, &'a CpuidEntry)| transmute::<_, &'a LeafBSubleaf>(&v.result))
                     .collect(),
-            ))
+            )
         }
     }
 }
@@ -112,14 +135,18 @@ impl IndexLeafMut<0xB> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         unsafe {
-            LeafBMut(transmute_vec(
+            LeafBMut(
                 self.0
                     .range_mut(CpuidKey::leaf(0xB)..CpuidKey::leaf(0xC))
-                    .map(|(_, v)| transmute::<_, &'a mut LeafBSubleaf>(&mut v.result))
+                    .map(|(_, v): (_, &'a mut CpuidEntry)| {
+                        transmute::<_, &'a mut LeafBSubleaf>(&mut v.result)
+                    })
                     .collect(),
-            ))
+            )
         }
     }
 }
@@ -132,12 +159,20 @@ impl IndexLeaf<0xF> for IntelCpuid {
         LeafF(
             self.0
                 .get(&CpuidKey::subleaf(0x7, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a LeafFSubleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a LeafFSubleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x7, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a LeafFSubleaf1>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a LeafFSubleaf1>(&entry.result)
+                }),
         )
     }
 }
@@ -147,14 +182,21 @@ impl IndexLeafMut<0xF> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         LeafFMut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x7, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut LeafFSubleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x7, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut LeafFSubleaf1>(&mut entry.result) }),
         )
     }
@@ -168,20 +210,36 @@ impl IndexLeaf<0x10> for IntelCpuid {
         Leaf10(
             self.0
                 .get(&CpuidKey::subleaf(0x10, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf10Subleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf10Subleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x10, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf10Subleaf1>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf10Subleaf1>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x10, 0x2))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf10Subleaf2>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf10Subleaf2>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x10, 0x3))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf10Subleaf3>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf10Subleaf3>(&entry.result)
+                }),
         )
     }
 }
@@ -191,22 +249,33 @@ impl IndexLeafMut<0x10> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf10Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x10, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf10Subleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x10, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf10Subleaf1>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x10, 0x2))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf10Subleaf2>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x10, 0x3))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf10Subleaf3>(&mut entry.result) }),
         )
     }
@@ -220,20 +289,30 @@ impl IndexLeaf<0x12> for IntelCpuid {
         Leaf12(
             self.0
                 .get(&CpuidKey::subleaf(0x12, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf12Subleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf12Subleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x12, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf12Subleaf1>(&entry.result) }),
-            // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf12Subleaf1>(&entry.result)
+                }),
+            // JUSTIFICATION: There is no safe alternative.
+            // SAFETY: Transmuting references to same size and alignment types is safe. For
+            // further information See `index_leaf!`.
             unsafe {
-                transmute_vec(
-                    self.0
-                        .range(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
-                        .map(|(_, v)| transmute::<_, &'a Leaf12SubleafGt1>(&v.result))
-                        .collect(),
-                )
+                self.0
+                    .range(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
+                    .map(|(_, v): (_, &'a CpuidEntry)| {
+                        transmute::<_, &'a Leaf12SubleafGt1>(&v.result)
+                    })
+                    .collect()
             },
         )
     }
@@ -244,23 +323,30 @@ impl IndexLeafMut<0x12> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf12Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x12, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf12Subleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x12, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf12Subleaf1>(&mut entry.result) }),
-            // SAFETY: Transmuting reference to same sized types is safe.
+            // JUSTIFICATION: There is no safe alternative.
+            // SAFETY: Transmuting references to same size and alignment types is safe. For
+            // further information See `index_leaf!`.
             unsafe {
-                transmute_vec(
-                    self.0
-                        .range_mut(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
-                        .map(|(_, v)| transmute::<_, &'a mut Leaf12SubleafGt1>(&mut v.result))
-                        .collect(),
-                )
+                self.0
+                    .range_mut(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
+                    .map(|(_, v)| transmute::<_, &'a mut Leaf12SubleafGt1>(&mut v.result))
+                    .collect()
             },
         )
     }
@@ -274,12 +360,20 @@ impl IndexLeaf<0x14> for IntelCpuid {
         Leaf14(
             self.0
                 .get(&CpuidKey::subleaf(0x14, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf14Subleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf14Subleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x14, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf14Subleaf1>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf14Subleaf1>(&entry.result)
+                }),
         )
     }
 }
@@ -289,14 +383,21 @@ impl IndexLeafMut<0x14> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf14Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x14, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf14Subleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x14, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf14Subleaf1>(&mut entry.result) }),
         )
     }
@@ -314,20 +415,36 @@ impl IndexLeaf<0x17> for IntelCpuid {
         Leaf17(
             self.0
                 .get(&CpuidKey::subleaf(0x17, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf17Subleaf0>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf17Subleaf0>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x17, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf17Subleaf1>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf17Subleaf1>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x17, 0x2))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf17Subleaf2>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf17Subleaf2>(&entry.result)
+                }),
             self.0
                 .get(&CpuidKey::subleaf(0x17, 0x3))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf17Subleaf3>(&entry.result) }),
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf17Subleaf3>(&entry.result)
+                }),
         )
     }
 }
@@ -337,22 +454,33 @@ impl IndexLeafMut<0x17> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf17Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x17, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf17Subleaf0>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x17, 0x1))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf17Subleaf1>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x17, 0x2))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf17Subleaf2>(&mut entry.result) }),
             self.0
                 .get_mut(&CpuidKey::subleaf(0x17, 0x3))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf17Subleaf3>(&mut entry.result) }),
         )
     }
@@ -366,16 +494,22 @@ impl IndexLeaf<0x18> for IntelCpuid {
         Leaf18(
             self.0
                 .get(&CpuidKey::subleaf(0x18, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
-                .map(|entry| unsafe { transmute::<_, &'a Leaf18Subleaf0>(&entry.result) }),
-            // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
+                .map(|entry: &'a CpuidEntry| unsafe {
+                    transmute::<_, &'a Leaf18Subleaf0>(&entry.result)
+                }),
+            // JUSTIFICATION: There is no safe alternative.
+            // SAFETY: Transmuting references to same size and alignment types is safe. For
+            // further information See `index_leaf!`.
             unsafe {
-                transmute_vec(
-                    self.0
-                        .range(CpuidKey::subleaf(0x18, 0x1)..CpuidKey::leaf(0x19))
-                        .map(|(_, v)| transmute::<_, &'a Leaf18SubleafGt0>(&v.result))
-                        .collect(),
-                )
+                self.0
+                    .range(CpuidKey::subleaf(0x18, 0x1)..CpuidKey::leaf(0x19))
+                    .map(|(_, v): (_, &'a CpuidEntry)| {
+                        transmute::<_, &'a Leaf18SubleafGt0>(&v.result)
+                    })
+                    .collect()
             },
         )
     }
@@ -386,19 +520,24 @@ impl IndexLeafMut<0x18> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
+        // To ensure safety there must be no mutable access to `self` after this block.
+        // E.g. if we where to insert an element, resulting in re-allocation, it would invalidate
+        // the acquired references.
         Leaf18Mut(
             self.0
                 .get_mut(&CpuidKey::subleaf(0x18, 0x0))
-                // SAFETY: Transmuting reference to same sized types is safe.
+                // JUSTIFICATION: There is no safe alternative.
+                // SAFETY: Transmuting references to same size and alignment types is safe. For
+                // further information See `index_leaf!`.
                 .map(|entry| unsafe { transmute::<_, &'a mut Leaf18Subleaf0>(&mut entry.result) }),
-            // SAFETY: Transmuting reference to same sized types is safe.
+            // JUSTIFICATION: There is no safe alternative.
+            // SAFETY: Transmuting references to same size and alignment types is safe. For
+            // further information See `index_leaf!`.
             unsafe {
-                transmute_vec(
-                    self.0
-                        .range_mut(CpuidKey::subleaf(0x18, 0x1)..CpuidKey::leaf(0x19))
-                        .map(|(_, v)| transmute::<_, &'a mut Leaf18SubleafGt0>(&mut v.result))
-                        .collect(),
-                )
+                self.0
+                    .range_mut(CpuidKey::subleaf(0x18, 0x1)..CpuidKey::leaf(0x19))
+                    .map(|(_, v)| transmute::<_, &'a mut Leaf18SubleafGt0>(&mut v.result))
+                    .collect()
             },
         )
     }
@@ -415,14 +554,14 @@ impl IndexLeaf<0x1F> for IntelCpuid {
 
     #[inline]
     fn index_leaf<'a>(&'a self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         Leaf1F(unsafe {
-            transmute_vec(
-                self.0
-                    .range(CpuidKey::leaf(0x1F)..CpuidKey::leaf(0x20))
-                    .map(|(_, v)| transmute::<_, &'a Leaf1FSubleaf>(&v.result))
-                    .collect(),
-            )
+            self.0
+                .range(CpuidKey::leaf(0x1F)..CpuidKey::leaf(0x20))
+                .map(|(_, v): (_, &'a CpuidEntry)| transmute::<_, &'a Leaf1FSubleaf>(&v.result))
+                .collect()
         })
     }
 }
@@ -432,14 +571,16 @@ impl IndexLeafMut<0x1F> for IntelCpuid {
 
     #[inline]
     fn index_leaf_mut<'a>(&'a mut self) -> Self::Output<'a> {
-        // SAFETY: Transmuting reference to same sized types is safe.
+        // JUSTIFICATION: There is no safe alternative.
+        // SAFETY: Transmuting references to same size and alignment types is safe. For
+        // further information See `index_leaf!`.
         Leaf1FMut(unsafe {
-            transmute_vec(
-                self.0
-                    .range_mut(CpuidKey::leaf(0x1F)..CpuidKey::leaf(0x20))
-                    .map(|(_, v)| transmute::<_, &'a mut Leaf1FSubleaf>(&mut v.result))
-                    .collect(),
-            )
+            self.0
+                .range_mut(CpuidKey::leaf(0x1F)..CpuidKey::leaf(0x20))
+                .map(|(_, v): (_, &'a mut CpuidEntry)| {
+                    transmute::<_, &'a mut Leaf1FSubleaf>(&mut v.result)
+                })
+                .collect()
         })
     }
 }

--- a/src/vmm/src/cpuid/mod.rs
+++ b/src/vmm/src/cpuid/mod.rs
@@ -53,7 +53,7 @@ pub use intel::IntelCpuid;
 
 /// Indexing implementations (shared between AMD and Intel).
 mod indexing;
-pub(crate) use indexing::{index_leaf, transmute_vec};
+pub(crate) use indexing::index_leaf;
 pub use indexing::{IndexLeaf, IndexLeafMut};
 
 /// Leaf structs (shared between AMD and Intel).
@@ -85,6 +85,18 @@ pub const VENDOR_ID_AMD_STR: &str = unsafe { std::str::from_utf8_unchecked(VENDO
 /// To store the brand string we have 3 leaves, each with 4 registers, each with 4 bytes.
 pub const BRAND_STRING_LENGTH: usize = 3 * 4 * 4;
 
+/// Mimic of [`std::arch::x86_64::__cpuid`] that wraps [`cpuid_count`].
+fn cpuid(leaf: u32) -> std::arch::x86_64::CpuidResult {
+    cpuid_count(leaf, 0)
+}
+
+/// Safe wrapper around [`std::arch::x86_64::__cpuid_count`].
+fn cpuid_count(leaf: u32, subleaf: u32) -> std::arch::x86_64::CpuidResult {
+    // JUSTIFICATION: There is no safe alternative.
+    // SAFETY: The `cfg(cpuid)` wrapping the `cpuid` module guarantees `CPUID` is supported.
+    unsafe { std::arch::x86_64::__cpuid_count(leaf, subleaf) }
+}
+
 /// Gets the Intel default brand.
 // As we pass through host frequency, we require CPUID and thus `cfg(cpuid)`.
 /// Gets host brand string.
@@ -100,20 +112,16 @@ pub const BRAND_STRING_LENGTH: usize = 3 * 4 * 4;
 #[inline]
 #[must_use]
 pub fn host_brand_string() -> [u8; BRAND_STRING_LENGTH] {
-    // SAFETY: Safe we check `CPUID` availability with `cfg(cpuid)`.
-    let leaf_a = unsafe { core::arch::x86_64::__cpuid(0x80000002) };
-
-    // SAFETY: Safe we check `CPUID` availability with `cfg(cpuid)`.
-    let leaf_b = unsafe { core::arch::x86_64::__cpuid(0x80000003) };
-
-    // SAFETY: Safe we check `CPUID` availability with `cfg(cpuid)`.
-    let leaf_c = unsafe { core::arch::x86_64::__cpuid(0x80000004) };
+    let leaf_a = cpuid(0x80000002);
+    let leaf_b = cpuid(0x80000003);
+    let leaf_c = cpuid(0x80000004);
 
     let arr = [
         leaf_a.eax, leaf_a.ebx, leaf_a.ecx, leaf_a.edx, leaf_b.eax, leaf_b.ebx, leaf_b.ecx,
         leaf_b.edx, leaf_c.eax, leaf_c.ebx, leaf_c.ecx, leaf_c.edx,
     ];
 
+    // JUSTIFICATION: There is no safe alternative.
     // SAFETY: Transmuting `[u32;12]` to `[u8;BRAND_STRING_LENGTH]` (`[u8;48]`) is always safe.
     unsafe { std::mem::transmute(arr) }
 }
@@ -284,6 +292,7 @@ impl CpuidTrait for kvm_bindings::CpuId {
             .find(|entry| entry.function == *leaf && entry.index == *subleaf);
 
         entry_opt.map(|entry| {
+            // JUSTIFICATION: There is no safe alternative.
             // SAFETY: The `kvm_cpuid_entry2` and `CpuidEntry` are `repr(C)` with known sizes.
             unsafe {
                 let arr: &[u8; size_of::<kvm_bindings::kvm_cpuid_entry2>()] = transmute(entry);
@@ -303,6 +312,7 @@ impl CpuidTrait for kvm_bindings::CpuId {
             .iter_mut()
             .find(|entry| entry.function == *leaf && entry.index == *subleaf);
         entry_opt.map(|entry| {
+            // JUSTIFICATION: There is no safe alternative.
             // SAFETY: The `kvm_cpuid_entry2` and `CpuidEntry` are `repr(C)` with known sizes.
             unsafe {
                 let arr: &mut [u8; size_of::<kvm_bindings::kvm_cpuid_entry2>()] = transmute(entry);

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.57, "AMD": 79.16, "ARM": 82.09}
+    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.09, "ARM": 82.19}
 else:
-    COVERAGE_DICT = {"Intel": 76.06, "AMD": 76.88, "ARM": 79.04}
+    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.13}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Reduce occurrences of the `unsafe` keyword and adds additional documentation where present.

## Reason

Improves documentation on possibly unsafe areas of code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
