### PR TITLE
perf: update snaphot perf baselines for x86/5.10

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -46,7 +46,7 @@ CREATE_LATENCY_BASELINES = {
         "2vcpu_256mb.json": {"FULL": {"target": 180}, "DIFF": {"target": 70}},
         "2vcpu_512mb.json": {
             "FULL": {"target": 280},
-            "DIFF": {"target": 75},
+            "DIFF": {"target": 90},
         },
     },
     "aarch64": {
@@ -61,11 +61,13 @@ CREATE_LATENCY_BASELINES = {
     },
 }
 
-# The latencies are pretty high during integration tests and
-# this is tracked here:
+# The latencies for x86 are pretty high due to a design
+# in the cgroups V1 implementation in the kernel. We recommend
+# switching to cgroups v2 for much lower snap resume latencies.
+# More details on this:
 # https://github.com/firecracker-microvm/firecracker/issues/2027
-# TODO: Update the table after fix. Target is < 5ms.
-# since they might be lower.
+# Latencies for snap resume on cgroups V2 can be found in our
+# long-running performance configs (i.e. integration_tests/performance/configs).
 LOAD_LATENCY_BASELINES = {
     "x86_64": {
         "m5d.metal": {
@@ -77,12 +79,12 @@ LOAD_LATENCY_BASELINES = {
             },
             "5.10": {
                 "sync": {
-                    "2vcpu_256mb.json": {"target": 60},
-                    "2vcpu_512mb.json": {"target": 60},
+                    "2vcpu_256mb.json": {"target": 70},
+                    "2vcpu_512mb.json": {"target": 75},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 190},
-                    "2vcpu_512mb.json": {"target": 190},
+                    "2vcpu_256mb.json": {"target": 210},
+                    "2vcpu_512mb.json": {"target": 210},
                 },
             },
         },
@@ -113,12 +115,12 @@ LOAD_LATENCY_BASELINES = {
             },
             "5.10": {
                 "sync": {
-                    "2vcpu_256mb.json": {"target": 60},
-                    "2vcpu_512mb.json": {"target": 60},
+                    "2vcpu_256mb.json": {"target": 70},
+                    "2vcpu_512mb.json": {"target": 70},
                 },
                 "async": {
-                    "2vcpu_256mb.json": {"target": 220},
-                    "2vcpu_512mb.json": {"target": 220},
+                    "2vcpu_256mb.json": {"target": 245},
+                    "2vcpu_512mb.json": {"target": 245},
                 },
             },
         },


### PR DESCRIPTION
## Changes

- Update baselines for the snapshot performance test for x86
- Update doc to point to the use of cgroups V1 with x86 platforms (which result in high latencies)

## Reason

Intermittent failures were noticed on kernel 5.10 & x86 platforms

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
