### PR TITLE
CPU Template Wrapping and Deserialization

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3,7 +3,6 @@
 
 //! Enables pre-boot setup, instantiation and booting of a Firecracker VMM.
 
-#[cfg(target_arch = "aarch64")]
 use std::collections::HashMap;
 #[cfg(target_arch = "x86_64")]
 use std::convert::TryFrom;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3,6 +3,7 @@
 
 //! Enables pre-boot setup, instantiation and booting of a Firecracker VMM.
 
+#[cfg(target_arch = "aarch64")]
 use std::collections::HashMap;
 #[cfg(target_arch = "x86_64")]
 use std::convert::TryFrom;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -48,11 +48,11 @@ use crate::device_manager::persist::MMIODevManagerConstructorArgs;
 use crate::guest_config::aarch64::Aarch64CpuConfiguration;
 #[cfg(target_arch = "x86_64")]
 use crate::guest_config::cpuid::{Cpuid, RawCpuid};
-use crate::guest_config::templates;
 #[cfg(target_arch = "aarch64")]
 use crate::guest_config::templates::aarch64::{create_guest_cpu_config, Aarch64CpuTemplate};
 #[cfg(target_arch = "x86_64")]
 use crate::guest_config::templates::x86_64::{create_guest_cpu_config, X86_64CpuTemplate};
+use crate::guest_config::templates::Error as GuestConfigError;
 #[cfg(target_arch = "x86_64")]
 use crate::guest_config::x86_64::X86_64CpuConfiguration;
 use crate::persist::{MicrovmState, MicrovmStateError};
@@ -69,7 +69,7 @@ use crate::{device_manager, Error, EventManager, RestoreVcpusError, Vmm, VmmEven
 #[derive(Debug)]
 pub enum StartMicrovmError {
     /// Error using CPU template to configure vCPUs
-    ApplyCpuTemplate(templates::Error),
+    ApplyCpuTemplate(GuestConfigError),
     /// Unable to attach block device to Vmm.
     AttachBlockDevice(io::Error),
     /// This error is thrown by the minimal boot loader implementation.
@@ -300,7 +300,7 @@ fn create_vmm_and_vcpus(
                     .map_err(ApplyCpuTemplate)?,
                 );
             } else {
-                return Err(ApplyCpuTemplate(templates::Error::Internal(
+                return Err(ApplyCpuTemplate(GuestConfigError::Internal(
                     "Unable to access a vCPU".to_string(),
                 )));
             }
@@ -346,7 +346,7 @@ fn create_vmm_and_vcpus(
                     .map_err(ApplyCpuTemplate)?,
                 );
             } else {
-                return Err(ApplyCpuTemplate(templates::Error::Internal(
+                return Err(ApplyCpuTemplate(GuestConfigError::Internal(
                     "Unable to access a vCPU".to_string(),
                 )));
             }

--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -3,10 +3,8 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
-
 /// CPU configuration for aarch64 CPUs
-#[derive(Deserialize, Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct Aarch64CpuConfiguration {
     /// Register values as a key pair
     /// Key: Register pointer

--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -3,8 +3,10 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 /// CPU configuration for aarch64 CPUs
-#[derive(Default, Debug)]
+#[derive(Deserialize, Default, Debug, Serialize)]
 pub struct Aarch64CpuConfiguration {
     /// Register values as a key pair
     /// Key: Register pointer

--- a/src/vmm/src/guest_config/aarch64/mod.rs
+++ b/src/vmm/src/guest_config/aarch64/mod.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 /// CPU configuration for aarch64 CPUs
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Aarch64CpuConfiguration {
     /// Register values as a key pair
     /// Key: Register pointer

--- a/src/vmm/src/guest_config/cpuid/mod.rs
+++ b/src/vmm/src/guest_config/cpuid/mod.rs
@@ -40,7 +40,7 @@ use std::mem::{size_of, transmute};
 pub mod common;
 
 /// Raw CPUID specification handling.
-mod cpuid_ffi;
+pub(crate) mod cpuid_ffi;
 pub use cpuid_ffi::*;
 
 /// AMD CPUID specification handling.

--- a/src/vmm/src/guest_config/mod.rs
+++ b/src/vmm/src/guest_config/mod.rs
@@ -8,6 +8,9 @@ pub mod cpuid;
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 
+/// Module for types used for custom CPU templates
+pub mod templates;
+
 /// Module containing type implementations needed for x86 CPU configuration
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -140,8 +140,10 @@ pub mod aarch64 {}
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86_64")]
     use crate::guest_config::templates::x86_64::X86_64CpuTemplate;
 
+    #[cfg(target_arch = "x86_64")]
     const X86_64_TEMPLATE_JSON: &str = r#"{
         "msr_modifiers":  [
             {
@@ -175,11 +177,44 @@ mod tests {
         ]
     }"#;
 
+    #[cfg(target_arch = "aarch64")]
+    use crate::guest_config::templates::aarch64::Aarch64CpuTemplate;
+
+    #[cfg(target_arch = "aarch64")]
+    const AARCH64_TEMPLATE_JSON: &str = r#"{
+        "reg_modifiers":  [
+            {
+                "addr": "0x0AAC",
+                "mask": {
+                    "value": "0b0101",
+                    "filter": "0b1111"
+                }
+            },
+            {
+                "addr": "0x0AAB",
+                "mask": {
+                    "value": "0b0110",
+                    "filter": "0b1111"
+                }
+            }
+        ]
+    }"#;
+
     #[test]
     fn test_serialization_lifecycle() {
-        let cpu_config: X86_64CpuTemplate = serde_json::from_str(X86_64_TEMPLATE_JSON)
-            .expect("Failed to deserialize x86_64 CPU template.");
+        #[cfg(target_arch = "x86_64")]
+        {
+            let cpu_config: X86_64CpuTemplate = serde_json::from_str(X86_64_TEMPLATE_JSON)
+                .expect("Failed to deserialize x86_64 CPU template.");
+            assert_eq!(4, cpu_config.msr_modifiers.len());
+        }
 
-        assert_eq!(4, cpu_config.msr_modifiers.len());
+        #[cfg(target_arch = "aarch64")]
+        {
+            let cpu_config: Aarch64CpuTemplate = serde_json::from_str(AARCH64_TEMPLATE_JSON)
+                .expect("Failed to deserialize aarch64 CPU template.");
+
+            assert_eq!(2, cpu_config.reg_modifiers.len());
+        }
     }
 }

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -1,0 +1,185 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use serde::de::Error as SerdeError;
+use serde::{Deserialize, Deserializer};
+
+fn deserialize_u64_from_str<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let number_str = String::deserialize(deserializer)?;
+    let deserialized_number: u64 = if number_str.len() > 2 {
+        match &number_str[0..2] {
+            "0b" => u64::from_str_radix(&number_str[2..], 2),
+            "0x" => u64::from_str_radix(&number_str[2..], 16),
+            _ => u64::from_str(&number_str),
+        }
+        .map_err(|err| {
+            SerdeError::custom(format!(
+                "Failed to parse string [{}] as a number for CPU template - {:?}",
+                number_str, err
+            ))
+        })?
+    } else {
+        u64::from_str(&number_str).map_err(|err| {
+            SerdeError::custom(format!(
+                "Failed to parse string [{}] as a decimal number for CPU template - {:?}",
+                number_str, err
+            ))
+        })?
+    };
+
+    Ok(deserialized_number)
+}
+
+/// Guest config sub-module specifically useful for
+/// config templates.
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64 {
+    use std::str::FromStr;
+
+    use serde::de::Error as SerdeError;
+    use serde::{Deserialize, Deserializer};
+
+    use crate::guest_config::templates::deserialize_u64_from_str;
+
+    /// CPUID register enumeration
+    #[allow(unused)]
+    #[allow(missing_docs)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub enum CpuidRegister {
+        Eax,
+        Ebx,
+        Ecx,
+        Edx,
+    }
+
+    /// Composite type that holistically provides
+    /// the location of a specific register being used
+    /// in the context of a CPUID tree.
+    #[allow(unused)]
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct CpuidRegisterId {
+        leaf: u32,
+        subleaf: u32,
+        flags: crate::guest_config::cpuid::cpuid_ffi::KvmCpuidFlags,
+        pointer: CpuidRegister,
+    }
+
+    /// Wrapper type to containing x86_64 CPU config modifiers.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct X86_64CpuTemplate {
+        /// Modifiers for CPUID configuration.
+        // pub cpuid_modifiers: Vec<RegisterBitMask>,
+        /// Modifiers for model specific registers.
+        pub msr_modifiers: Vec<RegisterModifier>,
+    }
+
+    /// Bit-mask based wrapper to apply
+    /// changes to a given register's value
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct RegisterModifier {
+        /// Pointer of the location to be bit masked.
+        #[serde(deserialize_with = "deserialize_u32_from_str")]
+        addr: u32,
+        /// Mask to be applied to register's value at the address
+        /// provided.
+        mask: BitMask,
+    }
+
+    fn deserialize_u32_from_str<'de, D>(deserializer: D) -> Result<u32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let number_str = String::deserialize(deserializer)?;
+        let deserialized_number: u32 = if number_str.len() > 2 {
+            match &number_str[0..2] {
+                "0b" => u32::from_str_radix(&number_str[2..], 2),
+                "0x" => u32::from_str_radix(&number_str[2..], 16),
+                _ => u32::from_str(&number_str),
+            }
+            .map_err(|err| {
+                SerdeError::custom(format!(
+                    "Failed to parse string [{}] as a number for CPU template - {:?}",
+                    number_str, err
+                ))
+            })?
+        } else {
+            u32::from_str(&number_str).map_err(|err| {
+                SerdeError::custom(format!(
+                    "Failed to parse string [{}] as a decimal number for CPU template - {:?}",
+                    number_str, err
+                ))
+            })?
+        };
+
+        Ok(deserialized_number)
+    }
+
+    /// Bit mask to adjust targeted bits to the value,
+    /// applied by the filter only.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct BitMask {
+        /// Mask value is to be applied according
+        /// to what is allowed through by the filter.
+        #[serde(deserialize_with = "deserialize_u64_from_str")]
+        filter: u64,
+        /// Mask value to be applied.
+        #[serde(deserialize_with = "deserialize_u64_from_str")]
+        value: u64,
+    }
+}
+
+/// Guest config sub-module specifically useful for
+/// CPU templates to configure aarch64 CPUs.
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64 {}
+
+#[cfg(test)]
+mod tests {
+    use crate::guest_config::templates::x86_64::X86_64CpuTemplate;
+
+    const X86_64_TEMPLATE_JSON: &str = r#"{
+        "msr_modifiers":  [
+            {
+                "addr": "0x0",
+                "mask": {
+                    "value": "0b0101",
+                    "filter": "0b0111"
+                }
+            },
+            {
+                "addr": "0x1",
+                "mask": {
+                    "value": "0b0100",
+                    "filter": "0b1111"
+                }
+            },
+            {
+                "addr": "2",
+                "mask": {
+                    "value": "0b0100",
+                    "filter": "0b1111"
+                }
+            },
+            {
+                "addr": "0xbbca",
+                "mask": {
+                    "value": "0b0100",
+                    "filter": "0x1111"
+                }
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn test_serialization_lifecycle() {
+        let cpu_config: X86_64CpuTemplate = serde_json::from_str(X86_64_TEMPLATE_JSON)
+            .expect("Failed to deserialize x86_64 CPU template.");
+
+        assert_eq!(4, cpu_config.msr_modifiers.len());
+    }
+}

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -403,6 +403,21 @@ pub mod x86_64 {
     }
 }
 
+/// Errors thrown while configuring templates.
+#[cfg(target_arch = "x86_64")]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum Error {
+    /// Failure in processing the CPUID in template for x86_64 CPU configuration.
+    #[error("Template changes a CPUID entry not supported by the host - [{0}]")]
+    CpuidFeatureNotSupported(String),
+    /// Failure in processing the MSRs in template for x86_64 CPU configuration.
+    #[error("Template changes an MSR entry not supported by the host - [{0}]")]
+    MsrNotSupported(String),
+    /// Internal and unexpected error occurred while using custom templates.
+    #[error("Internal error occurred while using templates - [{0}]")]
+    Internal(String),
+}
+
 /// Guest config sub-module specifically for
 /// config templates.
 #[cfg(target_arch = "aarch64")]
@@ -417,7 +432,7 @@ pub mod aarch64 {
     use crate::guest_config::templates::{deserialize_u64_from_str, Error};
 
     /// Wrapper type to containing aarch64 CPU config modifiers.
-    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
     pub struct Aarch64CpuTemplate {
         /// Modifiers for registers on Aarch64 CPUs.
         pub reg_modifiers: Vec<RegisterModifier>,
@@ -581,6 +596,18 @@ pub mod aarch64 {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+/// Errors thrown while configuring templates.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum Error {
+    /// Failure in processing the aarch64 CPU template.
+    #[error("Template changes a register not supported by the host - [{0}]")]
+    Aarch64RegNotSupported(String),
+    /// Internal and unexpected error occurred while using custom templates.
+    #[error("Internal error occurred while using templates - [{0}]")]
+    Internal(String),
+}
+
 fn deserialize_u64_from_str<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
@@ -610,28 +637,19 @@ where
     Ok(deserialized_number)
 }
 
-/// Errors thrown while configuring templates.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum Error {
-    /// Failure in processing the CPUID configuration.
-    #[error("Error deserializing CPUID")]
-    Cpuid,
-    /// Unknown failure in processing the CPU template.
-    #[error("Internal error processing CPU template")]
-    Internal,
-}
-
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "x86_64")]
     use kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC;
     use serde_json::Value;
 
+    #[cfg(target_arch = "aarch64")]
+    use crate::guest_config::aarch64::Aarch64CpuConfiguration;
     #[cfg(target_arch = "x86_64")]
     use crate::guest_config::cpuid::KvmCpuidFlags;
     #[cfg(target_arch = "aarch64")]
     use crate::guest_config::templates::aarch64::{
-        Aarch64CpuTemplate, RegisterModifier, RegisterValueFilter,
+        create_guest_cpu_config, Aarch64CpuTemplate, RegisterModifier, RegisterValueFilter,
     };
     #[cfg(target_arch = "x86_64")]
     use crate::guest_config::templates::x86_64::{
@@ -648,7 +666,7 @@ mod tests {
         "cpuid_modifiers": [
             {
                 "leaf": "0x80000001",
-                "subleaf": "0x0007",
+                "subleaf": "0b000111",
                 "flags": 0,
                 "modifiers": [
                     {
@@ -675,7 +693,7 @@ mod tests {
             {
                 "leaf": "0x80000003",
                 "subleaf": "0x0004",
-                "flags": 0,
+                "flags": 1,
                 "modifiers": [
                     {
                         "register": "edx",
@@ -720,7 +738,7 @@ mod tests {
                 "bitmap": "0bx00100xxx1xxxx00xxx1xxxxxxxxxxx1"
             },
             {
-                "addr": "0x1",
+                "addr": "0b1",
                 "bitmap": "0bx00111xxx1xxxx111xxxxx101xxxxxx1"
             },
             {
@@ -783,8 +801,18 @@ mod tests {
             assert_eq!(guest_config_result.unwrap(), host_configuration);
         }
 
-        // TODO - Aarch64 test
-        // #[cfg(target_arch = "aarch64")]
+        #[cfg(target_arch = "aarch64")]
+        {
+            let host_configuration = supported_cpu_config();
+            let guest_config_result =
+                create_guest_cpu_config(&Aarch64CpuTemplate::default(), &host_configuration);
+            assert!(
+                guest_config_result.is_ok(),
+                "{}",
+                guest_config_result.unwrap_err()
+            );
+            assert_eq!(guest_config_result.unwrap(), host_configuration);
+        }
     }
 
     #[test]
@@ -802,8 +830,18 @@ mod tests {
             assert_ne!(guest_config_result.unwrap(), host_configuration);
         }
 
-        // TODO - Aarch64 test
-        // #[cfg(target_arch = "aarch64")]
+        #[cfg(target_arch = "aarch64")]
+        {
+            let host_configuration = supported_cpu_config();
+            let guest_config_result =
+                create_guest_cpu_config(&build_test_template(), &host_configuration);
+            assert!(
+                guest_config_result.is_ok(),
+                "{}",
+                guest_config_result.unwrap_err()
+            );
+            assert_ne!(guest_config_result.unwrap(), host_configuration);
+        }
     }
 
     #[test]
@@ -960,7 +998,14 @@ mod tests {
     fn supported_cpu_config() -> X86_64CpuConfiguration {
         X86_64CpuConfiguration {
             cpuid: cpuid_templates::t2::template(),
-            msrs: Default::default(),
+            msrs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn supported_cpu_config() -> Aarch64CpuConfiguration {
+        Aarch64CpuConfiguration {
+            regs: std::collections::HashMap::from([(0x8000, 0b1000), (0x8001, 0b1010)]),
         }
     }
 }

--- a/src/vmm/src/guest_config/templates/mod.rs
+++ b/src/vmm/src/guest_config/templates/mod.rs
@@ -6,6 +6,9 @@ use std::str::FromStr;
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Deserializer};
 
+// TODO: Refactor code to merge deserialize_* functions for modules x86_64 and aarch64
+/// Templates module to contain sub-modules for aarch64 and x86_64 templates
+
 fn deserialize_u64_from_str<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
@@ -35,19 +38,35 @@ where
     Ok(deserialized_number)
 }
 
+/// Errors thrown while configuring templates.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum Error {
+    /// Failure in processing the CPUID configuration.
+    #[error("Error deserializing CPUID")]
+    Cpuid,
+    /// Unknown failure in processing the CPU template.
+    #[error("Internal error processing CPU template")]
+    Internal,
+}
+
 /// Guest config sub-module specifically useful for
 /// config templates.
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64 {
+    use std::collections::{BTreeMap, HashMap};
     use std::str::FromStr;
 
     use serde::de::Error as SerdeError;
     use serde::{Deserialize, Deserializer};
 
-    use crate::guest_config::templates::deserialize_u64_from_str;
+    use crate::guest_config::cpuid::cpuid_ffi::KvmCpuidFlags;
+    use crate::guest_config::cpuid::{
+        AmdCpuid, Cpuid, CpuidEntry, CpuidKey, CpuidRegisters, IntelCpuid,
+    };
+    use crate::guest_config::templates::{deserialize_u64_from_str, Error};
+    use crate::guest_config::x86_64::X86_64CpuConfiguration;
 
     /// CPUID register enumeration
-    #[allow(unused)]
     #[allow(missing_docs)]
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub enum CpuidRegister {
@@ -57,37 +76,180 @@ pub mod x86_64 {
         Edx,
     }
 
+    /// Target register to be modified by a bitmap.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct CpuidRegisterModifier {
+        /// CPUID register to be modified by the bitmap.
+        #[serde(deserialize_with = "deserialize_cpuid_register")]
+        pub register: CpuidRegister,
+        /// Bit mapping to be applied as a modifier to the
+        /// register's value at the address provided.
+        pub bitmap: RegisterValueFilter,
+    }
+
     /// Composite type that holistically provides
     /// the location of a specific register being used
     /// in the context of a CPUID tree.
-    #[allow(unused)]
     #[derive(Debug, Deserialize, Eq, PartialEq)]
-    pub struct CpuidRegisterId {
-        leaf: u32,
-        subleaf: u32,
-        flags: crate::guest_config::cpuid::cpuid_ffi::KvmCpuidFlags,
-        pointer: CpuidRegister,
+    pub struct CpuidLeafModifier {
+        /// Leaf value.
+        #[serde(deserialize_with = "deserialize_u32_from_str")]
+        pub leaf: u32,
+        /// Sub-Leaf value.
+        #[serde(deserialize_with = "deserialize_u32_from_str")]
+        pub subleaf: u32,
+        /// KVM feature flags for this leaf-subleaf.
+        #[serde(deserialize_with = "deserialize_kvm_cpuid_flags")]
+        pub flags: crate::guest_config::cpuid::cpuid_ffi::KvmCpuidFlags,
+        /// All registers to be modified under the sub-leaf.
+        pub modifiers: Vec<CpuidRegisterModifier>,
     }
 
     /// Wrapper type to containing x86_64 CPU config modifiers.
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct X86_64CpuTemplate {
         /// Modifiers for CPUID configuration.
-        // pub cpuid_modifiers: Vec<RegisterBitMask>,
+        #[serde(default)]
+        pub cpuid_modifiers: Vec<CpuidLeafModifier>,
         /// Modifiers for model specific registers.
+        #[serde(default)]
         pub msr_modifiers: Vec<RegisterModifier>,
     }
 
-    /// Bit-mask based wrapper to apply
-    /// changes to a given register's value
+    /// Bit-mapped value to adjust targeted bits of a register.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct RegisterValueFilter {
+        /// Filter to be used when writing the value bits.
+        #[serde(deserialize_with = "deserialize_u64_from_str")]
+        pub filter: u64,
+        /// Value value to be applied.
+        #[serde(deserialize_with = "deserialize_u64_from_str")]
+        pub value: u64,
+    }
+
+    /// Wrapper of a mask defined as a bitmap to apply
+    /// changes to a given register's value.
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     pub struct RegisterModifier {
-        /// Pointer of the location to be bit masked.
+        /// Pointer of the location to be bit mapped.
         #[serde(deserialize_with = "deserialize_u32_from_str")]
-        addr: u32,
-        /// Mask to be applied to register's value at the address
-        /// provided.
-        mask: BitMask,
+        pub addr: u32,
+        /// Bit mapping to be applied as a modifier to the
+        /// register's value at the address provided.
+        pub bitmap: RegisterValueFilter,
+    }
+
+    /// CPU template with modifiers to be applied on
+    /// top of an existing configuration to generate
+    /// the guest configuration to be used.
+    pub fn create_guest_cpu_config(
+        template: &X86_64CpuTemplate,
+        host_config: &X86_64CpuConfiguration,
+    ) -> Result<X86_64CpuConfiguration, Error> {
+        let mut guest_msrs_map: HashMap<u32, u64> = HashMap::new();
+        let mut guest_cpuid_map: BTreeMap<CpuidKey, CpuidEntry>;
+
+        // Get the hash map of CPUID data
+        if host_config.cpuid.amd().is_some() {
+            guest_cpuid_map = host_config.cpuid.amd().unwrap().0.clone();
+        } else if host_config.cpuid.intel().is_some() {
+            guest_cpuid_map = host_config.cpuid.intel().unwrap().0.clone();
+        } else {
+            return Err(Error::Cpuid);
+        }
+
+        // Apply CPUID modifiers
+        for mod_leaf in &template.cpuid_modifiers {
+            let cpuid_key = CpuidKey {
+                leaf: mod_leaf.leaf,
+                subleaf: mod_leaf.subleaf,
+            };
+
+            let cpuid_entry_option = guest_cpuid_map.get(&cpuid_key);
+            let mut guest_cpuid_entry = if let Some(entry) = cpuid_entry_option {
+                entry.clone()
+            } else {
+                CpuidEntry::default()
+            };
+            guest_cpuid_entry.flags = mod_leaf.flags;
+
+            let (mut mod_eax, mut mod_ebx, mut mod_ecx, mut mod_edx) = (
+                u64::from(guest_cpuid_entry.result.eax),
+                u64::from(guest_cpuid_entry.result.ebx),
+                u64::from(guest_cpuid_entry.result.ecx),
+                u64::from(guest_cpuid_entry.result.edx),
+            );
+
+            for mod_reg in &mod_leaf.modifiers {
+                match mod_reg.register {
+                    CpuidRegister::Eax => mod_eax = apply_mask(Some(&mod_eax), &mod_reg.bitmap),
+                    CpuidRegister::Ebx => mod_ebx = apply_mask(Some(&mod_ebx), &mod_reg.bitmap),
+                    CpuidRegister::Ecx => mod_ecx = apply_mask(Some(&mod_ecx), &mod_reg.bitmap),
+                    CpuidRegister::Edx => mod_edx = apply_mask(Some(&mod_edx), &mod_reg.bitmap),
+                }
+            }
+
+            guest_cpuid_entry = CpuidEntry {
+                flags: mod_leaf.flags,
+                result: CpuidRegisters {
+                    eax: mod_eax as u32,
+                    ebx: mod_ebx as u32,
+                    ecx: mod_ecx as u32,
+                    edx: mod_edx as u32,
+                },
+            };
+
+            guest_cpuid_map.insert(cpuid_key, guest_cpuid_entry);
+        }
+
+        // Apply MSR modifiers
+        for modifier in &template.msr_modifiers {
+            guest_msrs_map.insert(
+                modifier.addr,
+                apply_mask(host_config.msrs.get(&modifier.addr), &modifier.bitmap),
+            );
+        }
+
+        if host_config.cpuid.amd().is_some() {
+            Ok(X86_64CpuConfiguration {
+                cpuid: Cpuid::Amd(AmdCpuid(guest_cpuid_map)),
+                msrs: guest_msrs_map,
+            })
+        } else if host_config.cpuid.intel().is_some() {
+            Ok(X86_64CpuConfiguration {
+                cpuid: Cpuid::Intel(IntelCpuid(guest_cpuid_map)),
+                msrs: guest_msrs_map,
+            })
+        } else {
+            Err(Error::Internal)
+        }
+    }
+
+    fn deserialize_kvm_cpuid_flags<'de, D>(deserializer: D) -> Result<KvmCpuidFlags, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let flag = u32::deserialize(deserializer)?;
+        Ok(KvmCpuidFlags(flag))
+    }
+
+    fn deserialize_cpuid_register<'de, D>(deserializer: D) -> Result<CpuidRegister, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let cpuid_register_str = String::deserialize(deserializer)?;
+
+        Ok(match cpuid_register_str.as_str() {
+            "eax" => CpuidRegister::Eax,
+            "ebx" => CpuidRegister::Ebx,
+            "ecx" => CpuidRegister::Ecx,
+            "edx" => CpuidRegister::Edx,
+            _ => {
+                return Err(D::Error::custom(
+                    "Invalid CPUID register. Must be one of [eax, ebx, ecx, edx]",
+                ))
+            }
+        })
     }
 
     fn deserialize_u32_from_str<'de, D>(deserializer: D) -> Result<u32, D::Error>
@@ -102,14 +264,14 @@ pub mod x86_64 {
                 _ => u32::from_str(&number_str),
             }
             .map_err(|err| {
-                SerdeError::custom(format!(
+                D::Error::custom(format!(
                     "Failed to parse string [{}] as a number for CPU template - {:?}",
                     number_str, err
                 ))
             })?
         } else {
             u32::from_str(&number_str).map_err(|err| {
-                SerdeError::custom(format!(
+                D::Error::custom(format!(
                     "Failed to parse string [{}] as a decimal number for CPU template - {:?}",
                     number_str, err
                 ))
@@ -119,57 +281,233 @@ pub mod x86_64 {
         Ok(deserialized_number)
     }
 
-    /// Bit mask to adjust targeted bits to the value,
-    /// applied by the filter only.
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    pub struct BitMask {
-        /// Mask value is to be applied according
-        /// to what is allowed through by the filter.
-        #[serde(deserialize_with = "deserialize_u64_from_str")]
-        filter: u64,
-        /// Mask value to be applied.
-        #[serde(deserialize_with = "deserialize_u64_from_str")]
-        value: u64,
+    fn apply_mask(source: Option<&u64>, bitmap: &RegisterValueFilter) -> u64 {
+        if let Some(value) = source {
+            (value & !&bitmap.filter) | bitmap.value
+        } else {
+            bitmap.value
+        }
     }
 }
 
-/// Guest config sub-module specifically useful for
-/// CPU templates to configure aarch64 CPUs.
+/// Guest config sub-module specifically for
+/// config templates.
 #[cfg(target_arch = "aarch64")]
-pub mod aarch64 {}
+pub mod aarch64 {
+    use serde::Deserialize;
+
+    /// Wrapper type to containing aarch64 CPU config modifiers.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct Aarch64CpuTemplate {
+        /// Modifiers for registers on Aarch64 CPUs.
+        pub reg_modifiers: Vec<RegisterModifier>,
+    }
+
+    /// Wrapper of a mask defined as a bitmap to apply
+    /// changes to a given register's value.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct RegisterModifier {
+        /// Pointer of the location to be bit masked.
+        #[serde(deserialize_with = "deserialize_u64_from_str")]
+        pub addr: u64,
+        /// Bit mapping to be applied as a modifier to the
+        /// register's value at the address provided.
+        pub bitmap: RegisterValueFilter,
+    }
+
+    /// Bit-mapped value to adjust targeted bits of a register.
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    pub struct RegisterValueFilter {
+        /// Filter to be used when writing the value bits.
+        #[serde(deserialize_with = "deserialize_u128_from_str")]
+        pub filter: u128,
+        /// Value to be applied.
+        #[serde(deserialize_with = "deserialize_u128_from_str")]
+        pub value: u128,
+    }
+
+    /// CPU template with modifiers to be applied on
+    /// top of an existing configuration to generate
+    /// the guest configuration to be used.
+    pub fn create_guest_cpu_config(
+        _template: &Aarch64CpuTemplate,
+        _host_config: &Aarch64CpuConfiguration,
+    ) -> Result<Aarch64CpuConfiguration, Error> {
+        // TODO
+        Ok(Aarch64CpuConfiguration::default())
+    }
+
+    fn deserialize_u128_from_str<'de, D>(deserializer: D) -> Result<u128, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let number_str = String::deserialize(deserializer)?;
+        let deserialized_number: u128 = if number_str.len() > 2 {
+            match &number_str[0..2] {
+                "0b" => u128::from_str_radix(&number_str[2..], 2),
+                "0x" => u128::from_str_radix(&number_str[2..], 16),
+                _ => u128::from_str(&number_str),
+            }
+            .map_err(|err| {
+                D::Error::custom(format!(
+                    "Failed to parse string [{}] as a number for CPU template - {:?}",
+                    number_str, err
+                ))
+            })?
+        } else {
+            u128::from_str(&number_str).map_err(|err| {
+                D::Error::custom(format!(
+                    "Failed to parse string [{}] as a decimal number for CPU template - {:?}",
+                    number_str, err
+                ))
+            })?
+        };
+
+        Ok(deserialized_number)
+    }
+}
 
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "x86_64")]
-    use crate::guest_config::templates::x86_64::X86_64CpuTemplate;
+    use kvm_bindings::KVM_CPUID_FLAG_STATEFUL_FUNC;
+
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::cpuid::KvmCpuidFlags;
+    #[cfg(target_arch = "aarch64")]
+    use crate::guest_config::templates::aarch64::{
+        Aarch64CpuTemplate, RegisterModifier, RegisterValueFilter,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::templates::x86_64::{
+        create_guest_cpu_config, CpuidLeafModifier, CpuidRegister, CpuidRegisterModifier,
+        RegisterModifier, RegisterValueFilter, X86_64CpuTemplate,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use crate::guest_config::x86_64::X86_64CpuConfiguration;
+    #[cfg(target_arch = "x86_64")]
+    use crate::vstate::vcpu::x86_64::cpuid_templates;
 
     #[cfg(target_arch = "x86_64")]
     const X86_64_TEMPLATE_JSON: &str = r#"{
+        "cpuid_modifiers": [
+            {
+                "leaf": "0x80000001",
+                "subleaf": "0x0007",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "eax",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000002",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "ebx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    },
+                    {
+                        "register": "ecx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000003",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "edx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000004",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "edx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    },
+                    {
+                        "register": "ecx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    }
+                ]
+            },
+            {
+                "leaf": "0x80000005",
+                "subleaf": "0x0004",
+                "flags": 0,
+                "modifiers": [
+                    {
+                        "register": "eax",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    },
+                    {
+                        "register": "edx",
+                        "bitmap": {
+                            "value": "0b0101",
+                            "filter": "0b0111"
+                        }
+                    }
+                ]
+            }
+        ],
         "msr_modifiers":  [
             {
                 "addr": "0x0",
-                "mask": {
+                "bitmap": {
                     "value": "0b0101",
                     "filter": "0b0111"
                 }
             },
             {
                 "addr": "0x1",
-                "mask": {
+                "bitmap": {
                     "value": "0b0100",
                     "filter": "0b1111"
                 }
             },
             {
                 "addr": "2",
-                "mask": {
+                "bitmap": {
                     "value": "0b0100",
                     "filter": "0b1111"
                 }
             },
             {
                 "addr": "0xbbca",
-                "mask": {
+                "bitmap": {
                     "value": "0b0100",
                     "filter": "0x1111"
                 }
@@ -178,21 +516,18 @@ mod tests {
     }"#;
 
     #[cfg(target_arch = "aarch64")]
-    use crate::guest_config::templates::aarch64::Aarch64CpuTemplate;
-
-    #[cfg(target_arch = "aarch64")]
     const AARCH64_TEMPLATE_JSON: &str = r#"{
         "reg_modifiers":  [
             {
                 "addr": "0x0AAC",
-                "mask": {
+                "bitmap": {
                     "value": "0b0101",
                     "filter": "0b1111"
                 }
             },
             {
                 "addr": "0x0AAB",
-                "mask": {
+                "bitmap": {
                     "value": "0b0110",
                     "filter": "0b1111"
                 }
@@ -206,6 +541,7 @@ mod tests {
         {
             let cpu_config: X86_64CpuTemplate = serde_json::from_str(X86_64_TEMPLATE_JSON)
                 .expect("Failed to deserialize x86_64 CPU template.");
+            assert_eq!(5, cpu_config.cpuid_modifiers.len());
             assert_eq!(4, cpu_config.msr_modifiers.len());
         }
 
@@ -215,6 +551,88 @@ mod tests {
                 .expect("Failed to deserialize aarch64 CPU template.");
 
             assert_eq!(2, cpu_config.reg_modifiers.len());
+        }
+    }
+
+    #[test]
+    fn test_empty_template() {
+        #[cfg(target_arch = "x86_64")]
+        {
+            let host_configuration = supported_cpu_config();
+
+            let template = X86_64CpuTemplate {
+                cpuid_modifiers: vec![],
+                msr_modifiers: vec![],
+            };
+
+            let guest_config_result = create_guest_cpu_config(&template, &host_configuration);
+            assert!(
+                guest_config_result.is_ok(),
+                "{}",
+                guest_config_result.unwrap_err()
+            );
+            assert_eq!(guest_config_result.unwrap(), host_configuration);
+        }
+
+        // TODO - Aarch64 test
+        // #[cfg(target_arch = "aarch64")]
+    }
+
+    #[test]
+    fn test_template() {
+        #[cfg(target_arch = "x86_64")]
+        {
+            let host_configuration = supported_cpu_config();
+
+            let template = X86_64CpuTemplate {
+                cpuid_modifiers: Vec::from([CpuidLeafModifier {
+                    leaf: 0x1,
+                    subleaf: 0x1,
+                    flags: KvmCpuidFlags(KVM_CPUID_FLAG_STATEFUL_FUNC),
+                    modifiers: Vec::from([
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Eax,
+                            bitmap: RegisterValueFilter {
+                                filter: 0,
+                                value: 0,
+                            },
+                        },
+                        CpuidRegisterModifier {
+                            register: CpuidRegister::Eax,
+                            bitmap: RegisterValueFilter {
+                                filter: 0,
+                                value: 0,
+                            },
+                        },
+                    ]),
+                }]),
+                msr_modifiers: Vec::from([RegisterModifier {
+                    addr: 0x8000,
+                    bitmap: RegisterValueFilter {
+                        filter: 0,
+                        value: 0,
+                    },
+                }]),
+            };
+
+            let guest_config_result = create_guest_cpu_config(&template, &host_configuration);
+            assert!(
+                guest_config_result.is_ok(),
+                "{}",
+                guest_config_result.unwrap_err()
+            );
+            assert_ne!(guest_config_result.unwrap(), host_configuration);
+        }
+
+        // TODO - Aarch64 test
+        // #[cfg(target_arch = "aarch64")]
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn supported_cpu_config() -> X86_64CpuConfiguration {
+        X86_64CpuConfiguration {
+            cpuid: cpuid_templates::t2::template(),
+            msrs: Default::default(),
         }
     }
 }

--- a/src/vmm/src/guest_config/x86_64/mod.rs
+++ b/src/vmm/src/guest_config/x86_64/mod.rs
@@ -3,11 +3,13 @@
 
 use std::collections::HashMap;
 
+use crate::guest_config::cpuid::Cpuid;
+
 /// CPU configuration for x86_64 CPUs
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct X86_64CpuConfiguration {
     /// CPUID configuration
-    // pub cpuid: Cpuid,
+    pub cpuid: Cpuid,
     /// Register values as a key pair for model specific registers
     /// Key: MSR address
     /// Value: MSR value

--- a/src/vmm/src/guest_config/x86_64/mod.rs
+++ b/src/vmm/src/guest_config/x86_64/mod.rs
@@ -3,14 +3,13 @@
 
 use std::collections::HashMap;
 
-use crate::guest_config::cpuid::Cpuid;
-
 /// CPU configuration for x86_64 CPUs
+#[derive(Clone, Debug)]
 pub struct X86_64CpuConfiguration {
     /// CPUID configuration
-    pub cpuid: Cpuid,
+    // pub cpuid: Cpuid,
     /// Register values as a key pair for model specific registers
     /// Key: MSR address
     /// Value: MSR value
-    pub msrs: HashMap<u64, u64>,
+    pub msrs: HashMap<u32, u64>,
 }

--- a/src/vmm/src/vstate/vcpu/x86_64/mod.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64/mod.rs
@@ -26,7 +26,7 @@ use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use crate::vstate::vcpu::{VcpuConfig, VcpuEmulation};
 use crate::vstate::vm::Vm;
 
-mod cpuid_templates;
+pub(crate) mod cpuid_templates;
 
 // Tolerance for TSC frequency expected variation.
 // The value of 250 parts per million is based on

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.08, "AMD": 78.92, "ARM": 81.98}
+    COVERAGE_DICT = {"Intel": 78.08, "AMD": 78.92, "ARM": 81.88}
 else:
-    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.66, "ARM": 78.93}
+    COVERAGE_DICT = {"Intel": 75.88, "AMD": 76.66, "ARM": 78.84}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,7 +17,7 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.09, "ARM": 82.12}
+    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.02, "ARM": 82.12}
 else:
     COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.07}
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.09, "ARM": 82.19}
+    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.09, "ARM": 82.12}
 else:
-    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.13}
+    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.07}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.20, "AMD": 79.02, "ARM": 82.12}
+    COVERAGE_DICT = {"Intel": 78.08, "AMD": 78.92, "ARM": 81.98}
 else:
-    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.81, "ARM": 79.07}
+    COVERAGE_DICT = {"Intel": 75.93, "AMD": 76.66, "ARM": 78.93}
 
 PROC_MODEL = proc.proc_type()
 

--- a/tests/integration_tests/build/test_coverage.py
+++ b/tests/integration_tests/build/test_coverage.py
@@ -17,9 +17,9 @@ from host_tools import proc
 # Checkout the cpuid crate. In the future other
 # differences may appear.
 if utils.is_io_uring_supported():
-    COVERAGE_DICT = {"Intel": 78.08, "AMD": 78.92, "ARM": 81.88}
+    COVERAGE_DICT = {"Intel": 78.28, "AMD": 79.12, "ARM": 82.10}
 else:
-    COVERAGE_DICT = {"Intel": 75.88, "AMD": 76.66, "ARM": 78.84}
+    COVERAGE_DICT = {"Intel": 76.02, "AMD": 76.86, "ARM": 79.06}
 
 PROC_MODEL = proc.proc_type()
 


### PR DESCRIPTION
## Changes

Changes extend [PR/3483](https://github.com/firecracker-microvm/firecracker/pull/3483/) that have the `*CpuConfiguration` types defined.

* CPU template types for x86_64 and aarch64.
* `apply_template()` function for x86_64 to use the template to create `X86_64CpuConfiguration`.

## Reason

* CPU template types to be used to store the payload for `/cpu-config` API.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
