### PR TITLE
fix: Move clippy warnings into `.cargo/config`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,11 @@
 [build]
 target-dir = "build/cargo_target"
 target = "x86_64-unknown-linux-musl"
+rustflags = [
+  "-Dclippy::ptr_as_ptr",
+  "-Dclippy::undocumented_unsafe_blocks",
+  "-Dclippy::cast_lossless"
+]
 
 [net]
 git-fetch-with-cli = true

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! Implements the interface for intercepting API requests, forwarding them to the VMM
 //! and responding to the user.
 //! It is constructed on top of an HTTP Server that uses Unix Domain Sockets and `EPOLL` to

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64 and aarch64.
 use std::{fmt, result};

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -6,9 +6,7 @@
 // found in the THIRD-PARTY file.
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! Utility for configuring the CPUID (CPU identification) for the guest microVM.
 
 #![cfg(target_arch = "x86_64")]

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -5,9 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
 //! Emulates virtual and hardware devices.
 use std::io;
 

--- a/src/dumbo/src/lib.rs
+++ b/src/dumbo/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! Provides helper logic for parsing and writing protocol data units, and minimalist
 //! implementations of a TCP listener, a TCP connection, and an HTTP/1.1 server.
 pub mod pdu;

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -1,10 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
-
 mod api_server_adapter;
 mod metrics;
 

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! High-level interface over Linux io_uring.
 //!
 //! Aims to provide an easy-to-use interface, while making some Firecracker-specific simplifying

--- a/src/jailer/src/main.rs
+++ b/src/jailer/src/main.rs
@@ -1,10 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
-
 mod cgroup;
 mod chroot;
 mod env;

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! Crate that implements Firecracker specific functionality as far as logging and metrics
 //! collecting.
 

--- a/src/mmds/src/lib.rs
+++ b/src/mmds/src/lib.rs
@@ -1,10 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
-
 pub mod data_store;
 pub mod ns;
 pub mod persist;

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
+
 //! # Rate Limiter
 //!
 //! Provides a rate limiter written in Rust useful for IO operations that need to

--- a/src/rebase-snap/src/main.rs
+++ b/src/rebase-snap/src/main.rs
@@ -1,10 +1,6 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
-
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
 use std::os::unix::io::AsRawFd;

--- a/src/seccompiler/src/lib.rs
+++ b/src/seccompiler/src/lib.rs
@@ -1,9 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
 
 //! The library crate that defines common helper functions that are generally used in
 //! conjunction with seccompiler-bin.

--- a/src/snapshot/src/lib.rs
+++ b/src/snapshot/src/lib.rs
@@ -1,9 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 #![deny(missing_docs)]
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
 
 //! Provides version tolerant serialization and deserialization facilities and
 //! implements a persistent storage format for Firecracker state snapshots.

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,10 +1,6 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::ptr_as_ptr)]
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(clippy::cast_lossless)]
-
 // We use `utils` as a wrapper over `vmm_sys_util` to control the latter
 // dependency easier (i.e. update only in one place `vmm_sys_util` version).
 // More specifically, we are re-exporting modules from `vmm_sys_util` as part

--- a/src/vm-memory/src/lib.rs
+++ b/src/vm-memory/src/lib.rs
@@ -4,7 +4,6 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 use std::io::Error as IoError;
 use std::os::unix::io::AsRawFd;
@@ -103,7 +102,7 @@ fn build_guarded_region(
     // SAFETY: Safe because the parameters are valid.
     unsafe {
         MmapRegionBuilder::new_with_bitmap(size, bitmap)
-            .with_raw_mmap_pointer(region_addr as *mut u8)
+            .with_raw_mmap_pointer(region_addr.cast::<u8>())
             .with_mmap_prot(prot)
             .with_mmap_flags(flags)
             .build()

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -9,7 +9,6 @@
 //! and other virtualization features to run a single lightweight micro-virtual
 //! machine (microVM).
 #![deny(missing_docs)]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -642,7 +642,7 @@ fn guest_memory_from_uffd(
         let host_base_addr = mem_region.as_ptr();
         let size = mem_region.size();
 
-        uffd.register(host_base_addr as _, size as _)
+        uffd.register(host_base_addr.cast(), size as _)
             .map_err(GuestMemoryFromUffdError::Register)?;
         backend_mappings.push(GuestRegionUffdMapping {
             base_host_virt_addr: host_base_addr as u64,


### PR DESCRIPTION
## Changes
Collected clippy warnings in the `.cargo/config`.

## Reason
Keeps clippy lints consistent across crates

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
