### PR TITLE
tools: move package installation to Dockerfile

### DIFF
--- a/resources/tests/build_kernel.sh
+++ b/resources/tests/build_kernel.sh
@@ -72,9 +72,6 @@ build_kernel() {
     cp "$KERNEL_CONFIG" "$KERNEL_DEST_DIR/.config"
     pushd "$KERNEL_DEST_DIR" >/dev/null
 
-    apt-get update
-    apt-get install -y flex bison bc
-
     local arch=$(uname -m)
     case $arch in
         "x86_64")

--- a/tools/devctr/Dockerfile
+++ b/tools/devctr/Dockerfile
@@ -50,6 +50,10 @@ RUN apt-get update \
         tini \
         # for mdl
         ruby \
+        # for building kernel
+        flex \
+        bison \
+        bc \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --upgrade pip poetry \
     && gem install mdl

--- a/tools/devtool
+++ b/tools/devtool
@@ -72,7 +72,7 @@
 DEVCTR_IMAGE_NO_TAG="public.ecr.aws/firecracker/fcuvm"
 
 # Development container tag
-DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v53}
+DEVCTR_IMAGE_TAG=${DEVCTR_IMAGE_TAG:-v54}
 
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.


### PR DESCRIPTION
## Changes

Moves package installation to Dockerfile and packs required packages into devctr.

## Reason

When building kernel, installing packages require the root permission. To make `tools/devtool build_kernel` pass without `sudo`, this commit packs required packages into devctr.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] If a specific issue led to this PR, this PR closes the issue.
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
