### PR TITLE
docs: update supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ The **API endpoint** can be used to:
 ## Supported platforms
 
 We continuously test Firecracker on machines with the following CPUs
-micro-architectures: Intel Skylake, Intel Cascade Lake, AMD Zen2 and
-ARM64 Neoverse N1.
+micro-architectures: Intel Skylake, Intel Cascade Lake, Intel Ice Lake, AMD
+Zen 3, ARM64 Neoverse N1 and ARM64 Neoverse V1.
 
 Firecracker is [generally available](docs/RELEASE_POLICY.md) on Intel x86_64,
 AMD x86_64 and ARM64 CPUs (starting from release v0.24) that offer hardware

--- a/docs/snapshotting/snapshot-support.md
+++ b/docs/snapshotting/snapshot-support.md
@@ -109,7 +109,7 @@ vCPU count and emulated devices count.
 The Firecracker CI runs snapshot tests on:
 
 - AWS **m5d.metal** and **m6i.metal** instances for Intel
-- AWS **m6g.metal** for ARM
+- AWS **m6g.metal** and **c7g.metal** for ARM
 - AWS **m6a.metal** for AMD
 
 We are running nightly performance tests for all the enumerated platforms on


### PR DESCRIPTION
## Changes / Reason

- Adds m6i.metal (Intel Ice Lake) and c7g.metal (ARM64 Neoverse V1). 
- Fixes AMD Zen 2 to AMD Zen 3 since m6a.metal is EPYC 7003 family.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
