### PR TITLE
test: Update `test_ensure_mod_tests`

### DIFF
--- a/tests/integration_tests/style/test_rust.py
+++ b/tests/integration_tests/style/test_rust.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests ensuring codebase style compliance for Rust."""
 
+import subprocess
+
 from framework import utils
 
 
@@ -27,34 +29,28 @@ def test_ensure_mod_tests():
 
     @type: style
     """
-    # List all source files containing rust #[test] attribute,
-    # (excluding generated files and integration test directories).
-    # Take the list and check each file contains 'mod tests {', output file
-    # name if it doesn't.
-    cmd = (
-        "/bin/bash "
-        "-c "
-        '"grep '
-        "--files-without-match "
-        "'mod tests {' "
-        "\\$(grep "
-        "--files-with-matches "
-        "--recursive "
-        "--exclude-dir=src/*_gen/* "
-        "'\\#\\[test\\]' ../src/*/src)\" "
-        '| grep -v "../src/io_uring/src/bindings.rs"'
-    )
+    excluding = [
+        "_gen/",
+        "/tests/",
+        "/test_utils",
+        "build/",
+        "src/io_uring/src/bindings.rs",
+    ]
 
-    # The outer grep returns 0 even if it finds files without the match, so we
-    # ignore the return code.
-    result = utils.run_cmd(cmd, no_shell=False, ignore_return_code=True)
+    # Files with `#[test]` without `mod tests`.
+    cmd = 'find ../src -type f -name "*.rs" |xargs grep --files-without-match "mod tests {" |xargs grep --files-with-matches "#\\[test\\]"'
+    res = subprocess.run(cmd, shell=True, capture_output=True, check=True)
+    tests_without_mods = res.stdout.decode("utf-8").split("\n")
 
-    stdout = result.stdout.strip()
+    # Files with `#[test]` without `mod tests` excluding file paths which contain any string from
+    # `excluding` or are empty.
+    final = [
+        f
+        for f in tests_without_mods
+        if not any(x in f for x in excluding) and len(f) > 0
+    ]
 
-    error_msg = (
-        f'Tests found in files without a "tests" module:\n {stdout} '
-        "To ensure code coverage is reported correctly, please check that "
-        'your tests are in a module named "tests".'
-    )
-
-    assert not stdout, error_msg
+    # Assert `final` is empty.
+    assert (
+        final == []
+    ), "`#[test]`s found in files without `mod tests`s. Code coverage requires that tests are in test modules."


### PR DESCRIPTION
## Changes

Updates `test_ensure_mod_tests` to allow easier filtering.

## Reason

It allows for easier filtering.

This was spawned from attempting to change the filter in https://github.com/firecracker-microvm/firecracker/pull/3528 and finding it awkward.

This change should also help support further checking:
1. Checking `mod tests` is at the end of the file.
2. Checking files with `mod tests` don't have `#[test]`s outside of this.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] API changes follow the [Runbook for Firecracker API changes][2].
- [x] User-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
- [x] New `TODO`s link to an issue.
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
