### PR TITLE
fix: memory monitor usage removed from snap restore test

### DIFF
--- a/tests/integration_tests/performance/test_snapshot_restore_performance.py
+++ b/tests/integration_tests/performance/test_snapshot_restore_performance.py
@@ -139,7 +139,6 @@ def get_snap_restore_latency(
         vcpu_count=vcpus,
         mem_size_mib=mem_size,
     )
-    basevm.memory_monitor.guest_mem_mib = mem_size
     assert basevm.api_session.is_status_no_content(response.status_code)
 
     extra_disk_paths = []


### PR DESCRIPTION
## Reason

Remove completely the usage of memory monitor in the snapshot restore latency test.

This is related to: https://github.com/firecracker-microvm/firecracker/pull/3454

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
