### PR TITLE
fix: create clean artifact dir for taking snapshot

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -27,6 +27,14 @@ from framework.utils_cpu_templates import SUPPORTED_CPU_TEMPLATES
 PLATFORM = platform.machine()
 
 
+def clean_and_mkdir(dir_path):
+    """
+    Create a clean directory
+    """
+    shutil.rmtree(dir_path, ignore_errors=True)
+    os.makedirs(dir_path)
+
+
 def _check_cpuid_x86(test_microvm, expected_cpu_count, expected_htt):
     expected_cpu_features = {
         "cpu count": "{} ({})".format(hex(expected_cpu_count), expected_cpu_count),
@@ -445,8 +453,7 @@ def _test_cpu_wrmsr_snapshot(context):
         / context.kernel.base_name()
         / get_cpu_template_dir(cpu_template)
     )
-    shutil.rmtree(snapshot_artifacts_dir, ignore_errors=True)
-    os.makedirs(snapshot_artifacts_dir)
+    clean_and_mkdir(snapshot_artifacts_dir)
 
     msrs_before_fname = Path(snapshot_artifacts_dir) / shared_names["msrs_before_fname"]
 
@@ -621,7 +628,7 @@ def _test_cpu_wrmsr_restore(context):
     tmp_snapshot_artifacts_dir = (
         Path() / chroot_dir / "tmp" / context.kernel.base_name()
     )
-    os.makedirs(tmp_snapshot_artifacts_dir)
+    clean_and_mkdir(tmp_snapshot_artifacts_dir)
 
     mem_fname_in_jail = Path(tmp_snapshot_artifacts_dir) / shared_names["mem_fname"]
     snapshot_fname_in_jail = (
@@ -743,7 +750,7 @@ def _test_cpu_cpuid_snapshot(context):
         / context.kernel.base_name()
         / cpu_template_dir
     )
-    os.makedirs(snapshot_artifacts_dir)
+    clean_and_mkdir(snapshot_artifacts_dir)
 
     cpuid_before_fname = (
         Path(snapshot_artifacts_dir) / shared_names["cpuid_before_fname"]
@@ -866,8 +873,7 @@ def _test_cpu_cpuid_restore(context):
     # Bring snapshot files from the 1st part of the test into the jail
     chroot_dir = vm.chroot()
     tmp_snapshot_artifacts_dir = Path(chroot_dir) / "tmp" / context.kernel.base_name()
-    shutil.rmtree(tmp_snapshot_artifacts_dir, ignore_errors=True)
-    os.makedirs(tmp_snapshot_artifacts_dir)
+    clean_and_mkdir(snapshot_artifacts_dir)
 
     mem_fname_in_jail = Path(tmp_snapshot_artifacts_dir) / shared_names["mem_fname"]
     snapshot_fname_in_jail = (


### PR DESCRIPTION
While running snapshot test multiple times on the same instance, the snapshot test fails while trying to create artifacts directory if the old artifact directories are not deleted manually so, delete old artifacts directories and create clean directory before taking a new snasphot to avoid such failures.

To reproduce the issue run below command, twice back to back, manually (not through buildkite) on an instance :
> tools/devtool -y test -- -s --nonci integration_tests/functional/test_cpu_features.py -k 'test_cpu_cpuid_snapshot or test_cpu_wrmsr_snapshot'

## Changes

Use a new function to delete existing old artifacts directory and create clean directory before taking a snapshot.

## Reason

Snapshot test fails while creating an artifact directory if old artifact directory is not removed manually.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

~~- [ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
-~~ [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).~~

---

~~- [ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
