### PR TITLE
Fix perf tests

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -21,7 +21,7 @@ from framework.defs import MIN_KERNEL_VERSION_FOR_IO_URING
 
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
 CMDLOG = logging.getLogger("commands")
-GET_CPU_LOAD = "top -bn1 -H -p {} | tail -n+8"
+GET_CPU_LOAD = "top -bn1 -H -p {} -w512 | tail -n+8"
 
 
 class ProcessManager:

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -90,7 +90,7 @@ class UffdHandler:
     def spawn(self):
         """Spawn handler process using arguments provided."""
         self._proc = subprocess.Popen(
-            self._args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1
+            self._args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
     def proc(self):


### PR DESCRIPTION
## Changes

The Ubuntu 22.04 upgrade brings some different behavior for the `top` command, where it truncates long lines with '+'.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
