### PR TITLE
Warn on `clippy::cast_sign_loss`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,8 @@ target = "x86_64-unknown-linux-musl"
 rustflags = [
   "-Dclippy::ptr_as_ptr",
   "-Dclippy::undocumented_unsafe_blocks",
-  "-Dclippy::cast_lossless"
+  "-Dclippy::cast_lossless",
+  "-Dclippy::cast_sign_loss"
 ]
 
 [net]

--- a/src/arch/src/aarch64/gic/gicv2/regs/mod.rs
+++ b/src/arch/src/aarch64/gic/gicv2/regs/mod.rs
@@ -73,10 +73,10 @@ mod tests {
 
         let vm_state = save_state(gic_fd, &mpidr).unwrap();
         let val: u32 = 0;
-        let gicd_statusr_off = 0x0010;
+        let gicd_statusr_off = 0x0010u64;
         let mut gic_dist_attr = kvm_bindings::kvm_device_attr {
             group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
-            attr: gicd_statusr_off as u64,
+            attr: gicd_statusr_off,
             addr: &val as *const u32 as u64,
             flags: 0,
         };

--- a/src/arch/src/aarch64/gic/gicv3/regs/icc_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/icc_regs.rs
@@ -83,6 +83,7 @@ impl VgicRegEngine for VgicSysRegEngine {
         KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS
     }
 
+    #[allow(clippy::cast_sign_loss)] // bit mask
     fn mpidr_mask() -> u64 {
         KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64
     }

--- a/src/arch/src/aarch64/gic/gicv3/regs/mod.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/mod.rs
@@ -75,10 +75,10 @@ mod tests {
 
         let vm_state = save_state(gic_fd, &mpidr).unwrap();
         let val: u32 = 0;
-        let gicd_statusr_off = 0x0010;
+        let gicd_statusr_off = 0x0010u64;
         let mut gic_dist_attr = kvm_bindings::kvm_device_attr {
             group: kvm_bindings::KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
-            attr: gicd_statusr_off as u64,
+            attr: gicd_statusr_off,
             addr: &val as *const u32 as u64,
             flags: 0,
         };

--- a/src/arch/src/aarch64/gic/gicv3/regs/redist_regs.rs
+++ b/src/arch/src/aarch64/gic/gicv3/regs/redist_regs.rs
@@ -60,6 +60,7 @@ impl VgicRegEngine for RedistRegEngine {
         KVM_DEV_ARM_VGIC_GRP_REDIST_REGS
     }
 
+    #[allow(clippy::cast_sign_loss)] // bit mask
     fn mpidr_mask() -> u64 {
         KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64
     }

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -193,7 +193,7 @@ impl Tap {
         if ret == -1 {
             return Err(IoError::last_os_error());
         }
-        Ok(ret as usize)
+        Ok(usize::try_from(ret).unwrap())
     }
 }
 

--- a/src/devices/src/virtio/net/test_utils.rs
+++ b/src/devices/src/virtio/net/test_utils.rs
@@ -308,7 +308,7 @@ pub fn get_element_from_queue(net: &Net, idx: usize) -> result::Result<u64, Devi
             idx as u16,
         )));
     }
-    Ok(net.queue_evts[idx].as_raw_fd() as u64)
+    Ok(u64::try_from(net.queue_evts[idx].as_raw_fd()).unwrap())
 }
 
 pub fn default_guest_mac() -> MacAddr {

--- a/src/devices/src/virtio/vsock/test_utils.rs
+++ b/src/devices/src/virtio/vsock/test_utils.rs
@@ -210,9 +210,9 @@ where
 
     pub fn get_element_from_interest_list(vsock: &Vsock<B>, idx: usize) -> u64 {
         match idx {
-            0..=2 => vsock.queue_events[idx].as_raw_fd() as u64,
-            3 => vsock.backend.as_raw_fd() as u64,
-            4 => vsock.activate_evt.as_raw_fd() as u64,
+            0..=2 => u64::try_from(vsock.queue_events[idx].as_raw_fd()).unwrap(),
+            3 => u64::try_from(vsock.backend.as_raw_fd()).unwrap(),
+            4 => u64::try_from(vsock.activate_evt.as_raw_fd()).unwrap(),
             _ => panic!("Index bigger than interest list"),
         }
     }

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -536,7 +536,11 @@ impl VsockMuxer {
         };
 
         self.epoll
-            .ctl(ControlOperation::Add, fd, EpollEvent::new(evset, fd as u64))
+            .ctl(
+                ControlOperation::Add,
+                fd,
+                EpollEvent::new(evset, u64::try_from(fd).unwrap()),
+            )
             .map(|_| {
                 self.listener_map.insert(fd, listener);
             })
@@ -686,7 +690,7 @@ impl VsockMuxer {
                         .ctl(
                             ControlOperation::Modify,
                             fd,
-                            EpollEvent::new(new_evset, fd as u64),
+                            EpollEvent::new(new_evset, u64::try_from(fd).unwrap()),
                         )
                         .unwrap_or_else(|err| {
                             // This really shouldn't happen, like, ever. However, "famous last

--- a/src/io_uring/src/lib.rs
+++ b/src/io_uring/src/lib.rs
@@ -527,30 +527,36 @@ mod tests {
                     for mut operation in set {
                         // Perform the sync op.
                         let count = match operation.opcode {
-                            OpCode::Write => SyscallReturnCode(unsafe {
-                                libc::pwrite(
-                                    file_sync.as_raw_fd(),
-                                    write_mem_region.as_ptr().add(operation.addr.unwrap())
-                                        as *const libc::c_void,
-                                    operation.len.unwrap() as usize,
-                                    operation.offset.unwrap() as i64,
-                                ) as libc::c_int
-                            })
-                            .into_result()
-                            .unwrap() as u32,
-                            OpCode::Read => SyscallReturnCode(unsafe {
-                                libc::pread(
-                                    file_sync.as_raw_fd(),
-                                    sync_read_mem_region
-                                        .as_ptr()
-                                        .add(operation.addr.unwrap())
-                                        .cast::<libc::c_void>(),
-                                    operation.len.unwrap() as usize,
-                                    operation.offset.unwrap() as i64,
-                                ) as libc::c_int
-                            })
-                            .into_result()
-                            .unwrap() as u32,
+                            OpCode::Write => u32::try_from(
+                                SyscallReturnCode(unsafe {
+                                    libc::pwrite(
+                                        file_sync.as_raw_fd(),
+                                        write_mem_region.as_ptr().add(operation.addr.unwrap())
+                                            as *const libc::c_void,
+                                        operation.len.unwrap() as usize,
+                                        operation.offset.unwrap() as i64,
+                                    ) as libc::c_int
+                                })
+                                .into_result()
+                                .unwrap(),
+                            )
+                            .unwrap(),
+                            OpCode::Read => u32::try_from(
+                                SyscallReturnCode(unsafe {
+                                    libc::pread(
+                                        file_sync.as_raw_fd(),
+                                        sync_read_mem_region
+                                            .as_ptr()
+                                            .add(operation.addr.unwrap())
+                                            .cast::<libc::c_void>(),
+                                        operation.len.unwrap() as usize,
+                                        operation.offset.unwrap() as i64,
+                                    ) as libc::c_int
+                                })
+                                .into_result()
+                                .unwrap(),
+                            )
+                            .unwrap(),
                             _ => unreachable!(),
                         };
 

--- a/src/io_uring/src/operation/cqe.rs
+++ b/src/io_uring/src/operation/cqe.rs
@@ -32,7 +32,7 @@ impl<T> Cqe<T> {
 
     /// Return the number of bytes successfully transferred by this operation.
     pub fn count(&self) -> u32 {
-        i32::max(self.res, 0) as u32
+        u32::try_from(self.res).unwrap_or(0)
     }
 
     /// Return the result associated to the IO operation.
@@ -42,7 +42,7 @@ impl<T> Cqe<T> {
         if res < 0 {
             Err(std::io::Error::from_raw_os_error(res))
         } else {
-            Ok(res as u32)
+            Ok(u32::try_from(self.res).unwrap())
         }
     }
 

--- a/src/io_uring/src/queue/submission.rs
+++ b/src/io_uring/src/queue/submission.rs
@@ -142,9 +142,9 @@ impl SubmissionQueue {
                 std::ptr::null::<libc::sigset_t>(),
             )
         } as libc::c_int)
-        .into_result()?
+        .into_result()?;
         // It's safe to convert to u32 since the syscall didn't return an error.
-        as u32;
+        let submitted = u32::try_from(submitted).unwrap();
 
         // This is safe since submitted <= self.to_submit. However we use a saturating_sub
         // for extra safety.

--- a/src/rate_limiter/src/lib.rs
+++ b/src/rate_limiter/src/lib.rs
@@ -419,6 +419,7 @@ impl RateLimiter {
                     // order to enforce the bandwidth limit we need to prevent
                     // further calls to the rate limiter for
                     // `ratio * refill_time` milliseconds.
+                    #[allow(clippy::cast_sign_loss)] // ratio is always positive
                     self.activate_timer(TimerState::Oneshot(Duration::from_millis(
                         (ratio * refill_time as f64) as u64,
                     )));
@@ -658,7 +659,7 @@ pub(crate) mod tests {
         // allowing rate of 1 token/ms.
         let capacity = 1000;
         let refill_ms = 1000;
-        let mut tb = TokenBucket::new(capacity, 0, refill_ms as u64).unwrap();
+        let mut tb = TokenBucket::new(capacity, 0, refill_ms).unwrap();
 
         assert_eq!(tb.reduce(123), BucketReduction::Success);
         assert_eq!(tb.budget(), capacity - 123);

--- a/src/seccompiler/src/backend.rs
+++ b/src/seccompiler/src/backend.rs
@@ -714,7 +714,7 @@ impl SeccompFilter {
         let mut built_syscall = Vec::with_capacity(1 + chain_len + 1);
         built_syscall.push(BPF_JUMP(
             BPF_JMP + BPF_JEQ + BPF_K,
-            syscall_number as u32,
+            u32::try_from(syscall_number).unwrap(),
             0,
             1,
         ));
@@ -954,8 +954,12 @@ mod tests {
         }
 
         // Build seccomp filter.
-        let filter =
-            SeccompFilter::new(rule_map, SeccompAction::Errno(failure_code as u32), ARCH).unwrap();
+        let filter = SeccompFilter::new(
+            rule_map,
+            SeccompAction::Errno(u32::try_from(failure_code).unwrap()),
+            ARCH,
+        )
+        .unwrap();
 
         // We need to run the validation inside another thread in order to avoid setting
         // the seccomp filter for the entire unit tests process.

--- a/src/utils/src/byte_order.rs
+++ b/src/utils/src/byte_order.rs
@@ -29,6 +29,7 @@ macro_rules! generate_write_fn {
 
 generate_read_fn!(read_le_u16, u16, u8, 2, from_le_bytes);
 generate_read_fn!(read_le_u32, u32, u8, 4, from_le_bytes);
+generate_read_fn!(read_le_u32_from_i8, u32, i8, 4, from_le_bytes);
 generate_read_fn!(read_le_u64, u64, u8, 8, from_le_bytes);
 generate_read_fn!(read_le_i32, i32, i8, 4, from_le_bytes);
 

--- a/src/utils/src/kernel_version.rs
+++ b/src/utils/src/kernel_version.rs
@@ -48,8 +48,11 @@ impl KernelVersion {
         }
 
         Self::parse(String::from_utf8(
-            #[allow(clippy::unnecessary_cast)]
-            name.release.iter().map(|c| *c as u8).collect(),
+            #[allow(clippy::useless_conversion)]
+            name.release
+                .iter()
+                .map(|c| u8::try_from(*c).unwrap())
+                .collect(),
         )?)
     }
 

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -27,6 +27,6 @@ pub fn get_page_size() -> Result<usize, errno::Error> {
     // SAFETY: Safe because the parameters are valid.
     match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
         -1 => Err(errno::Error::last()),
-        ps => Ok(ps as usize),
+        ps => Ok(usize::try_from(ps).unwrap()),
     }
 }

--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -149,8 +149,9 @@ pub fn get_time_ns(clock_type: ClockType) -> u64 {
     };
     // SAFETY: Safe because the parameters are valid.
     unsafe { libc::clock_gettime(clock_type.into(), &mut time_struct) };
-    seconds_to_nanoseconds(time_struct.tv_sec).expect("Time conversion overflow") as u64
-        + (time_struct.tv_nsec as u64)
+    u64::try_from(seconds_to_nanoseconds(time_struct.tv_sec).expect("Time conversion overflow"))
+        .unwrap()
+        + u64::try_from(time_struct.tv_nsec).unwrap()
 }
 
 /// Returns a timestamp in microseconds based on the provided clock type.
@@ -244,7 +245,7 @@ mod tests {
     #[test]
     fn test_seconds_to_nanoseconds() {
         assert_eq!(
-            seconds_to_nanoseconds(100).unwrap() as u64,
+            u64::try_from(seconds_to_nanoseconds(100).unwrap()).unwrap(),
             100 * NANOS_PER_SECOND
         );
 

--- a/src/vmm/src/signal_handler.rs
+++ b/src/vmm/src/signal_handler.rs
@@ -66,7 +66,8 @@ fn log_sigsys_err(si_code: c_int, info: *mut siginfo_t) {
 
     // SAFETY: Other signals which might do async unsafe things incompatible with the rest of this
     // function are blocked due to the sa_mask used when registering the signal handler.
-    let syscall = unsafe { *(info as *const i32).offset(SI_OFF_SYSCALL) as usize };
+    let syscall = unsafe { *(info as *const i32).offset(SI_OFF_SYSCALL) };
+    let syscall = usize::try_from(syscall).unwrap();
     error!(
         "Shutting down VM after intercepting a bad syscall ({}).",
         syscall

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -783,6 +783,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_sign_loss)] // always positive, no u32::try_from(f64)
     fn test_is_tsc_scaling_required() {
         // Test `is_tsc_scaling_required` as if it were on the same
         // CPU model as the one in the snapshot state.
@@ -809,6 +810,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_sign_loss)] // always positive, no u32::try_from(f64)
     fn test_set_tsc() {
         let (vm, vcpu, _) = setup_vcpu(0x1000);
         let mut state = vcpu.save_state().unwrap();


### PR DESCRIPTION
Sets clippy to warn on the lint `clippy::cast_sign_loss` as mentioned in #3200

## Changes
Sets the `-Dclippy::cast_sign_loss` flag and fixes existing issues. I could not identify any real cast issues, so this PR adds a few documented `#[allow(clippy::cast_sign_loss)]`. Many casts are caused by signed integer return values from libc.

## Reason

Closes #3200

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
