### PR TITLE
Update contributing guidelines with DCO references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,9 @@
 ## License Acceptance
 
 By submitting this pull request, I confirm that my contribution is made under
-the terms of the Apache 2.0 license.
+the terms of the Apache 2.0 license. For more information on following
+Developer Certificate of Origin and signing off your commits, please check
+[`CONTRIBUTING.md`][3].
 
 ## PR Checklist
 
@@ -28,3 +30,4 @@ the terms of the Apache 2.0 license.
 
 [1]: https://github.com/rust-vmm
 [2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
+[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,3 +108,64 @@ Your contribution needs to meet the following standards:
   part of your contribution contravenes this license by signing off on all your
   commits with `git -s`. Ensure that every file in your pull request has a
   header referring to the repository license file.
+
+## Developer Certificate of Origin
+
+Firecracker is an open source product released under the [Apache 2.0 license](LICENSE).
+
+We respect intellectual property rights of others and we want to make sure all
+incoming contributions are correctly attributed and licensed.
+A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
+
+The DCO is a declaration attached to every contribution made by every
+developer. In the commit message of the contribution, the developer simply adds
+a `Signed-off-by` statement and thereby agrees to the DCO, which you can find
+below or at DeveloperCertificate.org (<http://developercertificate.org/>).
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+We require that every contribution to Firecracker is signed with a Developer
+Certificate of Origin. DCO checks are enabled via <https://github.com/apps/dco>,
+and your PR will fail CI without it.
+
+Additionally, we kindly ask you to use your real name. We do not accept
+anonymous contributors, nor those utilizing pseudonyms.
+Each commit must include a DCO which looks like this:
+
+```
+Signed-off-by: Jane Smith <jane.smith@email.com>
+```
+
+You may type this line on your own when writing your commit messages.
+However, if your `user.name` and `user.email` are set in your git config,
+you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of
+the commit message automatically.
+
+Forgot to add DCO to a commit? Amend it with `git commit --amend -s`.


### PR DESCRIPTION
## Changes

Added in our documentation explicit reference to the Developer Certificate of Origin (DCO) mechanism used by this project.

## Reason

We have been following DCO guidelines since the beginning of Firecracker and recently we even added a DCO app to validate automatically that contributions conform to such process. We are aligning our documentations to explicitly call out DCO policy and help a member of the community to be informed when contributing into the project.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
~~- [ ] All added/changed functionality is tested.~~
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~~- [ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
