### PR TITLE
fix(cpuid): add leaf 0xb / subleaf 1 as needed

### DIFF
--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.98, "AMD": 81.92, "ARM": 82.43}
+    COVERAGE_DICT = {"Intel": 82.98, "AMD": 81.99, "ARM": 82.43}
 else:
-    COVERAGE_DICT = {"Intel": 80.11, "AMD": 79.05, "ARM": 79.34}
+    COVERAGE_DICT = {"Intel": 80.11, "AMD": 79.13, "ARM": 79.34}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

To keep backward compatibility for guest VM CPU topology, the sub-leaf is added as needed.

## Reason

The following commit changed the bahavior of KVM_GET_SUPPORTED_CPUID to no longer include leaf 0xb / sub-leaf 1.
https://lore.kernel.org/all/20221027092036.2698180-1-pbonzini@redhat.com/ 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
