### PR TITLE
Snapshot bump

### DIFF
--- a/src/vmm/src/version_map.rs
+++ b/src/vmm/src/version_map.rs
@@ -29,6 +29,8 @@ pub const FC_V1_0_SNAP_VERSION: u16 = 4;
 pub const FC_V1_1_SNAP_VERSION: u16 = 5;
 /// Snap version for Firecracker v1.2
 pub const FC_V1_2_SNAP_VERSION: u16 = 6;
+/// Snap version for Firecracker v1.3
+pub const FC_V1_3_SNAP_VERSION: u16 = 7;
 
 lazy_static! {
     // Note: until we have a better design, this needs to be updated when the version changes.
@@ -58,6 +60,11 @@ lazy_static! {
         #[cfg(target_arch = "x86_64")]
         version_map.set_type_version(VcpuState::type_id(), 3);
 
+        // v1.3 - no changes introduced, but we need to bump as mapping
+        // between firecracker minor versions and snapshot versions needs
+        // to be 1-to-1 (see below)
+        version_map.new_version();
+
         version_map
     };
 
@@ -82,6 +89,7 @@ lazy_static! {
         mapping.insert(String::from("1.0.0"), FC_V1_0_SNAP_VERSION);
         mapping.insert(String::from("1.1.0"), FC_V1_1_SNAP_VERSION);
         mapping.insert(String::from("1.2.0"), FC_V1_2_SNAP_VERSION);
+        mapping.insert(String::from("1.3.0"), FC_V1_3_SNAP_VERSION);
 
         mapping
     };


### PR DESCRIPTION
## Changes

Cherry-picks the snapshot version bump from the 1.3 release branch, as well as introduces a regression test (thanks to pablob@ for the code!) that ensure we do not forget to bump snapshot version prior to a release again.

## Reason

We forgot to bump snapshot version prior to releasing 1.3.0

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
