### PR TITLE
Output metrics from performance tests

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Common helpers to create Buildkite pipelines
+"""
+
+DEFAULT_INSTANCES = [
+    "m5d.metal",
+    "m6i.metal",
+    "m6a.metal",
+    "m6g.metal",
+]
+
+DEFAULT_KERNELS = ["linux_4.14", "linux_5.10"]
+
+
+def group(label, command, instances, kernels, agent_tags=None, **kwargs):
+    """
+    Generate a group step with specified parameters, for each instance+kernel
+    combination
+
+    https://buildkite.com/docs/pipelines/group-step
+    """
+    if agent_tags is None:
+        agent_tags = []
+    # Use the 1st character of the group name (should be an emoji)
+    label1 = label[0]
+    steps = []
+    for instance in instances:
+        for kv in kernels:
+            agents = [f"instance={instance}", f"kv={kv}"] + agent_tags
+            step = {
+                "command": command,
+                "label": f"{label1} {instance} {kv}",
+                "agents": agents,
+                **kwargs,
+            }
+            steps.append(step)
+
+    return {"group": label, "steps": steps}

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite performance pipelines dynamically"""
+
+import argparse
+import json
+
+from common import group, DEFAULT_INSTANCES, DEFAULT_KERNELS
+
+perf_test = {
+    "block": [
+        {
+            "label": "🖴 Block Performance - Sync",
+            "test_path": "integration_tests/performance/test_block_performance.py::test_block_performance_sync",
+            "devtool_opts": "-r 16834m -c 1-10 -m 0",
+            "timeout_in_minutes": 120,
+        },
+        {
+            "label": "🖴 Block Performance - Async",
+            "test_path": "integration_tests/performance/test_block_performance.py::test_block_performance_async",
+            "devtool_opts": "-r 16834m -c 1-10 -m 0",
+            "kernels": ["linux_5.10"],
+            "timeout_in_minutes": 120,
+        },
+    ],
+    "snapshot-latency": {
+        "label": "📸 Snapshot Latency",
+        "test_path": "integration_tests/performance/test_snapshot_restore_performance.py",
+        "devtool_opts": "-c 1-12 -m 0",
+        "timeout_in_minutes": 45,
+    },
+    "vsock-throughput": {
+        "label": "🧦 Vsock Throughput",
+        "test_path": "integration_tests/performance/test_vsock_throughput.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 20,
+    },
+    "network-latency": {
+        "label": "🖧 Network Latency",
+        "test_path": "integration_tests/performance/test_network_latency.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 10,
+    },
+    "network-throughput": {
+        "label": "🖧 Network TCP Throughput",
+        "test_path": "integration_tests/performance/test_network_tcp_throughput.py",
+        "devtool_opts": "-c 1-10 -m 0",
+        "timeout_in_minutes": 45,
+    },
+}
+
+
+def build_group(test):
+    """Build a Buildkite pipeline `group` step"""
+    devtool_opts = test.pop("devtool_opts")
+    test_path = test.pop("test_path")
+    return group(
+        label=test.pop("label"),
+        command=f"./tools/devtool -y test {devtool_opts} -- --nonci -s --dump-results-to-file --log-cli-level=INFO {test_path}",
+        agent_tags=["ag=1"],
+        artifacts=["./test_results/*"],
+        instances=test.pop("instances"),
+        kernels=test.pop("kernels"),
+        # and the rest can be command arguments
+        **test
+    )
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--test",
+    required=True,
+    choices=list(perf_test.keys()),
+    help="performance test"
+)
+parser.add_argument(
+    "--add-instance",
+    required=False,
+    action="append",
+    default=DEFAULT_INSTANCES,
+)
+args = parser.parse_args()
+if not args.add_instance:
+    args.add_instance = DEFAULT_INSTANCES
+group_steps = []
+tests = perf_test[args.test]
+if isinstance(tests, dict):
+    tests = [tests]
+for test_data in tests:
+    test_data.setdefault("kernels", DEFAULT_KERNELS)
+    test_data.setdefault("instances", args.add_instance)
+    group_steps.append(build_group(test_data))
+
+
+pipeline = {
+    "env": {
+        "AWS_EMF_SERVICE_NAME": "PerfTests",
+        "AWS_EMF_NAMESPACE": "PerfTests",
+    },
+    "agents": {"queue": "public-prod-us-east-1"},
+    "steps": group_steps
+}
+print(json.dumps(pipeline, indent=4, sort_keys=True, ensure_ascii=False))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -576,36 +576,38 @@ def firecracker_artifacts(*args, **kwargs):
 
 
 @pytest.fixture(params=firecracker_artifacts(), ids=firecracker_id)
-def firecracker_release(request):
+def firecracker_release(request, record_property):
     """Return all supported firecracker binaries."""
     firecracker = request.param
+    record_property("firecracker_release", firecracker.version)
     firecracker.download()
     firecracker.jailer().download()
     return firecracker
 
 
 @pytest.fixture(params=ARTIFACTS_COLLECTION.kernels(), ids=lambda kernel: kernel.name())
-def guest_kernel(request):
+def guest_kernel(request, record_property):
     """Return all supported guest kernels."""
     kernel = request.param
+    record_property("guest_kernel", kernel.name())
     kernel.download()
     return kernel
 
 
-@pytest.fixture(
-    params=ARTIFACTS_COLLECTION.disks("ubuntu"), ids=lambda rootfs: rootfs.name()
-)
-def rootfs(request):
+@pytest.fixture(params=ARTIFACTS_COLLECTION.disks("ubuntu"), ids=lambda fs: fs.name())
+def rootfs(request, record_property):
     """Return all supported rootfs."""
-    rootfs = request.param
-    rootfs.download()
-    rootfs.ssh_key().download()
-    return rootfs
+    fs = request.param
+    record_property("rootfs", fs.name())
+    fs.download()
+    fs.ssh_key().download()
+    return fs
 
 
 @pytest.fixture(params=SUPPORTED_CPU_TEMPLATES)
-def cpu_template(request):
+def cpu_template(request, record_property):
     """Return all CPU templates supported by the vendor."""
+    record_property("cpu_template", request.param)
     return request.param
 
 

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -89,9 +89,9 @@ class Microvm:
         self._path = os.path.join(resource_path, microvm_id)
         self._kernel_path = os.path.join(self._path, MICROVM_KERNEL_RELPATH)
         self._fsfiles_path = os.path.join(self._path, MICROVM_FSFILES_RELPATH)
-        self._kernel_file = ""
-        self._rootfs_file = ""
-        self._initrd_file = ""
+        self.kernel_file = ""
+        self.rootfs_file = ""
+        self.initrd_file = ""
 
         # The binaries this microvm will use to start.
         self._fc_binary_path = fc_binary_path
@@ -100,7 +100,7 @@ class Microvm:
         assert os.path.exists(self._jailer_binary_path)
 
         # Create the jailer context associated with this microvm.
-        self._jailer = JailerContext(
+        self.jailer = JailerContext(
             jailer_id=self._microvm_id,
             exec_file=self._fc_binary_path,
         )
@@ -152,7 +152,7 @@ class Microvm:
         # hostname is set from the MAC address used to configure the microVM.
         self._ssh_config = {
             "username": "root",
-            "netns_file_path": self._jailer.netns_file_path(),
+            "netns_file_path": self.jailer.netns_file_path(),
         }
 
         # Deal with memory monitoring.
@@ -162,7 +162,7 @@ class Microvm:
         # Cpu load monitoring has to be explicitly enabled using
         # the `enable_cpu_load_monitor` method.
         self._cpu_load_monitor = None
-        self._vcpus_count = None
+        self.vcpus_count = None
 
         # External clone/exec tool, because Python can't into clone
         self.bin_cloner_path = bin_cloner_path
@@ -171,7 +171,7 @@ class Microvm:
         self.expect_kill_by_signal = False
 
         # MMDS content from file
-        self._metadata_file = None
+        self.metadata_file = None
 
     def kill(self):
         """All clean up associated with this microVM should go here."""
@@ -188,7 +188,7 @@ class Microvm:
             # as well as an intentional eye-sore in the test report.
             LOG.error(self.log_data)
 
-        if self._jailer.daemonize:
+        if self.jailer.daemonize:
             if self.jailer_clone_pid:
                 utils.run_cmd(
                     "kill -9 {}".format(self.jailer_clone_pid), ignore_return_code=True
@@ -246,36 +246,6 @@ class Microvm:
         return self._microvm_id
 
     @property
-    def jailer(self):
-        """Return the jailer context associated with this microVM."""
-        return self._jailer
-
-    @jailer.setter
-    def jailer(self, jailer):
-        """Setter for associating a different jailer to the default one."""
-        self._jailer = jailer
-
-    @property
-    def kernel_file(self):
-        """Return the name of the kernel file used by this microVM to boot."""
-        return self._kernel_file
-
-    @kernel_file.setter
-    def kernel_file(self, path):
-        """Set the path to the kernel file."""
-        self._kernel_file = path
-
-    @property
-    def initrd_file(self):
-        """Return the name of the initrd file used by this microVM to boot."""
-        return self._initrd_file
-
-    @initrd_file.setter
-    def initrd_file(self, path):
-        """Set the path to the initrd file."""
-        self._initrd_file = path
-
-    @property
     def log_data(self):
         """Return the log data.
 
@@ -287,16 +257,6 @@ class Microvm:
         return log_data
 
     @property
-    def rootfs_file(self):
-        """Return the path to the image this microVM can boot into."""
-        return self._rootfs_file
-
-    @rootfs_file.setter
-    def rootfs_file(self, path):
-        """Set the path to the image associated."""
-        self._rootfs_file = path
-
-    @property
     def fsfiles(self):
         """Path to filesystem used by this microvm to attach new drives."""
         return self._fsfiles_path
@@ -305,21 +265,6 @@ class Microvm:
     def ssh_config(self):
         """Get the ssh configuration used to ssh into some microVMs."""
         return self._ssh_config
-
-    @ssh_config.setter
-    def ssh_config(self, key, value):
-        """Set the dict values inside this configuration."""
-        setattr(self._ssh_config, key, value)
-
-    @property
-    def metadata_file(self):
-        """Return the path to a file used for populating MMDS."""
-        return self._metadata_file
-
-    @metadata_file.setter
-    def metadata_file(self, path):
-        """Set the path to a file to use for populating MMDS."""
-        self._metadata_file = path
 
     @property
     def memory_monitor(self):
@@ -465,16 +410,6 @@ class Microvm:
         """Get the screen PID."""
         return self._screen_pid
 
-    @property
-    def vcpus_count(self):
-        """Get the vcpus count."""
-        return self._vcpus_count
-
-    @vcpus_count.setter
-    def vcpus_count(self, vcpus_count: int):
-        """Set the vcpus count."""
-        self._vcpus_count = vcpus_count
-
     def pin_vmm(self, cpu_id: int) -> bool:
         """Pin the firecracker process VMM thread to a cpu list."""
         if self.jailer_clone_pid:
@@ -515,8 +450,8 @@ class Microvm:
     ):
         """Start a microVM as a daemon or in a screen session."""
         # pylint: disable=subprocess-run-check
-        self._jailer.setup(use_ramdisk=use_ramdisk)
-        self._api_socket = self._jailer.api_socket_path()
+        self.jailer.setup(use_ramdisk=use_ramdisk)
+        self._api_socket = self.jailer.api_socket_path()
         self._api_session = Session()
 
         self.actions = Actions(self._api_socket, self._api_session)
@@ -562,7 +497,7 @@ class Microvm:
                 {"metadata": os.path.basename(self.metadata_file)}
             )
 
-        jailer_param_list = self._jailer.construct_param_list()
+        jailer_param_list = self.jailer.construct_param_list()
 
         # When the daemonize flag is on, we want to clone-exec into the
         # jailer rather than executing it via spawning a shell. Going
@@ -574,7 +509,7 @@ class Microvm:
         # 1) Python doesn't provide os.clone() interface, and
         # 2) Python's ctypes libc interface appears to be broken, causing
         # our clone / exec to deadlock at some point.
-        if self._jailer.daemonize:
+        if self.jailer.daemonize:
             self.daemonize_jailer(jailer_param_list)
         else:
             # This file will collect any output from 'screen'ed Firecracker.
@@ -593,7 +528,7 @@ class Microvm:
         # We expect the jailer to start within 80 ms. However, we wait for
         # 1 sec since we are rechecking the existence of the socket 5 times
         # and leave 0.2 delay between them.
-        if "no-api" not in self._jailer.extra_args:
+        if "no-api" not in self.jailer.extra_args:
             self._wait_create()
         if create_logger:
             self.check_log_message("Running Firecracker")
@@ -601,7 +536,7 @@ class Microvm:
     @retry(delay=0.2, tries=5)
     def _wait_create(self):
         """Wait until the API socket and chroot folder are available."""
-        os.stat(self._jailer.api_socket_path())
+        os.stat(self.jailer.api_socket_path())
 
     @retry(delay=0.1, tries=5)
     def check_log_message(self, message):
@@ -808,7 +743,7 @@ class Microvm:
         """Create tap device and configure ssh."""
         assert tapname is not None
         tap = net_tools.Tap(
-            tapname, self._jailer.netns, ip="{}/{}".format(host_ip, netmask_len)
+            tapname, self.jailer.netns, ip="{}/{}".format(host_ip, netmask_len)
         )
         self.config_ssh(guest_ip)
         return tap

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -18,6 +18,7 @@ import select
 import shutil
 import time
 import weakref
+from functools import cached_property
 from pathlib import Path
 
 from threading import Lock
@@ -830,6 +831,11 @@ class Microvm:
         )
         assert response.ok
         return True
+
+    @cached_property
+    def ssh(self):
+        """Return a cached SSH connection"""
+        return net_tools.SSHConnection(self.ssh_config)
 
     def start_console_logger(self, log_fifo):
         """

--- a/tests/framework/properties.py
+++ b/tests/framework/properties.py
@@ -1,26 +1,96 @@
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint:disable=broad-except
+# pylint:disable=too-few-public-methods
+
 """
 Metadata we want to attach to tests for further analysis and troubleshooting
 """
 
 import platform
+import re
 import subprocess
+from pathlib import Path
 
-from framework.utils_cpuid import get_cpu_model_name
+from framework.utils_imdsv2 import imdsv2_get
+from framework.utils_cpuid import get_cpu_model_name, get_cpu_vendor
 
 
 def run_cmd(cmd):
     """Return the stdout of a command"""
-    stdout = subprocess.check_output(cmd, shell=True).decode().strip()
-    return stdout
+    return subprocess.check_output(cmd, shell=True).decode().strip()
 
 
-GLOBAL_PROPS = {
-    "architecture": platform.machine(),
-    "host_linux_kernel": platform.release(),
-    "libc_ver": "-".join(platform.libc_ver()),
-    "cpu_model": get_cpu_model_name(),
-    "commit_id": run_cmd("git rev-parse HEAD"),
-}
+def get_kernel_version(level):
+    """Return the current kernel version in format `major.minor.patch`."""
+    linux_version = platform.release()
+    # 5.15.0-56-generic
+    # major, minor, patch
+    mmp = linux_version.split("-")[0].split(".")
+    return ".".join(mmp[:level])
+
+
+def get_os_version():
+    """Get the OS version
+
+    >>> get_os_version()
+    Ubuntu 18.04.6 LTS
+    """
+
+    os_release = Path("/etc/os-release").read_text(encoding="ascii")
+    match = re.search('PRETTY_NAME="(.*)"', os_release)
+    return match.group(1)
+
+
+class GlobalProps:
+    """Class to hold metadata about the testrun environment"""
+
+    def __init__(self):
+        self.cpu_architecture: str = platform.machine()
+        self.cpu_model = get_cpu_model_name()
+        self.cpu_vendor = get_cpu_vendor().name.lower()
+        self.cpu_microcode = run_cmd(
+            "grep microcode /proc/cpuinfo |head -1 |awk '{print $3}'"
+        )
+        self.host_linux_full_version = platform.release()
+        # major.minor
+        self.host_linux_version = get_kernel_version(2)
+        # major.minor.patch
+        self.host_linux_patch = get_kernel_version(3)
+        self.os = get_os_version()
+        self.libc_ver = "-".join(platform.libc_ver())
+        self.git_commit_id = run_cmd("git rev-parse HEAD")
+        self.git_branch = run_cmd("git show -s --pretty=%D HEAD")
+        self.git_origin_url = run_cmd("git config --get remote.origin.url")
+        self.rust_version = run_cmd("rustc --version |awk '{print $2}'")
+
+        self.environment = self._detect_environment()
+        if self.is_ec2:
+            self.instance = imdsv2_get("/meta-data/instance-type")
+            self.ami = imdsv2_get("/meta-data/ami-id")
+        else:
+            self.instance = "NA"
+            self.ami = "NA"
+
+    @property
+    def is_ec2(self):
+        """Are we running on an EC2 instance?"""
+        return self.environment == "ec2"
+
+    def _detect_environment(self):
+        """Detect what kind of environment we are running under
+
+        The most reliable way is to just query IMDSv2
+        https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+        """
+
+        try:
+            imdsv2_get("/meta-data/instance-type")
+            return "ec2"
+        except Exception:
+            return "local"
+
+
+global_props = GlobalProps()
+# TBD could do a props fixture for tests to use...

--- a/tests/framework/utils_cpuid.py
+++ b/tests/framework/utils_cpuid.py
@@ -9,7 +9,6 @@ from enum import Enum, auto
 
 from framework.utils import run_cmd
 from framework.utils_imdsv2 import imdsv2_get
-import host_tools.network as net_tools
 
 ARM_CPU_DICT = {"0xd0c": "ARM_NEOVERSE_N1", "0xd40": "ARM_NEOVERSE_V1"}
 
@@ -56,8 +55,7 @@ def check_guest_cpuid_output(
     vm, guest_cmd, expected_header, expected_separator, expected_key_value_store
 ):
     """Parse cpuid output inside guest and match with expected one."""
-    ssh_connection = net_tools.SSHConnection(vm.ssh_config)
-    _, stdout, stderr = ssh_connection.execute_command(guest_cmd)
+    _, stdout, stderr = vm.ssh.execute_command(guest_cmd)
 
     assert stderr.read() == ""
     while True:
@@ -127,10 +125,8 @@ def get_guest_cpuid(vm):
      - register ("eax", "ebx", "ecx" or "edx")
     and the value is the register value (integer).
     """
-    ssh_conn = net_tools.SSHConnection(vm.ssh_config)
-
     read_cpuid_cmd = "cpuid -1 --raw | grep -v CPU"
-    _, stdout, stderr = ssh_conn.execute_command(read_cpuid_cmd)
+    _, stdout, stderr = vm.ssh.execute_command(read_cpuid_cmd)
     assert stderr.read() == ""
 
     return build_cpuid_dict(stdout)

--- a/tests/framework/utils_imdsv2.py
+++ b/tests/framework/utils_imdsv2.py
@@ -50,6 +50,7 @@ class IMDSv2Client:
         Get a metadata path from IMDSv2
 
         >>> IMDSv2Client().get("/meta-data/instance-type")
+        >>> m5d.metal
         """
         headers = {IMDSV2_HDR_TOKEN: self.get_token()}
         url = f"{self.endpoint}/{self.version}{path}"

--- a/tests/host_tools/metrics.py
+++ b/tests/host_tools/metrics.py
@@ -1,0 +1,91 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixture to send metrics to AWS CloudWatch
+
+We use the aws-embedded-metrics library although it has some sharp corners,
+namely:
+
+1. It uses asyncio, which complicates the flushing a bit.
+
+2. It has an stateful API. Setting dimensions will override previous ones.
+
+Example:
+
+    set_dimensions("instance")
+    put_metric("duration", 1)
+    set_dimensions("cpu")
+    put_metric("duration", 1)
+
+This will end with 2 identical metrics with dimension "cpu" (the last one). The
+correct way of doing it is:
+
+    set_dimensions("instance")
+    put_metric("duration", 1)
+    flush()
+    set_dimensions("cpu")
+    put_metric("duration", 1)
+
+This is not very intuitive, but we assume all metrics within a test will have
+the same dimensions.
+
+# Debugging
+
+You can override the destination of the metrics to stdout with:
+
+    AWS_EMF_NAMESPACE=$USER-test
+    AWS_EMF_ENVIRONMENT=local ./tools/devtest test
+
+# References:
+
+- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+- https://github.com/awslabs/aws-embedded-metrics-python
+"""
+
+import asyncio
+import os
+
+from aws_embedded_metrics.logger.metrics_logger_factory import create_metrics_logger
+
+
+class MetricsWrapperDummy:
+    """Send metrics to /dev/null"""
+
+    def set_dimensions(self, *args, **kwargs):
+        """Set dimensions"""
+
+    def put_metric(self, *args, **kwargs):
+        """Put a datapoint with given dimensions"""
+
+    def set_property(self, *args, **kwargs):
+        """Set a property"""
+
+    def flush(self):
+        """Flush any remaining metrics"""
+
+
+class MetricsWrapper:
+    """A convenient metrics logger"""
+
+    def __init__(self, logger):
+        self.logger = logger
+
+    def __getattr__(self, attr):
+        """Dispatch methods to logger instance"""
+        if attr not in self.__dict__:
+            return getattr(self.logger, attr)
+        return getattr(self, attr)
+
+    def flush(self):
+        """Flush any remaining metrics"""
+        asyncio.run(self.logger.flush())
+
+
+def get_metrics_logger():
+    """Get a new metrics logger object"""
+    # if no metrics namespace, don't output metrics
+    if "AWS_EMF_NAMESPACE" not in os.environ:
+        return MetricsWrapperDummy()
+    logger = create_metrics_logger()
+    logger.reset_dimensions(False)
+    return MetricsWrapper(logger)

--- a/tests/host_tools/network.py
+++ b/tests/host_tools/network.py
@@ -41,6 +41,8 @@ class SSHConnection:
         exit_code, stdout, stderr = self._exec(cmd_string)
         return exit_code, StringIO(stdout), StringIO(stderr)
 
+    run = execute_command
+
     def scp_file(self, local_path, remote_path):
         """Copy a files to the VM using scp."""
         cmd = (

--- a/tests/integration_tests/build/test_binary_size.py
+++ b/tests/integration_tests/build/test_binary_size.py
@@ -34,7 +34,7 @@ BINARY_SIZE_TOLERANCE = 0.05
 
 
 @pytest.mark.timeout(500)
-def test_firecracker_binary_size(record_property):
+def test_firecracker_binary_size(record_property, metrics):
     """
     Test if the size of the firecracker binary is within expected ranges.
 
@@ -53,10 +53,12 @@ def test_firecracker_binary_size(record_property):
         "firecracker_binary_size",
         f"{result}B ({FC_BINARY_SIZE_TARGET}B ±{BINARY_SIZE_TOLERANCE:.0%})",
     )
+    metrics.set_dimensions({"cpu_arch": MACHINE})
+    metrics.put_metric("firecracker_binary_size", result, unit="Bytes")
 
 
 @pytest.mark.timeout(500)
-def test_jailer_binary_size(record_property):
+def test_jailer_binary_size(record_property, metrics):
     """
     Test if the size of the jailer binary is within expected ranges.
 
@@ -75,6 +77,8 @@ def test_jailer_binary_size(record_property):
         "jailer_binary_size",
         f"{result}B ({JAILER_BINARY_SIZE_TARGET}B ±{BINARY_SIZE_TOLERANCE:.0%})",
     )
+    metrics.set_dimensions({"cpu_arch": MACHINE})
+    metrics.put_metric("jailer_binary_size", result, unit="Bytes")
 
 
 def check_binary_size(name, binary_path, size_target, tolerance):

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -43,7 +43,7 @@ COVERAGE_MAX_DELTA = 0.05
 
 
 @pytest.mark.timeout(400)
-def test_coverage(monkeypatch, record_property):
+def test_coverage(monkeypatch, record_property, metrics):
     """Test code coverage
 
     @type: build
@@ -100,6 +100,8 @@ def test_coverage(monkeypatch, record_property):
     record_property(
         "coverage", f"{coverage}% {coverage_target}% ±{COVERAGE_MAX_DELTA:.2f}%"
     )
+    metrics.set_dimensions({"cpu_arch": ARCH})
+    metrics.put_metric("code_coverage", coverage, unit="Percent")
 
     assert coverage == pytest.approx(
         coverage_target, abs=COVERAGE_MAX_DELTA

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -91,10 +91,8 @@ def test_drive_io_engine(test_microvm_with_api, network_config):
 
     test_microvm.start()
 
-    ssh_conn = net_tools.SSHConnection(test_microvm.ssh_config)
-
     # Execute a simple command to check that the guest booted successfully.
-    rc, _, stderr = ssh_conn.execute_command("sync")
+    rc, _, stderr = test_microvm.ssh.execute_command("sync")
     assert rc == 0
     assert stderr.read() == ""
 

--- a/tests/integration_tests/functional/test_concurrency.py
+++ b/tests/integration_tests/functional/test_concurrency.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Ensure multiple microVMs work correctly when spawned simultaneously."""
 
-import host_tools.network as net_tools
-
 NO_OF_MICROVMS = 20
 
 
@@ -23,4 +21,4 @@ def test_run_concurrency(microvm_factory, network_config, guest_kernel, rootfs):
 
         # We check that the vm is running by testing that the ssh does
         # not time out.
-        net_tools.SSHConnection(microvm.ssh_config)
+        microvm.ssh.run("true")

--- a/tests/integration_tests/functional/test_drives.py
+++ b/tests/integration_tests/functional/test_drives.py
@@ -8,7 +8,6 @@ import platform
 from framework import utils
 
 import host_tools.drive as drive_tools
-import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.logging as log_tools
 
 PARTUUID = {"x86_64": "f647d602-01", "aarch64": "69d7c052-01"}
@@ -43,19 +42,18 @@ def test_rescan_file(test_microvm_with_api, network_config):
 
     test_microvm.start()
 
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-    _check_block_size(ssh_connection, "/dev/vdb", fs.size())
+    _check_block_size(test_microvm.ssh, "/dev/vdb", fs.size())
 
     # Check if reading from the entire disk results in a file of the same size
     # or errors out, after a truncate on the host.
     truncated_size = block_size // 2
     utils.run_cmd(f"truncate --size {truncated_size}M {fs.path}")
     block_copy_name = "dev_vdb_copy"
-    _, _, stderr = ssh_connection.execute_command(
+    _, _, stderr = test_microvm.ssh.execute_command(
         f"dd if=/dev/vdb of={block_copy_name} bs=1M count={block_size}"
     )
     assert "dd: error reading '/dev/vdb': Input/output error" in stderr.read()
-    _check_file_size(ssh_connection, f"{block_copy_name}", truncated_size * MB)
+    _check_file_size(test_microvm.ssh, f"{block_copy_name}", truncated_size * MB)
 
     response = test_microvm.drive.patch(
         drive_id="scratch",
@@ -63,7 +61,7 @@ def test_rescan_file(test_microvm_with_api, network_config):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    _check_block_size(ssh_connection, "/dev/vdb", fs.size())
+    _check_block_size(test_microvm.ssh, "/dev/vdb", fs.size())
 
 
 def test_device_ordering(test_microvm_with_api, network_config):
@@ -112,7 +110,7 @@ def test_device_ordering(test_microvm_with_api, network_config):
     # However, the rootfs is the root device and goes first,
     # so we expect to see this order: rootfs, fs1, fs2.
     # The devices are identified by their size.
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
     _check_block_size(ssh_connection, "/dev/vda", rootfs_size)
     _check_block_size(ssh_connection, "/dev/vdb", fs1.size())
     _check_block_size(ssh_connection, "/dev/vdc", fs2.size())
@@ -141,9 +139,7 @@ def test_rescan_dev(test_microvm_with_api, network_config):
 
     test_microvm.start()
 
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-
-    _check_block_size(ssh_connection, "/dev/vdb", fs1.size())
+    _check_block_size(test_microvm.ssh, "/dev/vdb", fs1.size())
 
     fs2 = drive_tools.FilesystemFile(
         os.path.join(test_microvm.fsfiles, "fs2"), size=512
@@ -161,7 +157,7 @@ def test_rescan_dev(test_microvm_with_api, network_config):
         )
         assert session.is_status_no_content(response.status_code)
 
-        _check_block_size(ssh_connection, "/dev/vdb", fs2.size())
+        _check_block_size(test_microvm.ssh, "/dev/vdb", fs2.size())
     finally:
         if loopback_device:
             utils.run_cmd(["losetup", "--detach", loopback_device])
@@ -305,13 +301,11 @@ def test_patch_drive(test_microvm_with_api, network_config):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-
     # The `lsblk` command should output 2 lines to STDOUT: "SIZE" and the size
     # of the device, in bytes.
     blksize_cmd = "lsblk -b /dev/vdb --output SIZE"
     size_bytes_str = "536870912"  # = 512 MiB
-    _, stdout, stderr = ssh_connection.execute_command(blksize_cmd)
+    _, stdout, stderr = test_microvm.ssh.execute_command(blksize_cmd)
     assert stderr.read() == ""
     stdout.readline()  # skip "SIZE"
     assert stdout.readline().strip() == size_bytes_str
@@ -352,9 +346,8 @@ def test_no_flush(test_microvm_with_api, network_config):
     assert fc_metrics["block"]["flush_count"] == 0
 
     # Have the guest drop the caches to generate flush requests.
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
     cmd = "sync; echo 1 > /proc/sys/vm/drop_caches"
-    _, _, stderr = ssh_connection.execute_command(cmd)
+    _, _, stderr = test_microvm.ssh.execute_command(cmd)
     assert stderr.read() == ""
 
     # Verify all flush commands were ignored even after
@@ -395,9 +388,8 @@ def test_flush(test_microvm_with_api, network_config):
     test_microvm.start()
 
     # Have the guest drop the caches to generate flush requests.
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
     cmd = "sync; echo 1 > /proc/sys/vm/drop_caches"
-    _, _, stderr = ssh_connection.execute_command(cmd)
+    _, _, stderr = test_microvm.ssh.execute_command(cmd)
     assert stderr.read() == ""
 
     # On average, dropping the caches right after boot generates
@@ -507,14 +499,13 @@ def test_patch_drive_limiter(test_microvm_with_api, network_config):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     # Validate IOPS stays within above configured limits.
     # For example, the below call will validate that reading 1000 blocks
     # of 512b will complete in at 0.8-1.2 seconds ('dd' is not very accurate,
     # so we target to stay within 30% error).
-    check_iops_limit(ssh_connection, 512, 1000, 0.7, 1.3)
-    check_iops_limit(ssh_connection, 4096, 1000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 512, 1000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 4096, 1000, 0.7, 1.3)
 
     # Patch ratelimiter
     response = test_microvm.drive.patch(
@@ -526,8 +517,8 @@ def test_patch_drive_limiter(test_microvm_with_api, network_config):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    check_iops_limit(ssh_connection, 512, 2000, 0.7, 1.3)
-    check_iops_limit(ssh_connection, 4096, 2000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 512, 2000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 4096, 2000, 0.7, 1.3)
 
     # Patch ratelimiter
     response = test_microvm.drive.patch(
@@ -535,8 +526,8 @@ def test_patch_drive_limiter(test_microvm_with_api, network_config):
     )
     assert test_microvm.api_session.is_status_no_content(response.status_code)
 
-    check_iops_limit(ssh_connection, 512, 10000, 0.7, 1.3)
-    check_iops_limit(ssh_connection, 4096, 10000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 512, 10000, 0.7, 1.3)
+    check_iops_limit(test_microvm.ssh, 4096, 10000, 0.7, 1.3)
 
 
 def _check_block_size(ssh_connection, dev_path, size):
@@ -568,8 +559,6 @@ def _process_blockdev_output(blockdev_out, assert_dict, keys_array):
 
 
 def _check_drives(test_microvm, assert_dict, keys_array):
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-
-    _, stdout, stderr = ssh_connection.execute_command("blockdev --report")
+    _, stdout, stderr = test_microvm.ssh.execute_command("blockdev --report")
     assert stderr.read() == ""
     _process_blockdev_output(stdout.read(), assert_dict, keys_array)

--- a/tests/integration_tests/functional/test_feat_parity.py
+++ b/tests/integration_tests/functional/test_feat_parity.py
@@ -10,7 +10,6 @@ from framework.artifacts import DiskArtifact
 from framework.builder import MicrovmBuilder
 import framework.utils_cpuid as cpuid_utils
 from framework.utils_cpu_templates import SUPPORTED_CPU_TEMPLATES
-import host_tools.network as net_tools
 
 
 # CPU templates designed to provide instruction set feature parity
@@ -320,10 +319,9 @@ def test_feat_parity_msr_arch_cap(
     vm = create_vm(vm_builder, inst_set_cpu_template, microvm, guest_kernel, disk)
     vm.start()
 
-    ssh_conn = net_tools.SSHConnection(vm.ssh_config)
     arch_capabilities_addr = "0x10a"
     rdmsr_cmd = f"rdmsr {arch_capabilities_addr}"
-    _, stdout, stderr = ssh_conn.execute_command(rdmsr_cmd)
+    _, stdout, stderr = vm.ssh.execute_command(rdmsr_cmd)
 
     if inst_set_cpu_template == "T2CL":
         assert stderr.read() == ""

--- a/tests/integration_tests/functional/test_max_devices.py
+++ b/tests/integration_tests/functional/test_max_devices.py
@@ -4,7 +4,6 @@
 
 import platform
 import pytest
-import host_tools.network as net_tools
 
 # IRQs are available from 5 to 23, so the maximum number of devices
 # supported at the same time is 19.
@@ -41,9 +40,8 @@ def test_attach_maximum_devices(test_microvm_with_api, network_config):
     # Test that network devices attached are operational.
     for i in range(MAX_DEVICES_ATTACHED - 1):
         test_microvm.ssh_config["hostname"] = guest_ips[i]
-        ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
         # Verify if guest can run commands.
-        exit_code, _, _ = ssh_connection.execute_command("sync")
+        exit_code, _, _ = test_microvm.ssh.execute_command("sync")
         assert exit_code == 0
 
 

--- a/tests/integration_tests/functional/test_max_vcpus.py
+++ b/tests/integration_tests/functional/test_max_vcpus.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Tests scenario for microvms with max vcpus(32)."""
-import host_tools.network as net_tools  # pylint: disable=import-error
 
 MAX_VCPUS = 32
 
@@ -21,8 +20,7 @@ def test_max_vcpus(test_microvm_with_api, network_config):
 
     microvm.start()
 
-    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
     cmd = "nproc"
-    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _, stdout, stderr = microvm.ssh.execute_command(cmd)
     assert stderr.read() == ""
     assert int(stdout.read()) == MAX_VCPUS

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -725,7 +725,7 @@ def test_mmds_snapshot(bin_cloner_path, version):
         )
 
 
-def test_mmds_older_snapshot(bin_cloner_path):
+def test_mmds_older_snapshot(bin_cloner_path, firecracker_release):
     """
     Test MMDS behavior restoring older snapshots in the current version.
 
@@ -735,55 +735,21 @@ def test_mmds_older_snapshot(bin_cloner_path):
     @type: functional
     """
     vm_builder = MicrovmBuilder(bin_cloner_path)
-
-    # Validate restoring a past snapshot in the current version.
-    artifacts = ArtifactCollection(_test_images_s3_bucket())
-    # Fetch all firecracker binaries.
-    firecracker_artifacts = artifacts.firecrackers(
-        min_version="1.1.0", max_version=get_firecracker_version_from_toml()
+    net_iface = NetIfaceConfig()
+    vm_instance = vm_builder.build_vm_nano(
+        net_ifaces=[net_iface],
+        fc_binary=firecracker_release.local_path(),
+        jailer_binary=firecracker_release.jailer().local_path(),
     )
-    for firecracker in firecracker_artifacts:
-        firecracker.download()
-        jailer = firecracker.jailer()
-        jailer.download()
 
-        net_iface = NetIfaceConfig()
-        vm_instance = vm_builder.build_vm_nano(
-            net_ifaces=[net_iface],
-            fc_binary=firecracker.local_path(),
-            jailer_binary=jailer.local_path(),
-        )
-
-        fc_version = firecracker.base_name()[1:]
-        # If the version is smaller or equal to 1.0.0, we expect that
-        # MMDS will be initialised with V1 by default.
-        # Otherwise, we may configure V2.
-        if compare_versions(fc_version, "1.0.0") <= 0:
-            mmds_version = "V1"
-        else:
-            mmds_version = "V2"
-
-        # Check if we need to configure MMDS the old way, by
-        # setting `allow_mmds_requests`.
-        # If we do (for v0.25), reissue the network PUT api call.
-        if compare_versions(fc_version, "1.0.0") < 0:
-            basevm = vm_instance.vm
-            guest_mac = net_tools.mac_from_ip(net_iface.guest_ip)
-            response = basevm.network.put(
-                iface_id=net_iface.dev_name,
-                host_dev_name=net_iface.tap_name,
-                guest_mac=guest_mac,
-                allow_mmds_requests=True,
-            )
-            assert basevm.api_session.is_status_no_content(response.status_code)
-
-        _validate_mmds_snapshot(
-            vm_instance,
-            vm_builder,
-            mmds_version,
-            net_iface,
-            target_fc_version=fc_version,
-        )
+    mmds_version = "V2"
+    _validate_mmds_snapshot(
+        vm_instance,
+        vm_builder,
+        mmds_version,
+        net_iface,
+        target_fc_version=firecracker_release.snapshot_version,
+    )
 
 
 def test_mmds_v2_negative(test_microvm_with_api, network_config):

--- a/tests/integration_tests/functional/test_mmds.py
+++ b/tests/integration_tests/functional/test_mmds.py
@@ -20,7 +20,6 @@ from framework.utils import (
 )
 from conftest import _test_images_s3_bucket
 
-import host_tools.network as net_tools
 import host_tools.logging as log_tools
 
 # Minimum lifetime of token.
@@ -100,7 +99,7 @@ def _validate_mmds_snapshot(
 
     snapshot_builder = SnapshotBuilder(basevm)
 
-    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
+    ssh_connection = basevm.ssh
     _run_guest_cmd(ssh_connection, f"ip route add {ipv4_address} dev eth0", "")
 
     # Generate token if needed.
@@ -135,7 +134,7 @@ def _validate_mmds_snapshot(
         snapshot, resume=True, fc_binary=fc_path, jailer_binary=jailer_path
     )
 
-    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
+    ssh_connection = microvm.ssh
 
     # Check the reported mmds config. In versions up to (including) v1.0.0 this
     # was not populated after restore.
@@ -229,7 +228,7 @@ def test_custom_ipv4(test_microvm_with_api, network_config, version):
 
     test_microvm.basic_config(vcpu_count=1)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     _run_guest_cmd(ssh_connection, f"ip route add {ipv4_address} dev eth0", "")
 
@@ -304,7 +303,7 @@ def test_json_response(test_microvm_with_api, network_config, version):
 
     test_microvm.basic_config(vcpu_count=1)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     cmd = "ip route add {} dev eth0".format(DEFAULT_IPV4)
     _run_guest_cmd(ssh_connection, cmd, "")
@@ -371,7 +370,7 @@ def test_mmds_response(test_microvm_with_api, network_config, version):
 
     test_microvm.basic_config(vcpu_count=1)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     cmd = "ip route add {} dev eth0".format(DEFAULT_IPV4)
     _run_guest_cmd(ssh_connection, cmd, "")
@@ -440,7 +439,7 @@ def test_larger_than_mss_payloads(test_microvm_with_api, network_config, version
     test_microvm.start()
 
     # Make sure MTU is 1500 bytes.
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     _run_guest_cmd(ssh_connection, "ip link set dev eth0 mtu 1500", "")
 
@@ -564,7 +563,7 @@ def test_guest_mmds_hang(test_microvm_with_api, network_config, version):
 
     test_microvm.basic_config(vcpu_count=1)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     _run_guest_cmd(ssh_connection, f"ip route add {DEFAULT_IPV4} dev eth0", "")
 
@@ -815,7 +814,7 @@ def test_mmds_v2_negative(test_microvm_with_api, network_config):
 
     test_microvm.basic_config(vcpu_count=1)
     test_microvm.start()
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    ssh_connection = test_microvm.ssh
 
     _run_guest_cmd(ssh_connection, f"ip route add {DEFAULT_IPV4} dev eth0", "")
 

--- a/tests/integration_tests/functional/test_net.py
+++ b/tests/integration_tests/functional/test_net.py
@@ -4,7 +4,6 @@
 import time
 
 from framework import utils
-import host_tools.network as net_tools
 
 # The iperf version to run this tests with
 IPERF_BINARY = "iperf3"
@@ -31,8 +30,7 @@ def test_high_ingress_traffic(test_microvm_with_api, network_config):
     test_microvm.start()
 
     # Start iperf3 server on the guest.
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-    ssh_connection.execute_command("{} -sD\n".format(IPERF_BINARY))
+    test_microvm.ssh.execute_command("{} -sD\n".format(IPERF_BINARY))
     time.sleep(1)
 
     # Start iperf3 client on the host. Send 1Gbps UDP traffic.
@@ -49,7 +47,7 @@ def test_high_ingress_traffic(test_microvm_with_api, network_config):
     # Check if the high ingress traffic broke the net interface.
     # If the net interface still works we should be able to execute
     # ssh commands.
-    exit_code, _, _ = ssh_connection.execute_command("echo success\n")
+    exit_code, _, _ = test_microvm.ssh.execute_command("echo success\n")
     assert exit_code == 0
 
 

--- a/tests/integration_tests/functional/test_pause_resume.py
+++ b/tests/integration_tests/functional/test_pause_resume.py
@@ -6,7 +6,6 @@ import os
 from framework.builder import MicrovmBuilder
 from framework.resources import DescribeInstance
 import host_tools.logging as log_tools
-import host_tools.network as net_tools  # pylint: disable=import-error
 
 
 def verify_net_emulation_paused(metrics):
@@ -56,10 +55,8 @@ def test_pause_resume(bin_cloner_path):
     assert microvm.api_session.is_status_no_content(response.status_code)
     microvm.start()
 
-    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
-
     # Verify guest is active.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code == 0
 
     # Pausing the microVM after it's been started is successful.
@@ -70,7 +67,7 @@ def test_pause_resume(bin_cloner_path):
     microvm.flush_metrics(metrics_fifo)
 
     # Verify guest is no longer active.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code != 0
 
     # Verify emulation was indeed paused and no events from either
@@ -78,7 +75,7 @@ def test_pause_resume(bin_cloner_path):
     verify_net_emulation_paused(microvm.flush_metrics(metrics_fifo))
 
     # Verify guest is no longer active.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code != 0
 
     # Pausing the microVM when it is already `Paused` is allowed
@@ -91,7 +88,7 @@ def test_pause_resume(bin_cloner_path):
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     # Verify guest is active again.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code == 0
 
     # Resuming the microVM when it is already `Resumed` is allowed
@@ -100,7 +97,7 @@ def test_pause_resume(bin_cloner_path):
     assert microvm.api_session.is_status_no_content(response.status_code)
 
     # Verify guest is still active.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code == 0
 
     microvm.kill()

--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -4,7 +4,6 @@
 import time
 
 from framework import utils
-import host_tools.network as net_tools  # pylint: disable=import-error
 
 # The iperf version to run this tests with
 IPERF_BINARY = "iperf3"
@@ -423,10 +422,9 @@ def _patch_iface_bw(test_microvm, iface_id, rx_or_tx, new_bucket_size, new_refil
 def _start_iperf_on_guest(test_microvm, hostname):
     """Start iperf in server mode through an SSH connection."""
     test_microvm.ssh_config["hostname"] = hostname
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
 
     iperf_cmd = "{} -sD -f KBytes\n".format(IPERF_BINARY)
-    ssh_connection.execute_command(iperf_cmd)
+    test_microvm.ssh.execute_command(iperf_cmd)
 
     # Wait for the iperf daemon to start.
     time.sleep(1)
@@ -435,8 +433,7 @@ def _start_iperf_on_guest(test_microvm, hostname):
 def _run_iperf_on_guest(test_microvm, iperf_cmd, hostname):
     """Run a client related iperf command through an SSH connection."""
     test_microvm.ssh_config["hostname"] = hostname
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-    _, stdout, stderr = ssh_connection.execute_command(iperf_cmd)
+    _, stdout, stderr = test_microvm.ssh.execute_command(iperf_cmd)
     assert stderr.read() == ""
 
     out = stdout.read()

--- a/tests/integration_tests/functional/test_rtc.py
+++ b/tests/integration_tests/functional/test_rtc.py
@@ -6,7 +6,6 @@ import platform
 import pytest
 
 from framework import utils
-from host_tools.network import SSHConnection
 
 DMESG_LOG_REGEX = r"rtc-pl031\s+(\d+).rtc: setting system clock to"
 
@@ -27,16 +26,14 @@ def test_rtc(test_microvm_with_api, network_config):
     _tap, _, _ = vm.ssh_network_config(network_config, "1")
 
     vm.start()
-    conn = SSHConnection(vm.ssh_config)
-
     # check that the kernel creates an rtcpl031 base device.
-    _, stdout, _ = conn.execute_command("dmesg")
+    _, stdout, _ = vm.ssh.execute_command("dmesg")
     rtc_log = re.findall(DMESG_LOG_REGEX, stdout.read())
     assert rtc_log is not None
 
-    _, stdout, _ = conn.execute_command("stat /dev/rtc0")
+    _, stdout, _ = vm.ssh.execute_command("stat /dev/rtc0")
     assert "character special file" in stdout.read()
 
     _, host_stdout, _ = utils.run_cmd("date +%s")
-    _, guest_stdout, _ = conn.execute_command("date +%s")
+    _, guest_stdout, _ = vm.ssh.execute_command("date +%s")
     assert abs(int(guest_stdout.read()) - int(host_stdout)) < 5

--- a/tests/integration_tests/functional/test_shut_down.py
+++ b/tests/integration_tests/functional/test_shut_down.py
@@ -9,7 +9,6 @@ import platform
 from framework import utils
 
 import host_tools.logging as log_tools
-import host_tools.network as net_tools  # pylint: disable=import-error
 
 
 def test_reboot(test_microvm_with_api, network_config):
@@ -54,9 +53,7 @@ def test_reboot(test_microvm_with_api, network_config):
     assert len(lines) == 1
     # Rebooting Firecracker sends an exit event and should gracefully kill.
     # the instance.
-    ssh_connection = net_tools.SSHConnection(vm.ssh_config)
-
-    ssh_connection.execute_command("reboot")
+    vm.ssh.execute_command("reboot")
 
     while True:
         # Pytest's timeout will kill the test even if the loop doesn't exit.

--- a/tests/integration_tests/functional/test_signals.py
+++ b/tests/integration_tests/functional/test_signals.py
@@ -9,7 +9,6 @@ from time import sleep
 import resource as res
 import pytest
 
-import host_tools.network as net_tools
 from framework import utils
 
 signum_str = {
@@ -155,10 +154,9 @@ def test_handled_signals(test_microvm_with_api, network_config):
     firecracker_pid = int(microvm.jailer_clone_pid)
 
     # Open a SSH connection to validate the microVM stays alive.
-    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
     # Just validate a simple command: `nproc`
     cmd = "nproc"
-    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _, stdout, stderr = microvm.ssh.execute_command(cmd)
     assert stderr.read() == ""
     assert int(stdout.read()) == 2
 
@@ -169,6 +167,6 @@ def test_handled_signals(test_microvm_with_api, network_config):
     os.kill(firecracker_pid, 35)
 
     # Validate the microVM is still up and running.
-    _, stdout, stderr = ssh_connection.execute_command(cmd)
+    _, stdout, stderr = microvm.ssh.execute_command(cmd)
     assert stderr.read() == ""
     assert int(stdout.read()) == 2

--- a/tests/integration_tests/functional/test_snapshot_version.py
+++ b/tests/integration_tests/functional/test_snapshot_version.py
@@ -7,8 +7,6 @@ import pytest
 from framework.artifacts import NetIfaceConfig
 from framework.builder import SnapshotBuilder, MicrovmBuilder
 
-import host_tools.network as net_tools  # pylint: disable=import-error
-
 # Firecracker v0.23 used 16 IRQ lines. For virtio devices,
 # IRQs are available from 5 to 23, so the maximum number
 # of devices allowed at the same time was 11.
@@ -33,9 +31,8 @@ def _create_and_start_microvm_with_net_devices(
     test_microvm.start()
 
     if network_config is not None:
-        ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
         # Verify if guest can run commands.
-        exit_code, _, _ = ssh_connection.execute_command("sync")
+        exit_code, _, _ = test_microvm.ssh.execute_command("sync")
         assert exit_code == 0
 
 
@@ -131,7 +128,7 @@ def test_create_with_newer_virtio_features(bin_cloner_path):
     # we can be sure that the block device was activated.
     iface = NetIfaceConfig()
     test_microvm.ssh_config["hostname"] = iface.guest_ip
-    _ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
+    test_microvm.ssh.run("true")
 
     # Create directory and files for saving snapshot state and memory.
     snapshot_builder = SnapshotBuilder(test_microvm)

--- a/tests/integration_tests/functional/test_topology.py
+++ b/tests/integration_tests/functional/test_topology.py
@@ -9,7 +9,6 @@ from ast import literal_eval
 
 import pytest
 import framework.utils_cpuid as utils
-import host_tools.network as net_tools
 
 TOPOLOGY_STR = {1: "0", 2: "0,1", 16: "0-15"}
 PLATFORM = platform.machine()
@@ -92,8 +91,7 @@ def _check_cache_topology_arm(test_microvm, no_cpus):
 
     cache_files = ["level", "type", "size", "coherency_line_size", "number_of_sets"]
 
-    ssh_connection = net_tools.SSHConnection(test_microvm.ssh_config)
-    _, stdout, stderr = ssh_connection.execute_command(
+    _, stdout, stderr = test_microvm.ssh.execute_command(
         "/usr/local/bin/get_cache_info.sh"
     )
     assert stderr.read() == ""

--- a/tests/integration_tests/functional/test_uffd.py
+++ b/tests/integration_tests/functional/test_uffd.py
@@ -16,8 +16,6 @@ from framework.artifacts import SnapshotMemBackendType
 from framework.builder import MicrovmBuilder, SnapshotBuilder
 from framework.utils import run_cmd, UffdHandler
 
-import host_tools.network as net_tools
-
 SOCKET_PATH = "/firecracker-uffd.sock"
 
 
@@ -36,10 +34,9 @@ def create_snapshot(bin_cloner_path):
     assert basevm.api_session.is_status_no_content(response.status_code)
 
     basevm.start()
-    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
 
     # Verify if guest can run commands.
-    exit_code, _, _ = ssh_connection.execute_command("sync")
+    exit_code, _, _ = basevm.ssh.execute_command("sync")
     assert exit_code == 0
 
     # Create a snapshot builder from a microvm.
@@ -188,8 +185,7 @@ def test_valid_handler(bin_cloner_path, test_microvm_with_api, uffd_handler_path
     assert vm.api_session.is_status_no_content(response.status_code)
 
     # Verify if guest can run commands.
-    ssh_connection = net_tools.SSHConnection(vm.ssh_config)
-    exit_code, _, _ = ssh_connection.execute_command("sync")
+    exit_code, _, _ = vm.ssh.execute_command("sync")
     assert exit_code == 0
 
 

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -27,7 +27,6 @@ from framework.utils import (
 )
 from framework.utils_cpuid import get_cpu_model_name, get_instance_type
 import host_tools.drive as drive_tools
-import host_tools.network as net_tools  # pylint: disable=import-error
 import framework.stats as st
 from integration_tests.performance.configs import defs
 from integration_tests.performance.utils import handle_failure
@@ -389,7 +388,6 @@ def fio_workload(context):
         )
     )
 
-    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
     env_id = (
         f"{context.kernel.name()}/{context.disk.name()}/"
         f"{io_engine.lower()}_{context.microvm.name()}"
@@ -403,7 +401,7 @@ def fio_workload(context):
                 func_kwargs={
                     "env_id": env_id,
                     "basevm": basevm,
-                    "ssh_conn": ssh_connection,
+                    "ssh_conn": basevm.ssh,
                     "mode": mode,
                     "bs": bs,
                 },

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -7,7 +7,7 @@ import re
 import os
 import json
 import pytest
-import host_tools.network as net_tools
+
 from conftest import ARTIFACTS_COLLECTION
 from framework.artifacts import ArtifactSet
 from framework.matrix import TestMatrix, TestContext
@@ -225,7 +225,7 @@ def _g2h_send_ping(context):
         func_kwargs={"requests": context.custom["requests"]},
     )
     cmd = PING.format(context.custom["requests"], interval_between_req, DEFAULT_HOST_IP)
-    prod = producer.SSHCommand(cmd, net_tools.SSHConnection(basevm.ssh_config))
+    prod = producer.SSHCommand(cmd, basevm.ssh)
 
     st_core.add_pipe(producer=prod, consumer=cons, tag=f"{env_id}/ping")
 

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -27,7 +27,6 @@ from framework.utils import (
     DictQuery,
 )
 from framework.utils_cpuid import get_cpu_model_name, get_instance_type
-import host_tools.network as net_tools
 
 TEST_ID = "network_tcp_throughput"
 kernel_version = get_kernel_version(level=1)
@@ -138,12 +137,11 @@ def produce_iperf_output(
         )
 
         modes_len = len(modes)
-        ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
         for client_idx in range(load_factor * basevm.vcpus_count):
             futures.append(
                 executor.submit(
                     spawn_iperf_client,
-                    ssh_connection,
+                    basevm.ssh,
                     client_idx,
                     # Distribute the modes evenly.
                     modes[client_idx % modes_len],

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -24,7 +24,6 @@ from framework.utils_cpuid import get_instance_type
 from framework.stats import core, consumer, producer, types, criteria, function
 from integration_tests.performance.utils import handle_failure
 
-import host_tools.network as net_tools  # pylint: disable=import-error
 import host_tools.logging as log_tools
 
 # How many latencies do we sample per test.
@@ -216,10 +215,8 @@ def snapshot_resume_producer(logger, vm_builder, snapshot, snapshot_type, use_ra
     )
 
     # Attempt to connect to resumed microvm.
-    ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
-
     # Verify if guest can run commands.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = microvm.ssh.execute_command("ls")
     assert exit_code == 0
 
     value = 0
@@ -387,10 +384,9 @@ def _test_snapshot_resume_latency(context):
     )
     basevm = vm_instance.vm
     basevm.start()
-    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
 
     # Check if guest works.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = basevm.ssh.execute_command("ls")
     assert exit_code == 0
 
     logger.info("Create {}.".format(snapshot_type))
@@ -473,10 +469,9 @@ def test_older_snapshot_resume_latency(
     )
     basevm = vm_instance.vm
     basevm.start()
-    ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
 
     # Check if guest works.
-    exit_code, _, _ = ssh_connection.execute_command("ls")
+    exit_code, _, _ = basevm.ssh.execute_command("ls")
     assert exit_code == 0
 
     # The snapshot builder expects disks as paths, not artifacts.

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -22,7 +22,6 @@ from framework.stats.metadata import DictProvider as DictMetadataProvider
 from framework.utils import get_kernel_version, DictQuery
 from framework.utils_cpuid import get_cpu_model_name, get_instance_type
 import host_tools.drive as drive_tools
-import host_tools.network as net_tools  # pylint: disable=import-error
 import framework.stats as st
 from integration_tests.performance.configs import defs
 from integration_tests.performance.utils import handle_failure
@@ -180,9 +179,8 @@ def get_snap_restore_latency(
             full_snapshot, resume=True, use_ramdisk=True
         )
         # Attempt to connect to resumed microvm.
-        ssh_connection = net_tools.SSHConnection(microvm.ssh_config)
         # Check if guest still runs commands.
-        exit_code, _, _ = ssh_connection.execute_command("dmesg")
+        exit_code, _, _ = microvm.ssh.execute_command("dmesg")
         assert exit_code == 0
 
         value = 0

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -26,7 +26,6 @@ from framework.utils import (
 )
 from framework.utils_cpuid import get_cpu_model_name, get_instance_type
 from framework.utils_vsock import make_host_port_path, VSOCK_UDS_PATH
-import host_tools.network as net_tools
 from integration_tests.performance.configs import defs
 from integration_tests.performance.utils import handle_failure
 
@@ -152,12 +151,11 @@ def produce_iperf_output(
         )
 
         modes_len = len(modes)
-        ssh_connection = net_tools.SSHConnection(basevm.ssh_config)
         for client_idx in range(load_factor * basevm.vcpus_count):
             futures.append(
                 executor.submit(
                     spawn_iperf_client,
-                    ssh_connection,
+                    basevm.ssh,
                     client_idx,
                     # Distribute the modes evenly.
                     modes[client_idx % modes_len],

--- a/tests/integration_tests/security/test_spectre_meltdown.py
+++ b/tests/integration_tests/security/test_spectre_meltdown.py
@@ -10,7 +10,6 @@ import pytest
 import requests
 
 from framework import utils
-from host_tools.network import SSHConnection
 
 
 CHECKER_URL = "https://meltdown.ovh"
@@ -94,8 +93,7 @@ def run_spectre_meltdown_checker_on_guest(
     spectre_meltdown_checker,
 ):
     """Run the spectre / meltdown checker on guest"""
-    conn = SSHConnection(microvm.ssh_config)
     remote_path = f"/bin/{CHECKER_FILENAME}"
-    conn.scp_file(spectre_meltdown_checker, remote_path)
-    ecode, stdout, stderr = conn.execute_command(f"sh {remote_path} --explain")
+    microvm.ssh.scp_file(spectre_meltdown_checker, remote_path)
+    ecode, stdout, stderr = microvm.ssh.execute_command(f"sh {remote_path} --explain")
     assert ecode == 0, f"stdout:\n{stdout.read()}\nstderr:\n{stderr.read()}\n"

--- a/tools/devtool
+++ b/tools/devtool
@@ -656,6 +656,7 @@ cmd_test() {
         --workdir "$CTR_FC_ROOT_DIR/tests" \
         --cpuset-cpus="$cpuset_cpus" \
         --cpuset-mems="$cpuset_mems" \
+        -e AWS_EMF_AGENT_ENDPOINT -e AWS_EMF_SERVICE_NAME -e AWS_EMF_NAMESPACE -e AWS_EMF_DISABLE_METRIC_EXTRACTION \
         -v /boot:/boot \
         ${ramdisk_args} \
         -- \


### PR DESCRIPTION
## Changes

- Add support for CloudWatch EMF metrics   
- Add a duration/failure metrics for all tests
- Various cleanups I encountered while fixing intermittent issues and writing this code.

This is a start and there will be followups to cover the rest of the performance tests, and some cleanups to make things more fine-grained. 

## Reason

To output metrics from the tests and see historical patterns.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~- [ ] This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
