### PR TITLE
Disable memory monitor for nightly performance tests

### DIFF
--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -98,6 +98,7 @@ class MicrovmBuilder:
         smt=None,
         daemonize=True,
         io_engine=None,
+        monitor_memory=True,
     ):
         """Build a fresh microvm."""
         vm = Microvm(
@@ -105,6 +106,7 @@ class MicrovmBuilder:
             fc_binary_path=fc_binary,
             jailer_binary_path=jailer_binary,
             bin_cloner_path=self.bin_cloner_path,
+            monitor_memory=monitor_memory,
         )
         vm.jailer.daemonize = daemonize
         # Start firecracker.
@@ -171,7 +173,8 @@ class MicrovmBuilder:
             track_dirty_pages=diff_snapshots,
             cpu_template=cpu_template,
         )
-        vm.memory_monitor.guest_mem_mib = microvm_config["mem_size_mib"]
+        if monitor_memory:
+            vm.memory_monitor.guest_mem_mib = microvm_config["mem_size_mib"]
         assert vm.api_session.is_status_no_content(response.status_code)
 
         vm.vcpus_count = int(microvm_config["vcpu_count"])

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -56,7 +56,6 @@ from framework.resources import (
 LOG = logging.getLogger("microvm")
 data_lock = Lock()
 
-
 # pylint: disable=R0904
 class Microvm:
     """Class to represent a Firecracker microvm.

--- a/tests/integration_tests/performance/test_block_performance.py
+++ b/tests/integration_tests/performance/test_block_performance.py
@@ -351,7 +351,11 @@ def fio_workload(context):
     ssh_key = context.disk.ssh_key()
     # Create a fresh microvm from artifacts.
     vm_instance = vm_builder.build(
-        kernel=context.kernel, disks=[rw_disk], ssh_key=ssh_key, config=context.microvm
+        kernel=context.kernel,
+        disks=[rw_disk],
+        ssh_key=ssh_key,
+        config=context.microvm,
+        monitor_memory=False,
     )
     basevm = vm_instance.vm
 

--- a/tests/integration_tests/performance/test_network_latency.py
+++ b/tests/integration_tests/performance/test_network_latency.py
@@ -184,7 +184,11 @@ def _g2h_send_ping(context):
     ssh_key = context.disk.ssh_key()
     # Create a fresh microvm from aftifacts.
     vm_instance = vm_builder.build(
-        kernel=context.kernel, disks=[rw_disk], ssh_key=ssh_key, config=context.microvm
+        kernel=context.kernel,
+        disks=[rw_disk],
+        ssh_key=ssh_key,
+        config=context.microvm,
+        monitor_memory=False,
     )
     basevm = vm_instance.vm
     basevm.start()

--- a/tests/integration_tests/performance/test_network_tcp_throughput.py
+++ b/tests/integration_tests/performance/test_network_tcp_throughput.py
@@ -352,7 +352,11 @@ def iperf_workload(context):
     ssh_key = context.disk.ssh_key()
     # Create a fresh microvm from artifacts.
     vm_instance = vm_builder.build(
-        kernel=context.kernel, disks=[rw_disk], ssh_key=ssh_key, config=context.microvm
+        kernel=context.kernel,
+        disks=[rw_disk],
+        ssh_key=ssh_key,
+        config=context.microvm,
+        monitor_memory=False,
     )
     basevm = vm_instance.vm
     basevm.start()

--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -132,6 +132,7 @@ def get_snap_restore_latency(
         net_ifaces=ifaces,
         use_ramdisk=True,
         io_engine="Sync",
+        monitor_memory=False,
     )
     basevm = vm_instance.vm
     response = basevm.machine_cfg.put(

--- a/tests/integration_tests/performance/test_vsock_throughput.py
+++ b/tests/integration_tests/performance/test_vsock_throughput.py
@@ -312,7 +312,11 @@ def iperf_workload(context):
     ssh_key = context.disk.ssh_key()
     # Create a fresh microvm from artifacts.
     vm_instance = vm_builder.build(
-        kernel=context.kernel, disks=[rw_disk], ssh_key=ssh_key, config=context.microvm
+        kernel=context.kernel,
+        disks=[rw_disk],
+        ssh_key=ssh_key,
+        config=context.microvm,
+        monitor_memory=False,
     )
     basevm = vm_instance.vm
     # Create a vsock device


### PR DESCRIPTION
## Changes

Disable the memory monitor for nightly performance tests

## Reason

Since the monitor's sampling rate was increased to 20 times per second, it seemingly started to interfere with the results of the performance tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
