### PR TITLE
chore: update maintainers and release status table

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,5 +13,5 @@ Firecracker is maintained by a dedicated team within Amazon:
 - Nikita Kalyazin <kalyazin@amazon.com>
 - Pablo Barbachano <pablob@amazon.com>
 - Patrick Roy <roypat@amazon.com>
+- Sudan Landge <sudanl@amazon.com>
 - Takahiro Itazuri <itazur@amazon.com>
-- Vibha Acharya <vibharya@amazon.com>

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -86,8 +86,9 @@ also be specifying the supported kernel versions.
 
 | Release | Release Date | Latest Patch | Min. end of support | Official end of Support        |
 | ------: | -----------: | -----------: | ------------------: | :----------------------------- |
+| v1.3    |   2023-03-02 | v1.3.0       |          2023-09-02 | Supported                      |
 | v1.2    |   2022-11-30 | v1.2.0       |          2023-05-30 | Supported                      |
-| v1.1    |   2022-05-06 | v1.1.4       |          2022-11-06 | Supported                      |
+| v1.1    |   2022-05-06 | v1.1.4       |          2022-11-06 | 2023-03-02 (v1.3 released)     |
 | v1.0    |   2022-01-31 | v1.0.2       |          2022-07-31 | 2022-11-30 (v1.2 released)     |
 | v0.25   |   2021-03-13 | v0.25.2      |          2021-09-13 | 2022-03-13 (end of 1y support) |
 


### PR DESCRIPTION
## Changes

- Update a list of maintainers.
- Update release status table along with firecracker v1.3.0 release.

## Reason

...

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- ~~[ ] All added/changed functionality is tested.~~
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- ~~[ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
