### PR TITLE
Add common types for CPU configuration

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -864,7 +864,7 @@ pub fn configure_system_for_boot(
     {
         for vcpu in vcpus.iter_mut() {
             vcpu.kvm_vcpu
-                .configure(vmm.guest_memory(), entry_addr)
+                .configure(vmm.guest_memory(), entry_addr, &vcpu_config)
                 .map_err(Error::VcpuConfigure)
                 .map_err(Internal)?;
         }

--- a/src/vmm/src/guest_config/common/mod.rs
+++ b/src/vmm/src/guest_config/common/mod.rs
@@ -1,0 +1,158 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO - Remove allow(unused) once types have been used
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::ops::Add;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_arch = "x86_64")]
+use crate::guest_config::cpuid::Cpuid;
+
+/// Type defined to represent registers across CPU vendors
+/// (pointers and values)
+pub trait Numeric: Copy + Add<Self, Output = Self> {}
+impl Numeric for u32 {}
+impl Numeric for u64 {}
+impl Numeric for u128 {}
+
+/// Map to find and define model-specific registers
+#[cfg(target_arch = "x86_64")]
+#[allow(unused)]
+pub struct MsrRegisterMap {
+    register_map: HashMap<RegisterPointer<u32>, RegisterValue<u32>>,
+}
+/// Map to find and define registers for 64-bit ARM CPUs
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(unused)]
+pub struct Aarch64RegisterMap {
+    register_map: HashMap<RegisterPointer<u64>, RegisterValue<u128>>,
+}
+
+/// A trait type to be customized for each CPU architecture
+/// to modify CPU configuration for the Firecracker guest
+pub trait ConfigurationModifier {
+    /// Applies the CPUTemplate against the CPUConfiguration
+    fn apply_template(&self, cpu_template: CustomCpuTemplate) -> Box<CpuConfiguration>;
+}
+
+/// CPU configuration that can be of the host or the guest.
+/// Expected to be populated in part or modified by
+/// types implementing ConfigurationModifier
+#[allow(unused)]
+pub struct CpuConfiguration {
+    /// Hashed set containing register configuration
+    /// divided up by type of register. See `RegisterSet`
+    pub register_config: Vec<RegisterSet>,
+}
+
+impl CpuConfiguration {
+    /// Factory method to instantiate CPUConfiguration
+    /// with the provided `RegisterSet`
+    pub fn new(register_config: Vec<RegisterSet>) -> CpuConfiguration {
+        CpuConfiguration { register_config }
+    }
+}
+
+/// Template indicating a modification of CPU configuration
+/// to be applied against the `CPUConfiguration` type
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CustomCpuTemplate {
+    /// Modifier masks with pointer data for the modifiers
+    /// intended registers
+    pub modifiers: Vec<RegisterModifierSet>,
+}
+
+/// Modifier for a CPU configuration containing
+/// the location of the value to be modified,
+/// and provides a value to be applied alongside
+/// a filter to be applied
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RegisterModifier<T: Numeric> {
+    /// Location of the register to be modified
+    /// by the mask value and filter
+    pub pointer: RegisterPointer<T>,
+    /// Mask value to be applied
+    pub value: T,
+    /// Mask value is to be applied according
+    /// to what is allowed through by the filter
+    pub filter: T,
+}
+
+/// Numeric wrapper type acting as a marker type
+/// for the register's pointer
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum RegisterPointer<T: Numeric> {
+    /// Pointer(location) of a specific register
+    NumericPointer(T),
+    /// Register pointer for CPUID that is Leaf/Subleaf aware
+    CpuidPointer(CpuidRegisterPointer),
+}
+
+/// Numeric wrapper type acting as a marker type
+/// for the register's value
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RegisterValue<T: Numeric> {
+    /// Value of a specific register
+    pub value: T,
+}
+
+/// CPUID register enumeration
+#[allow(unused)]
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum CpuidRegister {
+    Eax,
+    Ebx,
+    Ecx,
+    Edx,
+}
+
+/// Composite type that holistically provides
+/// the location of a specific register being used
+/// in the context of a CPUID tree
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct CpuidRegisterPointer {
+    leaf: u32,
+    subleaf: u32,
+    pointer: CpuidRegister,
+}
+
+/// Enumerates the types of registers and contains
+/// a property capable of containing the data
+/// formatted for the register type
+#[allow(unused)]
+#[allow(missing_docs)]
+pub enum RegisterSet {
+    #[cfg(target_arch = "x86_64")]
+    CpuId(Cpuid),
+    #[cfg(target_arch = "x86_64")]
+    Msrs(MsrRegisterMap),
+    #[cfg(target_arch = "aarch64")]
+    Aarch64Registers(Aarch64RegisterMap),
+}
+
+/// Intended to correlate to the RegisterSet.
+/// Enumerates the types of register modifiers
+/// with data intended to modify the correlated
+/// registers
+#[allow(unused)]
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum RegisterModifierSet {
+    #[cfg(target_arch = "x86_64")]
+    CpuIdModifierSet(Vec<RegisterModifier<u32>>),
+    #[cfg(target_arch = "x86_64")]
+    MsrsModifierSet(Vec<RegisterModifier<u64>>),
+    #[cfg(target_arch = "aarch64")]
+    Aarch64RegistersModifierSet(Vec<RegisterModifier<u128>>),
+}

--- a/src/vmm/src/guest_config/mod.rs
+++ b/src/vmm/src/guest_config/mod.rs
@@ -1,5 +1,52 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Contains common types for vmm to use internally
+/// as well as by user interface related code.
+pub mod common;
 #[cfg(cpuid)]
 pub mod cpuid;
+
+// TODO Remove allow(unused) once implementation added
+/// Module containing type implementations needed for x86 CPU configuration
+#[allow(unused)]
+#[cfg(target_arch = "x86_64")]
+pub mod x86_config {
+
+    use crate::guest_config::common::{ConfigurationModifier, CpuConfiguration, CustomCpuTemplate};
+
+    impl ConfigurationModifier for CpuConfiguration {
+        fn apply_template(&self, cpu_template: CustomCpuTemplate) -> Box<CpuConfiguration> {
+            // TODO - Apply template
+            get_host_cpu_configuration()
+        }
+    }
+
+    fn get_host_cpu_configuration() -> Box<CpuConfiguration> {
+        // TODO - Retrieve host configuration
+
+        Box::new(CpuConfiguration::new(Vec::new()))
+    }
+}
+
+// TODO Remove allow(unused) once implementation added
+/// Module containing type implementations needed for aarch64 (ARM) CPU configuration
+#[allow(unused)]
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64_config {
+
+    use crate::guest_config::common::{ConfigurationModifier, CpuConfiguration, CustomCpuTemplate};
+
+    impl ConfigurationModifier for CpuConfiguration {
+        fn apply_template(&self, cpu_template: CustomCpuTemplate) -> Box<CpuConfiguration> {
+            // TODO - Apply template
+            get_host_cpu_configuration()
+        }
+    }
+
+    fn get_host_cpu_configuration() -> Box<CpuConfiguration> {
+        // TODO - Retrieve host configuration
+
+        Box::new(CpuConfiguration::new(Vec::new()))
+    }
+}

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -225,6 +225,7 @@ impl VmResources {
             vcpu_count: self.vm_config().vcpu_count,
             smt: self.vm_config().smt,
             cpu_template: self.vm_config().cpu_template,
+            custom_cpu_template: self.vm_config().custom_cpu_template.clone(),
         }
     }
 
@@ -1262,6 +1263,7 @@ mod tests {
             vcpu_count: vm_resources.vm_config().vcpu_count,
             smt: vm_resources.vm_config().smt,
             cpu_template: vm_resources.vm_config().cpu_template,
+            custom_cpu_template: None,
         };
 
         let vcpu_config = vm_resources.vcpu_config();

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -6,6 +6,8 @@ use serde::{de, Deserialize, Serialize};
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 
+use crate::guest_config::common::CustomCpuTemplate;
+
 /// The default memory size of the VM, in MiB.
 pub const DEFAULT_MEM_SIZE_MIB: usize = 128;
 /// Firecracker aims to support small scale workloads only, so limit the maximum
@@ -65,13 +67,17 @@ pub struct VmConfig {
     /// Enables or disabled SMT.
     #[serde(default, deserialize_with = "deserialize_smt")]
     pub smt: bool,
-    /// A CPU template that it is used to filter the CPU features exposed to the guest.
+    /// A CPU template (hard coded) that it is used to filter the
+    /// CPU features exposed to the guest.
     #[serde(
         default,
         deserialize_with = "deserialize_cpu_template",
         skip_serializing_if = "CpuFeaturesTemplate::is_none"
     )]
     pub cpu_template: CpuFeaturesTemplate,
+    /// CPU template to be defined by the user
+    #[serde(skip_serializing)]
+    pub custom_cpu_template: Option<CustomCpuTemplate>,
     /// Enables or disables dirty page tracking. Enabling allows incremental snapshots.
     #[serde(default)]
     pub track_dirty_pages: bool,
@@ -84,6 +90,7 @@ impl Default for VmConfig {
             mem_size_mib: DEFAULT_MEM_SIZE_MIB,
             smt: false,
             cpu_template: CpuFeaturesTemplate::None,
+            custom_cpu_template: None,
             track_dirty_pages: false,
         }
     }

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.09, "ARM": 82.19}
+    COVERAGE_DICT = {"Intel": 78.21, "AMD": 79.05, "ARM": 82.19}
 else:
-    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.13}
+    COVERAGE_DICT = {"Intel": 75.94, "AMD": 76.78, "ARM": 79.13}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

* Common types to be used by Firecracker for configuring guest vCPUs.
* Lowered test coverage pending implementation and usage of the common types.

## Reason

These common types will be subject to change, but will serve as a middle "tier" between Firecracker and KVM, as well as Firecracker interfaces and Firecracker internally (`vmm` crate).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
