### PR TITLE
fix: ignore Inter processor interrupt MSRs

### DIFF
--- a/tests/integration_tests/functional/test_cpu_features.py
+++ b/tests/integration_tests/functional/test_cpu_features.py
@@ -223,6 +223,15 @@ MSR_EXCEPTION_LIST = [
     "0xc0010007",  # MSR_K7_PERFCTR3
     "0xc001020b",  # Performance Event Counter MSR_F15H_PERF_CTR5
     "0xc0011029",  # MSR_F10H_DECFG also referred to as MSR_AMD64_DE_CFG
+    "0x830"     ,  # IA32_X2APIC_ICR is interrupt command register and,
+                   # bit 0-7 represent interrupt vector that varies.
+    "0x83F"     ,  # IA32_X2APIC_SELF_IPI
+                   # A self IPI is semantically identical to an
+                   # inter-processor interrupt sent via the ICR,
+                   # with a Destination Shorthand of Self,
+                   # Trigger Mode equal to Edge,
+                   # and a Delivery Mode equal to Fixed.
+                   # bit 0-7 represent interrupt vector that varies.
 ]
 # fmt: on
 


### PR DESCRIPTION
Bit 0-7 of ICR 0x830 and SelfIPI 0x83F MSR represent interrupt vector numbers which could vary so add the 2 MSRs to the exception list.

## Changes

Ignore MSR 0x830 and 0x83F when comparing MSR states before and after the snapshot-restore.

## Reason

Bit 0-7 of ICR 0x830 and SelfIPI 0x83F MSR represent interrupt vector numbers which could vary so MSR values before and after snapshot-restore could be different.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~~- [ ] API changes follow the [Runbook for Firecracker API changes][2].~~
~~- [ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested. [tested here](https://buildkite.com/firecracker/cpu-template-rdmsr-and-cpuid-wrmsr-snapshot-restore-test/builds/88#_).
~~- [ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

~~- [ ] This functionality can be added in [`rust-vmm`][1].~~

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
