### PR TITLE
Cpuid leaf12

### DIFF
--- a/src/vmm/src/cpuid/intel/indexing.rs
+++ b/src/vmm/src/cpuid/intel/indexing.rs
@@ -308,7 +308,7 @@ impl IndexLeaf<0x12> for IntelCpuid {
             // further information See `index_leaf!`.
             unsafe {
                 self.0
-                    .range(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
+                    .range(CpuidKey::subleaf(0x12, 0x2)..CpuidKey::leaf(0x13))
                     .map(|(_, v): (_, &'a CpuidEntry)| {
                         transmute::<_, &'a Leaf12SubleafGt1>(&v.result)
                     })
@@ -344,7 +344,7 @@ impl IndexLeafMut<0x12> for IntelCpuid {
             // further information See `index_leaf!`.
             unsafe {
                 self.0
-                    .range_mut(CpuidKey::leaf(0x12)..CpuidKey::leaf(0x2))
+                    .range_mut(CpuidKey::subleaf(0x12, 0x2)..CpuidKey::leaf(0x13))
                     .map(|(_, v)| transmute::<_, &'a mut Leaf12SubleafGt1>(&mut v.result))
                     .collect()
             },


### PR DESCRIPTION
## Changes

Correct leaf 0x12 indexing

## Reason

The previous implementation could return multiple mutable references to the same value, this fix corrects this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
