### PR TITLE
feat: send notification when  pr opened

### DIFF
--- a/.github/workflows/send_pr_notification.yml
+++ b/.github/workflows/send_pr_notification.yml
@@ -1,0 +1,19 @@
+name: Send notification on PR opened
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  send_notification:
+    if: ${{ github.event.label.name }} == "Status:\ Reviewer"
+    runs-on: ubuntu-latest
+    steps:
+      - name: notify
+        run: |
+          curl -X POST ${{ secrets.SLACK_PR_NOTIFICATION_WEBHOOK }} \
+               -H 'Content-Type: application/json' \
+               -d '{ "GITHUB_PR_URL": "${{ github.event.pull_request.html_url }}",
+                     "PR_ADDITIONS": "${{ github.event.pull_request.additions }}",
+                     "PR_DELETIONS": "${{ github.event.pull_request.deletions }}",
+                     "PR_CHANGED_FILES": "${{ github.event.pull_request.changed_files }}"}'


### PR DESCRIPTION
## Reason

Add pr notification.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality can be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
