### PR TITLE
chore: new c7g.metal performance baselines

### DIFF
--- a/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_latency_config_4.14.json
@@ -11,8 +11,8 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "ping": {
-                                                    "delta_percentage": 23.1,
-                                                    "target": 0.026
+                                                    "delta_percentage": 10.1,
+                                                    "target": 0.024
                                                 }
                                             }
                                         }
@@ -38,7 +38,7 @@
                                             "Avg": {
                                                 "ping": {
                                                     "delta_percentage": 0.1,
-                                                    "target": 0
+                                                    "target": 0.0
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_network_tcp_throughput_config_4.14.json
@@ -63,76 +63,76 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 140
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 147
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 162
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 160
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 151
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 164
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 167
+                                                    "delta_percentage": 5,
+                                                    "target": 200
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 13,
-                                                    "target": 124
+                                                    "delta_percentage": 15,
+                                                    "target": 158
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 168
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 146
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 145
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 163
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 162
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 152
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 157
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 165
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 163
+                                                    "delta_percentage": 5,
+                                                    "target": 197
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 166
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
@@ -277,47 +277,47 @@
                                         "1vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 11,
                                                     "target": 62
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 53
+                                                    "target": 52
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 87
+                                                    "delta_percentage": 10,
+                                                    "target": 86
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 8,
-                                                    "target": 60
+                                                    "target": 59
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 95
+                                                    "target": 94
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 98
+                                                    "target": 97
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 12,
+                                                    "delta_percentage": 10,
                                                     "target": 62
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 53
+                                                    "delta_percentage": 9,
+                                                    "target": 52
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 10,
                                                     "target": 84
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 81
+                                                    "target": 80
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
+                                                    "delta_percentage": 7,
                                                     "target": 91
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
@@ -329,76 +329,76 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "tcp-p1024K-ws16K-bd": {
-                                                    "delta_percentage": 9,
-                                                    "target": 49
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 54
+                                                    "delta_percentage": 8,
+                                                    "target": 73
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 10,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 10,
-                                                    "target": 77
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 10,
-                                                    "target": 72
+                                                    "delta_percentage": 7,
+                                                    "target": 90
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 86
+                                                    "delta_percentage": 7,
+                                                    "target": 96
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 88
+                                                    "delta_percentage": 7,
+                                                    "target": 93
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 81
-                                                },
-                                                "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
+                                                    "delta_percentage": 6,
                                                     "target": 92
                                                 },
+                                                "tcp-p1024K-wsDEFAULT-h2g": {
+                                                    "delta_percentage": 6,
+                                                    "target": 98
+                                                },
                                                 "tcp-pDEFAULT-ws16K-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 50
+                                                    "delta_percentage": 8,
+                                                    "target": 68
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 52
+                                                    "delta_percentage": 8,
+                                                    "target": 73
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 11,
-                                                    "target": 51
+                                                    "delta_percentage": 9,
+                                                    "target": 59
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 11,
-                                                    "target": 78
+                                                    "delta_percentage": 7,
+                                                    "target": 88
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 11,
-                                                    "target": 72
+                                                    "delta_percentage": 8,
+                                                    "target": 89
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 82
+                                                    "delta_percentage": 6,
+                                                    "target": 97
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 84
+                                                    "delta_percentage": 6,
+                                                    "target": 93
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 84
+                                                    "delta_percentage": 6,
+                                                    "target": 91
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 90
+                                                    "delta_percentage": 6,
+                                                    "target": 98
                                                 }
                                             }
                                         }
@@ -544,51 +544,51 @@
                                             "total": {
                                                 "tcp-p1024K-ws16K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 4775
+                                                    "target": 4773
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
-                                                    "delta_percentage": 6,
-                                                    "target": 4574
+                                                    "delta_percentage": 5,
+                                                    "target": 4553
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 38675
+                                                    "delta_percentage": 8,
+                                                    "target": 38390
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 21105
+                                                    "target": 21129
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 60149
+                                                    "delta_percentage": 19,
+                                                    "target": 58234
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 42224
+                                                    "delta_percentage": 6,
+                                                    "target": 42356
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4782
+                                                    "delta_percentage": 6,
+                                                    "target": 4757
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 4567
+                                                    "target": 4545
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
                                                     "delta_percentage": 14,
-                                                    "target": 34980
+                                                    "target": 35171
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
                                                     "delta_percentage": 5,
-                                                    "target": 25649
+                                                    "target": 25736
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 49484
+                                                    "delta_percentage": 9,
+                                                    "target": 50441
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 5,
-                                                    "target": 40868
+                                                    "delta_percentage": 6,
+                                                    "target": 41299
                                                 }
                                             }
                                         },
@@ -596,75 +596,75 @@
                                             "total": {
                                                 "tcp-p1024K-ws16K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 4507
+                                                    "target": 6351
                                                 },
                                                 "tcp-p1024K-ws16K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5699
+                                                    "delta_percentage": 10,
+                                                    "target": 7935
                                                 },
                                                 "tcp-p1024K-ws16K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 5599
+                                                    "target": 6422
                                                 },
                                                 "tcp-p1024K-ws256K-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 30976
+                                                    "delta_percentage": 6,
+                                                    "target": 36960
                                                 },
                                                 "tcp-p1024K-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 34284
+                                                    "delta_percentage": 8,
+                                                    "target": 43085
                                                 },
                                                 "tcp-p1024K-ws256K-h2g": {
                                                     "delta_percentage": 7,
-                                                    "target": 30134
+                                                    "target": 34405
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 41987
+                                                    "delta_percentage": 8,
+                                                    "target": 45086
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 42780
+                                                    "delta_percentage": 8,
+                                                    "target": 49155
                                                 },
                                                 "tcp-p1024K-wsDEFAULT-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 38252
+                                                    "delta_percentage": 6,
+                                                    "target": 41969
                                                 },
                                                 "tcp-pDEFAULT-ws16K-bd": {
                                                     "delta_percentage": 6,
-                                                    "target": 4503
+                                                    "target": 6333
                                                 },
                                                 "tcp-pDEFAULT-ws16K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 5669
+                                                    "delta_percentage": 10,
+                                                    "target": 7923
                                                 },
                                                 "tcp-pDEFAULT-ws16K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 5599
+                                                    "delta_percentage": 6,
+                                                    "target": 6420
                                                 },
                                                 "tcp-pDEFAULT-ws256K-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 30554
+                                                    "delta_percentage": 6,
+                                                    "target": 34993
                                                 },
                                                 "tcp-pDEFAULT-ws256K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 33465
+                                                    "delta_percentage": 11,
+                                                    "target": 41585
                                                 },
                                                 "tcp-pDEFAULT-ws256K-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 28471
+                                                    "delta_percentage": 6,
+                                                    "target": 34203
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 37902
+                                                    "delta_percentage": 7,
+                                                    "target": 41913
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 42966
+                                                    "delta_percentage": 8,
+                                                    "target": 46427
                                                 },
                                                 "tcp-pDEFAULT-wsDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 36370
+                                                    "target": 40017
                                                 }
                                             }
                                         }

--- a/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
+++ b/tests/integration_tests/performance/configs/test_vsock_throughput_config_4.14.json
@@ -39,40 +39,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 149
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 5,
-                                                    "target": 174
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 7,
-                                                    "target": 147
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 142
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 173
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 154
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 6,
-                                                    "target": 142
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 168
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 149
+                                                    "delta_percentage": 4,
+                                                    "target": 200
                                                 }
                                             }
                                         }
@@ -158,15 +158,15 @@
                                             "Avg": {
                                                 "vsock-p1024-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 58
+                                                    "target": 59
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 9,
-                                                    "target": 55
+                                                    "target": 56
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 8,
-                                                    "target": 59
+                                                    "delta_percentage": 9,
+                                                    "target": 60
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 9,
@@ -174,7 +174,7 @@
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 9,
-                                                    "target": 59
+                                                    "target": 60
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 9,
@@ -185,40 +185,40 @@
                                         "2vcpu_1024mb.json": {
                                             "Avg": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 13,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 89
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 70
+                                                    "delta_percentage": 8,
+                                                    "target": 71
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 16,
-                                                    "target": 59
+                                                    "delta_percentage": 8,
+                                                    "target": 77
                                                 },
                                                 "vsock-p1024K-bd": {
-                                                    "delta_percentage": 16,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 75
                                                 },
                                                 "vsock-p1024K-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 64
+                                                    "delta_percentage": 8,
+                                                    "target": 66
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 13,
-                                                    "target": 80
+                                                    "delta_percentage": 8,
+                                                    "target": 84
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 15,
-                                                    "target": 65
+                                                    "delta_percentage": 7,
+                                                    "target": 76
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 8,
-                                                    "target": 64
+                                                    "target": 66
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 80
+                                                    "delta_percentage": 7,
+                                                    "target": 85
                                                 }
                                             }
                                         }
@@ -303,68 +303,68 @@
                                         "1vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 9,
-                                                    "target": 2773
+                                                    "delta_percentage": 6,
+                                                    "target": 2676
                                                 },
                                                 "vsock-p1024-h2g": {
-                                                    "delta_percentage": 12,
-                                                    "target": 1958
+                                                    "delta_percentage": 10,
+                                                    "target": 2003
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 9930
+                                                    "target": 9961
                                                 },
                                                 "vsock-p1024K-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6500
+                                                    "target": 6503
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
-                                                    "delta_percentage": 6,
-                                                    "target": 9984
+                                                    "delta_percentage": 7,
+                                                    "target": 9969
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 6400
+                                                    "target": 6399
                                                 }
                                             }
                                         },
                                         "2vcpu_1024mb.json": {
                                             "total": {
                                                 "vsock-p1024-bd": {
-                                                    "delta_percentage": 8,
-                                                    "target": 3235
+                                                    "delta_percentage": 7,
+                                                    "target": 4267
                                                 },
                                                 "vsock-p1024-g2h": {
-                                                    "delta_percentage": 7,
-                                                    "target": 3474
+                                                    "delta_percentage": 9,
+                                                    "target": 3416
                                                 },
                                                 "vsock-p1024-h2g": {
                                                     "delta_percentage": 6,
-                                                    "target": 2853
+                                                    "target": 3789
                                                 },
                                                 "vsock-p1024K-bd": {
                                                     "delta_percentage": 7,
-                                                    "target": 4723
+                                                    "target": 6691
                                                 },
                                                 "vsock-p1024K-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10299
+                                                    "target": 10162
                                                 },
                                                 "vsock-p1024K-h2g": {
-                                                    "delta_percentage": 8,
-                                                    "target": 5716
+                                                    "delta_percentage": 9,
+                                                    "target": 7630
                                                 },
                                                 "vsock-pDEFAULT-bd": {
-                                                    "delta_percentage": 7,
-                                                    "target": 4720
+                                                    "delta_percentage": 8,
+                                                    "target": 6736
                                                 },
                                                 "vsock-pDEFAULT-g2h": {
                                                     "delta_percentage": 6,
-                                                    "target": 10317
+                                                    "target": 10185
                                                 },
                                                 "vsock-pDEFAULT-h2g": {
-                                                    "delta_percentage": 9,
-                                                    "target": 5819
+                                                    "delta_percentage": 8,
+                                                    "target": 7755
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Fixes: 0f224d0f8a80c13f06121f14f92b8509e0f22f86

## Changes

Complete the performance baselines for c7g on linux 4.14

## Reason

Last PR was missing the 4.14

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~- [ ] If a specific issue led to this PR, this PR closes the issue.~
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~
~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
~- [ ] New `TODO`s link to an issue.~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~- [ ] This functionality can be added in [`rust-vmm`][1].~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
