### PR TITLE
Fix CPU Load Monitor silently crashing

### DIFF
--- a/tests/integration_tests/functional/test_rate_limiter.py
+++ b/tests/integration_tests/functional/test_rate_limiter.py
@@ -165,7 +165,6 @@ def test_rx_rate_limiting_cpu_load(test_microvm_with_api, network_config):
     )
 
     test_microvm.start()
-
     # Start iperf server on guest.
     _start_iperf_on_guest(test_microvm, guest_ip)
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -660,7 +660,7 @@ cmd_test() {
         -v /boot:/boot \
         ${ramdisk_args} \
         -- \
-        pytest "$@"
+        pytest -W error::pytest.PytestUnraisableExceptionWarning -W error::pytest.PytestUnhandledThreadExceptionWarning "$@"
 
     ret=$?
 


### PR DESCRIPTION
We used to get CI failures resulting from

```
File "/firecracker/tests/host_tools/cpu_load.py", line 70, in run
   cpu_load = utils.ProcessManager.get_cpu_percent(self._process_pid)["real"]
KeyError: 'real'
```

At some point, pytest started to only issue warnings on exception in non-main threads, instead of failing the test. This means that it looked like these spurious failures went away, even though they really did not.

The CPU load monitor in its current form was broken, as the `get_cpu_percent` function returns a dictionary mapping process names to CPU utilization of each individual thread (despite it being annotated to return a single float). However, CpuLoadMonitor expected that dictionary to contain the cpu utilization under a key named 'real'. I'm assuming at some point in the past, `get_cpu_percent` was updated from returning the `top`-columns of the firecracker process to its current implementation, but the load monitor was not updated.

This commit changes the CpuLoadMonitor implementation to use `get_cpu_percent` correctly. Additionally, the delay between subsequent samples is reduces to 50ms (from 1s), to match behavior of the memory monitor, see #3441.

Lastly, the test_rate_limiter::test_rx_rate_limiting_cpu_load test never actually checked the cpu utilization samples to not exceed the threshold, so this is fixed too.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] ~~If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] ~~API changes follow the [Runbook for Firecracker API changes][2].~~
- [ ] ~~User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- [ ] ~~New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
