### PR TITLE
fix(tests): accept multiple firecracker threads with the same name

### DIFF
--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -152,7 +152,7 @@ def run_fio(env_id, basevm, ssh_conn, mode, bs):
         result = {}
         cpu_load = cpu_load_future.result()
         tag = "firecracker"
-        assert tag in cpu_load and len(cpu_load[tag]) == 1
+        assert tag in cpu_load and len(cpu_load[tag]) > 0
 
         data = list(cpu_load[tag].values())[0]
         data_len = len(data)

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -162,7 +162,7 @@ def produce_iperf_output(
 
         # We expect a single emulation thread tagged with `firecracker` name.
         tag = "firecracker"
-        assert tag in cpu_load and len(cpu_load[tag]) == 1
+        assert tag in cpu_load and len(cpu_load[tag]) > 0
         for thread_id in cpu_load[tag]:
             data = cpu_load[tag][thread_id]
             data_len = len(data)

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -176,7 +176,7 @@ def produce_iperf_output(
 
         # We expect a single emulation thread tagged with `firecracker` name.
         tag = "firecracker"
-        assert tag in cpu_load and len(cpu_load[tag]) == 1
+        assert tag in cpu_load and len(cpu_load[tag]) > 0
         thread_id = list(cpu_load[tag])[0]
         data = cpu_load[tag][thread_id]
         vmm_util = sum(data) / len(data)


### PR DESCRIPTION
Since the Ubuntu 22 update we find there may be more than a thread with the firecracker name. We don't know exactly this can happen, but it doesn't change the result of the test.

Signed-off-by: Pablo Barbáchano <pablob@amazon.com>

## Changes

...

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
~- [ ] All added/changed functionality is tested.~
~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
