### PR TITLE
chore: add os tag to agent config of pipelines

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -15,11 +15,12 @@ DEFAULT_INSTANCES = [
     "c7g.metal",
 ]
 
-DEFAULT_KERNELS = ["linux_4.14", "linux_5.10"]
+DEFAULT_PLATFORMS = [("al2", "linux_4.14"), ("al2", "linux_5.10")]
+
 DEFAULT_QUEUE = "public-prod-us-east-1"
 
 
-def group(label, command, instances, kernels, agent_tags=None, **kwargs):
+def group(label, command, instances, platforms, agent_tags=None, **kwargs):
     """
     Generate a group step with specified parameters, for each instance+kernel
     combination
@@ -32,11 +33,11 @@ def group(label, command, instances, kernels, agent_tags=None, **kwargs):
     label1 = label[0]
     steps = []
     for instance in instances:
-        for kv in kernels:
-            agents = [f"instance={instance}", f"kv={kv}"] + agent_tags
+        for (os, kv) in platforms:
+            agents = [f"instance={instance}", f"kv={kv}", f"os={os}"] + agent_tags
             step = {
                 "command": command,
-                "label": f"{label1} {instance} {kv}",
+                "label": f"{label1} {instance} {os} {kv}",
                 "agents": agents,
                 **kwargs,
             }

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -6,7 +6,7 @@
 
 import argparse
 
-from common import DEFAULT_INSTANCES, DEFAULT_KERNELS, group, pipeline_to_json
+from common import DEFAULT_INSTANCES, DEFAULT_PLATFORMS, group, pipeline_to_json
 
 
 perf_test = {
@@ -53,7 +53,7 @@ def build_group(test):
         agent_tags=["ag=1"],
         artifacts=["./test_results/*"],
         instances=test.pop("instances"),
-        kernels=test.pop("kernels"),
+        platforms=test.pop("platforms"),
         # and the rest can be command arguments
         **test,
     )
@@ -74,9 +74,10 @@ parser.add_argument(
     default=[],
 )
 parser.add_argument(
-    "--kernels",
+    "--platforms",
     required=False,
     action="append",
+    nargs=2,
     default=[],
 )
 parser.add_argument("--retries", type=int, default=0)
@@ -89,14 +90,14 @@ parser.add_argument(
 args = parser.parse_args()
 if not args.instances:
     args.instances = DEFAULT_INSTANCES
-if not args.kernels:
-    args.kernels = DEFAULT_KERNELS
+if not args.platforms:
+    args.platforms = DEFAULT_PLATFORMS
 if args.extra:
     args.extra = dict(val.split("=", maxsplit=1) for val in args.extra)
 group_steps = []
 tests = [perf_test[test] for test in args.test]
 for test_data in tests:
-    test_data.setdefault("kernels", args.kernels)
+    test_data.setdefault("platforms", args.platforms)
     test_data.setdefault("instances", args.instances)
     test_data.update(args.extra)
     if args.retries > 0:

--- a/.buildkite/pipeline_pr.py
+++ b/.buildkite/pipeline_pr.py
@@ -7,7 +7,7 @@
 import subprocess
 from pathlib import Path
 
-from common import DEFAULT_INSTANCES, DEFAULT_KERNELS, DEFAULT_QUEUE, group, pipeline_to_json
+from common import DEFAULT_INSTANCES, DEFAULT_PLATFORMS, DEFAULT_QUEUE, group, pipeline_to_json
 
 # Buildkite default job priority is 0. Setting this to 1 prioritizes PRs over
 # scheduled jobs and other batch jobs.
@@ -30,7 +30,7 @@ step_style = {
 
 defaults = {
     "instances": DEFAULT_INSTANCES,
-    "kernels": DEFAULT_KERNELS,
+    "platforms": DEFAULT_PLATFORMS,
     # buildkite step parameters
     "priority": DEFAULT_PRIORITY,
     "timeout_in_minutes": 30,


### PR DESCRIPTION
## Reason

Clearly specify the OS of the agents on which PR pipeline should run. 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
