### PR TITLE
Update vsock baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -462,15 +462,15 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 99
-                                                },
-                                                "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
                                                     "target": 99
                                                 },
-                                                "vsock-p1024K-h2g": {
+                                                "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
+                                                    "target": 99
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -478,7 +478,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -486,23 +486,23 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 197
+                                                    "delta_percentage": 5,
+                                                    "target": 198
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 104
+                                                    "target": 98
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 179
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 112
+                                                    "target": 117
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -510,15 +510,15 @@
                                                     "target": 117
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 114
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 197
+                                                    "delta_percentage": 5,
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 118
                                                 }
                                             }
@@ -534,7 +534,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -546,11 +546,11 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -558,12 +558,12 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 134
+                                                    "delta_percentage": 7,
+                                                    "target": 133
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 98
+                                                    "delta_percentage": 8,
+                                                    "target": 92
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 7,
@@ -571,7 +571,7 @@
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 105
+                                                    "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
@@ -586,8 +586,8 @@
                                                     "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 197
+                                                    "delta_percentage": 5,
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
@@ -604,24 +604,24 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 49
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 17,
+                                                    "delta_percentage": 15,
                                                     "target": 36
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 54
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
@@ -632,39 +632,39 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 71
-                                                },
-                                                "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
                                                     "target": 70
                                                 },
-                                                "vsock-p1024-h2g": {
+                                                "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 63
+                                                    "target": 72
+                                                },
+                                                "vsock-p1024-h2g": {
+                                                    "delta_percentage": 10,
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 71
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 7,
+                                                    "target": 65
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 16,
+                                                    "delta_percentage": 11,
                                                     "target": 73
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 71
+                                                    "delta_percentage": 9,
+                                                    "target": 72
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 63
+                                                    "delta_percentage": 9,
+                                                    "target": 64
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 13,
+                                                    "delta_percentage": 17,
                                                     "target": 74
                                                 }
                                             }
@@ -680,19 +680,19 @@
                                                     "target": 50
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 11,
                                                     "target": 40
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 36
+                                                    "delta_percentage": 11,
+                                                    "target": 35
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
+                                                    "delta_percentage": 9,
+                                                    "target": 71
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 10,
                                                     "target": 39
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -704,27 +704,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 56
+                                                    "delta_percentage": 8,
+                                                    "target": 55
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 72
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 70
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 12,
                                                     "target": 47
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 76
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -732,11 +732,11 @@
                                                     "target": 69
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 15,
-                                                    "target": 48
+                                                    "delta_percentage": 13,
+                                                    "target": 46
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 76
                                                 }
                                             }
@@ -750,43 +750,43 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 23,
-                                                    "target": 1225
+                                                    "delta_percentage": 25,
+                                                    "target": 1064
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 103,
-                                                    "target": 443
+                                                    "delta_percentage": 94,
+                                                    "target": 420
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 4956
+                                                    "target": 4927
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3035
+                                                    "delta_percentage": 5,
+                                                    "target": 3027
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 5057
+                                                    "target": 5018
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 2971
+                                                    "target": 2950
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 8,
                                                     "target": 1324
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2090
+                                                    "delta_percentage": 6,
+                                                    "target": 1955
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 1524
                                                 },
                                                 "vsock-p1024K-bd": {
@@ -794,24 +794,24 @@
                                                     "target": 3437
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5836
+                                                    "delta_percentage": 6,
+                                                    "target": 5708
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 4103
+                                                    "delta_percentage": 10,
+                                                    "target": 4132
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3428
+                                                    "delta_percentage": 6,
+                                                    "target": 3431
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 5792
+                                                    "target": 5713
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 4010
+                                                    "delta_percentage": 12,
+                                                    "target": 4041
                                                 }
                                             }
                                         }
@@ -823,27 +823,27 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 1426
+                                                    "target": 1429
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 1238
+                                                    "target": 1229
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9000
+                                                    "target": 8968
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 3072
+                                                    "target": 3050
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9775
+                                                    "target": 9756
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2969
+                                                    "delta_percentage": 7,
+                                                    "target": 2984
                                                 }
                                             }
                                         },
@@ -851,39 +851,39 @@
                                             "total": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 1444
+                                                    "target": 1442
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2104
+                                                    "delta_percentage": 6,
+                                                    "target": 1971
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 1930
+                                                    "target": 1921
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 3632
+                                                    "target": 3640
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 13800
+                                                    "target": 14030
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3838
+                                                    "target": 3845
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 3592
+                                                    "target": 3614
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 14045
+                                                    "delta_percentage": 7,
+                                                    "target": 13629
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3674
+                                                    "target": 3682
                                                 }
                                             }
                                         }
@@ -905,7 +905,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -921,7 +921,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -933,15 +933,15 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 88
+                                                    "delta_percentage": 9,
+                                                    "target": 85
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 173
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 118
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -949,11 +949,11 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 129
+                                                    "delta_percentage": 7,
+                                                    "target": 128
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 119
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -961,8 +961,8 @@
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 128
+                                                    "delta_percentage": 7,
+                                                    "target": 129
                                                 }
                                             }
                                         }
@@ -973,7 +973,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -1001,40 +1001,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 16,
-                                                    "target": 129
+                                                    "delta_percentage": 18,
+                                                    "target": 127
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 81
+                                                    "target": 79
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 153
+                                                    "delta_percentage": 7,
+                                                    "target": 152
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 104
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
+                                                    "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
+                                                    "delta_percentage": 6,
                                                     "target": 117
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 106
+                                                    "delta_percentage": 6,
+                                                    "target": 105
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 117
+                                                    "delta_percentage": 7,
+                                                    "target": 118
                                                 }
                                             }
                                         }
@@ -1047,11 +1047,11 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 10,
                                                     "target": 50
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 44
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -1060,14 +1060,14 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 61
+                                                    "target": 62
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 52
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 61
                                                 }
                                             }
@@ -1075,15 +1075,15 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 67
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 68
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 64
                                                 },
                                                 "vsock-p1024K-bd": {
@@ -1091,20 +1091,20 @@
                                                     "target": 64
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 65
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 76
+                                                    "target": 77
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 9,
-                                                    "target": 64
+                                                    "target": 65
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 64
+                                                    "delta_percentage": 7,
+                                                    "target": 65
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
@@ -1119,27 +1119,27 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 52
+                                                    "delta_percentage": 10,
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 10,
                                                     "target": 46
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 40
+                                                    "delta_percentage": 11,
+                                                    "target": 39
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 63
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 40
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 }
                                             }
@@ -1151,36 +1151,36 @@
                                                     "target": 55
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 69
+                                                    "delta_percentage": 7,
+                                                    "target": 70
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 61
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 45
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 70
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 62
+                                                    "delta_percentage": 8,
+                                                    "target": 61
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 9,
                                                     "target": 46
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 69
+                                                    "delta_percentage": 8,
+                                                    "target": 70
                                                 }
                                             }
                                         }
@@ -1193,68 +1193,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2360
+                                                    "delta_percentage": 7,
+                                                    "target": 2304
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 1787
+                                                    "delta_percentage": 6,
+                                                    "target": 1770
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6945
+                                                    "delta_percentage": 6,
+                                                    "target": 6876
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4700
+                                                    "delta_percentage": 7,
+                                                    "target": 4658
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7022
+                                                    "delta_percentage": 6,
+                                                    "target": 6943
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4589
+                                                    "delta_percentage": 7,
+                                                    "target": 4547
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2065
+                                                    "delta_percentage": 8,
+                                                    "target": 2013
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2959
+                                                    "target": 2877
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2360
+                                                    "delta_percentage": 8,
+                                                    "target": 2308
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5297
+                                                    "target": 5296
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7676
+                                                    "delta_percentage": 6,
+                                                    "target": 7489
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5617
+                                                    "delta_percentage": 5,
+                                                    "target": 5620
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5236
+                                                    "target": 5239
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 7653
+                                                    "target": 7518
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5538
+                                                    "target": 5547
                                                 }
                                             }
                                         }
@@ -1265,68 +1265,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2514
+                                                    "delta_percentage": 6,
+                                                    "target": 2466
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 2145
+                                                    "delta_percentage": 6,
+                                                    "target": 2143
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12232
+                                                    "target": 12206
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4812
+                                                    "delta_percentage": 7,
+                                                    "target": 4764
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 12398
+                                                    "delta_percentage": 6,
+                                                    "target": 12298
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4653
+                                                    "delta_percentage": 7,
+                                                    "target": 4592
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2401
+                                                    "delta_percentage": 7,
+                                                    "target": 2394
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2996
+                                                    "target": 2920
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2956
+                                                    "delta_percentage": 5,
+                                                    "target": 2964
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 5552
+                                                    "target": 5536
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 16520
+                                                    "delta_percentage": 5,
+                                                    "target": 16532
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5698
+                                                    "delta_percentage": 6,
+                                                    "target": 5701
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5505
+                                                    "delta_percentage": 6,
+                                                    "target": 5515
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 4,
-                                                    "target": 16788
+                                                    "delta_percentage": 5,
+                                                    "target": 16614
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5523
+                                                    "delta_percentage": 6,
+                                                    "target": 5535
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -2246,7 +2246,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -2258,7 +2258,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -2274,12 +2274,12 @@
                                                     "target": 188
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 21,
-                                                    "target": 133
+                                                    "delta_percentage": 48,
+                                                    "target": 110
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 173
+                                                    "delta_percentage": 5,
+                                                    "target": 174
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
@@ -2287,22 +2287,22 @@
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 130
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 121
+                                                    "delta_percentage": 6,
+                                                    "target": 122
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 131
                                                 }
                                             }
@@ -2318,23 +2318,23 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 99
-                                                },
-                                                "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 99
                                                 },
-                                                "vsock-p1024K-h2g": {
+                                                "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
+                                                    "target": 99
+                                                },
+                                                "vsock-p1024K-h2g": {
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -2342,16 +2342,16 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 15,
-                                                    "target": 112
+                                                    "delta_percentage": 23,
+                                                    "target": 115
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 35,
-                                                    "target": 115
+                                                    "delta_percentage": 64,
+                                                    "target": 85
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 162
+                                                    "target": 163
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
@@ -2362,19 +2362,19 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 123
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 105
+                                                    "target": 106
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 8,
                                                     "target": 121
                                                 }
                                             }
@@ -2393,7 +2393,7 @@
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 11,
-                                                    "target": 49
+                                                    "target": 48
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 9,
@@ -2404,11 +2404,11 @@
                                                     "target": 58
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 11,
                                                     "target": 54
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 8,
                                                     "target": 58
                                                 }
                                             }
@@ -2416,12 +2416,12 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 71
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
+                                                    "delta_percentage": 9,
+                                                    "target": 71
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 8,
@@ -2429,10 +2429,10 @@
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 61
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 63
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -2440,11 +2440,11 @@
                                                     "target": 74
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 62
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 63
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -2461,14 +2461,14 @@
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 52
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -2476,7 +2476,7 @@
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 11,
                                                     "target": 41
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -2488,24 +2488,24 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 14,
-                                                    "target": 52
+                                                    "delta_percentage": 23,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 70
+                                                    "delta_percentage": 7,
+                                                    "target": 71
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 63
+                                                    "delta_percentage": 10,
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 8,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 49
+                                                    "delta_percentage": 8,
+                                                    "target": 48
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
@@ -2516,8 +2516,8 @@
                                                     "target": 58
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 50
+                                                    "delta_percentage": 8,
+                                                    "target": 49
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
@@ -2535,67 +2535,67 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2707
+                                                    "target": 2693
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 2160
+                                                    "target": 2163
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8254
+                                                    "delta_percentage": 7,
+                                                    "target": 8257
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6006
+                                                    "target": 5994
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 8341
+                                                    "delta_percentage": 7,
+                                                    "target": 8333
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5845
+                                                    "delta_percentage": 5,
+                                                    "target": 5827
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 2962
+                                                    "delta_percentage": 7,
+                                                    "target": 2970
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 3428
+                                                    "target": 3330
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2994
+                                                    "delta_percentage": 7,
+                                                    "target": 3003
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 6880
+                                                    "target": 6885
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 9670
+                                                    "delta_percentage": 8,
+                                                    "target": 9614
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7132
+                                                    "delta_percentage": 5,
+                                                    "target": 7119
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 6798
+                                                    "target": 6794
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 9608
+                                                    "target": 9638
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 7008
+                                                    "target": 7006
                                                 }
                                             }
                                         }
@@ -2607,67 +2607,67 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2882
+                                                    "target": 2902
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 2636
+                                                    "target": 2645
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 14166
+                                                    "target": 14312
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 6157
+                                                    "target": 6131
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 14348
+                                                    "delta_percentage": 7,
+                                                    "target": 14453
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5983
+                                                    "target": 5974
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 2805
+                                                    "delta_percentage": 12,
+                                                    "target": 2836
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 3507
+                                                    "delta_percentage": 9,
+                                                    "target": 3414
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 3253
+                                                    "delta_percentage": 11,
+                                                    "target": 3263
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 7178
+                                                    "delta_percentage": 6,
+                                                    "target": 7167
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 19986
+                                                    "delta_percentage": 8,
+                                                    "target": 20160
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7457
+                                                    "delta_percentage": 7,
+                                                    "target": 7497
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 7111
+                                                    "target": 7123
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 20311
+                                                    "delta_percentage": 8,
+                                                    "target": 20262
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 7138
+                                                    "delta_percentage": 7,
+                                                    "target": 7176
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_5.10.json
@@ -458,7 +458,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -490,12 +490,12 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 94
+                                                    "delta_percentage": 11,
+                                                    "target": 90
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 178
+                                                    "target": 179
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
@@ -507,10 +507,10 @@
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 133
+                                                    "target": 134
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 122
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -518,8 +518,8 @@
                                                     "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 134
+                                                    "delta_percentage": 7,
+                                                    "target": 133
                                                 }
                                             }
                                         }
@@ -530,7 +530,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -559,15 +559,15 @@
                                             "Avg": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 148
+                                                    "target": 149
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 13,
                                                     "target": 83
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 172
+                                                    "target": 171
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
@@ -575,11 +575,11 @@
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 120
+                                                    "target": 119
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 6,
@@ -587,11 +587,11 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 119
+                                                    "target": 120
                                                 }
                                             }
                                         }
@@ -612,11 +612,11 @@
                                                     "target": 47
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 54
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -624,19 +624,19 @@
                                                     "target": 54
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 60
+                                                    "delta_percentage": 8,
+                                                    "target": 59
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 68
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 76
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -644,7 +644,7 @@
                                                     "target": 67
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 63
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -656,11 +656,11 @@
                                                     "target": 77
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 64
+                                                    "delta_percentage": 9,
+                                                    "target": 63
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 67
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
@@ -676,7 +676,7 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
+                                                    "delta_percentage": 9,
                                                     "target": 56
                                                 },
                                                 "vsock-p1024-h2g": {
@@ -684,43 +684,43 @@
                                                     "target": 50
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 11,
+                                                    "delta_percentage": 9,
                                                     "target": 41
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 61
+                                                    "delta_percentage": 8,
+                                                    "target": 60
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 11,
                                                     "target": 42
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 61
+                                                    "delta_percentage": 9,
+                                                    "target": 60
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 67
+                                                    "delta_percentage": 9,
+                                                    "target": 68
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 75
+                                                    "target": 76
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 61
+                                                    "target": 60
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 61
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 49
                                                 },
                                                 "vsock-p1024K-h2g": {
@@ -728,16 +728,16 @@
                                                     "target": 68
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 60
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 50
+                                                    "target": 49
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 69
+                                                    "target": 68
                                                 }
                                             }
                                         }
@@ -751,67 +751,67 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 2200
+                                                    "target": 2187
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 1819
+                                                    "delta_percentage": 6,
+                                                    "target": 1818
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6835
+                                                    "delta_percentage": 6,
+                                                    "target": 6844
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5275
+                                                    "target": 5287
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 6897
+                                                    "delta_percentage": 6,
+                                                    "target": 6892
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5159
+                                                    "target": 5150
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2212
+                                                    "delta_percentage": 5,
+                                                    "target": 2189
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 2836
+                                                    "target": 2774
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 2544
+                                                    "target": 2529
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 5828
+                                                    "target": 5774
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 7089
+                                                    "delta_percentage": 6,
+                                                    "target": 7079
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5906
+                                                    "delta_percentage": 6,
+                                                    "target": 5820
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 5780
+                                                    "delta_percentage": 6,
+                                                    "target": 5710
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 7076
+                                                    "target": 7089
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 5824
+                                                    "target": 5778
                                                 }
                                             }
                                         }
@@ -822,68 +822,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 2336
+                                                    "delta_percentage": 6,
+                                                    "target": 2349
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 2207
+                                                    "target": 2211
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12422
+                                                    "target": 12400
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5398
+                                                    "target": 5378
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 12543
+                                                    "target": 12530
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 5228
+                                                    "target": 5222
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 2642
+                                                    "delta_percentage": 9,
+                                                    "target": 2690
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 2768
+                                                    "target": 2758
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 2699
+                                                    "delta_percentage": 8,
+                                                    "target": 2668
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 6145
+                                                    "delta_percentage": 6,
+                                                    "target": 6043
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 16562
+                                                    "target": 16528
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6173
+                                                    "target": 6121
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 6076
+                                                    "target": 6013
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 16826
+                                                    "target": 16608
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 5947
+                                                    "delta_percentage": 7,
+                                                    "target": 5928
                                                 }
                                             }
                                         }
@@ -901,11 +901,11 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -913,7 +913,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -921,7 +921,7 @@
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 }
                                             }
@@ -930,39 +930,39 @@
                                             "Avg": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 198
+                                                    "target": 197
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 17,
-                                                    "target": 101
+                                                    "delta_percentage": 14,
+                                                    "target": 92
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
                                                     "target": 183
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 114
+                                                    "delta_percentage": 6,
+                                                    "target": 119
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 120
+                                                    "target": 119
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 116
+                                                    "delta_percentage": 7,
+                                                    "target": 115
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 120
+                                                    "delta_percentage": 7,
+                                                    "target": 121
                                                 }
                                             }
                                         }
@@ -973,11 +973,11 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-g2h": {
@@ -985,15 +985,15 @@
                                                     "target": 99
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 5,
                                                     "target": 99
                                                 }
                                             }
@@ -1001,15 +1001,15 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 143
+                                                    "delta_percentage": 7,
+                                                    "target": 146
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 91
+                                                    "delta_percentage": 12,
+                                                    "target": 87
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 168
                                                 },
                                                 "vsock-p1024K-bd": {
@@ -1021,7 +1021,7 @@
                                                     "target": 198
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 114
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1030,10 +1030,10 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 197
+                                                    "target": 198
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 6,
                                                     "target": 115
                                                 }
                                             }
@@ -1047,19 +1047,19 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 51
+                                                    "delta_percentage": 7,
+                                                    "target": 53
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 12,
                                                     "target": 37
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 54
+                                                    "delta_percentage": 9,
+                                                    "target": 55
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 69
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
@@ -1068,7 +1068,7 @@
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 69
+                                                    "target": 68
                                                 }
                                             }
                                         },
@@ -1080,35 +1080,35 @@
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 75
+                                                    "target": 76
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 62
+                                                    "delta_percentage": 8,
+                                                    "target": 63
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 7,
                                                     "target": 71
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 65
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 15,
-                                                    "target": 77
+                                                    "delta_percentage": 14,
+                                                    "target": 75
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 72
+                                                    "delta_percentage": 8,
+                                                    "target": 71
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 65
+                                                    "target": 68
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 76
+                                                    "delta_percentage": 15,
+                                                    "target": 75
                                                 }
                                             }
                                         }
@@ -1119,27 +1119,27 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 53
+                                                    "delta_percentage": 8,
+                                                    "target": 54
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 14,
+                                                    "delta_percentage": 12,
                                                     "target": 41
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 11,
                                                     "target": 37
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 9,
                                                     "target": 70
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 8,
                                                     "target": 41
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
+                                                    "delta_percentage": 8,
                                                     "target": 69
                                                 }
                                             }
@@ -1147,27 +1147,27 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 61
+                                                    "delta_percentage": 12,
+                                                    "target": 62
                                                 },
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 75
+                                                    "target": 77
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 10,
                                                     "target": 56
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 69
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 12,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 52
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 6,
                                                     "target": 76
                                                 },
                                                 "vsock-pDEFAULT-bd": {
@@ -1175,11 +1175,11 @@
                                                     "target": 68
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 50
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
+                                                    "delta_percentage": 7,
                                                     "target": 76
                                                 }
                                             }
@@ -1193,28 +1193,28 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 1256
+                                                    "delta_percentage": 11,
+                                                    "target": 1202
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 62,
-                                                    "target": 453
+                                                    "delta_percentage": 56,
+                                                    "target": 454
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 4965
+                                                    "target": 4940
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3310
+                                                    "delta_percentage": 6,
+                                                    "target": 3292
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 5043
+                                                    "target": 5008
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3236
+                                                    "delta_percentage": 6,
+                                                    "target": 3215
                                                 }
                                             }
                                         },
@@ -1222,39 +1222,39 @@
                                             "total": {
                                                 "vsock-p1024-bd": {
                                                     "delta_percentage": 10,
-                                                    "target": 1262
+                                                    "target": 1252
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 1976
+                                                    "delta_percentage": 7,
+                                                    "target": 1834
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 1437
+                                                    "target": 1424
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3691
+                                                    "delta_percentage": 5,
+                                                    "target": 3663
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 5754
+                                                    "target": 5311
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 4148
+                                                    "delta_percentage": 10,
+                                                    "target": 4162
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 3676
+                                                    "delta_percentage": 5,
+                                                    "target": 3646
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 5737
+                                                    "target": 5326
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 11,
-                                                    "target": 4113
+                                                    "target": 4115
                                                 }
                                             }
                                         }
@@ -1266,67 +1266,67 @@
                                             "total": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 5,
-                                                    "target": 1395
+                                                    "target": 1389
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 4,
-                                                    "target": 1256
+                                                    "target": 1257
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9345
+                                                    "target": 9357
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3350
+                                                    "target": 3335
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10040
+                                                    "target": 10078
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 3250
+                                                    "delta_percentage": 7,
+                                                    "target": 3223
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 5,
-                                                    "target": 1533
+                                                    "delta_percentage": 7,
+                                                    "target": 1540
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 1982
+                                                    "delta_percentage": 6,
+                                                    "target": 1873
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 1720
+                                                    "target": 1707
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 3927
+                                                    "target": 3887
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 7,
-                                                    "target": 14218
+                                                    "target": 14397
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 4025
+                                                    "delta_percentage": 6,
+                                                    "target": 3998
                                                 },
                                                 "vsock-pDEFAULT-bd": {
                                                     "delta_percentage": 5,
-                                                    "target": 3891
+                                                    "target": 3867
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 14221
+                                                    "delta_percentage": 7,
+                                                    "target": 13998
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 3876
+                                                    "target": 3851
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Changes

Update vsock throughput baselines for `m5d` with kernels `4.14` and `5.10` and `m6i` with kernel `5.10`.

## Reason

We have seen that in these two instance types and related kernel versions vsock throughput tests have been flaky. The only change that has been committed to the repo around the time the tests started failing was the upgrade to Ubuntu 22.04 of our dev container.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
