### PR TITLE
fix(tests): reduce memory monitor sample timeout

### DIFF
--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -27,7 +27,7 @@ class MemoryMonitor(Thread):
     """
 
     MEMORY_THRESHOLD = 5 * 1024
-    MEMORY_SAMPLE_TIMEOUT_S = 1
+    MEMORY_SAMPLE_TIMEOUT_S = 0.05
     X86_MEMORY_GAP_START = 3407872
 
     def __init__(self):


### PR DESCRIPTION
## Changes

Reduce memory monitor sample timeout from 1 second to 50 milliseconds to decrease probability of false negatives.

## Reason

Since most of the tests run microVMs for a very short period of time, memory monitor often does not have a chance to execute and inspect Firecracker's address space.

A simple example: test_api_happy_start().
The change below makes the VM run for 200 milliseconds longer and counts the guest memory in as Firecracker's own memory to trigger a problem that the memory monitor should spot. The memory monitor should have noticed the excessive memory usage, but it did not, because it never saw the address space with the guest in it.
```
diff --git a/tests/host_tools/memory.py b/tests/host_tools/memory.py
index 0d160aa4..032984cc 100644
--- a/tests/host_tools/memory.py
+++ b/tests/host_tools/memory.py
@@ -156,6 +156,7 @@ class MemoryMonitor(Thread):
         return False

     def is_in_guest_mem_regions(self, address):
+        return False
         """Check if the address is inside a guest memory region."""
         for guest_mem_start, guest_mem_end in [
             (self._guest_mem_start_1, self._guest_mem_end_1),
diff --git a/tests/integration_tests/functional/test_api.py b/tests/integration_tests/functional/test_api.py
index e3e93889..dd72e20b 100644
--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -44,6 +44,8 @@ def test_api_happy_start(test_microvm_with_api):

     test_microvm.start()

+    time.sleep(0.2)
+

 def test_drive_io_engine(test_microvm_with_api, network_config):
     """
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
