### PR TITLE
docs: Update `getting-started.md`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,394 +1,42 @@
 # Getting Started with Firecracker
 
-## Contents
-
-- [Prerequisites](#prerequisites)
-- [Getting the Firecracker Binary](#getting-the-firecracker-binary)
-- [Running Firecracker](#running-firecracker)
-- [Building From Source](#building-from-source)
-- [Running the Integration Test Suite](#running-the-integration-test-suite)
-- [Appendix A: Setting Up KVM Access](#appendix-a-setting-up-kvm-access)
-- [Appendix B: Setting Up Docker](#appendix-b-setting-up-docker)
-
 ## Prerequisites
 
-If you need an opinionated way of running Firecracker, launch an `i3.metal`
-instance using Ubuntu 18.04 on EC2. Firecracker uses
-[KVM](https://www.linux-kvm.org) and needs read/write access that can be
-granted as shown below:
+You can check if your system meets the requirements by running
+`firecracker/tools/devtool checkenv`.
 
-```console
-sudo setfacl -m u:${USER}:rw /dev/kvm
-```
+An opinionated way to run Firecracker is to launch an
+[EC2](https://aws.amazon.com/ec2/) `i3.metal` instance with Ubuntu 18.04.
 
-The generic requirements are explained below:
+Nested virtualization is not supported on non-metal EC2 instances. This is why
+`.metal` instances are used.
 
-- **Linux**
+### Architecture & OS
 
-  Firecracker currently supports physical Linux **x86_64** and **aarch64**
-  hosts. The currently supported kernel versions can be found [here](kernel-policy.md).
+Firecracker supports **x86_64** and **aarch64** Linux, see
+[specific supported kernels](kernel-policy.md).
 
-- **KVM**
+### KVM
 
-  Please make sure that:
-    1. you have KVM enabled in your Linux kernel, and
-    2. you have read/write access to `/dev/kvm`.
-       If you need help setting up access to `/dev/kvm`, you should check out
-       [Appendix A](#appendix-a-setting-up-kvm-access).
+Firecracker requires [the KVM Linux kernel module](https://www.linux-kvm.org/).
 
-To check if your system meets the requirements to run Firecracker, clone
-the repository and execute `tools/devtool checkenv`.
-
-## Getting the Firecracker Binary
-
-Firecracker is linked statically against
-[musl](https://musl.libc.org/), having no library dependencies. You can
-just download the latest binary from our
-[release page](https://github.com/firecracker-microvm/firecracker/releases),
-and run it on your x86_64 or aarch64 Linux machine.
-
-On the EC2 instance, this binary can be downloaded as:
-
-```wrap
-release_url="https://github.com/firecracker-microvm/firecracker/releases"
-latest=$(basename $(curl -fsSLI -o /dev/null -w  %{url_effective} ${release_url}/latest))
-arch=`uname -m`
-curl -L ${release_url}/download/${latest}/firecracker-${latest}-${arch}.tgz \
-| tar -xz
-```
-
-Rename the binary to "firecracker":
-
-```console
-mv release-${latest}-$(uname -m)/firecracker-${latest}-$(uname -m) firecracker
-```
-
-If, instead, you'd like to build Firecracker yourself, you should check out
-the [Building From Source section](#building-from-source) in this doc.
-
-## Running Firecracker
-
-In production, Firecracker is designed to be run securely, inside
-an execution jail, carefully set up by the `jailer` binary. This is how
-our
-[integration test suite](#running-the-integration-test-suite) does it.
-However, if you just want to see Firecracker booting up a guest Linux
-machine, you can do that as well.
-
-First, make sure you have the `firecracker` binary available - either
-[downloaded from our release page](#getting-the-firecracker-binary), or
-[built from source](#building-from-source).
-
-Next, you will need an uncompressed Linux kernel binary, and an ext4
-file system image (to use as rootfs).
-
-1. To run an `x86_64` guest you can download such resources from:
-   [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin)
-   and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/rootfs/bionic.rootfs.ext4).
-1. To run an `aarch64` guest, download them from:
-   [kernel](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/kernels/vmlinux.bin)
-   and [rootfs](https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/aarch64/rootfs/bionic.rootfs.ext4).
-
-Now, let's open up two shell prompts: one to run Firecracker, and another one
-to control it (by writing to the API socket). For the purpose of this guide,
-**make sure the two shells run in the same directory where you placed the
-`firecracker` binary**.
-
-In your **first shell**:
-
-- make sure Firecracker can create its API socket:
+The presence of the KVM module can be checked with:
 
 ```bash
-rm -f /tmp/firecracker.socket
+lsmod | grep kvm
 ```
 
-- then, start Firecracker:
+An example output where it is enabled:
 
 ```bash
-./firecracker --api-sock /tmp/firecracker.socket
+kvm_intel             348160  0
+kvm                   970752  1 kvm_intel
+irqbypass              16384  1 kvm
 ```
-
-In your **second shell** prompt:
-
-- get the kernel and rootfs, if you don't have any available:
-
-  ```bash
-  arch=`uname -m`
-  dest_kernel="hello-vmlinux.bin"
-  dest_rootfs="hello-rootfs.ext4"
-  image_bucket_url="https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/$arch"
-
-  if [ ${arch} = "x86_64" ]; then
-      kernel="${image_bucket_url}/kernels/vmlinux.bin"
-      rootfs="${image_bucket_url}/rootfs/bionic.rootfs.ext4"
-  elif [ ${arch} = "aarch64" ]; then
-      kernel="${image_bucket_url}/kernels/vmlinux.bin"
-      rootfs="${image_bucket_url}/rootfs/bionic.rootfs.ext4"
-  else
-      echo "Cannot run firecracker on $arch architecture!"
-      exit 1
-  fi
-
-  echo "Downloading $kernel..."
-  curl -fsSL -o $dest_kernel $kernel
-
-  echo "Downloading $rootfs..."
-  curl -fsSL -o $dest_rootfs $rootfs
-
-  echo "Saved kernel file to $dest_kernel and root block device to $dest_rootfs."
-  ```
-
-- set the guest kernel (assuming you are in the same directory as the
-  above script was run):
-
-  ```bash
-  arch=`uname -m`
-  kernel_path=$(pwd)"/hello-vmlinux.bin"
-
-  if [ ${arch} = "x86_64" ]; then
-      curl --unix-socket /tmp/firecracker.socket -i \
-        -X PUT 'http://localhost/boot-source'   \
-        -H 'Accept: application/json'           \
-        -H 'Content-Type: application/json'     \
-        -d "{
-              \"kernel_image_path\": \"${kernel_path}\",
-              \"boot_args\": \"console=ttyS0 reboot=k panic=1 pci=off\"
-         }"
-  elif [ ${arch} = "aarch64" ]; then
-      curl --unix-socket /tmp/firecracker.socket -i \
-        -X PUT 'http://localhost/boot-source'   \
-        -H 'Accept: application/json'           \
-        -H 'Content-Type: application/json'     \
-        -d "{
-              \"kernel_image_path\": \"${kernel_path}\",
-              \"boot_args\": \"keep_bootcon console=ttyS0 reboot=k panic=1 pci=off\"
-         }"
-  else
-      echo "Cannot run firecracker on $arch architecture!"
-      exit 1
-  fi
-  ```
-
-- set the guest rootfs:
-
-  ```bash
-  rootfs_path=$(pwd)"/hello-rootfs.ext4"
-  curl --unix-socket /tmp/firecracker.socket -i \
-    -X PUT 'http://localhost/drives/rootfs' \
-    -H 'Accept: application/json'           \
-    -H 'Content-Type: application/json'     \
-    -d "{
-          \"drive_id\": \"rootfs\",
-          \"path_on_host\": \"${rootfs_path}\",
-          \"is_root_device\": true,
-          \"is_read_only\": false
-     }"
-  ```
-
-- start the guest machine:
-
-  ```bash
-  curl --unix-socket /tmp/firecracker.socket -i \
-    -X PUT 'http://localhost/actions'       \
-    -H  'Accept: application/json'          \
-    -H  'Content-Type: application/json'    \
-    -d '{
-        "action_type": "InstanceStart"
-     }'
-  ```
-
-Going back to your first shell, you should now see a serial TTY prompting you
-to log into the guest machine. If you used our `hello-rootfs.ext4` image,
-you can login as `root`, using the password `root`.
-
-When you're done, issuing a `reboot` command inside the guest will actually
-shutdown Firecracker gracefully. This is due to the fact that Firecracker
-doesn't implement guest power management.
-
-**Note**: the default microVM will have 1 vCPU and 128 MiB RAM. If you wish to
-customize that (say, 2 vCPUs and 1024MiB RAM), you can do so before issuing
-the `InstanceStart` call, via this API command:
-
-```bash
-curl --unix-socket /tmp/firecracker.socket -i  \
-  -X PUT 'http://localhost/machine-config' \
-  -H 'Accept: application/json'            \
-  -H 'Content-Type: application/json'      \
-  -d '{
-      "vcpu_count": 2,
-      "mem_size_mib": 1024
-  }'
-```
-
-### Configuring the microVM without sending API requests
-
-If you'd like to boot up a guest machine without using the API socket, you can
-do that by passing the parameter `--config-file` to the Firecracker process.
-The command for starting Firecracker with this option will look like this:
-
-```wrap
-./firecracker --api-sock /tmp/firecracker.socket --config-file <path_to_the_configuration_file>
-```
-
-`path_to_the_configuration_file` should represent the path to a file that
-contains a JSON which stores the entire configuration for all of the microVM's
-resources. The JSON **must** contain the configuration for the guest kernel and
-rootfs, as these are mandatory, but all of the other resources are optional,
-so it's your choice if you want to configure them or not. Because using this
-configuration method will also start the microVM, you need to specify all
-desired pre-boot configurable resources in that JSON. The names of the
-resources are the ones from the `firecracker.yaml` file and the names of
-their fields are the same that are used in API requests. You can find an
-example of configuration file at `tests/framework/vm_config.json`.
-After the machine is booted, you can still use the socket to send
-API requests for post-boot operations.
-
-## Building From Source
-
-The quickest way to build and test Firecracker is by using our development
-tool ([`tools/devtool`](../tools/devtool)). It employs a
-per-architecture [Docker container](../tools/devctr/)  to store the software toolchain
-used throughout the development process. If you need help setting up
-[Docker](https://docker.com) on your system, you can check out
-[Appendix B: Setting Up Docker](#appendix-b-setting-up-docker).
-
-### Getting the Firecracker Sources
-
-Get a copy of the Firecracker sources by cloning our GitHub repo:
-
-```bash
-git clone https://github.com/firecracker-microvm/firecracker
-```
-
-All development happens on the main branch and we use git tags to mark
-releases. If you are interested in a specific release (e.g. v0.10.1), you can
-check it out with:
-
-```bash
-git checkout tags/v0.10.1
-```
-
-### Building Firecracker
-
-Within the Firecracker repository root directory:
-
-1. With the __default__ musl target:
-
-   ```tools/devtool build```
-
-1. (__Experimental only__) using the gnu target:
-
-   ```tools/devtool build -l gnu```
-
-This will build and place the two Firecracker binaries at:
-
-- `build/cargo_target/${toolchain}/debug/firecracker` and
-- `build/cargo_target/${toolchain}/debug/jailer`.
-
-If you would like to test a new feature and work with
-dependencies on libraries located in private git repos, you
-can use the `--ssh-keys` flag to specify the paths to your
-public and private SSH keys on the host. Both of them are
-required for git authentication when fetching the repositories.
-
-```bash
-tools/devtool build --ssh-keys ~/.ssh/id_rsa.pub ~/.ssh/id_rsa
-```
-
-Please note that only a single set of credentials is supported.
-`devtool` cannot fetch multiple private repos which rely on
-different credentials.
-
-The default build profile is `debug`. If you want to build
-the release binaries (optimized and stripped of debug info),
-use the `--release` option:
-
-```bash
-tools/devtool build --release
-```
-
-Extensive usage information about `devtool` and its various functions and
-arguments is available via:
-
-```bash
-tools/devtool --help
-```
-
-### Alternative: Building Firecracker without devtool
-
-It is possible to build Firecracker without invoking `devtool` by instead
-running `cargo build`. However, binaries generated like this should not
-be used in production and are considered experimental.
-
-Note that the default target for Firecracker is `x86_64-unknown-linux-musl`
-(set in `.cargo/config`). If you want to build an ARM binary, you need to
-pass `--target aarch64-unknown-linux-musl` to `cargo build`, even if
-compiling on an ARM machine. Otherwise it will try to build an `x86_64` binary.
-
-### Alternative: Building Firecracker using glibc
-
-The toolchain that Firecracker is tested against and that is recommended for
-building production releases is the one that is automatically used by building
-using `devtool`. In this configuration, Firecracker is currently built as a
-static binary linked against the [musl](https://www.musl-libc.org/) libc
-implementation.
-
-Firecracker also builds using [glibc](https://www.gnu.org/software/libc/)
-toolchains, such as the default Rust toolchains provided in certain Linux
-distributions:
-
-```bash
-arch=`uname -m`
-cargo build --target ${arch}-unknown-linux-gnu
-```
-
-That being said, Firecracker binaries linked with glibc are always considered
-experimental and should not be used in production.
-
-## Running the Integration Test Suite
-
-You can also use our development tool to run the integration test suite:
-
-```bash
-tools/devtool test
-```
-
-Please note that the test suite is designed to ensure our
-[SLA parameters](../SPECIFICATION.md) as measured on EC2 .metal instances
-and, as such, some performance tests may fail when run on a regular desktop
-machine. Specifically, don't be alarmed if you see
-`tests/integration_tests/performance/test_process_startup_time.py` failing when
-not run on an EC2 .metal instance. You can skip performance tests with:
-
-```bash
- ./tools/devtool test -- --ignore integration_tests/performance
- ```
-
-## Troubleshooting
-
-### Errors while using `curl` to access the API
-
-Points to check to confirm the API socket is running and accessible:
-
-- Check that the user running the Firecracker process and the user using `curl`
-  have equivalent privileges. For example, if you run Firecracker with **sudo**
-  that you run `curl` with **sudo** as well.
-- [SELinux](https://man7.org/linux/man-pages/man8/selinux.8.html) can regulate
-  access to sockets on RHEL based distributions. How user's permissions are
-  configured is environmentally specific, but for the purposes of
-  troubleshooting you can check if it is enabled in `/etc/selinux/config`.
-- With the Firecracker process running using `--api-sock /tmp/firecracker.socket`,
-  confirm that the socket is open:
-  - `ss -a | grep '/tmp/firecracker.socket'`
-  - If you have socat available, try `socat - UNIX-CONNECT:/tmp/firecracker.socket`
-    This will throw an explicit error if the socket is inaccessible, or it will pause
-    and wait for input to continue.
-
-## Appendix A: Setting Up KVM Access
 
 Some Linux distributions use the `kvm` group to manage access to `/dev/kvm`,
 while others rely on access control lists. If you have the ACL package for your
-distro installed, you can grant your user access via:
+distro installed, you can grant Read+Write access with:
 
 ```bash
 sudo setfacl -m u:${USER}:rw /dev/kvm
@@ -411,49 +59,234 @@ You can check if you have access to `/dev/kvm` with:
 [ -r /dev/kvm ] && [ -w /dev/kvm ] && echo "OK" || echo "FAIL"
 ```
 
-**Note:** If you've just added your user to the `kvm` group via `usermod`, don't
-forget to log out and then back in, so this change takes effect.
+## Running Firecracker
 
-## Appendix B: Setting Up Docker
-
-To get Docker, you can either use the
-[official Docker install instructions](https://docs.docker.com/install/)
-, or the package manager available on your specific Linux distribution:
-
-- on Debian / Ubuntu
-
-  ```bash
-  sudo apt-get update
-  sudo apt-get install docker.io
-  ```
-
-- on Fedora / CentOS / RHEL / Amazon Linux
-
-  ```bash
-  sudo yum install docker
-  ```
-
-Then, for any of the above, you will need to start the Docker daemon
-and add your user to the `docker` group.
+In production, Firecracker is designed to be run inside
+an execution jail, set up by the [`jailer`](../src/jailer/) binary. This is how
+our [integration test suite](#running-the-integration-test-suite) does it. This
+guide will not use the [`jailer`](../src/jailer/).
 
 ```bash
+ARCH="$(uname -m)"
+
+# Download a linux kernel binary
+wget https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin
+
+# Download a rootfs
+wget https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.ext4
+
+# Download the ssh key for the rootfs
+wget https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.id_rsa
+
+# Set user read permission on the ssh key
+chmod 400 ./ubuntu-18.04.id_rsa
+
+# Clone the firecracker repository
+git clone https://github.com/firecracker-microvm/firecracker
+
+# Start docker
 sudo systemctl start docker
-sudo usermod -aG docker $USER
+
+# Build firecracker
+#
+# It is possible to build for gnu, by passing the arguments '-l gnu'.
+#
+# This will produce the firecracker and jailer binaries under
+# `./firecracker/build/cargo_target/${toolchain}/debug`.
+#
+sudo ./firecracker/tools/devtool build
+
+API_SOCKET="./firecracker.socket"
+
+# Remove API unix socket
+rm -f $API_SOCKET
+
+# Run firecracker
+./firecracker/build/cargo_target/${ARCH}-unknown-linux-musl/debug/firecracker \
+    --api-sock "${API_SOCKET}"
 ```
 
-Don't forget to log out and then back in again, so that the user
-change takes effect.
-
-If you wish to have Docker started automatically after boot, you can:
+In a new terminal (do not close the 1st one):
 
 ```bash
-sudo systemctl enable docker
+TAP_DEV="tap0"
+TAP_IP="172.16.0.1"
+MASK_SHORT="/30"
+
+# Setup network interface
+sudo ip link del "$TAP_DEV" 2> /dev/null || true
+sudo ip tuntap add dev "$TAP_DEV" mode tap
+sudo ip addr add "${TAP_IP}${MASK_SHORT}" dev "$TAP_DEV"
+sudo ip link set dev "$TAP_DEV" up
+
+# Enable ip forwarding
+sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
+
+# Set up microVM internet access
+sudo iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE || true
+sudo iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT \
+    || true
+sudo iptables -D FORWARD -i tap0 -o eth0 -j ACCEPT || true
+sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+sudo iptables -I FORWARD 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+sudo iptables -I FORWARD 1 -i tap0 -o eth0 -j ACCEPT
+
+API_SOCKET="./firecracker.socket"
+LOGFILE="./firecracker.log"
+
+# Create log file
+touch $LOGFILE
+
+# Set log file
+curl -X PUT --unix-socket "${API_SOCKET}" \
+    --data "{
+        \"log_path\": \"${LOGFILE}\",
+        \"level\": \"Debug\",
+        \"show_level\": true,
+        \"show_log_origin\": true
+    }" \
+    "http://localhost/logger"
+
+KERNEL="./vmlinux.bin"
+KERNEL_BOOT_ARGS="console=ttyS0 reboot=k panic=1 pci=off"
+
+ARCH=$(uname -m)
+
+if [ ${ARCH} = "aarch64" ]; then
+    KERNEL_BOOT_ARGS="keep_bootcon ${KERNEL_BOOT_ARGS}"
+fi
+
+# Set boot source
+curl -X PUT --unix-socket "${API_SOCKET}" \
+    --data "{
+        \"kernel_image_path\": \"${KERNEL}\",
+        \"boot_args\": \"${KERNEL_BOOT_ARGS}\"
+    }" \
+    "http://localhost/boot-source"
+
+ROOTFS="./ubuntu-18.04.ext4"
+
+# Set rootfs
+curl -X PUT --unix-socket "${API_SOCKET}" \
+    --data "{
+        \"drive_id\": \"rootfs\",
+        \"path_on_host\": \"${ROOTFS}\",
+        \"is_root_device\": true,
+        \"is_read_only\": false
+    }" \
+    "http://localhost/drives/rootfs"
+
+# The IP address of a guest is derived from its MAC address with
+# `fcnet-setup.sh`, this has been pre-configured in the guest rootfs. It is
+# important that `TAP_IP` and `FC_MAC` match this.
+FC_MAC="06:00:AC:10:00:02"
+
+# Set network interface
+curl -X PUT --unix-socket "${API_SOCKET}" \
+    --data "{
+        \"iface_id\": \"net1\",
+        \"guest_mac\": \"$FC_MAC\",
+        \"host_dev_name\": \"$TAP_DEV\"
+    }" \
+    "http://localhost/network-interfaces/net1"
+
+# API requests are handled asynchronously, it is important the configuration is
+# set, before `InstanceStart`.
+sleep 0.015s
+
+# Start microVM
+curl -X PUT --unix-socket "${API_SOCKET}" \
+    --data "{
+        \"action_type\": \"InstanceStart\"
+    }" \
+    "http://localhost/actions"
+
+# API requests are handled asynchronously, it is important the microVM has been
+# started before we attempt to SSH into it.
+sleep 0.015s
+
+# SSH into the microVM
+sudo ssh -i ./ubuntu-18.04.id_rsa 172.16.0.2
+
+# Use `root` for both the login and password.
+# Run `reboot` to exit.
 ```
 
-We recommend testing your Docker configuration by running a lightweight
-test container and checking for net connectivity:
+Issuing a `reboot` command inside the guest will gracefully shutdown Firecracker.
+This is due to the fact that Firecracker doesn't implement guest power management.
+
+### Configuring the microVM without sending API requests
+
+You can boot a guest without using the API socket by passing the parameter
+`--config-file` to the Firecracker process.
+E.g.:
+
+```wrap
+./firecracker --api-sock /tmp/firecracker.socket --config-file <path_to_the_configuration_file>
+```
+
+`path_to_the_configuration_file` is the path to a JSON file with the
+configuration for all of the microVM's resources. The JSON **must** contain the
+configuration for the guest kernel and rootfs, all of the other resources are
+optional. This configuration method will also start the microVM, as such you
+need to specify all desired pre-boot configurable resources in the JSON. The
+names of the resources can be seen in
+[`firecracker.yaml`](../src/api_server/swagger/firecracker.yaml) and the
+names of their fields are the same that are used in the API requests.
+
+An example of configuration file is provided:
+[`tests/framework/vm_config.json`](../tests/framework/vm_config.json).
+
+After the microVM is started you can still use the socket to send API requests
+for post-boot operations.
+
+### Building Firecracker
+
+SSH can be used to work with libraries from private git repos by passing
+the `--ssh-keys` flag to specify the paths to your public and private SSH keys
+on the host. Both are required for git authentication when fetching the
+repositories.
 
 ```bash
-docker pull alpine
-docker run --rm -it alpine ping -c 3 amazon.com
+tools/devtool build --ssh-keys ~/.ssh/id_rsa.pub ~/.ssh/id_rsa
 ```
+
+Only a single set of credentials is supported. `devtool` cannot fetch multiple
+private repos which rely on different credentials.
+
+`tools/devtool build` builds in `debug` to build release binaries pass
+`--release` e.g. `tools/devtool build --release`
+
+Documentation on `devtool` can be seen with `tools/devtool --help`.
+
+## Running the Integration Test Suite
+
+Integration tests can be run with `tools/devtool test`.
+
+The test suite is designed to ensure our [SLA parameters](../SPECIFICATION.md)
+as measured on EC2 .metal instances, as such performance tests may fail when not
+run on these machines. Specifically, don't be alarmed if you see
+`tests/integration_tests/performance/test_process_startup_time.py` failing when
+not run on an EC2 .metal instance. You can skip performance tests with:
+
+```bash
+./tools/devtool test -- --ignore integration_tests/performance
+```
+
+## Errors while using `curl` to access the API
+
+Points to check to confirm the API socket is running and accessible:
+
+- Check that the user running the Firecracker process and the user using `curl`
+  have equivalent privileges. For example, if you run Firecracker with **sudo**
+  that you run `curl` with **sudo** as well.
+- [SELinux](https://man7.org/linux/man-pages/man8/selinux.8.html) can regulate
+  access to sockets on RHEL based distributions. How user's permissions are
+  configured is environmentally specific, but for the purposes of
+  troubleshooting you can check if it is enabled in `/etc/selinux/config`.
+- With the Firecracker process running using `--api-sock /tmp/firecracker.socket`,
+  confirm that the socket is open:
+  - `ss -a | grep '/tmp/firecracker.socket'`
+  - If you have socat available, try `socat - UNIX-CONNECT:/tmp/firecracker.socket`
+    This will throw an explicit error if the socket is inaccessible, or it will pause
+    and wait for input to continue.


### PR DESCRIPTION
## Changes

Updates `getting-started.md`.

The example now involves setting up a microVM you can SSH into.

See https://github.com/JonathanWoollett-Light/firecracker/blob/getting-started/docs/getting-started.md.

## Reason

Some of the instructions are out-dated and it is missing a simple guide to ssh into a microVM.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
