### PR TITLE
fix: fix Slack notification on pr

### DIFF
--- a/.github/workflows/send_pr_notification.yml
+++ b/.github/workflows/send_pr_notification.yml
@@ -6,14 +6,15 @@ on:
 
 jobs:
   send_notification:
-    if: ${{ github.event.label.name }} == "Status:\ Reviewer"
     runs-on: ubuntu-latest
     steps:
       - name: notify
         run: |
-          curl -X POST ${{ secrets.SLACK_PR_NOTIFICATION_WEBHOOK }} \
-               -H 'Content-Type: application/json' \
-               -d '{ "GITHUB_PR_URL": "${{ github.event.pull_request.html_url }}",
-                     "PR_ADDITIONS": "${{ github.event.pull_request.additions }}",
-                     "PR_DELETIONS": "${{ github.event.pull_request.deletions }}",
-                     "PR_CHANGED_FILES": "${{ github.event.pull_request.changed_files }}"}'
+          if ${{ github.event.label.name == format('Status{0} Reviewer', ':') }}; then
+            curl -X POST ${{ secrets.SLACK_PR_NOTIFICATION_WEBHOOK }} \
+                 -H 'Content-Type: application/json' \
+                 -d '{ "GITHUB_PR_URL": "${{ github.event.pull_request.html_url }}",
+                       "PR_ADDITIONS": "${{ github.event.pull_request.additions }}",
+                       "PR_DELETIONS": "${{ github.event.pull_request.deletions }}",
+                       "PR_CHANGED_FILES": "${{ github.event.pull_request.changed_files }}"}'
+           fi


### PR DESCRIPTION
## Reason

This is a fix of 0d68b15d8fcfd15da70adf405d1a536c89ca3e06. Unfortunately, the `if:` tag from GitHub action definition doesn't work as expected when comparing with a label that contains special characters such as `:`. I tried a couple of suggestions to escape that but none of then worked. However, filtering out the labels directly in the `run` tag works.

Fix tested successfully in a couple of situations such as:
- adding a different tag
- adding `Status: Reviewer`
- adding a different tag (after already tagged as `Status: Reviewer`)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
