### PR TITLE
test: detect partially missing baselines

### DIFF
--- a/tests/framework/stats/consumer.py
+++ b/tests/framework/stats/consumer.py
@@ -128,6 +128,14 @@ class Consumer(ABC):
 
                 pass_criteria = st_def.pass_criteria
                 if pass_criteria:
+                    # if the statistic definition contains a criteria but the
+                    # corresponding baseline is not defined, the test should fail.
+                    if pass_criteria.baseline == {}:
+                        self._failure_aggregator.add_row(
+                            f"Baseline data is not defined for '{ms_name}/{st_def.name}"
+                            f"/{pass_criteria.name}'."
+                        )
+                        continue
                     self._statistics[ms_name][st_def.name]["pass_criteria"] = {
                         pass_criteria.name: pass_criteria.baseline
                     }

--- a/tests/framework/stats/consumer.py
+++ b/tests/framework/stats/consumer.py
@@ -118,9 +118,9 @@ class Consumer(ABC):
                             "measurement."
                         )
                         continue
-                    self._statistics[ms_name][st_def.name] = self._statistics[ms_name][
-                        st_def.name
-                    ] = {"value": st_def.func(self._results[ms_name][self.DATA_KEY])}
+                    self._statistics[ms_name][st_def.name] = {
+                        "value": st_def.func(self._results[ms_name][self.DATA_KEY])
+                    }
                 else:
                     self._statistics[ms_name][st_def.name] = {
                         "value": self._results[ms_name][st_def.name]

--- a/tests/framework/stats/metadata.py
+++ b/tests/framework/stats/metadata.py
@@ -149,15 +149,19 @@ class DictProvider(Provider):
                 if name:
                     func = func_cls(name)
 
+                # When the statistic definition does not define a criteria, `criteria` is
+                # `None`. On the other hand, when the statistic definition defines a
+                # criteria but does not have the corresponding baseline, `criteria` is
+                # initialized with an empty baseline.
                 criteria = None
                 criteria_cls_name = st_def.get("criteria")
-                baseline = baseline_provider.get(ms_name, func.name)
-                if criteria_cls_name and baseline:
+                if criteria_cls_name:
                     criteria_cls = CriteriaFactory.get(criteria_cls_name)
                     assert criteria_cls, (
                         f"{criteria_cls_name} is not a " f"valid criteria."
                     )
-                    criteria = criteria_cls(baseline)
+                    baseline = baseline_provider.get(ms_name, func.name)
+                    criteria = criteria_cls(baseline if baseline else {})
 
                 st_list.append(StatisticDef(func, criteria))
 


### PR DESCRIPTION
## Changes

This commit introduces a mechanism to detect partially missing baselines.

## Reason

Sync block i/o performance baselines for c7g.metal are missing but not
detected in PR #3381.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- ~~[ ] If a specific issue led to this PR, this PR closes the issue.~~
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] API changes follow the [Runbook for Firecracker API changes][2].~~
- ~~[ ] User-facing changes are mentioned in `CHANGELOG.md`.~~
- [x] All added/changed functionality is tested.
- ~~[ ] New `TODO`s link to an issue.~~
- [x] Commits meet [contribution quality standards](https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md#contribution-quality-standards).

---

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
