### PR TITLE
Integration tests cleanups

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -32,11 +32,17 @@ def group(label, command, instances, platforms, agent_tags=None, **kwargs):
     # Use the 1st character of the group name (should be an emoji)
     label1 = label[0]
     steps = []
+    commands = command
+    if isinstance(command, str):
+        commands = [command]
     for instance in instances:
         for (os, kv) in platforms:
+            # fill any templated variables
+            step_commands = [cmd.format(instance=instance, os=os, kv=kv)
+                             for cmd in commands]
             agents = [f"instance={instance}", f"kv={kv}", f"os={os}"] + agent_tags
             step = {
-                "command": command,
+                "command": step_commands,
                 "label": f"{label1} {instance} {os} {kv}",
                 "agents": agents,
                 **kwargs,

--- a/.buildkite/pipeline_perf.py
+++ b/.buildkite/pipeline_perf.py
@@ -6,8 +6,8 @@
 
 import argparse
 
-from common import DEFAULT_INSTANCES, DEFAULT_PLATFORMS, group, pipeline_to_json
-
+from common import (DEFAULT_INSTANCES, DEFAULT_PLATFORMS, group,
+                    pipeline_to_json)
 
 perf_test = {
     "block": {
@@ -102,7 +102,9 @@ for test_data in tests:
     test_data.update(args.extra)
     if args.retries > 0:
         # retry if the step fails
-        test_data.setdefault("retry", {"automatic": {"exit_status": 1, "limit": args.retries}})
+        test_data.setdefault(
+            "retry", {"automatic": {"exit_status": 1, "limit": args.retries}}
+        )
     group_steps.append(build_group(test_data))
 
 pipeline = {
@@ -110,7 +112,6 @@ pipeline = {
         "AWS_EMF_SERVICE_NAME": "PerfTests",
         "AWS_EMF_NAMESPACE": "PerfTests",
     },
-    "agents": {"queue": "public-prod-us-east-1"},
     "steps": group_steps,
 }
 print(pipeline_to_json(pipeline))

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -93,10 +93,10 @@ impl DiskProperties {
             .read(true)
             .write(!is_disk_read_only)
             .open(PathBuf::from(&disk_image_path))
-            .map_err(Error::BackingFile)?;
+            .map_err(|x| Error::BackingFile(x, disk_image_path.clone()))?;
         let disk_size = disk_image
             .seek(SeekFrom::End(0))
-            .map_err(Error::BackingFile)?;
+            .map_err(|x| Error::BackingFile(x, disk_image_path.clone()))?;
 
         // We only support disk size, which uses the first two words of the configuration space.
         // If the image is not a multiple of the sector size, the tail bits are not exposed.

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -45,7 +45,7 @@ pub enum Error {
     // Error coming from the IO engine.
     FileEngine(io::Error),
     // Error manipulating the backing file.
-    BackingFile(std::io::Error),
+    BackingFile(std::io::Error, String),
     // Error opening eventfd.
     EventFd(std::io::Error),
     // Error creating an irqfd.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ import pytest
 
 import host_tools.cargo_build as build_tools
 from framework import defs, utils
-from framework.artifacts import ArtifactCollection, FirecrackerArtifact
+from framework.artifacts import ArtifactCollection, DiskArtifact, FirecrackerArtifact
 from framework.defs import _test_images_s3_bucket
 from framework.microvm import Microvm
 from framework.properties import global_props
@@ -492,6 +492,22 @@ def guest_kernel(request, record_property):
 @pytest.fixture(params=ARTIFACTS_COLLECTION.disks("ubuntu"), ids=lambda fs: fs.name())
 def rootfs(request, record_property):
     """Return all supported rootfs."""
+    fs = request.param
+    record_property("rootfs", fs.name())
+    fs.download()
+    fs.ssh_key().download()
+    return fs
+
+
+@pytest.fixture(
+    params=ARTIFACTS_COLLECTION.disks("bionic-msrtools"),
+    ids=lambda fs: fs.name() if isinstance(fs, DiskArtifact) else None,
+)
+def rootfs_msrtools(request, record_property):
+    """Common disk fixture for tests needing msrtools
+
+    When we regenerate the rootfs, we should include this always
+    """
     fs = request.param
     record_property("rootfs", fs.name())
     fs.download()

--- a/tests/framework/builder.py
+++ b/tests/framework/builder.py
@@ -333,42 +333,10 @@ class MicrovmBuilder:
             io_engine=io_engine,
         )
 
-    def build_vm_nano(
-        self,
-        fc_binary=None,
-        jailer_binary=None,
-        net_ifaces=None,
-        diff_snapshots=False,
-        daemonize=True,
-        io_engine=None,
-    ):
+    def build_vm_nano(self, **kwargs):
         """Create a clean VM in an initial state."""
         return self.build_from_artifacts(
-            "2vcpu_256mb",
-            "vmlinux-4.14",
-            "ubuntu-18.04",
-            None,
-            net_ifaces=net_ifaces,
-            diff_snapshots=diff_snapshots,
-            fc_binary=fc_binary,
-            jailer_binary=jailer_binary,
-            daemonize=daemonize,
-            io_engine=io_engine,
-        )
-
-    def build_vm_micro(
-        self, fc_binary=None, jailer_binary=None, net_ifaces=None, diff_snapshots=False
-    ):
-        """Create a clean VM in an initial state."""
-        return self.build_from_artifacts(
-            "2vcpu_512mb",
-            "vmlinux-4.14",
-            "ubuntu-18.04",
-            None,
-            net_ifaces=net_ifaces,
-            diff_snapshots=diff_snapshots,
-            fc_binary=fc_binary,
-            jailer_binary=jailer_binary,
+            "2vcpu_256mb", "vmlinux-4.14", "ubuntu-18.04", None, **kwargs
         )
 
     def cleanup(self):

--- a/tests/framework/microvm.py
+++ b/tests/framework/microvm.py
@@ -22,6 +22,7 @@ import weakref
 from functools import cached_property
 from pathlib import Path
 from threading import Lock
+from typing import Optional
 
 from retry import retry
 
@@ -539,6 +540,7 @@ class Microvm:
         use_initrd: bool = False,
         track_dirty_pages: bool = False,
         rootfs_io_engine=None,
+        cpu_template: Optional[str] = None,
     ):
         """Shortcut for quickly configuring a microVM.
 
@@ -556,6 +558,7 @@ class Microvm:
             smt=smt,
             mem_size_mib=mem_size_mib,
             track_dirty_pages=track_dirty_pages,
+            cpu_template=cpu_template,
         )
         assert self._api_session.is_status_no_content(
             response.status_code

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -1373,7 +1373,7 @@ def test_get_full_config(test_microvm_with_api):
     assert response.json() == expected_cfg
 
 
-def test_map_private_seccomp_regression(test_microvm_with_ssh):
+def test_map_private_seccomp_regression(test_microvm_with_api):
     """
     Seccomp mmap MAP_PRIVATE regression test.
 
@@ -1383,7 +1383,7 @@ def test_map_private_seccomp_regression(test_microvm_with_ssh):
 
     @type: regression
     """
-    test_microvm = test_microvm_with_ssh
+    test_microvm = test_microvm_with_api
     test_microvm.jailer.extra_args.update(
         {"http-api-max-payload-size": str(1024 * 1024 * 2)}
     )

--- a/tests/integration_tests/functional/test_api.py
+++ b/tests/integration_tests/functional/test_api.py
@@ -871,33 +871,36 @@ def _drive_patch(test_microvm):
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert "at least one property to patch: path_on_host, rate_limiter" in response.text
 
+    drive_path = "foo.bar"
+
     # Cannot patch drive permissions post boot.
     response = test_microvm.drive.patch(
-        drive_id="scratch", path_on_host="foo.bar", is_read_only=True
+        drive_id="scratch", path_on_host=drive_path, is_read_only=True
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert "unknown field `is_read_only`" in response.text
 
     # Cannot patch io_engine post boot.
     response = test_microvm.drive.patch(
-        drive_id="scratch", path_on_host="foo.bar", io_engine="Sync"
+        drive_id="scratch", path_on_host=drive_path, io_engine="Sync"
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert "unknown field `io_engine`" in response.text
 
     # Updates to `is_root_device` with a valid value are not allowed.
     response = test_microvm.drive.patch(
-        drive_id="scratch", path_on_host="foo.bar", is_root_device=False
+        drive_id="scratch", path_on_host=drive_path, is_root_device=False
     )
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert "unknown field `is_root_device`" in response.text
 
     # Updates to `path_on_host` with an invalid path are not allowed.
-    response = test_microvm.drive.patch(drive_id="scratch", path_on_host="foo.bar")
+    response = test_microvm.drive.patch(drive_id="scratch", path_on_host=drive_path)
     assert test_microvm.api_session.is_status_bad_request(response.status_code)
     assert (
         "Unable to patch the block device: BackingFile(Os { code: 2, "
-        'kind: NotFound, message: \\"No such file or directory\\" })' in response.text
+        f'kind: NotFound, message: \\"No such file or directory\\" }}, \\"{drive_path}\\")'
+        in response.text
     )
 
     fs = drive_tools.FilesystemFile(os.path.join(test_microvm.fsfiles, "scratch_new"))

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -465,7 +465,6 @@ def test_older_snapshot_resume_latency(
     @type: performance
     """
     logger = logging.getLogger("old_snapshot_load")
-
     builder = MicrovmBuilder(bin_cloner_path)
     snapshot_type = SnapshotType.FULL
     microvm.download()
@@ -476,8 +475,13 @@ def test_older_snapshot_resume_latency(
     logger.info("Source Jailer: %s", jailer.local_path())
 
     # Create a fresh microvm with the binary artifacts.
-    vm_instance = builder.build_vm_micro(
-        firecracker_release.local_path(), jailer.local_path()
+    vm_instance = builder.build_from_artifacts(
+        "2vcpu_512mb",
+        "vmlinux-4.14",
+        "ubuntu-18.04",
+        None,
+        fc_binary=firecracker_release.local_path(),
+        jailer_binary=jailer.local_path(),
     )
     basevm = vm_instance.vm
     basevm.start()

--- a/tests/integration_tests/security/test_jail.py
+++ b/tests/integration_tests/security/test_jail.py
@@ -580,13 +580,13 @@ def test_args_resource_limits(test_microvm_with_initrd):
     check_limits(pid, NOFILE, FSIZE)
 
 
-def test_negative_file_size_limit(test_microvm_with_ssh):
+def test_negative_file_size_limit(test_microvm_with_api):
     """
     Test creating snapshot file fails when size exceeds `fsize` limit.
 
     @type: negative
     """
-    test_microvm = test_microvm_with_ssh
+    test_microvm = test_microvm_with_api
     test_microvm.jailer.resource_limits = ["fsize=1024"]
 
     test_microvm.spawn()
@@ -624,13 +624,13 @@ def test_negative_file_size_limit(test_microvm_with_ssh):
         assert False, "Negative test failed"
 
 
-def test_negative_no_file_limit(test_microvm_with_ssh):
+def test_negative_no_file_limit(test_microvm_with_api):
     """
     Test microVM is killed when exceeding `no-file` limit.
 
     @type: negative
     """
-    test_microvm = test_microvm_with_ssh
+    test_microvm = test_microvm_with_api
     test_microvm.jailer.resource_limits = ["no-file=3"]
 
     # pylint: disable=W0703
@@ -643,13 +643,13 @@ def test_negative_no_file_limit(test_microvm_with_ssh):
         assert False, "Negative test failed"
 
 
-def test_new_pid_ns_resource_limits(test_microvm_with_ssh):
+def test_new_pid_ns_resource_limits(test_microvm_with_api):
     """
     Test that Firecracker process inherits jailer resource limits.
 
     @type: security
     """
-    test_microvm = test_microvm_with_ssh
+    test_microvm = test_microvm_with_api
 
     test_microvm.jailer.new_pid_ns = True
     test_microvm.jailer.resource_limits = RESOURCE_LIMITS


### PR DESCRIPTION
## Changes

More integration tests cleanups

## Reason

- Removing more uses of TestMatrix
- Clearing the way for further cleanups
- 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~- [ ] This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
