### PR TITLE
UFFD: Add sanity checks for information received through UDS

### DIFF
--- a/src/uffd_handler/src/handler.rs
+++ b/src/uffd_handler/src/handler.rs
@@ -225,7 +225,7 @@ mod tests {
     use utils::GuestRegionUffdMapping;
 
     use super::*;
-    use crate::create_mem_regions;
+    use crate::memory_region::create_mem_regions;
 
     const PAGE_SIZE: usize = 4096;
 

--- a/src/uffd_handler/src/memory_region.rs
+++ b/src/uffd_handler/src/memory_region.rs
@@ -5,7 +5,19 @@ use std::collections::HashMap;
 
 use utils::{get_page_size, GuestRegionUffdMapping};
 
-use crate::{Error, Result};
+use crate::Error;
+
+#[derive(Debug, thiserror::Error)]
+pub enum MemRegionError {
+    #[error("Host virtual address of region end overflows usize.")]
+    EndRegionOverflow,
+    #[error("The mapping exceeds the file end.")]
+    MappingPastEof,
+    #[error("The specified file offset and length cause overflow when added.")]
+    InvalidOffsetLength,
+    #[error("Size of snapshot memory file differs from the size of memory mappings.")]
+    SizeMismatch,
+}
 
 #[derive(Debug)]
 pub struct MemRegion {
@@ -22,6 +34,15 @@ pub enum MemPageState {
     Anonymous,
 }
 
+/// Construct memory regions from stream received from Firecracker process.
+pub fn mem_regions_from_stream(msg: &str, mem_file_size: usize) -> Result<Vec<MemRegion>, Error> {
+    let mappings = deserialize_mappings(msg)?;
+    memory_mappings_sanity_checks(&mappings, mem_file_size)
+        .map_err(Error::CorruptedMemoryMappings)?;
+
+    Ok(create_mem_regions(mappings))
+}
+
 /// Convert the guest memory mappings received from the Firecracker process
 /// into a vector of `MemRegion`s containing the guest mappings and page
 /// state information.
@@ -32,6 +53,8 @@ pub fn create_mem_regions(mappings: Vec<GuestRegionUffdMapping>) -> Vec<MemRegio
     for r in mappings.iter() {
         let mapping = *r;
         let mut addr = r.base_host_virt_addr;
+        // This cannot overflow because it has been previously validated during mappings sanity
+        // checks (see `memory_mappings_sanity_checks`).
         let end_addr = r.base_host_virt_addr + r.size;
         let mut page_states = HashMap::new();
 
@@ -48,18 +71,49 @@ pub fn create_mem_regions(mappings: Vec<GuestRegionUffdMapping>) -> Vec<MemRegio
     mem_regions
 }
 
-/// Deserialize memory mappings received through UDS from Firecracker.
-pub fn deserialize_mappings(msg: &str, size: usize) -> Result<Vec<GuestRegionUffdMapping>> {
-    let mappings = serde_json::from_str::<Vec<GuestRegionUffdMapping>>(msg)
-        .map_err(Error::DeserializeMemoryMappings)?;
-    let memsize: usize = mappings.iter().map(|r| r.size).sum();
-    // The mappings' memory size must match the size of the snapshot memory file, otherwise
-    // the memory mappings might be corrupted.
-    if memsize != size {
-        return Err(Error::CorruptedMemoryMappings);
+/// Perform sanity checks for deserialized mappings to ensure they are not corrupted:
+/// - The regions must not exceed memory file end.
+/// - The specified file offset and region size must not overflow when added.
+/// - The region end must not overflow usize.
+/// - The total mappings size must match the memory file size.
+fn memory_mappings_sanity_checks(
+    mappings: &Vec<GuestRegionUffdMapping>,
+    file_size: usize,
+) -> Result<(), MemRegionError> {
+    for region in mappings {
+        if let Some(region_end) = region.offset.checked_add(region.size as u64) {
+            if region_end > file_size as u64 {
+                // The region goes beyond file end.
+                return Err(MemRegionError::MappingPastEof);
+            }
+        } else {
+            // The specified file offset and region size cause overflow when added.
+            return Err(MemRegionError::InvalidOffsetLength);
+        }
+
+        if region
+            .base_host_virt_addr
+            .checked_add(region.size)
+            .is_none()
+        {
+            // The region end overflows usize.
+            return Err(MemRegionError::EndRegionOverflow);
+        }
     }
 
-    Ok(mappings)
+    let memsize: usize = mappings.iter().map(|r| r.size).sum();
+    // The mappings' memory size must match the size of the snapshot memory file.
+    if memsize != file_size {
+        return Err(MemRegionError::SizeMismatch);
+    }
+
+    Ok(())
+}
+
+/// Deserialize memory mappings received through UDS from Firecracker.
+fn deserialize_mappings(msg: &str) -> Result<Vec<GuestRegionUffdMapping>, Error> {
+    serde_json::from_str::<Vec<GuestRegionUffdMapping>>(msg)
+        .map_err(Error::DeserializeMemoryMappings)
 }
 
 #[cfg(test)]
@@ -119,37 +173,67 @@ mod tests {
         ];
 
         let msg = serde_json::to_string(&expected_mappings).unwrap();
-        let mappings = deserialize_mappings(&msg, PAGE_SIZE * 5).unwrap();
+        let mappings = deserialize_mappings(&msg).unwrap();
+        assert!(memory_mappings_sanity_checks(&mappings, PAGE_SIZE * 5).is_ok());
         assert_eq!(mappings, expected_mappings);
     }
 
     #[test]
-    fn test_deserialize_mappings_corrupted() {
-        let mappings = [GuestRegionUffdMapping {
-            base_host_virt_addr: 0x1000,
-            size: PAGE_SIZE,
-            offset: 0,
-        }];
-        let expected_size = PAGE_SIZE - 1;
-        let msg = serde_json::to_string(&mappings).unwrap();
-
-        // Deserialization fails because mappings don't match the expected size,
-        // thus they are corrupted.
-        let res = deserialize_mappings(&msg, expected_size);
-        assert!(res.is_err());
-        assert_eq!(
-            Error::CorruptedMemoryMappings.to_string(),
-            res.err().unwrap().to_string()
-        );
-    }
-
-    #[test]
     fn test_deserialize_mappings_invalid() {
-        let res = deserialize_mappings("foo bar", 0);
+        let res = deserialize_mappings("foo bar");
         assert!(res.is_err());
         assert!(matches!(
             res.err().unwrap(),
             Error::DeserializeMemoryMappings(_)
+        ));
+
+        let res = deserialize_mappings("");
+        assert!(res.is_err());
+        assert!(matches!(
+            res.err().unwrap(),
+            Error::DeserializeMemoryMappings(_)
+        ));
+    }
+
+    #[test]
+    fn test_mappings_sanity_checks_corrupted() {
+        let mut mappings = vec![GuestRegionUffdMapping {
+            base_host_virt_addr: 0x1000,
+            size: PAGE_SIZE,
+            offset: 0,
+        }];
+
+        // Sanity checks fail because mappings size doesn't match the expected file size.
+        let res = memory_mappings_sanity_checks(&mappings, PAGE_SIZE + 1);
+        assert!(res.is_err());
+        assert!(matches!(res.err().unwrap(), MemRegionError::SizeMismatch));
+
+        // Sanity checks fail because the region does not fit into the file entirely.
+        // The region begins at offset=0x100 and ends at 0x1100, while the file's size is
+        // PAGE_SIZE=0x1000.
+        mappings[0].offset = 0x100;
+        let res = memory_mappings_sanity_checks(&mappings, PAGE_SIZE);
+        assert!(res.is_err());
+        assert!(matches!(res.err().unwrap(), MemRegionError::MappingPastEof));
+
+        // Sanity checks fail because the specified file offset and length
+        // cause overflow when added.
+        mappings[0].offset = u64::MAX;
+        let res = memory_mappings_sanity_checks(&mappings, PAGE_SIZE);
+        assert!(res.is_err());
+        assert!(matches!(
+            res.err().unwrap(),
+            MemRegionError::InvalidOffsetLength
+        ));
+
+        // Sanity checks fail because the host address of the region end overflows usize.
+        mappings[0].offset = 0;
+        mappings[0].base_host_virt_addr = usize::MAX;
+        let res = memory_mappings_sanity_checks(&mappings, PAGE_SIZE);
+        assert!(res.is_err());
+        assert!(matches!(
+            res.err().unwrap(),
+            MemRegionError::EndRegionOverflow
         ));
     }
 }


### PR DESCRIPTION
## Changes

Add sanity checks for information received from Firecracker through UDS.

## Reason

Ensure the mappings received through UDS are not corrupted.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [X] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [X] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
