### PR TITLE
refactor: cpuid `get_max_cpus_per_package_test()`

### DIFF
--- a/src/vmm/src/cpuid/normalize.rs
+++ b/src/vmm/src/cpuid/normalize.rs
@@ -80,27 +80,6 @@ impl super::Cpuid {
             /// CPU is running on a hypervisor.
             pub const HYPERVISOR_BITINDEX: u8 = 31;
 
-            /// The maximum number of logical processors per package is computed as the closest
-            /// power of 2 higher or equal to the CPU count configured by the user.
-            const fn get_max_cpus_per_package(
-                cpu_count: u8,
-            ) -> Result<u8, GetMaxCpusPerPackageError> {
-                // This match is better than but approximately equivalent to
-                // `2.pow((cpu_count as f32).log2().ceil() as u8)` (`2^ceil(log_2(c))`).
-                match cpu_count {
-                    0 => Err(GetMaxCpusPerPackageError::Underflow),
-                    1 => Ok(1),
-                    2 => Ok(2),
-                    3..=4 => Ok(4),
-                    5..=8 => Ok(8),
-                    9..=16 => Ok(16),
-                    17..=32 => Ok(32),
-                    33..=64 => Ok(64),
-                    65..=128 => Ok(128),
-                    129..=u8::MAX => Err(GetMaxCpusPerPackageError::Overflow),
-                }
-            }
-
             let leaf_1 = self
                 .leaf_mut::<0x1>()
                 .ok_or(FeatureInformationError::MissingLeaf1)?;
@@ -147,5 +126,54 @@ impl super::Cpuid {
                 .normalize(cpu_index, cpu_count, cpu_bits)
                 .map_err(NormalizeCpuidError::Amd),
         }
+    }
+}
+
+/// The maximum number of logical processors per package is computed as the closest
+/// power of 2 higher or equal to the CPU count configured by the user.
+const fn get_max_cpus_per_package(cpu_count: u8) -> Result<u8, GetMaxCpusPerPackageError> {
+    // This match is better than but approximately equivalent to
+    // `2.pow((cpu_count as f32).log2().ceil() as u8)` (`2^ceil(log_2(c))`).
+    match cpu_count {
+        0 => Err(GetMaxCpusPerPackageError::Underflow),
+        // `0u8.checked_next_power_of_two()` returns `Some(1)`, this is not the desired behaviour so
+        // we use `next_power_of_two()` instead.
+        1..=128 => Ok(cpu_count.next_power_of_two()),
+        129..=u8::MAX => Err(GetMaxCpusPerPackageError::Overflow),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_max_cpus_per_package_test() {
+        assert_eq!(
+            get_max_cpus_per_package(0),
+            Err(GetMaxCpusPerPackageError::Underflow)
+        );
+        assert_eq!(get_max_cpus_per_package(1), Ok(1));
+        assert_eq!(get_max_cpus_per_package(2), Ok(2));
+        assert_eq!(get_max_cpus_per_package(3), Ok(4));
+        assert_eq!(get_max_cpus_per_package(4), Ok(4));
+        assert_eq!(get_max_cpus_per_package(5), Ok(8));
+        assert_eq!(get_max_cpus_per_package(8), Ok(8));
+        assert_eq!(get_max_cpus_per_package(9), Ok(16));
+        assert_eq!(get_max_cpus_per_package(16), Ok(16));
+        assert_eq!(get_max_cpus_per_package(17), Ok(32));
+        assert_eq!(get_max_cpus_per_package(32), Ok(32));
+        assert_eq!(get_max_cpus_per_package(33), Ok(64));
+        assert_eq!(get_max_cpus_per_package(64), Ok(64));
+        assert_eq!(get_max_cpus_per_package(65), Ok(128));
+        assert_eq!(get_max_cpus_per_package(128), Ok(128));
+        assert_eq!(
+            get_max_cpus_per_package(129),
+            Err(GetMaxCpusPerPackageError::Overflow)
+        );
+        assert_eq!(
+            get_max_cpus_per_package(u8::MAX),
+            Err(GetMaxCpusPerPackageError::Overflow)
+        );
     }
 }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.14, "AMD": 78.92, "ARM": 82.09}
+    COVERAGE_DICT = {"Intel": 78.14, "AMD": 78.98, "ARM": 82.09}
 else:
-    COVERAGE_DICT = {"Intel": 75.87, "AMD": 76.64, "ARM": 79.04}
+    COVERAGE_DICT = {"Intel": 75.87, "AMD": 76.70, "ARM": 79.04}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Adds unit test to `get_max_cpus_per_package_test()` within `src/vmm/src/cpuid/normalize.rs`.

## Reason

Improves testing coverage.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
