### PR TITLE
refactor: put guest MAC addr into NetIfaceConfig

### DIFF
--- a/tests/framework/artifacts.py
+++ b/tests/framework/artifacts.py
@@ -21,6 +21,7 @@ from framework.defs import (
 )
 from framework.utils import compare_versions, get_kernel_version
 from framework.utils_cpuid import get_instance_type
+import host_tools.network as net_tools
 from host_tools.snapshot_helper import merge_memory_bitmaps
 
 ARTIFACTS_LOCAL_ROOT = f"{DEFAULT_TEST_SESSION_ROOT_PATH}/ci-artifacts"
@@ -642,6 +643,7 @@ class NetIfaceConfig:
         """Initialize object."""
         self._host_ip = host_ip
         self._guest_ip = guest_ip
+        self._guest_mac = net_tools.mac_from_ip(guest_ip)
         self._tap_name = tap_name
         self._dev_name = dev_name
         self._netmask = netmask
@@ -655,6 +657,11 @@ class NetIfaceConfig:
     def guest_ip(self):
         """Return the guest IP."""
         return self._guest_ip
+
+    @property
+    def guest_mac(self):
+        """Return the guest MAC address."""
+        return self._guest_mac
 
     @property
     def tap_name(self):

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -20,7 +20,6 @@ from framework.artifacts import (
 )
 from framework import utils
 import host_tools.logging as log_tools
-import host_tools.network as net_tools
 
 
 class VmInstance:
@@ -136,11 +135,10 @@ class MicrovmBuilder:
                 netmask_len=iface.netmask,
                 tapname=iface.tap_name,
             )
-            guest_mac = net_tools.mac_from_ip(iface.guest_ip)
             response = vm.network.put(
                 iface_id=iface.dev_name,
                 host_dev_name=iface.tap_name,
-                guest_mac=guest_mac,
+                guest_mac=iface.guest_mac,
             )
             assert vm.api_session.is_status_no_content(response.status_code)
 

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -145,7 +145,7 @@ class MicrovmBuilder:
         with open(config.local_path(), encoding="utf-8") as microvm_config_file:
             microvm_config = json.load(microvm_config_file)
 
-        response = vm.basic_config(
+        vm.basic_config(
             add_root_device=False, boot_args="console=ttyS0 reboot=k panic=1"
         )
 


### PR DESCRIPTION
## Changes

This commit puts guest MAC address into `NetIfaceConfig` and generates it in its `__init__()`.

## Reason

Guest MAC address was generated in `MicrovmBuilder` and this makes code difficult to read. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
