### PR TITLE
test: make snapshot related tests for PR run on cgroupsv2 images

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -15,6 +15,17 @@ DEFAULT_INSTANCES = [
     "c7g.metal",
 ]
 
+DEFAULT_INSTANCES_X86 = [
+    "m5d.metal",
+    "m6i.metal",
+    "m6a.metal",
+]
+
+DEFAULT_INSTANCES_AARCH64 = [
+    "m6g.metal",
+    "c7g.metal",
+]
+
 DEFAULT_PLATFORMS = [("al2", "linux_4.14"), ("al2", "linux_5.10")]
 
 DEFAULT_QUEUE = "public-prod-us-east-1"

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -149,7 +149,13 @@ class CpuMap:
         See this issue for details:
         https://github.com/moby/moby/issues/20770.
         """
-        cmd = "cat {}/cpuset.cpus".format(CpuMap._cpuset_mountpoint())
+        # The real processor map is found at different paths based on cgroups version:
+        #  - cgroupsv1: /cpuset.cpus
+        #  - cgroupsv2: /cpuset.cpus.effective
+        # For more details, see https://docs.kernel.org/admin-guide/cgroup-v2.html#cpuset-interface-files
+        cmd = "cat /sys/fs/cgroup/cpuset.cpus.effective || cat {}/cpuset.cpus".format(
+            CpuMap._cpuset_mountpoint()
+        )
         _, cpulist, _ = run_cmd(cmd)
         return ListFormatParser(cpulist).parse()
 

--- a/tests/integration_tests/performance/test_snapshot_perf.py
+++ b/tests/integration_tests/performance/test_snapshot_perf.py
@@ -449,6 +449,7 @@ def _test_snapshot_resume_latency(context):
 ARTIFACTS = ArtifactCollection(_test_images_s3_bucket())
 
 
+@pytest.mark.ci_snapshot
 @pytest.mark.parametrize("io_engine", ENGINES)
 @pytest.mark.parametrize(
     "microvm", ARTIFACTS.microvms(keyword="2vcpu_512mb"), ids=lambda uvm: uvm.name()
@@ -536,6 +537,7 @@ def test_older_snapshot_resume_latency(
     results_file_dumper.dump(result)
 
 
+@pytest.mark.ci_snapshot
 def test_snapshot_create_full_latency(
     network_config, bin_cloner_path, results_file_dumper
 ):
@@ -576,6 +578,7 @@ def test_snapshot_create_full_latency(
     test_matrix.run_test(_test_snapshot_create_latency)
 
 
+@pytest.mark.ci_snapshot
 def test_snapshot_create_diff_latency(
     network_config, bin_cloner_path, results_file_dumper
 ):
@@ -616,6 +619,7 @@ def test_snapshot_create_diff_latency(
     test_matrix.run_test(_test_snapshot_create_latency)
 
 
+@pytest.mark.ci_snapshot
 @pytest.mark.parametrize("io_engine", ENGINES)
 def test_snapshot_resume_latency(
     network_config, bin_cloner_path, results_file_dumper, io_engine


### PR DESCRIPTION
## Changes

Make snapshot related tests for PR run on cgroupsv2 images.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] API changes follow the [Runbook for Firecracker API changes][2].
- [ ] User-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
- [ ] New `TODO`s link to an issue.
- [ ] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
