### PR TITLE
perf: update performance baselines for m6a.metal

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -2507,128 +2507,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4181,
-                                                    "delta_percentage": 6
+                                                    "target": 4091,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 31026,
-                                                    "delta_percentage": 29
+                                                    "target": 20130,
+                                                    "delta_percentage": 78
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 43625,
-                                                    "delta_percentage": 36
+                                                    "target": 22616,
+                                                    "delta_percentage": 38
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4179,
-                                                    "delta_percentage": 7
+                                                    "target": 4076,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 29993,
-                                                    "delta_percentage": 27
+                                                    "target": 13587,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 40741,
+                                                    "target": 47450,
                                                     "delta_percentage": 36
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3645,
+                                                    "target": 3529,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 23831,
-                                                    "delta_percentage": 23
+                                                    "target": 23795,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 64631,
-                                                    "delta_percentage": 25
-                                                },
-                                                "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3615,
+                                                    "target": 23049,
                                                     "delta_percentage": 9
                                                 },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3507,
+                                                    "delta_percentage": 7
+                                                },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 23779,
-                                                    "delta_percentage": 27
+                                                    "target": 23255,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 60296,
-                                                    "delta_percentage": 32
+                                                    "target": 22929,
+                                                    "delta_percentage": 20
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 7158,
-                                                    "delta_percentage": 8
+                                                    "target": 6989,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 38643,
-                                                    "delta_percentage": 26
+                                                    "target": 44483,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 44826,
-                                                    "delta_percentage": 37
+                                                    "target": 59074,
+                                                    "delta_percentage": 29
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 7090,
-                                                    "delta_percentage": 7
+                                                    "target": 6942,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 38378,
-                                                    "delta_percentage": 29
+                                                    "target": 45127,
+                                                    "delta_percentage": 19
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 44956,
-                                                    "delta_percentage": 32
+                                                    "target": 55578,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 6203,
-                                                    "delta_percentage": 11
+                                                    "target": 6149,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 45429,
-                                                    "delta_percentage": 33
+                                                    "target": 46254,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 56817,
-                                                    "delta_percentage": 39
+                                                    "target": 46107,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 6199,
-                                                    "delta_percentage": 12
+                                                    "target": 6170,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 44559,
-                                                    "delta_percentage": 29
+                                                    "target": 43865,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 53477,
-                                                    "delta_percentage": 44
+                                                    "target": 48747,
+                                                    "delta_percentage": 33
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 6258,
-                                                    "delta_percentage": 8
+                                                    "target": 6145,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 40953,
-                                                    "delta_percentage": 27
+                                                    "target": 43658,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 47874,
-                                                    "delta_percentage": 46
+                                                    "target": 59206,
+                                                    "delta_percentage": 31
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 6232,
-                                                    "delta_percentage": 8
+                                                    "target": 6116,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 38063,
-                                                    "delta_percentage": 25
+                                                    "target": 40963,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 48190,
-                                                    "delta_percentage": 33
+                                                    "target": 57605,
+                                                    "delta_percentage": 32
                                                 }
                                             }
                                         }
@@ -2639,128 +2639,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 2928,
-                                                    "delta_percentage": 13
-                                                },
-                                                "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 24731,
-                                                    "delta_percentage": 18
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 41090,
-                                                    "delta_percentage": 34
-                                                },
-                                                "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 2885,
+                                                    "target": 3093,
                                                     "delta_percentage": 11
                                                 },
+                                                "tcp-p1024K-ws256K-g2h": {
+                                                    "target": 16451,
+                                                    "delta_percentage": 21
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-g2h": {
+                                                    "target": 53465,
+                                                    "delta_percentage": 50
+                                                },
+                                                "tcp-pDEFAULT-ws16K-g2h": {
+                                                    "target": 2956,
+                                                    "delta_percentage": 9
+                                                },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 24507,
-                                                    "delta_percentage": 18
+                                                    "target": 12781,
+                                                    "delta_percentage": 27
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 41157,
-                                                    "delta_percentage": 35
+                                                    "target": 50905,
+                                                    "delta_percentage": 39
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 2915,
-                                                    "delta_percentage": 6
+                                                    "target": 2952,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 25350,
-                                                    "delta_percentage": 18
+                                                    "target": 25324,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 62673,
-                                                    "delta_percentage": 35
+                                                    "target": 23211,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 2899,
-                                                    "delta_percentage": 6
+                                                    "target": 2939,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 20674,
-                                                    "delta_percentage": 7
+                                                    "target": 21150,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 40997,
-                                                    "delta_percentage": 87
+                                                    "target": 24182,
+                                                    "delta_percentage": 50
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4539,
+                                                    "target": 4694,
                                                     "delta_percentage": 8
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 34434,
-                                                    "delta_percentage": 27
+                                                    "target": 37433,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 44490,
-                                                    "delta_percentage": 36
+                                                    "target": 53501,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4488,
-                                                    "delta_percentage": 9
+                                                    "target": 4648,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 34506,
-                                                    "delta_percentage": 24
+                                                    "target": 37834,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 43567,
-                                                    "delta_percentage": 28
+                                                    "target": 52741,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 4926,
-                                                    "delta_percentage": 8
+                                                    "target": 5010,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 36704,
-                                                    "delta_percentage": 16
+                                                    "target": 36414,
+                                                    "delta_percentage": 24
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 61138,
-                                                    "delta_percentage": 48
+                                                    "target": 48162,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 4947,
-                                                    "delta_percentage": 6
+                                                    "target": 5008,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 32395,
+                                                    "target": 33034,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 55088,
-                                                    "delta_percentage": 57
+                                                    "target": 54669,
+                                                    "delta_percentage": 41
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 4296,
-                                                    "delta_percentage": 10
+                                                    "target": 4438,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 37146,
-                                                    "delta_percentage": 12
+                                                    "target": 39785,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 52912,
-                                                    "delta_percentage": 38
+                                                    "target": 57234,
+                                                    "delta_percentage": 34
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 4320,
-                                                    "delta_percentage": 7
+                                                    "target": 4425,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 36602,
-                                                    "delta_percentage": 11
+                                                    "target": 38024,
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 52436,
-                                                    "delta_percentage": 39
+                                                    "target": 63303,
+                                                    "delta_percentage": 37
                                                 }
                                             }
                                         }
@@ -2782,23 +2782,23 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "target": 96,
-                                                    "delta_percentage": 17
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 69,
-                                                    "delta_percentage": 89
+                                                    "target": 92,
+                                                    "delta_percentage": 42
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 99,
@@ -2814,7 +2814,7 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "target": 99,
@@ -2833,20 +2833,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 115,
-                                                    "delta_percentage": 16
+                                                    "target": 187,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 119,
-                                                    "delta_percentage": 13
+                                                    "target": 168,
+                                                    "delta_percentage": 45
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2854,26 +2854,26 @@
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 198,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 4
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 196,
-                                                    "delta_percentage": 6
+                                                    "target": 198,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 195,
-                                                    "delta_percentage": 8
+                                                    "target": 197,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
@@ -2881,8 +2881,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 171,
-                                                    "delta_percentage": 27
+                                                    "target": 189,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 198,
@@ -2894,7 +2894,7 @@
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
                                                     "target": 185,
-                                                    "delta_percentage": 19
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         }
@@ -2910,7 +2910,7 @@
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "target": 99,
@@ -2922,11 +2922,11 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
@@ -2938,7 +2938,7 @@
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 99,
@@ -2946,11 +2946,11 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 }
                                             }
                                         },
@@ -2965,20 +2965,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 115,
-                                                    "delta_percentage": 18
+                                                    "target": 180,
+                                                    "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 118,
-                                                    "delta_percentage": 15
+                                                    "target": 168,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2989,8 +2989,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 192,
-                                                    "delta_percentage": 11
+                                                    "target": 197,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 198,
@@ -2998,10 +2998,10 @@
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 198,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
@@ -3009,15 +3009,15 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 122,
+                                                    "target": 197,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
@@ -3025,8 +3025,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 125,
-                                                    "delta_percentage": 13
+                                                    "target": 184,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         }
@@ -3039,76 +3039,76 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 49,
+                                                    "target": 48,
                                                     "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 72,
-                                                    "delta_percentage": 17
+                                                    "target": 49,
+                                                    "delta_percentage": 65
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 89,
-                                                    "delta_percentage": 12
+                                                    "target": 51,
+                                                    "delta_percentage": 45
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 48,
-                                                    "delta_percentage": 15
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 73,
-                                                    "delta_percentage": 16
+                                                    "target": 39,
+                                                    "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 85,
-                                                    "delta_percentage": 11
+                                                    "target": 79,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 33,
-                                                    "delta_percentage": 14
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 47,
-                                                    "delta_percentage": 25
+                                                    "target": 46,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 80,
-                                                    "delta_percentage": 7
+                                                    "target": 53,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 13
+                                                    "target": 33,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 56,
-                                                    "delta_percentage": 17
+                                                    "target": 55,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 84,
-                                                    "delta_percentage": 11
+                                                    "target": 54,
+                                                    "delta_percentage": 39
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 65,
+                                                    "target": 63,
                                                     "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 82,
+                                                    "target": 78,
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 89,
+                                                    "target": 92,
                                                     "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 64,
-                                                    "delta_percentage": 11
+                                                    "target": 63,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 81,
-                                                    "delta_percentage": 10
+                                                    "target": 76,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
                                                     "target": 88,
@@ -3116,50 +3116,50 @@
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 45,
-                                                    "delta_percentage": 12
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 86,
-                                                    "delta_percentage": 18
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 85,
-                                                    "delta_percentage": 12
-                                                },
-                                                "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 45,
                                                     "delta_percentage": 11
                                                 },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 84,
+                                                    "delta_percentage": 17
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 80,
+                                                    "delta_percentage": 25
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 46,
+                                                    "delta_percentage": 9
+                                                },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 89,
+                                                    "target": 88,
                                                     "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
+                                                    "target": 84,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 54,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 81,
-                                                    "delta_percentage": 11
+                                                    "target": 80,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 88,
-                                                    "delta_percentage": 9
+                                                    "target": 89,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 54,
-                                                    "delta_percentage": 12
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
                                                     "target": 79,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 89,
+                                                    "target": 90,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -3171,128 +3171,128 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 33,
-                                                    "delta_percentage": 12
+                                                    "target": 34,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 63,
-                                                    "delta_percentage": 14
+                                                    "target": 35,
+                                                    "delta_percentage": 47
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 88,
+                                                    "target": 80,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 32,
-                                                    "delta_percentage": 14
+                                                    "target": 33,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 62,
-                                                    "delta_percentage": 19
+                                                    "target": 36,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 84,
-                                                    "delta_percentage": 12
+                                                    "target": 80,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 29,
-                                                    "delta_percentage": 13
+                                                    "target": 30,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 52,
-                                                    "delta_percentage": 32
+                                                    "target": 48,
+                                                    "delta_percentage": 38
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 83,
-                                                    "delta_percentage": 9
+                                                    "target": 50,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 29,
-                                                    "delta_percentage": 13
+                                                    "target": 30,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 52,
-                                                    "delta_percentage": 30
+                                                    "delta_percentage": 29
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 67,
-                                                    "delta_percentage": 62
+                                                    "target": 52,
+                                                    "delta_percentage": 45
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 43,
+                                                    "target": 44,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 75,
-                                                    "delta_percentage": 13
+                                                    "target": 65,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
+                                                    "target": 85,
                                                     "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 43,
-                                                    "delta_percentage": 13
-                                                },
-                                                "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 74,
                                                     "delta_percentage": 12
                                                 },
+                                                "tcp-pDEFAULT-ws256K-g2h": {
+                                                    "target": 66,
+                                                    "delta_percentage": 15
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 8
+                                                    "target": 84,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 37,
+                                                    "target": 39,
                                                     "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 70,
-                                                    "delta_percentage": 11
+                                                    "target": 71,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 89,
-                                                    "delta_percentage": 9
+                                                    "target": 77,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 38,
-                                                    "delta_percentage": 12
+                                                    "target": 39,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 70,
+                                                    "target": 73,
                                                     "delta_percentage": 19
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 89,
-                                                    "delta_percentage": 12
-                                                },
-                                                "tcp-p1024K-ws16K-bd": {
-                                                    "target": 45,
-                                                    "delta_percentage": 10
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 79,
-                                                    "delta_percentage": 26
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 93,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 45,
+                                                    "target": 84,
                                                     "delta_percentage": 13
                                                 },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 46,
+                                                    "delta_percentage": 13
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 72,
+                                                    "delta_percentage": 18
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 89,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 46,
+                                                    "delta_percentage": 12
+                                                },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 80,
-                                                    "delta_percentage": 26
+                                                    "target": 73,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 94,
-                                                    "delta_percentage": 8
+                                                    "target": 96,
+                                                    "delta_percentage": 7
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_5.10.json
@@ -2507,128 +2507,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4252,
-                                                    "delta_percentage": 7
+                                                    "target": 4331,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 33485,
-                                                    "delta_percentage": 26
+                                                    "target": 19226,
+                                                    "delta_percentage": 83
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 49144,
-                                                    "delta_percentage": 37
+                                                    "target": 24141,
+                                                    "delta_percentage": 62
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4228,
+                                                    "target": 4293,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 33248,
-                                                    "delta_percentage": 24
+                                                    "target": 14016,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 46047,
-                                                    "delta_percentage": 33
+                                                    "target": 48480,
+                                                    "delta_percentage": 45
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3763,
+                                                    "target": 3845,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 24337,
+                                                    "target": 24735,
                                                     "delta_percentage": 19
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 66060,
-                                                    "delta_percentage": 11
+                                                    "target": 23167,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3763,
+                                                    "target": 3829,
                                                     "delta_percentage": 7
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 24976,
-                                                    "delta_percentage": 22
+                                                    "target": 24938,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 61922,
-                                                    "delta_percentage": 29
+                                                    "target": 22374,
+                                                    "delta_percentage": 10
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 7041,
+                                                    "target": 7149,
                                                     "delta_percentage": 8
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 42692,
-                                                    "delta_percentage": 28
+                                                    "target": 43902,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 51470,
-                                                    "delta_percentage": 31
+                                                    "target": 59185,
+                                                    "delta_percentage": 41
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 6979,
-                                                    "delta_percentage": 7
+                                                    "target": 7104,
+                                                    "delta_percentage": 8
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 41864,
-                                                    "delta_percentage": 28
+                                                    "target": 42520,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 49508,
-                                                    "delta_percentage": 27
+                                                    "target": 54731,
+                                                    "delta_percentage": 41
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 6440,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 45389,
-                                                    "delta_percentage": 32
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 58972,
-                                                    "delta_percentage": 37
-                                                },
-                                                "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 6467,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 43503,
-                                                    "delta_percentage": 27
-                                                },
-                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 54187,
-                                                    "delta_percentage": 44
-                                                },
-                                                "tcp-p1024K-ws16K-bd": {
-                                                    "target": 6380,
-                                                    "delta_percentage": 6
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 43005,
-                                                    "delta_percentage": 22
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 53703,
-                                                    "delta_percentage": 32
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 6377,
+                                                    "target": 6524,
                                                     "delta_percentage": 7
                                                 },
+                                                "tcp-p1024K-ws256K-h2g": {
+                                                    "target": 45427,
+                                                    "delta_percentage": 33
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "target": 45902,
+                                                    "delta_percentage": 8
+                                                },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 6545,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 43771,
+                                                    "delta_percentage": 26
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-h2g": {
+                                                    "target": 49363,
+                                                    "delta_percentage": 33
+                                                },
+                                                "tcp-p1024K-ws16K-bd": {
+                                                    "target": 6453,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 41587,
+                                                    "delta_percentage": 25
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 61265,
+                                                    "delta_percentage": 38
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 6470,
+                                                    "delta_percentage": 8
+                                                },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 39714,
-                                                    "delta_percentage": 20
+                                                    "target": 40455,
+                                                    "delta_percentage": 24
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 50767,
-                                                    "delta_percentage": 28
+                                                    "target": 58807,
+                                                    "delta_percentage": 45
                                                 }
                                             }
                                         }
@@ -2639,128 +2639,128 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 3043,
-                                                    "delta_percentage": 14
+                                                    "target": 3088,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 27466,
-                                                    "delta_percentage": 20
+                                                    "target": 16976,
+                                                    "delta_percentage": 26
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 48850,
-                                                    "delta_percentage": 39
+                                                    "target": 54005,
+                                                    "delta_percentage": 58
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 3017,
-                                                    "delta_percentage": 15
+                                                    "target": 3085,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 26877,
-                                                    "delta_percentage": 19
+                                                    "target": 13056,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 45088,
-                                                    "delta_percentage": 36
+                                                    "target": 50799,
+                                                    "delta_percentage": 54
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 3052,
+                                                    "target": 3119,
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 25921,
-                                                    "delta_percentage": 18
+                                                    "target": 23528,
+                                                    "delta_percentage": 20
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 67913,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 3036,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 21735,
+                                                    "target": 23280,
                                                     "delta_percentage": 10
                                                 },
+                                                "tcp-pDEFAULT-ws16K-h2g": {
+                                                    "target": 3098,
+                                                    "delta_percentage": 5
+                                                },
+                                                "tcp-pDEFAULT-ws256K-h2g": {
+                                                    "target": 22048,
+                                                    "delta_percentage": 8
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 33721,
-                                                    "delta_percentage": 29
+                                                    "target": 22601,
+                                                    "delta_percentage": 35
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 4453,
-                                                    "delta_percentage": 6
+                                                    "target": 4520,
+                                                    "delta_percentage": 7
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 37807,
-                                                    "delta_percentage": 27
+                                                    "target": 38188,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 49635,
-                                                    "delta_percentage": 35
+                                                    "target": 53762,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 4413,
-                                                    "delta_percentage": 7
+                                                    "target": 4495,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 37796,
-                                                    "delta_percentage": 26
+                                                    "target": 36991,
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 47868,
-                                                    "delta_percentage": 27
+                                                    "target": 53304,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 5156,
-                                                    "delta_percentage": 7
+                                                    "target": 5243,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 36495,
-                                                    "delta_percentage": 20
+                                                    "target": 37406,
+                                                    "delta_percentage": 18
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 67051,
-                                                    "delta_percentage": 40
+                                                    "target": 46219,
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 5166,
+                                                    "target": 5244,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 33282,
-                                                    "delta_percentage": 12
+                                                    "target": 34141,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 60868,
-                                                    "delta_percentage": 53
+                                                    "target": 55129,
+                                                    "delta_percentage": 36
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 3907,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 38712,
-                                                    "delta_percentage": 10
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 56578,
-                                                    "delta_percentage": 35
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 3903,
-                                                    "delta_percentage": 7
-                                                },
-                                                "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 37510,
+                                                    "target": 4054,
                                                     "delta_percentage": 9
                                                 },
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 39698,
+                                                    "delta_percentage": 11
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
+                                                    "target": 50045,
+                                                    "delta_percentage": 24
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 4060,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 37680,
+                                                    "delta_percentage": 7
+                                                },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 55382,
-                                                    "delta_percentage": 37
+                                                    "target": 62248,
+                                                    "delta_percentage": 42
                                                 }
                                             }
                                         }
@@ -2781,24 +2781,24 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 99,
-                                                    "delta_percentage": 6
+                                                    "target": 92,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "target": 99,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 85,
-                                                    "delta_percentage": 69
+                                                    "target": 74,
+                                                    "delta_percentage": 80
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 99,
@@ -2810,7 +2810,7 @@
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 99,
@@ -2833,8 +2833,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 119,
-                                                    "delta_percentage": 13
+                                                    "target": 186,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
@@ -2845,19 +2845,19 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 121,
-                                                    "delta_percentage": 11
+                                                    "target": 157,
+                                                    "delta_percentage": 52
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
@@ -2869,8 +2869,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 196,
-                                                    "delta_percentage": 7
+                                                    "target": 198,
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "target": 198,
@@ -2881,20 +2881,20 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 184,
-                                                    "delta_percentage": 16
+                                                    "target": 186,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 191,
-                                                    "delta_percentage": 13
+                                                    "target": 186,
+                                                    "delta_percentage": 21
                                                 }
                                             }
                                         }
@@ -2910,7 +2910,7 @@
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "target": 99,
@@ -2930,15 +2930,15 @@
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 99,
@@ -2965,8 +2965,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 118,
-                                                    "delta_percentage": 16
+                                                    "target": 173,
+                                                    "delta_percentage": 45
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
                                                     "target": 198,
@@ -2977,8 +2977,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 122,
-                                                    "delta_percentage": 14
+                                                    "target": 163,
+                                                    "delta_percentage": 48
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 198,
@@ -2993,7 +2993,7 @@
                                                     "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
@@ -3013,11 +3013,11 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 123,
-                                                    "delta_percentage": 11
+                                                    "target": 197,
+                                                    "delta_percentage": 6
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
@@ -3025,8 +3025,8 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 126,
-                                                    "delta_percentage": 15
+                                                    "target": 185,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         }
@@ -3039,127 +3039,127 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 48,
-                                                    "delta_percentage": 13
+                                                    "target": 49,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 71,
-                                                    "delta_percentage": 19
+                                                    "target": 49,
+                                                    "delta_percentage": 69
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
-                                                    "delta_percentage": 15
+                                                    "target": 55,
+                                                    "delta_percentage": 57
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 48,
-                                                    "delta_percentage": 12
+                                                    "target": 49,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 71,
-                                                    "delta_percentage": 17
+                                                    "target": 40,
+                                                    "delta_percentage": 28
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 84,
-                                                    "delta_percentage": 10
+                                                    "target": 83,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 12
+                                                    "target": 35,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 46,
-                                                    "delta_percentage": 24
+                                                    "target": 48,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 83,
-                                                    "delta_percentage": 6
+                                                    "target": 53,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 34,
-                                                    "delta_percentage": 15
+                                                    "target": 35,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 56,
-                                                    "delta_percentage": 17
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 86,
-                                                    "delta_percentage": 10
+                                                    "target": 54,
+                                                    "delta_percentage": 34
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 65,
+                                                    "target": 66,
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
                                                     "target": 80,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
+                                                    "target": 92,
+                                                    "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 65,
+                                                    "target": 66,
                                                     "delta_percentage": 9
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 81,
-                                                    "delta_percentage": 11
+                                                    "target": 78,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 47,
+                                                    "target": 90,
                                                     "delta_percentage": 10
                                                 },
+                                                "tcp-p1024K-ws16K-h2g": {
+                                                    "target": 48,
+                                                    "delta_percentage": 11
+                                                },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 89,
-                                                    "delta_percentage": 14
+                                                    "target": 87,
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 88,
-                                                    "delta_percentage": 9
+                                                    "target": 83,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 47,
-                                                    "delta_percentage": 12
+                                                    "target": 48,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 92,
+                                                    "target": 91,
                                                     "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 90,
-                                                    "delta_percentage": 7
+                                                    "target": 86,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 55,
-                                                    "delta_percentage": 10
-                                                },
-                                                "tcp-p1024K-ws256K-bd": {
-                                                    "target": 81,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 88,
-                                                    "delta_percentage": 8
-                                                },
-                                                "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 56,
-                                                    "delta_percentage": 10
-                                                },
-                                                "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 79,
+                                                    "target": 57,
                                                     "delta_percentage": 9
                                                 },
-                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                "tcp-p1024K-ws256K-bd": {
+                                                    "target": 79,
+                                                    "delta_percentage": 13
+                                                },
+                                                "tcp-p1024K-wsDEFAULT-bd": {
                                                     "target": 89,
+                                                    "delta_percentage": 7
+                                                },
+                                                "tcp-pDEFAULT-ws16K-bd": {
+                                                    "target": 57,
+                                                    "delta_percentage": 9
+                                                },
+                                                "tcp-pDEFAULT-ws256K-bd": {
+                                                    "target": 81,
+                                                    "delta_percentage": 10
+                                                },
+                                                "tcp-pDEFAULT-wsDEFAULT-bd": {
+                                                    "target": 90,
                                                     "delta_percentage": 8
                                                 }
                                             }
@@ -3172,126 +3172,126 @@
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "target": 33,
-                                                    "delta_percentage": 15
+                                                    "delta_percentage": 13
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 59,
-                                                    "delta_percentage": 24
+                                                    "target": 36,
+                                                    "delta_percentage": 56
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 13
+                                                    "target": 82,
+                                                    "delta_percentage": 16
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 33,
-                                                    "delta_percentage": 13
+                                                    "target": 34,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 59,
-                                                    "delta_percentage": 25
+                                                    "target": 36,
+                                                    "delta_percentage": 21
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 83,
-                                                    "delta_percentage": 12
+                                                    "target": 81,
+                                                    "delta_percentage": 19
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "target": 31,
-                                                    "delta_percentage": 18
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "target": 52,
-                                                    "delta_percentage": 31
+                                                    "target": 44,
+                                                    "delta_percentage": 61
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 87,
-                                                    "delta_percentage": 8
+                                                    "target": 51,
+                                                    "delta_percentage": 35
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "target": 31,
-                                                    "delta_percentage": 19
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "target": 54,
                                                     "delta_percentage": 29
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 61,
-                                                    "delta_percentage": 35
+                                                    "target": 52,
+                                                    "delta_percentage": 38
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "target": 44,
-                                                    "delta_percentage": 10
+                                                    "target": 45,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "target": 73,
-                                                    "delta_percentage": 12
+                                                    "target": 66,
+                                                    "delta_percentage": 30
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "target": 87,
-                                                    "delta_percentage": 8
+                                                    "target": 86,
+                                                    "delta_percentage": 10
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "target": 44,
+                                                    "target": 45,
                                                     "delta_percentage": 11
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "target": 74,
-                                                    "delta_percentage": 12
+                                                    "target": 67,
+                                                    "delta_percentage": 22
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "target": 86,
-                                                    "delta_percentage": 8
+                                                    "target": 85,
+                                                    "delta_percentage": 11
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "target": 39,
-                                                    "delta_percentage": 13
+                                                    "target": 40,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "target": 73,
-                                                    "delta_percentage": 19
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "target": 94,
-                                                    "delta_percentage": 7
+                                                    "target": 76,
+                                                    "delta_percentage": 23
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "target": 39,
+                                                    "target": 40,
                                                     "delta_percentage": 13
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "target": 74,
-                                                    "delta_percentage": 21
+                                                    "target": 75,
+                                                    "delta_percentage": 17
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "target": 94,
-                                                    "delta_percentage": 10
+                                                    "target": 86,
+                                                    "delta_percentage": 14
                                                 },
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "target": 43,
-                                                    "delta_percentage": 10
+                                                    "target": 44,
+                                                    "delta_percentage": 12
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "target": 77,
+                                                    "target": 73,
                                                     "delta_percentage": 25
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "target": 92,
-                                                    "delta_percentage": 7
+                                                    "target": 84,
+                                                    "delta_percentage": 15
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "target": 43,
+                                                    "target": 44,
                                                     "delta_percentage": 12
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "target": 80,
-                                                    "delta_percentage": 29
+                                                    "target": 76,
+                                                    "delta_percentage": 25
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "target": 95,
+                                                    "target": 97,
                                                     "delta_percentage": 7
                                                 }
                                             }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -1415,68 +1415,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 9567,
-                                                    "delta_percentage": 8
+                                                    "target": 9372,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 9649,
+                                                    "target": 9432,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2668,
-                                                    "delta_percentage": 14
+                                                    "target": 1923,
+                                                    "delta_percentage": 92
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5943,
-                                                    "delta_percentage": 12
+                                                    "target": 6111,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5825,
-                                                    "delta_percentage": 11
+                                                    "target": 5991,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2385,
-                                                    "delta_percentage": 7
+                                                    "target": 2068,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 11813,
-                                                    "delta_percentage": 13
+                                                    "target": 11526,
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 11749,
-                                                    "delta_percentage": 13
+                                                    "target": 11438,
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 4538,
-                                                    "delta_percentage": 11
+                                                    "target": 4362,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 7521,
-                                                    "delta_percentage": 10
+                                                    "target": 7561,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 7349,
-                                                    "delta_percentage": 13
+                                                    "target": 7487,
+                                                    "delta_percentage": 12
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2857,
-                                                    "delta_percentage": 11
+                                                    "target": 2750,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 6903,
+                                                    "target": 6996,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 6891,
-                                                    "delta_percentage": 8
+                                                    "target": 6982,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2649,
-                                                    "delta_percentage": 14
+                                                    "target": 1886,
+                                                    "delta_percentage": 9
                                                 }
                                             }
                                         }
@@ -1487,68 +1487,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 17049,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 16959,
+                                                    "target": 17364,
                                                     "delta_percentage": 9
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 17350,
+                                                    "delta_percentage": 10
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 3189,
+                                                    "target": 3422,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 5992,
-                                                    "delta_percentage": 10
+                                                    "target": 6179,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 5832,
-                                                    "delta_percentage": 11
+                                                    "target": 6071,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2740,
-                                                    "delta_percentage": 7
+                                                    "target": 2880,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 24278,
-                                                    "delta_percentage": 9
+                                                    "target": 24728,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 24267,
-                                                    "delta_percentage": 11
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 4666,
+                                                    "target": 24974,
                                                     "delta_percentage": 10
                                                 },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 4576,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 8499,
+                                                    "target": 8606,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 8099,
-                                                    "delta_percentage": 8
+                                                    "target": 8221,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 4023,
+                                                    "target": 4111,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 7158,
+                                                    "target": 7331,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 7094,
-                                                    "delta_percentage": 9
+                                                    "target": 7274,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3378,
-                                                    "delta_percentage": 17
+                                                    "target": 3425,
+                                                    "delta_percentage": 16
                                                 }
                                             }
                                         }
@@ -1566,11 +1566,11 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
@@ -1578,7 +1578,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
@@ -1597,28 +1597,28 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 192,
-                                                    "delta_percentage": 14
+                                                    "target": 196,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 121,
-                                                    "delta_percentage": 7
+                                                    "target": 122,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 123,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 167,
-                                                    "delta_percentage": 11
-                                                },
-                                                "vsock-p1024K-bd": {
-                                                    "target": 113,
+                                                    "target": 173,
                                                     "delta_percentage": 6
                                                 },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 112,
+                                                    "delta_percentage": 7
+                                                },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 114,
-                                                    "delta_percentage": 8
+                                                    "target": 113,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
                                                     "target": 197,
@@ -1661,7 +1661,7 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 197,
+                                                    "target": 198,
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1669,19 +1669,19 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 196,
-                                                    "delta_percentage": 10
+                                                    "target": 197,
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 118,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 118,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 146,
+                                                    "target": 145,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
@@ -1690,11 +1690,11 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 124,
-                                                    "delta_percentage": 35
+                                                    "target": 118,
+                                                    "delta_percentage": 40
                                                 }
                                             }
                                         }
@@ -1707,16 +1707,16 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 47,
-                                                    "delta_percentage": 11
+                                                    "target": 46,
+                                                    "delta_percentage": 13
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 47,
-                                                    "delta_percentage": 11
+                                                    "target": 46,
+                                                    "delta_percentage": 13
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 42,
-                                                    "delta_percentage": 13
+                                                    "target": 37,
+                                                    "delta_percentage": 25
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 59,
@@ -1727,8 +1727,8 @@
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 40,
-                                                    "delta_percentage": 10
+                                                    "target": 36,
+                                                    "delta_percentage": 13
                                                 }
                                             }
                                         },
@@ -1736,39 +1736,39 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 60,
-                                                    "delta_percentage": 10
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 60,
                                                     "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 63,
+                                                    "target": 64,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 71,
-                                                    "delta_percentage": 11
+                                                    "target": 72,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 71,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 11
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 10
+                                                    "target": 58,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 63,
+                                                    "target": 62,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 63,
+                                                    "target": 62,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 66,
-                                                    "delta_percentage": 7
+                                                    "target": 63,
+                                                    "delta_percentage": 8
                                                 }
                                             }
                                         }
@@ -1783,23 +1783,23 @@
                                                     "delta_percentage": 15
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 31,
-                                                    "delta_percentage": 13
+                                                    "target": 32,
+                                                    "delta_percentage": 15
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 44,
-                                                    "delta_percentage": 10
+                                                    "target": 45,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 60,
+                                                    "target": 59,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 10
+                                                    "target": 59,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 38,
+                                                    "target": 39,
                                                     "delta_percentage": 12
                                                 }
                                             }
@@ -1808,27 +1808,27 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 37,
-                                                    "delta_percentage": 14
+                                                    "delta_percentage": 13
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 37,
-                                                    "delta_percentage": 13
+                                                    "delta_percentage": 17
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 62,
-                                                    "delta_percentage": 9
+                                                    "target": 63,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 72,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
                                                     "target": 71,
                                                     "delta_percentage": 8
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 70,
+                                                    "delta_percentage": 8
+                                                },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 55,
-                                                    "delta_percentage": 9
+                                                    "target": 56,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 60,
@@ -1836,11 +1836,11 @@
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 59,
-                                                    "delta_percentage": 8
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 48,
-                                                    "delta_percentage": 31
+                                                    "target": 47,
+                                                    "delta_percentage": 34
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -1415,68 +1415,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 9489,
-                                                    "delta_percentage": 11
+                                                    "target": 9401,
+                                                    "delta_percentage": 14
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 9502,
-                                                    "delta_percentage": 11
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 2686,
+                                                    "target": 9465,
                                                     "delta_percentage": 15
                                                 },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 6654,
-                                                    "delta_percentage": 11
+                                                "vsock-p1024-g2h": {
+                                                    "target": 2698,
+                                                    "delta_percentage": 14
                                                 },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 6513,
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 6835,
                                                     "delta_percentage": 9
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 6689,
+                                                    "delta_percentage": 8
+                                                },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2377,
-                                                    "delta_percentage": 7
+                                                    "target": 2483,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 11373,
-                                                    "delta_percentage": 15
+                                                    "target": 11349,
+                                                    "delta_percentage": 17
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 11423,
-                                                    "delta_percentage": 16
+                                                    "target": 11146,
+                                                    "delta_percentage": 14
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 4057,
+                                                    "target": 3966,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 8208,
-                                                    "delta_percentage": 9
+                                                    "target": 8245,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 8035,
-                                                    "delta_percentage": 9
+                                                    "target": 8143,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2862,
+                                                    "target": 2989,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 7747,
-                                                    "delta_percentage": 8
+                                                    "target": 7785,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 7668,
+                                                    "target": 7738,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 2435,
-                                                    "delta_percentage": 11
+                                                    "target": 2616,
+                                                    "delta_percentage": 12
                                                 }
                                             }
                                         }
@@ -1487,68 +1487,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 17587,
-                                                    "delta_percentage": 8
+                                                    "target": 18016,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 17662,
-                                                    "delta_percentage": 8
+                                                    "target": 18147,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 2994,
-                                                    "delta_percentage": 12
+                                                    "target": 3153,
+                                                    "delta_percentage": 8
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 6716,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 6456,
+                                                    "target": 6866,
                                                     "delta_percentage": 9
                                                 },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 6615,
+                                                    "delta_percentage": 8
+                                                },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 2743,
-                                                    "delta_percentage": 7
+                                                    "target": 2851,
+                                                    "delta_percentage": 6
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 24716,
-                                                    "delta_percentage": 6
+                                                    "target": 25111,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 24949,
+                                                    "target": 25475,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 4089,
+                                                    "target": 3994,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "target": 9197,
-                                                    "delta_percentage": 10
+                                                    "target": 9257,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 8761,
+                                                    "target": 8819,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 3977,
-                                                    "delta_percentage": 6
+                                                    "target": 4045,
+                                                    "delta_percentage": 7
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "target": 7963,
+                                                    "target": 8081,
                                                     "delta_percentage": 10
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 7888,
-                                                    "delta_percentage": 8
+                                                    "target": 7991,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 3172,
-                                                    "delta_percentage": 12
+                                                    "target": 3280,
+                                                    "delta_percentage": 15
                                                 }
                                             }
                                         }
@@ -1566,7 +1566,7 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
@@ -1589,35 +1589,35 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 198,
-                                                    "delta_percentage": 5
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
                                                     "target": 197,
                                                     "delta_percentage": 5
                                                 },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 198,
+                                                    "delta_percentage": 5
+                                                },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 151,
-                                                    "delta_percentage": 17
+                                                    "target": 130,
+                                                    "delta_percentage": 16
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 124,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 125,
-                                                    "delta_percentage": 7
+                                                    "target": 126,
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 175,
-                                                    "delta_percentage": 8
+                                                    "target": 172,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 114,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 115,
+                                                    "target": 114,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-p1024-bd": {
@@ -1634,15 +1634,15 @@
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 5
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 99,
@@ -1650,7 +1650,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "target": 99,
-                                                    "delta_percentage": 6
+                                                    "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "target": 99,
@@ -1669,32 +1669,32 @@
                                                     "delta_percentage": 5
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 162,
-                                                    "delta_percentage": 18
+                                                    "target": 135,
+                                                    "delta_percentage": 16
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 120,
                                                     "delta_percentage": 7
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 120,
+                                                    "target": 119,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 146,
+                                                    "target": 143,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 105,
-                                                    "delta_percentage": 7
+                                                    "delta_percentage": 6
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "target": 106,
                                                     "delta_percentage": 6
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 110,
-                                                    "delta_percentage": 22
+                                                    "target": 111,
+                                                    "delta_percentage": 31
                                                 }
                                             }
                                         }
@@ -1707,16 +1707,88 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 49,
-                                                    "delta_percentage": 13
+                                                    "target": 50,
+                                                    "delta_percentage": 15
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "target": 49,
-                                                    "delta_percentage": 11
+                                                    "target": 50,
+                                                    "delta_percentage": 15
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "target": 46,
+                                                    "target": 47,
+                                                    "delta_percentage": 12
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 59,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 43,
                                                     "delta_percentage": 11
+                                                }
+                                            }
+                                        },
+                                        "2vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 63,
+                                                    "delta_percentage": 12
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 63,
+                                                    "delta_percentage": 10
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 69,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "target": 73,
+                                                    "delta_percentage": 7
+                                                },
+                                                "vsock-pDEFAULT-h2g": {
+                                                    "target": 73,
+                                                    "delta_percentage": 8
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "target": 64,
+                                                    "delta_percentage": 11
+                                                },
+                                                "vsock-p1024K-bd": {
+                                                    "target": 63,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-pDEFAULT-bd": {
+                                                    "target": 63,
+                                                    "delta_percentage": 9
+                                                },
+                                                "vsock-p1024-bd": {
+                                                    "target": 69,
+                                                    "delta_percentage": 8
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "vmlinux-5.10.bin": {
+                                    "ubuntu-18.04.ext4": {
+                                        "1vcpu_1024mb.json": {
+                                            "Avg": {
+                                                "vsock-p1024K-g2h": {
+                                                    "target": 34,
+                                                    "delta_percentage": 15
+                                                },
+                                                "vsock-pDEFAULT-g2h": {
+                                                    "target": 34,
+                                                    "delta_percentage": 14
+                                                },
+                                                "vsock-p1024-g2h": {
+                                                    "target": 49,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "target": 60,
@@ -1735,84 +1807,12 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024K-g2h": {
-                                                    "target": 63,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 62,
-                                                    "delta_percentage": 12
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 69,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 73,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 73,
-                                                    "delta_percentage": 9
-                                                },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 63,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-p1024K-bd": {
-                                                    "target": 63,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-pDEFAULT-bd": {
-                                                    "target": 63,
-                                                    "delta_percentage": 7
-                                                },
-                                                "vsock-p1024-bd": {
-                                                    "target": 68,
-                                                    "delta_percentage": 9
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "vmlinux-5.10.bin": {
-                                    "ubuntu-18.04.ext4": {
-                                        "1vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "target": 34,
-                                                    "delta_percentage": 13
-                                                },
-                                                "vsock-pDEFAULT-g2h": {
-                                                    "target": 34,
-                                                    "delta_percentage": 15
-                                                },
-                                                "vsock-p1024-g2h": {
-                                                    "target": 48,
-                                                    "delta_percentage": 13
-                                                },
-                                                "vsock-p1024K-h2g": {
-                                                    "target": 60,
-                                                    "delta_percentage": 10
-                                                },
-                                                "vsock-pDEFAULT-h2g": {
-                                                    "target": 59,
-                                                    "delta_percentage": 8
-                                                },
-                                                "vsock-p1024-h2g": {
-                                                    "target": 41,
-                                                    "delta_percentage": 11
-                                                }
-                                            }
-                                        },
-                                        "2vcpu_1024mb.json": {
-                                            "Avg": {
-                                                "vsock-p1024K-g2h": {
-                                                    "target": 39,
+                                                    "target": 38,
                                                     "delta_percentage": 13
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "target": 39,
-                                                    "delta_percentage": 14
+                                                    "delta_percentage": 13
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "target": 68,
@@ -1823,24 +1823,24 @@
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "target": 71,
+                                                    "target": 72,
                                                     "delta_percentage": 8
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "target": 59,
-                                                    "delta_percentage": 8
+                                                    "target": 61,
+                                                    "delta_percentage": 9
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "target": 60,
                                                     "delta_percentage": 9
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "target": 60,
-                                                    "delta_percentage": 9
+                                                    "target": 59,
+                                                    "delta_percentage": 10
                                                 },
                                                 "vsock-p1024-bd": {
-                                                    "target": 46,
-                                                    "delta_percentage": 25
+                                                    "target": 48,
+                                                    "delta_percentage": 30
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Updates performance baselines for m6a.metal.

## Reason

Due to the image update on 2022-12-16, some performance tests start to fail on m6a.metal.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
