### PR TITLE
Uffd: inform Firecracker of crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ name = "uffd_handler"
 version = "1.4.0"
 dependencies = [
  "libc",
+ "nix",
  "serde",
  "serde_json",
  "thiserror",

--- a/src/uffd_handler/Cargo.toml
+++ b/src/uffd_handler/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2.117"
+nix = "0.23.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 thiserror = "1.0.32"

--- a/src/uffd_handler/src/handler.rs
+++ b/src/uffd_handler/src/handler.rs
@@ -107,21 +107,17 @@ pub struct PageFaultHandler<T: UffdManager> {
     mem_regions: Vec<MemRegion>,
     backing_buffer: *const libc::c_void,
     pub uffd: T,
-    // Not currently used but included to demonstrate how a page fault handler can
-    // fetch Firecracker's PID in order to make it aware of any crashes/exits.
-    _firecracker_pid: u32,
 }
 
 impl<T> PageFaultHandler<T>
 where
     T: UffdManager,
 {
-    pub fn new(mem_regions: Vec<MemRegion>, buff: *const libc::c_void, uffd: T, pid: u32) -> Self {
+    pub fn new(mem_regions: Vec<MemRegion>, buff: *const libc::c_void, uffd: T) -> Self {
         PageFaultHandler {
             mem_regions,
             backing_buffer: buff,
             uffd,
-            _firecracker_pid: pid,
         }
     }
 
@@ -265,7 +261,7 @@ mod tests {
             offset: 0,
         }];
 
-        PageFaultHandler::new(create_mem_regions(mappings), ptr::null(), MockUffd {}, 0)
+        PageFaultHandler::new(create_mem_regions(mappings), ptr::null(), MockUffd {})
     }
 
     #[test]

--- a/tests/host_tools/demo_uffd/Cargo.lock
+++ b/tests/host_tools/demo_uffd/Cargo.lock
@@ -91,6 +91,7 @@ name = "demo_uffd"
 version = "1.1.0"
 dependencies = [
  "libc",
+ "nix",
  "serde",
  "serde_json",
  "uffd_handler",
@@ -320,6 +321,7 @@ name = "uffd_handler"
 version = "1.4.0"
 dependencies = [
  "libc",
+ "nix",
  "serde",
  "serde_json",
  "thiserror",

--- a/tests/host_tools/demo_uffd/Cargo.toml
+++ b/tests/host_tools/demo_uffd/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2.117"
+nix = "0.23.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 userfaultfd = "0.5.0"


### PR DESCRIPTION
## Changes

Configure UFFD handler to send a SIGBUS signal to Firecracker in case something goes wrong while handling the page faults.

## Reason

Firecracker relies on the userfaultfd handler process to handle page faults. In case this userspace process crashes, the requested page will never be copied to RAM and Firecracker will freeze waiting for the unavailable memory. Sending a SIGBUS signal to Firecracker will prevent it to stale.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~[ ] If a specific issue led to this PR, this PR closes the issue.~
- [X The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[ ] API changes follow the [Runbook for Firecracker API changes][2].~
- ~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~
- [X] All added/changed functionality is tested.
- ~[ ] New `TODO`s link to an issue.~
- [X] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
