### PR TITLE
Fix clippy lints in rust integration tests

### DIFF
--- a/src/devices/tests/integration_tests.rs
+++ b/src/devices/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 mod serial_utils;
 
 use std::io;

--- a/src/devices/tests/serial_utils/mod.rs
+++ b/src/devices/tests/serial_utils/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io;
-use std::os::raw::c_void;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use devices::legacy::ReadableFd;
@@ -11,7 +10,8 @@ pub struct MockSerialInput(pub RawFd);
 
 impl io::Read for MockSerialInput {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let count = unsafe { libc::read(self.0, buf.as_mut_ptr() as *mut c_void, buf.len()) };
+        let count =
+            unsafe { libc::read(self.0, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
         if count < 0 {
             return Err(io::Error::last_os_error());
         }

--- a/src/io_uring/tests/integration_tests.rs
+++ b/src/io_uring/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use std::os::unix::fs::FileExt;
 use std::os::unix::io::AsRawFd;
 use std::thread;
@@ -301,7 +303,7 @@ fn test_write() {
     // Create & init a memory mapping for storing the write buffers.
     let mem_region: MmapRegion = MmapRegion::build(
         None,
-        NUM_BYTES as usize,
+        NUM_BYTES,
         libc::PROT_READ | libc::PROT_WRITE,
         libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
     )
@@ -312,7 +314,7 @@ fn test_write() {
     for i in 0..NUM_BYTES {
         mem_region
             .as_volatile_slice()
-            .write_obj(i as u8, i as usize)
+            .write_obj(i as u8, i)
             .unwrap();
     }
 
@@ -342,7 +344,7 @@ fn test_read() {
     // Create & init a memory mapping for storing the read buffers.
     let mem_region: MmapRegion = MmapRegion::build(
         None,
-        NUM_BYTES as usize,
+        NUM_BYTES,
         libc::PROT_READ | libc::PROT_WRITE,
         libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
     )

--- a/src/io_uring/tests/test_utils/mod.rs
+++ b/src/io_uring/tests/test_utils/mod.rs
@@ -27,7 +27,7 @@ pub fn drive_submission_and_completion(
                     0,
                     mem_region
                         .as_volatile_slice()
-                        .subslice(i as usize, 1)
+                        .subslice(i, 1)
                         .unwrap()
                         .as_ptr() as usize,
                     1,
@@ -38,7 +38,7 @@ pub fn drive_submission_and_completion(
                     0,
                     mem_region
                         .as_volatile_slice()
-                        .subslice(i as usize, 1)
+                        .subslice(i, 1)
                         .unwrap()
                         .as_ptr() as usize,
                     1,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -108,8 +108,8 @@ fn test_dirty_bitmap_success() {
     thread::sleep(Duration::from_millis(100));
     let bitmap = vmm.lock().unwrap().get_dirty_bitmap().unwrap();
     let num_dirty_pages: u32 = bitmap
-        .iter()
-        .map(|(_, bitmap_per_region)| {
+        .values()
+        .map(|bitmap_per_region| {
             // Gently coerce to u32
             let num_dirty_pages_per_region: u32 =
                 bitmap_per_region.iter().map(|n| n.count_ones()).sum();
@@ -286,7 +286,7 @@ fn test_snapshot_load_sanity_checks() {
     );
 
     // Create MAX_SUPPORTED_VCPUS vCPUs starting from 1 vCPU.
-    for _ in 0..(MAX_SUPPORTED_VCPUS as f64).log2() as usize {
+    for _ in 0..f64::from(MAX_SUPPORTED_VCPUS).log2() as usize {
         microvm_state
             .vcpu_states
             .append(&mut microvm_state.vcpu_states.clone());


### PR DESCRIPTION
## Changes

Fix/Suppress clippy lints in-line with test modules

## Reason

For some reason, these are not picked up by `cargo clippy --all`, only if the `--fix` flag is also passed. This is messing up my pre-commit hook.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
