### PR TITLE
Define base CPU config types

### DIFF
--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 
 /// CPU configuration for aarch64 CPUs
+#[derive(Default)]
 pub struct Aarch64CpuConfiguration {
     /// Register values as a key pair
     /// Key: Register pointer

--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -1,0 +1,12 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+/// CPU configuration for aarch64 CPUs
+pub struct Aarch64CpuConfiguration {
+    /// Register values as a key pair
+    /// Key: Register pointer
+    /// Value: Register value
+    pub regs: HashMap<u64, u128>,
+}

--- a/src/vmm/src/guest_config/mod.rs
+++ b/src/vmm/src/guest_config/mod.rs
@@ -3,3 +3,11 @@
 
 #[cfg(cpuid)]
 pub mod cpuid;
+
+/// Module containing type implementations needed for aarch64 (ARM) CPU configuration
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
+/// Module containing type implementations needed for x86 CPU configuration
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;

--- a/src/vmm/src/guest_config/x86_64/mod.rs
+++ b/src/vmm/src/guest_config/x86_64/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::guest_config::cpuid::Cpuid;
+
+/// CPU configuration for x86_64 CPUs
+pub struct X86_64CpuConfiguration {
+    /// CPUID configuration
+    pub cpuid: Cpuid,
+    /// Register values as a key pair for model specific registers
+    /// Key: MSR address
+    /// Value: MSR value
+    pub msrs: HashMap<u64, u64>,
+}


### PR DESCRIPTION
## Changes

* Common types to be used by Firecracker for configuring guest vCPUs.

## Reason

Common types for CPU templates to be applied by `vmm` crate to configure guest vCPUs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
