### PR TITLE
Add error handling when screen/firecracker processes have not launched successfully

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -21,6 +21,7 @@ from retry.api import retry_call
 
 from framework.defs import MIN_KERNEL_VERSION_FOR_IO_URING
 
+FLUSH_CMD = 'screen -S {session} -X colon "logfile flush 0^M"'
 CommandReturn = namedtuple("CommandReturn", "returncode stdout stderr")
 CMDLOG = logging.getLogger("commands")
 GET_CPU_LOAD = "top -bn1 -H -p {} -w512 | tail -n+8"
@@ -760,17 +761,22 @@ def start_screen_process(screen_log, session_name, binary_path, binary_params):
         delay=1,
     ).group(1)
 
-    binary_clone_pid = int(
-        open("/proc/{0}/task/{0}/children".format(screen_pid), encoding="utf-8")
-        .read()
-        .strip()
-    )
+    # Make sure the screen process launched successfully
+    # As the parent process for the binary.
+    screen_ps = psutil.Process(int(screen_pid))
+    wait_process_running(screen_ps)
 
     # Configure screen to flush stdout to file.
-    flush_cmd = 'screen -S {session} -X colon "logfile flush 0^M"'
-    run_cmd(flush_cmd.format(session=session_name))
+    run_cmd(FLUSH_CMD.format(session=session_name))
 
-    return screen_pid, binary_clone_pid
+    children_count = len(screen_ps.children())
+    if children_count != 1:
+        raise RuntimeError(
+            f"Failed to retrieve child process id for binary {binary_path}. "
+            f"screen session process had [{children_count}]"
+        )
+
+    return screen_pid, screen_ps.children()[0].pid
 
 
 def guest_run_fio_iteration(ssh_connection, iteration):
@@ -790,3 +796,13 @@ def check_filesystem(ssh_connection, disk_fmt, disk):
     cmd = "fsck.{} -n {}".format(disk_fmt, disk)
     exit_code, _, stderr = ssh_connection.execute_command(cmd)
     assert exit_code == 0, stderr.read()
+
+
+@retry(delay=0.5, tries=5)
+def wait_process_running(process):
+    """Wait for a process to run.
+
+    Will return successfully if the process is in
+    a running state and will otherwise raise an exception.
+    """
+    assert process.is_running()


### PR DESCRIPTION
## Changes

* Check to make sure the screen process in integration tests is started successfully.
* Check the parent process' status with a retry added to confirm the screen process is up and running.
* Try-and-except blocks added at multiple stages of the screen sessions startup for clearer error handling.

## Reason

Motivated by a [build error in Buildkite for Firecracker's CI pipeline](https://buildkite.com/firecracker/firecracker-pr/builds/1013#01865063-028d-473b-8ffa-346e1388e5c1).

The `screen` application is used to boot up Firecracker in a detached mode, and is used to launch the Firecracker process (or Jailer as a wrapper) for integration tests to be run against. This results in two processes being launched, the screen process, and the binary application's process (that is a child process of the screen process). It is rare that this boot up logic fails, but when it does can be an opaque issue.

Error handling for:
* If a runtime or system error occurs, due to the child process crashing very quickly, ending the parent screen process as well.
* If there is a race condition of the screen process launching, but the forking of the process for the child process has not completed yet.

Both cases can result in  a missing/empty `children` file (`/proc/{PPID}/task/{PPID}/children`) for the parent process. This is what can lead to the error seen in the CI pipeline, `ValueError: invalid literal for int() with base 10: ''`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].
