### PR TITLE
chore(ci): add script to generate rdmsr pipelines

### DIFF
--- a/.buildkite/pipeline_cpu_template.py
+++ b/.buildkite/pipeline_cpu_template.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite CPU template pipelines dynamically"""
+
+import argparse
+import json
+
+from common import group, DEFAULT_INSTANCES, DEFAULT_KERNELS
+
+cpu_template_test = {
+    "rdmsr": [
+        {
+            "label": "🖴 rdmsr",
+            "test_path": "integration_tests/functional/test_cpu_features.py::test_cpu_rdmsr",
+            "devtool_opts": " ",
+            "instances": ["m5d.metal", "m6i.metal", "m6a.metal"],
+        },
+    ],
+}
+
+
+def build_group(test):
+    """Build a Buildkite pipeline `group` step"""
+    devtool_opts = test.pop("devtool_opts")
+    test_path = test.pop("test_path")
+    return group(
+        label=test.pop("label"),
+        command=f"./tools/devtool -y test {devtool_opts} -- --nonci -s --dump-results-to-file --log-cli-level=INFO {test_path}",
+        instances=test.pop("instances"),
+        kernels=test.pop("kernels"),
+        # and the rest can be command arguments
+        **test
+    )
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--test",
+    required=True,
+    choices=list(cpu_template_test.keys()),
+    help="CPU template test"
+)
+parser.add_argument(
+    "--add-instance",
+    required=False,
+    action="append",
+    default=DEFAULT_INSTANCES,
+)
+args = parser.parse_args()
+if not args.add_instance:
+    args.add_instance = DEFAULT_INSTANCES
+group_steps = []
+tests = cpu_template_test[args.test]
+if isinstance(tests, dict):
+    tests = [tests]
+for test_data in tests:
+    test_data.setdefault("kernels", DEFAULT_KERNELS)
+    test_data.setdefault("instances", args.add_instance)
+    group_steps.append(build_group(test_data))
+
+
+pipeline = {
+    "env": {
+        "AWS_EMF_SERVICE_NAME": "CPUTemplateTests",
+        "AWS_EMF_NAMESPACE": "CPUTemplateTests",
+    },
+    "agents": {"queue": "public-prod-us-east-1"},
+    "steps": group_steps
+}
+print(json.dumps(pipeline, indent=4, sort_keys=True, ensure_ascii=False))

--- a/.buildkite/pipeline_cpu_template_new.py
+++ b/.buildkite/pipeline_cpu_template_new.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Buildkite performance pipelines dynamically"""
+
+import json
+
+from common import group, DEFAULT_INSTANCES, DEFAULT_KERNELS
+
+
+CMD1 = ["tools/devtool -y test -- -s --nonci integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_snapshot or test_cpu_cpuid_snapshot'"]
+CMD2 = [
+    "buildkite-agent artifact download tests/snapshot_artifacts/**/* .",
+    "tools/devtool -y test -- -s --nonci integration_tests/functional/test_cpu_features.py -k 'test_cpu_wrmsr_restore or test_cpu_cpuid_restore'"
+]
+
+
+groups = []
+# for instance in DEFAULT_INSTANCES:
+for instance in ["m5d.metal", "m6i.metal", "m6a.metal"]:
+    for kv in ["linux_4.14"]:
+        steps = []
+        agents = [f"instance={instance}", f"kv={kv}"]
+        label = f"{instance} {kv}"
+        common = {
+            "agents": agents,
+            "timeout": 30,
+        }
+        step1 = {
+            "commands": CMD1,
+            "label": label + " wrmsr snapshot",
+            "artifact_paths": "tests/snapshot_artifacts/**/*",
+            **common
+        }
+        step2 = {
+            "commands": CMD2,
+            "label": label + " wrmsr restore",
+            **common
+        }
+        steps.append(step1)
+        steps.append("wait")
+        #steps.append({"wait": ""})
+        steps.append(step2)
+        groups.append({"group": label, "steps": steps})
+
+pipeline = {
+    "agents": {"queue": "public-prod-us-east-1"},
+    "steps": groups
+}
+print(json.dumps(pipeline, indent=4, sort_keys=True, ensure_ascii=False))


### PR DESCRIPTION
## Changes

Add script to generate CPU template pipelines

## Reason

To reduce the effort to create new pipelines and maintain existing ones.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] The description of changes is clear and encompassing.
~~- [ ] Any required documentation changes (code and docs) are included in this PR.~~
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~~- [ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
