### PR TITLE
Do not allow using T2CL on Intel Skylake

### DIFF
--- a/src/arch/src/x86_64/cpu_model.rs
+++ b/src/arch/src/x86_64/cpu_model.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::arch::x86_64::__cpuid as host_cpuid;
+use std::cmp::{Eq, Ordering, PartialEq, PartialOrd};
+
+/// Structure representing x86_64 CPU model.
+#[derive(Debug, Eq, PartialEq)]
+pub struct CpuModel {
+    /// Extended family.
+    pub extended_family: u8,
+    /// Extended model.
+    pub extended_model: u8,
+    /// Family.
+    pub family: u8,
+    /// Model.
+    pub model: u8,
+    /// Stepping.
+    pub stepping: u8,
+}
+
+impl CpuModel {
+    /// Get CPU model from current machine.
+    pub fn get_cpu_model() -> Self {
+        // SAFETY: This operation is safe as long as the processor implements this CPUID function.
+        // 0x1 is the defined code for getting the processor version information.
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        let eax = unsafe { host_cpuid(0x1) }.eax;
+        CpuModel::from(&eax)
+    }
+}
+
+impl From<&u32> for CpuModel {
+    fn from(eax: &u32) -> Self {
+        CpuModel {
+            extended_family: ((eax >> 20) & 0xff) as u8,
+            extended_model: ((eax >> 16) & 0xf) as u8,
+            family: ((eax >> 8) & 0xf) as u8,
+            model: ((eax >> 4) & 0xf) as u8,
+            stepping: (eax & 0xf) as u8,
+        }
+    }
+}
+
+impl From<&CpuModel> for u32 {
+    fn from(cpu_model: &CpuModel) -> Self {
+        u32::from(cpu_model.extended_family) << 20
+            | u32::from(cpu_model.extended_model) << 16
+            | u32::from(cpu_model.family) << 8
+            | u32::from(cpu_model.model) << 4
+            | u32::from(cpu_model.stepping)
+    }
+}
+
+impl PartialOrd for CpuModel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(u32::from(self).cmp(&u32::from(other)))
+    }
+}
+
+impl Ord for CpuModel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u32::from(self).cmp(&u32::from(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SKYLAKE: CpuModel = CpuModel {
+        extended_family: 0,
+        extended_model: 5,
+        family: 6,
+        model: 5,
+        stepping: 4,
+    };
+
+    const CASCADE_LAKE: CpuModel = CpuModel {
+        extended_family: 0,
+        extended_model: 5,
+        family: 6,
+        model: 5,
+        stepping: 7,
+    };
+
+    #[test]
+    fn cpu_model_from() {
+        let skylake_eax = 0x00050654;
+        assert_eq!(u32::from(&SKYLAKE), skylake_eax);
+        assert_eq!(CpuModel::from(&skylake_eax), SKYLAKE);
+    }
+
+    #[test]
+    fn cpu_model_ord() {
+        assert_eq!(SKYLAKE, SKYLAKE);
+        assert!(SKYLAKE < CASCADE_LAKE);
+        assert!(CASCADE_LAKE > SKYLAKE);
+    }
+}

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -5,6 +5,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+/// Logic for handling x86_64 CPU models.
+pub mod cpu_model;
 mod gdt;
 /// Contains logic for setting up Advanced Programmable Interrupt Controller (local version).
 pub mod interrupts;

--- a/src/cpuid/src/template/intel/t2cl.rs
+++ b/src/cpuid/src/template/intel/t2cl.rs
@@ -1,6 +1,9 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::arch::x86_64::__cpuid as host_cpuid;
+
+use arch::x86_64::cpu_model::CpuModel;
 use arch::x86_64::msr::{ArchCapaMSRFlags, MSR_IA32_ARCH_CAPABILITIES};
 use kvm_bindings::{kvm_cpuid_entry2, kvm_msr_entry, CpuId};
 

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -67,6 +67,9 @@ pub enum Error {
     /// The maximum number of addressable logical CPUs cannot be stored in an `u8`.
     #[error("The maximum number of addressable logical CPUs cannot be stored in an `u8`.")]
     VcpuCountOverflow,
+    /// The operation is not permitted for the current CPU model.
+    #[error("The operation is not permitted for the current CPU model.")]
+    InvalidModel,
 }
 
 pub type EntryTransformerFn =

--- a/tests/framework/utils_cpu_templates.py
+++ b/tests/framework/utils_cpu_templates.py
@@ -19,6 +19,10 @@ def get_supported_cpu_templates():
     """
     vendor = cpuid_utils.get_cpu_vendor()
     if vendor == cpuid_utils.CpuVendor.INTEL:
+        # T2CL template is only supported on Cascade Lake and newer CPUs.
+        skylake_model = "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
+        if cpuid_utils.get_cpu_model_name() == skylake_model:
+            return set(INTEL_TEMPLATES) - set(["T2CL"])
         return INTEL_TEMPLATES
     if vendor == cpuid_utils.CpuVendor.AMD:
         return AMD_TEMPLATES

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -5,7 +5,15 @@
 import pytest
 
 from framework import utils
+import framework.utils_cpuid as cpuid_utils
 from host_tools import proc
+
+
+def is_on_skylake():
+    """Test is executed on a Skylake host."""
+    skylake_model = "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
+    return cpuid_utils.get_cpu_model_name() == skylake_model
+
 
 # We have different coverages based on the host kernel version. This is
 # caused by io_uring, which is only supported by FC for kernels newer
@@ -17,9 +25,13 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.98, "AMD": 81.99, "ARM": 82.43}
+    COVERAGE_DICT = {"Intel": 82.97, "AMD": 81.99, "ARM": 82.43}
 else:
-    COVERAGE_DICT = {"Intel": 80.11, "AMD": 79.13, "ARM": 79.34}
+    COVERAGE_DICT = {
+        "Intel": 79.83 if is_on_skylake() else 80.13,
+        "AMD": 79.13,
+        "ARM": 79.34,
+    }
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -227,30 +227,7 @@ MSR_EXCEPTION_LIST = [
 # fmt: on
 
 
-def get_msr_supported_templates():
-    """
-    Return the list of CPU templates supported for MSR-related tests.
-    """
-    # CPU templates supported for the MSR tests
-    msr_supported_templates = ["T2A", "T2S"]
-
-    # CPU templates which need additional checks are added below:
-
-    # Cascade Lake on m5d.metal has MSR 0x122 state as implemented whereas,
-    # Skylake on m5d.metal has MSR 0x122 state as unimplemented.
-    # Since the conflict is seen only with Skylake and Cascade lake,
-    # we add T2CL (Cascade Lake) template only when CPU is not Skylake.
-    t2cl_exception_list = [
-        # Note: we may need to update this list if there are
-        # more conflicting CPU models reported in the future.
-        "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz",  # Skylake
-    ]
-    if cpuid_utils.get_cpu_model_name() not in t2cl_exception_list:
-        msr_supported_templates.append("T2CL")
-    return msr_supported_templates
-
-
-MSR_SUPPORTED_TEMPLATES = get_msr_supported_templates()
+MSR_SUPPORTED_TEMPLATES = ["T2A", "T2S"]
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Changes

Add a runtime check that T2CL CPU template can only be used on Cascade Lake or newer Intel CPUs.

## Reason

The T2CL CPU template is only applicable to Cascade Lake and newer Intel CPUs. We need to guarantee it cannot be used on older versions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
