### PR TITLE
Add unittests for T2CL CPU template

### DIFF
--- a/src/arch/src/x86_64/cpu_model.rs
+++ b/src/arch/src/x86_64/cpu_model.rs
@@ -24,7 +24,6 @@ impl CpuModel {
     pub fn get_cpu_model() -> Self {
         // SAFETY: This operation is safe as long as the processor implements this CPUID function.
         // 0x1 is the defined code for getting the processor version information.
-        #[allow(clippy::undocumented_unsafe_blocks)]
         let eax = unsafe { host_cpuid(0x1) }.eax;
         CpuModel::from(&eax)
     }

--- a/src/cpuid/src/template/intel/t2cl.rs
+++ b/src/cpuid/src/template/intel/t2cl.rs
@@ -93,3 +93,147 @@ static EXTRA_MSR_ENTRIES: &[u32] = &[MSR_IA32_ARCH_CAPABILITIES];
 pub fn msr_entries_to_save() -> &'static [u32] {
     EXTRA_MSR_ENTRIES
 }
+
+#[cfg(test)]
+mod tests {
+    use std::arch::x86_64::__cpuid as host_cpuid;
+
+    use super::*;
+
+    fn is_on_amd() -> bool {
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        let ebx = unsafe { host_cpuid(0x0) }.ebx;
+        // Checking for first 4 brand string letters is enough
+        // for test purposes.
+        ebx == 0x68747541
+    }
+
+    const CASCADE_LAKE: CpuModel = CpuModel {
+        extended_family: 0,
+        extended_model: 5,
+        family: 6,
+        model: 5,
+        stepping: 7,
+    };
+
+    #[test]
+    fn test_update_extended_feature_info_entry() {
+        use crate::cpu_leaf::leaf_0x80000001::*;
+
+        let mut entry = kvm_cpuid_entry2 {
+            ..Default::default()
+        };
+        let vmspec = VmSpec::new(0, 1, false).unwrap();
+        let res = update_extended_feature_info_entry(&mut entry, &vmspec);
+
+        assert!(matches!(res, Ok(())));
+
+        assert_eq!(entry.ecx & (1 << ecx::SSE4A_BITINDEX), 0);
+        assert_eq!(entry.ecx & (1 << ecx::MISALIGN_SSE_BITINDEX), 0);
+        assert_eq!(entry.ecx & (1 << ecx::PREFETCH_BITINDEX), 0);
+        assert_eq!(entry.ecx & (1 << ecx::MWAIT_EXTENDED_BITINDEX), 0);
+
+        assert_eq!(entry.edx & (1 << edx::MMX_EXT_BITINDEX), 0);
+        assert_eq!(entry.edx & (1 << edx::MMX_BITINDEX), 0);
+        assert_eq!(entry.edx & (1 << edx::FXSR_BITINDEX), 0);
+        assert_eq!(entry.edx & (1 << edx::FFXSR_BITINDEX), 0);
+        assert_eq!(entry.edx & (1 << edx::PDPE1GB_BITINDEX), 0);
+    }
+
+    #[test]
+    fn test_entry_transformer_fn() {
+        let transformer = T2CLCpuidTransformer;
+        let mut entry = kvm_cpuid_entry2 {
+            ..Default::default()
+        };
+
+        entry.function = leaf_0x1::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, Some(_)));
+
+        entry.function = leaf_0x7::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, Some(_)));
+
+        entry.function = leaf_0xd::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, Some(_)));
+
+        entry.function = leaf_0x80000001::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, Some(_)));
+
+        entry.function = leaf_0x80000008::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, Some(_)));
+
+        entry.function = leaf_0x8000001d::LEAF_NUM;
+        let res = transformer.entry_transformer_fn(&mut entry);
+        assert!(matches!(res, None));
+    }
+
+    #[test]
+    fn test_validate_at_least_cascade_lake() {
+        let cpu_model = CpuModel::get_cpu_model();
+
+        // t2cl::validate_at_least_cascade_lake() does not make sense on AMD CPUs.
+        if is_on_amd() {
+            return;
+        }
+
+        let res = validate_at_least_cascade_lake();
+
+        if cpu_model < CASCADE_LAKE {
+            assert!(matches!(res, Err(Error::InvalidModel)));
+        } else {
+            assert!(matches!(res, Ok(())));
+        }
+    }
+
+    #[test]
+    fn test_set_cpuid_entries() {
+        let mut cpuid = CpuId::new(0).unwrap();
+        let vmspec = VmSpec::new(0, 1, false).unwrap();
+        let cpu_model = CpuModel::get_cpu_model();
+
+        // t2cl::set_cpuid_entries() does not make sense on AMD CPUs.
+        if is_on_amd() {
+            return;
+        }
+
+        let res = set_cpuid_entries(&mut cpuid, &vmspec);
+
+        if cpu_model < CASCADE_LAKE {
+            assert!(matches!(res, Err(Error::InvalidModel)));
+        } else {
+            assert!(matches!(res, Ok(())));
+        }
+    }
+
+    #[test]
+    fn test_msr_entries_to_save() {
+        let res = msr_entries_to_save();
+
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0], MSR_IA32_ARCH_CAPABILITIES);
+    }
+
+    #[test]
+    fn test_update_msr_entries() {
+        let mut msrs = Vec::<kvm_msr_entry>::new();
+        update_msr_entries(&mut msrs);
+        let arch_cap = msrs[0];
+
+        assert_eq!(arch_cap.index, MSR_IA32_ARCH_CAPABILITIES);
+        assert_eq!(
+            arch_cap.data,
+            (ArchCapaMSRFlags::RDCL_NO
+                | ArchCapaMSRFlags::IBRS_ALL
+                | ArchCapaMSRFlags::SKIP_L1DFL_VMENTRY
+                | ArchCapaMSRFlags::MDS_NO
+                | ArchCapaMSRFlags::IF_PSCHANGE_MC_NO
+                | ArchCapaMSRFlags::TSX_CTRL)
+                .bits()
+        );
+    }
+}

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -5,14 +5,7 @@
 import pytest
 
 from framework import utils
-import framework.utils_cpuid as cpuid_utils
 from host_tools import proc
-
-
-def is_on_skylake():
-    """Test is executed on a Skylake host."""
-    skylake_model = "Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz"
-    return cpuid_utils.get_cpu_model_name() == skylake_model
 
 
 # We have different coverages based on the host kernel version. This is
@@ -25,13 +18,9 @@ def is_on_skylake():
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 82.97, "AMD": 81.99, "ARM": 82.43}
+    COVERAGE_DICT = {"Intel": 82.97, "AMD": 82.14, "ARM": 82.43}
 else:
-    COVERAGE_DICT = {
-        "Intel": 79.83 if is_on_skylake() else 80.13,
-        "AMD": 79.13,
-        "ARM": 79.34,
-    }
+    COVERAGE_DICT = {"Intel": 80.13, "AMD": 79.28, "ARM": 79.34}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Add fine-grained unittests for the T2CL CPU template. This is to avoid separate coverage targets for Skylake and non-Skylake CPUs.

## Reason

The T2CL CPU template code needs explicit coverage as the coarse-grained test in vmm is not executed for the T2CL on a Skylake.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
