### PR TITLE
fix: Reduce std `unchecked` calls

### DIFF
--- a/src/vmm/src/cpuid/amd/normalize.rs
+++ b/src/vmm/src/cpuid/amd/normalize.rs
@@ -247,6 +247,7 @@ impl super::AmdCpuid {
     }
 
     /// Update extended cache topology entry.
+    #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
     fn update_extended_cache_topology_entry(
         &mut self,
         cpu_count: u8,
@@ -261,9 +262,7 @@ impl super::AmdCpuid {
                     .eax
                     .num_sharing_cache_mut()
                     // SAFETY: We know `cpus_per_core > 0` therefore this is always safe.
-                    .checked_assign(u32::from(unsafe {
-                        cpus_per_core.checked_sub(1).unwrap_unchecked()
-                    }))
+                    .checked_assign(u32::from(cpus_per_core.checked_sub(1).unwrap()))
                     .map_err(ExtendedCacheTopologyError::NumSharingCache)?,
                 // L3 Cache
                 // The L3 cache is shared among all the logical threads
@@ -283,6 +282,7 @@ impl super::AmdCpuid {
     }
 
     /// Update extended apic id entry
+    #[allow(clippy::unwrap_used, clippy::unwrap_in_result)]
     fn update_extended_apic_id_entry(
         &mut self,
         cpu_index: u8,
@@ -300,7 +300,7 @@ impl super::AmdCpuid {
         // logical CPU 3 -> core id: 1
         let core_id =
             // SAFETY: We know `cpus_per_core != 0` therefore this is always safe.
-            unsafe { u32::from(cpu_index.checked_div(cpus_per_core).unwrap_unchecked()) };
+            u32::from(cpu_index.checked_div(cpus_per_core).unwrap());
 
         let leaf_8000001e = self
             .leaf_mut::<0x8000001e>()
@@ -320,9 +320,7 @@ impl super::AmdCpuid {
             .ebx
             .threads_per_compute_unit_mut()
             // SAFETY: We know `cpus_per_core > 0` therefore this is always safe.
-            .checked_assign(u32::from(unsafe {
-                cpus_per_core.checked_sub(1).unwrap_unchecked()
-            }))
+            .checked_assign(u32::from(cpus_per_core.checked_sub(1).unwrap()))
             .map_err(ExtendedApicIdError::ThreadPerComputeUnit)?;
 
         // SAFETY: We know the value always fits within the range and thus is always safe.

--- a/src/vmm/src/cpuid/cpuid_ffi.rs
+++ b/src/vmm/src/cpuid/cpuid_ffi.rs
@@ -59,7 +59,7 @@ pub struct RawCpuidResizeError(std::alloc::LayoutError);
 
 impl super::CpuidTrait for RawCpuid {
     /// Gets a given sub-leaf.
-    #[allow(clippy::transmute_ptr_to_ptr)]
+    #[allow(clippy::transmute_ptr_to_ptr, clippy::unwrap_used)]
     #[inline]
     fn get(&self, CpuidKey { leaf, subleaf }: &CpuidKey) -> Option<&CpuidEntry> {
         let entry_opt = self
@@ -71,15 +71,14 @@ impl super::CpuidTrait for RawCpuid {
             // SAFETY: The `RawKvmCpuidEntry` and `CpuidEntry` are `repr(C)` with known sizes.
             unsafe {
                 let arr: &[u8; size_of::<RawKvmCpuidEntry>()] = transmute(entry);
-                let arr2: &[u8; size_of::<CpuidEntry>()] =
-                    arr.get_unchecked(8..28).try_into().unwrap_unchecked();
+                let arr2: &[u8; size_of::<CpuidEntry>()] = arr[8..28].try_into().unwrap();
                 transmute::<_, &CpuidEntry>(arr2)
             }
         })
     }
 
     /// Gets a given sub-leaf.
-    #[allow(clippy::transmute_ptr_to_ptr)]
+    #[allow(clippy::transmute_ptr_to_ptr, clippy::unwrap_used)]
     #[inline]
     fn get_mut(&mut self, CpuidKey { leaf, subleaf }: &CpuidKey) -> Option<&mut CpuidEntry> {
         let entry_opt = self
@@ -91,7 +90,7 @@ impl super::CpuidTrait for RawCpuid {
             unsafe {
                 let arr: &mut [u8; size_of::<RawKvmCpuidEntry>()] = transmute(entry);
                 let arr2: &mut [u8; size_of::<CpuidEntry>()] =
-                    arr.get_unchecked_mut(8..28).try_into().unwrap_unchecked();
+                    (&mut arr[8..28]).try_into().unwrap();
                 transmute::<_, &mut CpuidEntry>(arr2)
             }
         })

--- a/src/vmm/src/cpuid/mod.rs
+++ b/src/vmm/src/cpuid/mod.rs
@@ -283,7 +283,7 @@ pub trait CpuidTrait {
 
 impl CpuidTrait for kvm_bindings::CpuId {
     /// Gets a given sub-leaf.
-    #[allow(clippy::transmute_ptr_to_ptr)]
+    #[allow(clippy::transmute_ptr_to_ptr, clippy::unwrap_used)]
     #[inline]
     fn get(&self, CpuidKey { leaf, subleaf }: &CpuidKey) -> Option<&CpuidEntry> {
         let entry_opt = self
@@ -296,15 +296,14 @@ impl CpuidTrait for kvm_bindings::CpuId {
             // SAFETY: The `kvm_cpuid_entry2` and `CpuidEntry` are `repr(C)` with known sizes.
             unsafe {
                 let arr: &[u8; size_of::<kvm_bindings::kvm_cpuid_entry2>()] = transmute(entry);
-                let arr2: &[u8; size_of::<CpuidEntry>()] =
-                    arr.get_unchecked(8..28).try_into().unwrap_unchecked();
+                let arr2: &[u8; size_of::<CpuidEntry>()] = arr[8..28].try_into().unwrap();
                 transmute::<_, &CpuidEntry>(arr2)
             }
         })
     }
 
     /// Gets a given sub-leaf.
-    #[allow(clippy::transmute_ptr_to_ptr)]
+    #[allow(clippy::transmute_ptr_to_ptr, clippy::unwrap_used)]
     #[inline]
     fn get_mut(&mut self, CpuidKey { leaf, subleaf }: &CpuidKey) -> Option<&mut CpuidEntry> {
         let entry_opt = self
@@ -317,7 +316,7 @@ impl CpuidTrait for kvm_bindings::CpuId {
             unsafe {
                 let arr: &mut [u8; size_of::<kvm_bindings::kvm_cpuid_entry2>()] = transmute(entry);
                 let arr2: &mut [u8; size_of::<CpuidEntry>()] =
-                    arr.get_unchecked_mut(8..28).try_into().unwrap_unchecked();
+                    (&mut arr[8..28]).try_into().unwrap();
                 transmute::<_, &mut CpuidEntry>(arr2)
             }
         })


### PR DESCRIPTION
## Changes

Reduced std `unchecked` calls.

## Reason

Avoids `unsafe`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
